### PR TITLE
perf(runtime): batch verbose runtime logs

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-01-runtime-log-coalescing.md
+++ b/agent-docs/exec-plans/active/2026-09-01-runtime-log-coalescing.md
@@ -1,0 +1,48 @@
+# Hosted runtime log coalescing
+
+Status: active
+Created: 2026-09-01
+Updated: 2026-09-01
+
+## Goal
+
+- Reduce verbose hosted runtime-log request fanout without delaying warnings, errors, invocation completion, or user-visible work.
+
+## Success criteria
+
+- Idle debug and info entries share one bounded coalescing window and batch through the existing request limits.
+- Reaching the existing entry or serialized-body limit starts the current writer immediately.
+- Invocation drain flushes queued entries immediately, while warn and error entries remain direct and awaited.
+- Cross-port FIFO order, preemption barriers, queue trimming, and failed-write behavior remain unchanged.
+- Focused regression tests prove the timing, bounds, drain, ordering, and failure behavior.
+
+## Scope
+
+- In scope: the assistant-runtime log queue owner, its comments, and focused queue tests.
+- Out of scope: log schema, Web persistence, retention, warning/error policy, or another queue owner.
+
+## Root-cause evidence
+
+- The existing queue starts its writer immediately whenever it was idle, so isolated verbose entries each cause a request despite the batching layer.
+- The queue already owns every required safety bound and invocation-end drain; request reduction requires changing only when that existing writer starts.
+
+## Plan
+
+1. Add one unref'd idle coalescing timer around the existing writer.
+2. Start the writer early at the existing entry or body-size request bound and during invocation drain.
+3. Add focused deterministic timing, ordering, bound, and failure regressions.
+4. Run focused assistant-runtime proof, complexity and diff review, exact-head CI, final ReviewGPT, and merge.
+
+## Deployment concerns
+
+- The change is confined to the assistant-runtime package consumed by the Cloudflare runner.
+- Old and new Web deployments accept the same log request schema, so no coordinated Web deployment is required.
+- Rollback restores the prior immediate-start behavior without data or schema migration.
+
+## Verification
+
+- Passed: focused hosted runtime-log queue suite (18 tests).
+- Passed: assistant-runtime package typecheck.
+- Passed: cyclomatic-complexity diff; the changed queue owner has no hotspot above the threshold and maximum complexity remains bounded.
+- Passed: `git diff --check` and parent inspection of the source, test, and plan diff.
+- Pending: exact-head required GitHub Actions, final ReviewGPT, and merge.

--- a/agent-docs/exec-plans/completed/2026-09-01-runtime-log-coalescing.md
+++ b/agent-docs/exec-plans/completed/2026-09-01-runtime-log-coalescing.md
@@ -1,6 +1,6 @@
 # Hosted runtime log coalescing
 
-Status: active
+Status: completed
 Created: 2026-09-01
 Updated: 2026-09-01
 
@@ -42,7 +42,11 @@ Updated: 2026-09-01
 ## Verification
 
 - Passed: focused hosted runtime-log queue suite (18 tests).
-- Passed: assistant-runtime package typecheck.
+- Passed: complete assistant-runtime suite (115 files passed, 1 skipped; 2,632 tests passed, 5 skipped).
+- Passed: Cloudflare runtime-bridge workspace suite (37 tests) after its test harness explicitly drained delayed verbose writes at the invocation boundary.
+- Passed: assistant-runtime and Cloudflare package typechecks.
 - Passed: cyclomatic-complexity diff; the changed queue owner has no hotspot above the threshold and maximum complexity remains bounded.
 - Passed: `git diff --check` and parent inspection of the source, test, and plan diff.
-- Pending: exact-head required GitHub Actions, final ReviewGPT, and merge.
+- Passed: final ReviewGPT reviewed the production implementation, identified the reverse-dependent Cloudflare test-harness gap, and accepted the recorded anomaly retrospective; the production design remained unchanged.
+- Required GitHub Actions remain the exact-head merge gate after this plan-closing commit.
+Completed: 2026-09-01

--- a/apps/cloudflare/test/runtime-bridge-workspace.test.ts
+++ b/apps/cloudflare/test/runtime-bridge-workspace.test.ts
@@ -41,6 +41,9 @@ import {
   type HostedWorkspaceRuntimeBridgeOptionsInput,
 } from "@murphai/assistant-runtime/hosted-invocation-testkit";
 import {
+  drainHostedRuntimeLogWritesBestEffort,
+} from "@murphai/assistant-runtime/hosted-invocation";
+import {
   HOSTED_EXECUTION_LAYERED_SNAPSHOT_REF_SCHEMA,
   HOSTED_EXECUTION_WORKING_SNAPSHOT_REF_SCHEMA,
 } from "@murphai/hosted-execution/bundles";
@@ -93,7 +96,7 @@ const blockedMailboxPayloadDecoder: HostedWorkspaceMailboxPayloadDecoder = {
 function createHostedWorkspaceRuntimeBridgeJobOptions(
   input: TestHostedWorkspaceRuntimeBridgeOptionsInput,
 ): HostedWorkspaceRuntimeJobOptions {
-  return createPackageHostedWorkspaceRuntimeBridgeJobOptions({
+  const options = createPackageHostedWorkspaceRuntimeBridgeJobOptions({
     ...input,
     decodeMailboxPayload: input.requireMailboxPayloadDecoder === true
       ? input.decodeMailboxPayload
@@ -103,9 +106,20 @@ function createHostedWorkspaceRuntimeBridgeJobOptions(
     waitForBackgroundAssistantWork:
       input.waitForBackgroundAssistantWork ?? (async () => {}),
   });
+  return {
+    ...options,
+    async createCheckpointSnapshot(checkpointInput, context) {
+      try {
+        return await options.createCheckpointSnapshot(checkpointInput, context);
+      } finally {
+        await drainHostedRuntimeLogWritesBestEffort();
+      }
+    },
+  };
 }
 
 afterEach(async () => {
+  await drainHostedRuntimeLogWritesBestEffort();
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
   await Promise.all(cleanupPaths.splice(0).map((target) =>

--- a/packages/assistant-runtime/src/hosted-runtime/runtime-logs.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/runtime-logs.ts
@@ -35,9 +35,11 @@ export function buildHostedRuntimeLogContextFields(
 // docs/contracts/00-invariants.md).
 // Debug/info entries are verbose diagnostics, not control flow: buffer them so
 // the caller returns immediately while one background writer drains the buffer
-// in enqueue order. The writer is self-clocking — everything logged while a
-// request is in flight coalesces into the next request — so a busy invocation
-// sends far fewer round trips without any entry waiting on a timer.
+// in enqueue order. When the queue is idle, one unref'd timer gives verbose
+// entries up to 30 seconds to coalesce; a full pending request or invocation-end
+// drain starts that same writer sooner. Once active, the writer is self-clocking
+// and everything logged while a request is in flight coalesces into the next
+// request.
 // warn/error entries still write directly and block only on their own write:
 // the crash-diagnostic tail must be durable before the runtime proceeds, and
 // must not wait behind queued verbose entries. `at` is stamped at enqueue, so
@@ -58,6 +60,7 @@ const HOSTED_RUNTIME_LOG_BATCH_MAX_ENTRIES = HOSTED_RUNTIME_LOG_REQUEST_MAX_ENTR
 // fail the whole request, not one entry, so the budget stays well under the
 // limit even for multi-byte diagnostics.
 const HOSTED_RUNTIME_LOG_BATCH_MAX_JSON_LENGTH = 64 * 1024;
+const HOSTED_RUNTIME_LOG_COALESCING_WINDOW_MS = 30_000;
 const HOSTED_RUNTIME_LOG_PREEMPTION_POLL_MS = 25;
 // A stalled log endpoint must not retain unbounded verbose diagnostics in a
 // warm runner process. This bounds debug/info entries across invocations and
@@ -84,6 +87,7 @@ type QueuedHostedRuntimeLogItem =
 
 const queuedHostedRuntimeLogItems: QueuedHostedRuntimeLogItem[] = [];
 let hostedRuntimeLogWriter: Promise<void> | null = null;
+let hostedRuntimeLogWriterStartTimer: ReturnType<typeof setTimeout> | null = null;
 
 export async function writeHostedRuntimeLogBestEffort(input: {
   entry: Omit<HostedRuntimeLogEntry, "at"> & { at?: string };
@@ -112,7 +116,7 @@ export async function writeHostedRuntimeLogBestEffort(input: {
     logPort,
   });
   trimQueuedHostedRuntimeVerboseLogEntries();
-  startHostedRuntimeLogWriter();
+  scheduleHostedRuntimeLogWriter();
 }
 
 /**
@@ -255,10 +259,68 @@ function trimQueuedHostedRuntimeVerboseLogEntries(): void {
   });
 }
 
+// Idle verbose entries get one bounded coalescing window. Reaching either
+// existing request bound starts the single writer immediately instead of
+// waiting for the window to expire.
+function scheduleHostedRuntimeLogWriter(): void {
+  if (hostedRuntimeLogWriter) {
+    return;
+  }
+  if (hasPendingHostedRuntimeLogBatchReachedBound()) {
+    startHostedRuntimeLogWriter();
+    return;
+  }
+  if (hostedRuntimeLogWriterStartTimer !== null) {
+    return;
+  }
+
+  hostedRuntimeLogWriterStartTimer = setTimeout(() => {
+    hostedRuntimeLogWriterStartTimer = null;
+    startHostedRuntimeLogWriter();
+  }, HOSTED_RUNTIME_LOG_COALESCING_WINDOW_MS);
+  hostedRuntimeLogWriterStartTimer.unref?.();
+}
+
+function hasPendingHostedRuntimeLogBatchReachedBound(): boolean {
+  const tail = queuedHostedRuntimeLogItems.at(-1);
+  if (!tail || tail.kind !== "entry") {
+    return false;
+  }
+
+  let entryCount = 0;
+  let jsonLength = JSON.stringify({ entries: [] }).length;
+  for (let index = queuedHostedRuntimeLogItems.length - 1; index >= 0; index -= 1) {
+    const item = queuedHostedRuntimeLogItems[index];
+    if (item?.kind !== "entry" || item.logPort !== tail.logPort) {
+      break;
+    }
+
+    jsonLength += JSON.stringify(item.entry).length + (entryCount === 0 ? 0 : 1);
+    entryCount += 1;
+    if (
+      entryCount >= HOSTED_RUNTIME_LOG_BATCH_MAX_ENTRIES
+      || jsonLength >= HOSTED_RUNTIME_LOG_BATCH_MAX_JSON_LENGTH
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function clearHostedRuntimeLogWriterStartTimer(): void {
+  if (hostedRuntimeLogWriterStartTimer === null) {
+    return;
+  }
+  clearTimeout(hostedRuntimeLogWriterStartTimer);
+  hostedRuntimeLogWriterStartTimer = null;
+}
+
 // One writer at a time keeps requests in enqueue order and lets everything
 // logged during an in-flight request coalesce into the next one.
 function startHostedRuntimeLogWriter(): void {
-  if (hostedRuntimeLogWriter) {
+  clearHostedRuntimeLogWriterStartTimer();
+  if (hostedRuntimeLogWriter || queuedHostedRuntimeLogItems.length === 0) {
     return;
   }
 
@@ -367,14 +429,17 @@ async function writeHostedRuntimeLogEntries(
 }
 
 // Awaited at invocation end so a normal shutdown never drops queued entries.
-// Queued writes swallow their own failures, so this never rejects. Re-reads the
-// writer after each await in case settled writes queued more entries.
+// Cancels any pending coalescing window and starts the existing writer
+// immediately. Queued writes swallow their own failures, so this never rejects.
+// Re-reads the writer and queue after each await in case settled writes queued
+// more entries.
 // The optional bound keeps a degraded log endpoint from delaying invocation
 // completion (result commit / checkpoint / next-wake handoff): on timeout the
 // drain returns while remaining writes keep flushing in the background.
 export async function drainHostedRuntimeLogWritesBestEffort(
   options?: { timeoutMs?: number },
 ): Promise<void> {
+  startHostedRuntimeLogWriter();
   const timeoutMs = options?.timeoutMs;
   let timedOut = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -389,10 +454,15 @@ export async function drainHostedRuntimeLogWritesBestEffort(
       });
 
   try {
-    while (hostedRuntimeLogWriter) {
+    while (hostedRuntimeLogWriter || queuedHostedRuntimeLogItems.length > 0) {
+      startHostedRuntimeLogWriter();
+      const writer = hostedRuntimeLogWriter;
+      if (!writer) {
+        continue;
+      }
       await (timeout
-        ? Promise.race([hostedRuntimeLogWriter, timeout])
-        : hostedRuntimeLogWriter);
+        ? Promise.race([writer, timeout])
+        : writer);
       if (timedOut) {
         console.warn("Hosted runtime log drain timed out; queued writes continue in the background.", {
           timeoutMs,

--- a/packages/assistant-runtime/test/hosted-invocation-bridge.test.ts
+++ b/packages/assistant-runtime/test/hosted-invocation-bridge.test.ts
@@ -565,13 +565,15 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
       return result;
     });
 
+    let pendingLogDrain: Promise<void> | null = null;
     try {
-      await vi.waitFor(() => {
-        expect(calls.logWrite).toHaveBeenCalledOnce();
-      });
       await vi.waitFor(() => {
         expect(checkpointSettled).toBe(true);
       }, { timeout: 250 });
+      pendingLogDrain = drainHostedRuntimeLogWritesBestEffort();
+      await vi.waitFor(() => {
+        expect(calls.logWrite).toHaveBeenCalledOnce();
+      });
       expect(finishedLogSettled).toBe(false);
       await expect(checkpoint).resolves.toMatchObject({
         snapshotRef: {
@@ -580,6 +582,7 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
       });
     } finally {
       releaseFinishedLog();
+      await pendingLogDrain;
       await checkpoint;
     }
 
@@ -724,6 +727,7 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
     expect(calls.abortSnapshotSession).toHaveBeenCalledOnce();
     expect(calls.putSnapshotObjectDirect).not.toHaveBeenCalled();
     expect(calls.completeSnapshotSession).not.toHaveBeenCalled();
+    await drainHostedRuntimeLogWritesBestEffort();
     await vi.waitFor(() => {
       const entries = calls.logWrite.mock.calls.flatMap(([request]) => request.entries);
       expect(entries.some((entry) => entry.eventCode === "checkpoint.snapshot_preempted"))
@@ -1336,6 +1340,7 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
     expect(checkpointRequest?.idleCheckpointTrigger).toBe("shutdown_signal");
     expect(checkpointRequest?.runtimeWakePendingAtCheckpoint).toBe(false);
 
+    await drainHostedRuntimeLogWritesBestEffort();
     const entries = calls.logWrite.mock.calls.flatMap(([request]) => request.entries);
     expect(JSON.stringify(entries)).not.toContain("item_terminal_7");
     const lifecycleEntries = entries.filter((entry) =>
@@ -1409,6 +1414,7 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
 
     await options.createCheckpointSnapshot(createCheckpointInput("idle_shutdown"));
 
+    await drainHostedRuntimeLogWritesBestEffort();
     const lifecycleEntries = calls.logWrite.mock.calls
       .flatMap(([request]) => request.entries)
       .filter((entry) => entry.eventCode.startsWith("checkpoint.snapshot_"));
@@ -1682,6 +1688,7 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
     await expectPresent(path.join(vaultRoot, nestedRef));
     await expectPresent(path.join(vaultRoot, legacyRef));
 
+    await drainHostedRuntimeLogWritesBestEffort();
     const entries = calls.logWrite.mock.calls.flatMap(([request]) => request.entries);
     expect(entries.some((entry) =>
       entry.redactedJson?.prunedAssistantRuntimeGeneratedDeliveryFileCount === 1
@@ -1841,6 +1848,7 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
     await expectPresent(path.join(vaultRoot, activeRef));
     expect(await readHostedWorkspaceSkippedInlineFiles({ vaultRoot })).toEqual([]);
 
+    await drainHostedRuntimeLogWritesBestEffort();
     const entries = calls.logWrite.mock.calls.flatMap(([request]) => request.entries);
     expect(entries.some((entry) =>
       entry.redactedJson?.prunedAssistantRuntimeGeneratedDeliveryFileCount === 1

--- a/packages/assistant-runtime/test/hosted-runtime-linq-event.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-linq-event.test.ts
@@ -11,6 +11,7 @@ import {
   normalizeHostedLinqAttachmentUrl,
   withHostedLinqAttachmentDownloadRetry,
 } from "../src/hosted-runtime/events/linq.ts";
+import { drainHostedRuntimeLogWritesBestEffort } from "../src/hosted-runtime/runtime-logs.ts";
 
 const originalLinqApiBaseUrl = process.env.LINQ_API_BASE_URL;
 const originalLinqApiToken = process.env.LINQ_API_TOKEN;
@@ -45,7 +46,8 @@ function createInjectedFetchLinqDriver(
   });
 }
 
-afterEach(() => {
+afterEach(async () => {
+  await drainHostedRuntimeLogWritesBestEffort();
   vi.clearAllMocks();
   vi.useRealTimers();
   if (originalLinqApiBaseUrl === undefined) {
@@ -394,6 +396,7 @@ describe("createHostedLinqAttachmentDownloadDriver", () => {
       driver.downloadUrl("https://cdn.linqapp.com/files/ok.bin", undefined),
     ).resolves.toEqual(Uint8Array.from([7, 8, 9]));
 
+    await drainHostedRuntimeLogWritesBestEffort();
     expect(logRequests).toHaveLength(1);
     const entry = logRequests[0]?.entries[0];
     assert.ok(entry);
@@ -444,6 +447,7 @@ describe("createHostedLinqAttachmentDownloadDriver", () => {
     }, undefined)).rejects.toThrow("Hosted Linq attachment metadata lookup failed.");
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    await drainHostedRuntimeLogWritesBestEffort();
     expect(logRequests).toHaveLength(1);
     const entry = logRequests[0]?.entries[0];
     assert.ok(entry);
@@ -744,6 +748,7 @@ describe("createHostedLinqAttachmentDownloadDriver", () => {
     }, undefined)).rejects.toThrow(
       "Hosted Linq attachment download failed with 403 Forbidden.",
     );
+    await drainHostedRuntimeLogWritesBestEffort();
     expect(logRequests).toHaveLength(1);
     const entry = logRequests[0]?.entries[0];
     assert.ok(entry);
@@ -789,6 +794,7 @@ describe("createHostedLinqAttachmentDownloadDriver", () => {
       "Hosted Linq attachment download failed with 404 Not Found.",
     );
 
+    await drainHostedRuntimeLogWritesBestEffort();
     expect(logRequests).toHaveLength(1);
     const entry = logRequests[0]?.entries[0];
     assert.ok(entry);

--- a/packages/assistant-runtime/test/hosted-runtime-log-queue.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-log-queue.test.ts
@@ -73,12 +73,14 @@ describe("hosted runtime log write queue", () => {
   afterEach(async () => {
     // Never leave the module-level tail pending across tests.
     await drainHostedRuntimeLogWritesBestEffort();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
   it.each(["debug", "info"] as const)(
-    "returns %s writes immediately while the port write is still pending",
+    "returns %s writes immediately without starting a request before the window",
     async (level) => {
+      vi.useFakeTimers();
       const { port, writes } = createControlledLogPort();
 
       await expect(writeHostedRuntimeLogBestEffort({
@@ -87,8 +89,12 @@ describe("hosted runtime log write queue", () => {
         platform: { logPort: port },
       })).resolves.toBeUndefined();
 
-      // The caller already returned, but the durable write has not settled.
       await flushMicrotasks();
+      expect(writes).toHaveLength(0);
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(writes).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(1);
       expect(writes).toHaveLength(1);
       // `at` is stamped at enqueue time, not at flush time.
       expect(writes[0]!.entries).toEqual([
@@ -99,12 +105,8 @@ describe("hosted runtime log write queue", () => {
         }),
       ]);
 
-      const drainSettled = trackSettled(drainHostedRuntimeLogWritesBestEffort());
-      await flushMicrotasks();
-      expect(drainSettled()).toBe(false);
       writes[0]!.resolve();
-      await flushMicrotasks();
-      expect(drainSettled()).toBe(true);
+      await expect(drainHostedRuntimeLogWritesBestEffort()).resolves.toBeUndefined();
     },
   );
 
@@ -127,27 +129,29 @@ describe("hosted runtime log write queue", () => {
       await flushMicrotasks();
       expect(infoSettled()).toBe(true);
       expect(directSettled()).toBe(false);
-      // The warn/error write starts immediately (synchronously, ahead of the
-      // microtask-scheduled info write): the crash-diagnostic tail must not
-      // wait behind backlog. `at` stamps preserve logical ordering for readers.
-      expect(writes).toHaveLength(2);
-      const directWrite = writes.find(
-        (write) => write.entries[0]!.at === "2026-06-12T00:00:02.000Z",
-      );
-      const infoWrite = writes.find(
-        (write) => write.entries[0]!.at === "2026-06-12T00:00:01.000Z",
-      );
-      expect(directWrite?.entries[0]!.level).toBe(level);
-      expect(infoWrite).toBeDefined();
+      // The warn/error starts immediately while the older info entry remains
+      // inside its coalescing window.
+      expect(writes).toHaveLength(1);
+      expect(writes[0]!.entries[0]).toEqual(expect.objectContaining({
+        at: "2026-06-12T00:00:02.000Z",
+        level,
+      }));
 
-      // The warn/error settles on its own write, independent of the info backlog.
-      directWrite!.resolve();
+      writes[0]!.resolve();
       await flushMicrotasks();
       expect(directSettled()).toBe(true);
 
-      infoWrite!.resolve();
+      const drainSettled = trackSettled(drainHostedRuntimeLogWritesBestEffort());
       await flushMicrotasks();
-      await expect(drainHostedRuntimeLogWritesBestEffort()).resolves.toBeUndefined();
+      expect(drainSettled()).toBe(false);
+      expect(writes).toHaveLength(2);
+      expect(writes[1]!.entries[0]).toEqual(expect.objectContaining({
+        at: "2026-06-12T00:00:01.000Z",
+        level: "info",
+      }));
+      writes[1]!.resolve();
+      await flushMicrotasks();
+      expect(drainSettled()).toBe(true);
     },
   );
 
@@ -186,7 +190,63 @@ describe("hosted runtime log write queue", () => {
     await expect(drainHostedRuntimeLogWritesBestEffort()).resolves.toBeUndefined();
   });
 
+  it("keeps a preempted direct suffix ahead of later rotated-port verbose entries", async () => {
+    vi.useFakeTimers();
+    const first = createControlledLogPort();
+    const second = createControlledLogPort();
+    let foregroundWaiting = false;
+    const entries = Array.from(
+      { length: HOSTED_RUNTIME_LOG_REQUEST_MAX_ENTRIES + 1 },
+      (_, index) => ({
+        ...buildQueueLogEntry("warn"),
+        errorCode: `DIRECT_DIAGNOSTIC_${index}`,
+      }),
+    );
+
+    const directWrite = writeHostedRuntimeLogEntriesBestEffort({
+      entries,
+      now: () => "2026-06-12T00:00:03.000Z",
+      platform: { logPort: first.port },
+      shouldYieldBetweenBatches: () => foregroundWaiting,
+    });
+    await flushMicrotasks();
+
+    expect(first.writes).toHaveLength(1);
+    expect(first.writes[0]!.entries).toHaveLength(HOSTED_RUNTIME_LOG_REQUEST_MAX_ENTRIES);
+
+    foregroundWaiting = true;
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(directWrite).resolves.toBeUndefined();
+
+    await writeHostedRuntimeLogBestEffort({
+      entry: buildQueueLogEntry("info"),
+      now: () => "2026-06-12T00:00:04.000Z",
+      platform: { logPort: second.port },
+    });
+    await flushMicrotasks();
+    expect(first.writes).toHaveLength(1);
+    expect(second.writes).toHaveLength(0);
+
+    first.writes[0]!.resolve();
+    await flushMicrotasks();
+    expect(first.writes).toHaveLength(2);
+    expect(first.writes[1]!.entries).toHaveLength(1);
+    expect(second.writes).toHaveLength(0);
+    expect(first.writes.flatMap((write) => write.entries).map((entry) => entry.errorCode)).toEqual(
+      entries.map((entry) => entry.errorCode),
+    );
+
+    first.writes[1]!.resolve();
+    await flushMicrotasks();
+    expect(second.writes).toHaveLength(1);
+    expect(second.writes[0]!.entries[0]!.at).toBe("2026-06-12T00:00:04.000Z");
+
+    second.writes[0]!.resolve();
+    await expect(drainHostedRuntimeLogWritesBestEffort()).resolves.toBeUndefined();
+  });
+
   it("bounded drain returns on timeout while queued writes keep flushing", async () => {
+    vi.useFakeTimers();
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const { port, writes } = createControlledLogPort();
 
@@ -197,11 +257,16 @@ describe("hosted runtime log write queue", () => {
     }));
     await flushMicrotasks();
     expect(infoSettled()).toBe(true);
-    expect(writes).toHaveLength(1);
+    expect(writes).toHaveLength(0);
 
     // The queued write never resolves within the bound: the drain must
-    // return (not hang) and warn that writes continue in the background.
-    await drainHostedRuntimeLogWritesBestEffort({ timeoutMs: 20 });
+    // cancel the window, start it immediately, then return (not hang) and warn
+    // that writes continue in the background.
+    const drain = drainHostedRuntimeLogWritesBestEffort({ timeoutMs: 20 });
+    await flushMicrotasks();
+    expect(writes).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(20);
+    await drain;
     expect(consoleWarn).toHaveBeenCalledWith(
       "Hosted runtime log drain timed out; queued writes continue in the background.",
       { timeoutMs: 20 },
@@ -212,7 +277,8 @@ describe("hosted runtime log write queue", () => {
     await expect(drainHostedRuntimeLogWritesBestEffort()).resolves.toBeUndefined();
   });
 
-  it("coalesces entries buffered during an in-flight request into one later request", async () => {
+  it("invocation drain cancels the window without leaving a delayed second start", async () => {
+    vi.useFakeTimers();
     const { port, writes } = createControlledLogPort();
 
     await writeHostedRuntimeLogBestEffort({
@@ -221,36 +287,46 @@ describe("hosted runtime log write queue", () => {
       platform: { logPort: port },
     });
     await flushMicrotasks();
-    expect(writes).toHaveLength(1);
+    expect(writes).toHaveLength(0);
 
-    // Entries logged while the first request is still in flight share one
-    // round trip instead of costing one each.
-    await writeHostedRuntimeLogBestEffort({
-      entry: buildQueueLogEntry("info"),
-      now: () => "2026-06-12T00:00:05.000Z",
-      platform: { logPort: port },
-    });
-    await writeHostedRuntimeLogBestEffort({
-      entry: buildQueueLogEntry("info"),
-      now: () => "2026-06-12T00:00:06.000Z",
-      platform: { logPort: port },
-    });
-    expect(writes).toHaveLength(1);
-
-    writes[0]!.resolve();
+    const drain = drainHostedRuntimeLogWritesBestEffort();
     await flushMicrotasks();
-    expect(writes).toHaveLength(2);
-    expect(writes[1]!.entries.map((entry) => entry.at)).toEqual([
+    expect(writes).toHaveLength(1);
+    writes[0]!.resolve();
+    await expect(drain).resolves.toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(writes).toHaveLength(1);
+  });
+
+  it("coalesces several idle verbose entries into one request at window end", async () => {
+    vi.useFakeTimers();
+    const { port, writes } = createControlledLogPort();
+
+    for (const [index, level] of (["info", "debug", "info"] as const).entries()) {
+      await writeHostedRuntimeLogBestEffort({
+        entry: buildQueueLogEntry(level),
+        now: () => `2026-06-12T00:00:0${index + 4}.000Z`,
+        platform: { logPort: port },
+      });
+    }
+    await flushMicrotasks();
+    expect(writes).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.entries.map((entry) => entry.at)).toEqual([
+      "2026-06-12T00:00:04.000Z",
       "2026-06-12T00:00:05.000Z",
       "2026-06-12T00:00:06.000Z",
     ]);
 
-    writes[1]!.resolve();
-    await flushMicrotasks();
+    writes[0]!.resolve();
     await expect(drainHostedRuntimeLogWritesBestEffort()).resolves.toBeUndefined();
   });
 
-  it("keeps each request within the callback entry and body bounds", async () => {
+  it("coalesces entries buffered during an in-flight request into one later request", async () => {
+    vi.useFakeTimers();
     const { port, writes } = createControlledLogPort();
 
     await writeHostedRuntimeLogBestEffort({
@@ -258,46 +334,125 @@ describe("hosted runtime log write queue", () => {
       now: () => "2026-06-12T00:01:00.000Z",
       platform: { logPort: port },
     });
-    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(30_000);
     expect(writes).toHaveLength(1);
+
+    // Entries logged while the first request is still in flight share one
+    // later round trip instead of costing one each.
+    for (const at of ["2026-06-12T00:01:01.000Z", "2026-06-12T00:01:02.000Z"]) {
+      await writeHostedRuntimeLogBestEffort({
+        entry: buildQueueLogEntry("info"),
+        now: () => at,
+        platform: { logPort: port },
+      });
+    }
+    expect(writes).toHaveLength(1);
+
+    writes[0]!.resolve();
+    await flushMicrotasks();
+    expect(writes).toHaveLength(2);
+    expect(writes[1]!.entries.map((entry) => entry.at)).toEqual([
+      "2026-06-12T00:01:01.000Z",
+      "2026-06-12T00:01:02.000Z",
+    ]);
+
+    writes[1]!.resolve();
+    await expect(drainHostedRuntimeLogWritesBestEffort()).resolves.toBeUndefined();
+  });
+
+  it("flushes promptly at the entry bound without reordering rotated ports", async () => {
+    vi.useFakeTimers();
+    const first = createControlledLogPort();
+    const second = createControlledLogPort();
+
+    await writeHostedRuntimeLogBestEffort({
+      entry: buildQueueLogEntry("info"),
+      now: () => "2026-06-12T00:02:00.000Z",
+      platform: { logPort: first.port },
+    });
 
     const bufferedCount = HOSTED_RUNTIME_LOG_REQUEST_MAX_ENTRIES + 3;
     for (let index = 0; index < bufferedCount; index += 1) {
       await writeHostedRuntimeLogBestEffort({
         entry: buildQueueLogEntry("info"),
-        now: () => `2026-06-12T00:02:${String(index).padStart(2, "0")}.000Z`,
-        platform: { logPort: port },
+        now: () => `2026-06-12T00:02:${String(index + 1).padStart(2, "0")}.000Z`,
+        platform: { logPort: second.port },
       });
     }
 
-    writes[0]!.resolve();
     await flushMicrotasks();
-    expect(writes[1]!.entries).toHaveLength(HOSTED_RUNTIME_LOG_REQUEST_MAX_ENTRIES);
+    // Filling the trailing second-port batch starts the writer immediately,
+    // but FIFO still sends the older first-port entry first.
+    expect(first.writes).toHaveLength(1);
+    expect(first.writes[0]!.entries).toHaveLength(1);
+    expect(second.writes).toHaveLength(0);
 
-    writes[1]!.resolve();
+    first.writes[0]!.resolve();
     await flushMicrotasks();
-    expect(writes[2]!.entries).toHaveLength(3);
+    expect(second.writes).toHaveLength(1);
+    expect(second.writes[0]!.entries).toHaveLength(HOSTED_RUNTIME_LOG_REQUEST_MAX_ENTRIES);
 
-    writes[2]!.resolve();
+    second.writes[0]!.resolve();
     await flushMicrotasks();
+    expect(second.writes).toHaveLength(2);
+    expect(second.writes[1]!.entries).toHaveLength(3);
+
+    second.writes[1]!.resolve();
     await expect(drainHostedRuntimeLogWritesBestEffort()).resolves.toBeUndefined();
   });
 
-  it("splits oversized diagnostics so one request never exceeds the body limit", async () => {
+  it("flushes promptly when the next diagnostic would cross the body bound", async () => {
     const { port, writes } = createControlledLogPort();
-    // An oversized single entry gets its own request instead of wedging the
-    // transport; two such entries must never share a request.
-    const bulkyDiagnostic = { statusSummary: "x".repeat(100 * 1024) };
+    const bulkyDiagnostic = { statusSummary: "x".repeat(40 * 1024) };
 
     await writeHostedRuntimeLogBestEffort({
-      entry: buildQueueLogEntry("info"),
+      entry: {
+        ...buildQueueLogEntry("info"),
+        redactedJson: bulkyDiagnostic,
+      },
       now: () => "2026-06-12T00:03:00.000Z",
       platform: { logPort: port },
     });
     await flushMicrotasks();
-    expect(writes).toHaveLength(1);
+    expect(writes).toHaveLength(0);
 
-    for (const at of ["2026-06-12T00:03:01.000Z", "2026-06-12T00:03:02.000Z"]) {
+    await writeHostedRuntimeLogBestEffort({
+      entry: {
+        ...buildQueueLogEntry("info"),
+        redactedJson: bulkyDiagnostic,
+      },
+      now: () => "2026-06-12T00:03:01.000Z",
+      platform: { logPort: port },
+    });
+    await flushMicrotasks();
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.entries).toHaveLength(1);
+    expect(JSON.stringify({ entries: writes[0]!.entries }).length).toBeLessThanOrEqual(
+      64 * 1024,
+    );
+
+    writes[0]!.resolve();
+    await flushMicrotasks();
+    expect(writes).toHaveLength(2);
+    expect(writes[1]!.entries).toHaveLength(1);
+    expect(JSON.stringify({ entries: writes[1]!.entries }).length).toBeLessThanOrEqual(
+      64 * 1024,
+    );
+
+    writes[1]!.resolve();
+    await flushMicrotasks();
+    await expect(drainHostedRuntimeLogWritesBestEffort()).resolves.toBeUndefined();
+  });
+
+  it("keeps oversized single diagnostics moving without combining them", async () => {
+    const { port, writes } = createControlledLogPort();
+    const bulkyDiagnostic = { statusSummary: "x".repeat(100 * 1024) };
+
+    for (const at of [
+      "2026-06-12T00:03:02.000Z",
+      "2026-06-12T00:03:03.000Z",
+      "2026-06-12T00:03:04.000Z",
+    ]) {
       await writeHostedRuntimeLogBestEffort({
         entry: {
           ...buildQueueLogEntry("info"),
@@ -307,17 +462,21 @@ describe("hosted runtime log write queue", () => {
         platform: { logPort: port },
       });
     }
+    await flushMicrotasks();
+    expect(writes).toHaveLength(1);
+    expect(writes[0]!.entries).toHaveLength(1);
 
     writes[0]!.resolve();
     await flushMicrotasks();
+    expect(writes).toHaveLength(2);
     expect(writes[1]!.entries).toHaveLength(1);
 
     writes[1]!.resolve();
     await flushMicrotasks();
+    expect(writes).toHaveLength(3);
     expect(writes[2]!.entries).toHaveLength(1);
 
     writes[2]!.resolve();
-    await flushMicrotasks();
     await expect(drainHostedRuntimeLogWritesBestEffort()).resolves.toBeUndefined();
   });
 
@@ -325,13 +484,16 @@ describe("hosted runtime log write queue", () => {
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const { port, writes } = createControlledLogPort();
 
-    await writeHostedRuntimeLogBestEffort({
-      entry: buildQueueLogEntry("info"),
-      now: () => "2026-06-12T00:04:00.000Z",
-      platform: { logPort: port },
-    });
+    for (let index = 0; index < HOSTED_RUNTIME_LOG_REQUEST_MAX_ENTRIES; index += 1) {
+      await writeHostedRuntimeLogBestEffort({
+        entry: buildQueueLogEntry("info"),
+        now: () => `2026-06-12T00:04:00.${String(index).padStart(3, "0")}Z`,
+        platform: { logPort: port },
+      });
+    }
     await flushMicrotasks();
     expect(writes).toHaveLength(1);
+    expect(writes[0]!.entries).toHaveLength(HOSTED_RUNTIME_LOG_REQUEST_MAX_ENTRIES);
 
     for (let index = 0; index < HOSTED_RUNTIME_LOG_MAX_QUEUED_ENTRIES + 1; index += 1) {
       await writeHostedRuntimeLogBestEffort({
@@ -362,6 +524,7 @@ describe("hosted runtime log write queue", () => {
   });
 
   it("keeps a rotated invocation's entries in order and on their own port", async () => {
+    vi.useFakeTimers();
     // A warm runner process outlives an invocation: the bounded invocation-end
     // drain can return while a request is still in flight, so the next
     // invocation's fresh log port appears mid-queue. Older entries must still
@@ -375,6 +538,7 @@ describe("hosted runtime log write queue", () => {
       now: () => "2026-06-12T01:00:00.000Z",
       platform: { logPort: first.port },
     });
+    const invocationDrain = drainHostedRuntimeLogWritesBestEffort({ timeoutMs: 20 });
     await flushMicrotasks();
     expect(first.writes).toHaveLength(1);
 
@@ -388,7 +552,8 @@ describe("hosted runtime log write queue", () => {
     }
 
     // The invocation-end drain gives up while that request is still open.
-    await drainHostedRuntimeLogWritesBestEffort({ timeoutMs: 20 });
+    await vi.advanceTimersByTimeAsync(20);
+    await invocationDrain;
 
     // The next invocation starts on a new port.
     await writeHostedRuntimeLogBestEffort({
@@ -426,6 +591,7 @@ describe("hosted runtime log write queue", () => {
   it("bounds retained info entries across repeated port rotations", async () => {
     // The cap is process-wide, not per port: rotating ports while the endpoint
     // is stalled must not multiply what a warm process retains.
+    vi.useFakeTimers();
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const stalled = createControlledLogPort();
     const rotations = 4;
@@ -437,7 +603,7 @@ describe("hosted runtime log write queue", () => {
       now: () => "2026-06-12T02:00:00.000Z",
       platform: { logPort: stalled.port },
     });
-    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(30_000);
     expect(stalled.writes).toHaveLength(1);
 
     let stamped = 0;
@@ -473,6 +639,7 @@ describe("hosted runtime log write queue", () => {
   });
 
   it("swallows batch write failures so the chain and later writes never reject", async () => {
+    vi.useFakeTimers();
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const { port, writes } = createControlledLogPort();
 
@@ -481,7 +648,7 @@ describe("hosted runtime log write queue", () => {
       now: () => "2026-06-12T00:00:04.000Z",
       platform: { logPort: port },
     });
-    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(30_000);
     expect(writes).toHaveLength(1);
 
     const secondInfoSettled = trackSettled(writeHostedRuntimeLogBestEffort({

--- a/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
@@ -2124,6 +2124,7 @@ describe("runHostedDeviceSyncPass", () => {
         runtimeLogPlatform: { logPort },
       },
     );
+    await drainHostedRuntimeLogWritesBestEffort();
 
     await vi.waitFor(() => {
       expect(logPort.write).toHaveBeenCalled();
@@ -2797,6 +2798,7 @@ describe("runHostedDeviceSyncPass", () => {
       5_000,
     );
 
+    await drainHostedRuntimeLogWritesBestEffort();
     assert.equal(logRequests.length, 1);
     const entry = logRequests[0]?.entries[0];
     assert.ok(entry);
@@ -6908,6 +6910,7 @@ describe("runHostedDeviceSyncWakeLane", () => {
     });
     const deviceSyncPort = createMaintenanceDeviceSyncPortStub();
 
+    let pendingLogDrain: Promise<void> | null = null;
     try {
       const result = await runHostedDeviceSyncWakeLane({
         deviceSyncPort,
@@ -6947,12 +6950,19 @@ describe("runHostedDeviceSyncWakeLane", () => {
       expect(Object.hasOwn(result, "systemProgressed")).toBe(false);
       expect(deviceSyncPort.fetchSnapshot).toHaveBeenCalledTimes(1);
       expect(drainWorker).toHaveBeenCalled();
+      pendingLogDrain = drainHostedRuntimeLogWritesBestEffort();
+      await vi.waitFor(() => {
+        expect(logRequests).toHaveLength(1);
+      });
       expect(logRequests.flatMap((request) => request.entries).map((entry) =>
         entry.eventCode
-      )).toEqual(["device-sync.pass_started"]);
+      )).toEqual([
+        "device-sync.pass_started",
+        "device-sync.pass_finished",
+      ]);
     } finally {
       releaseFirstLogWrite();
-      await drainHostedRuntimeLogWritesBestEffort();
+      await (pendingLogDrain ?? drainHostedRuntimeLogWritesBestEffort());
     }
 
     const lifecycleEntries = logRequests.flatMap((request) => request.entries);
@@ -7035,6 +7045,7 @@ describe("runHostedDeviceSyncWakeLane", () => {
       });
 
       await flushHostedRuntimeLogMicrotasks();
+      await drainHostedRuntimeLogWritesBestEffort();
       expect(logRequests.flatMap((request) => request.entries)).toEqual([
         expect.objectContaining({
           attemptId: "attempt_device_sync_timeout",

--- a/packages/assistant-runtime/test/hosted-runtime-telegram-event.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-telegram-event.test.ts
@@ -18,6 +18,7 @@ import {
   withHostedTelegramAttachmentDownloadLogging,
   withHostedTelegramAttachmentDownloadRetry,
 } from "../src/hosted-runtime/events/telegram.ts";
+import { drainHostedRuntimeLogWritesBestEffort } from "../src/hosted-runtime/runtime-logs.ts";
 
 const originalTelegramBotToken = process.env.TELEGRAM_BOT_TOKEN;
 const originalTelegramApiBaseUrl = process.env.TELEGRAM_API_BASE_URL;
@@ -43,7 +44,8 @@ function restoreTelegramEnv() {
   }
 }
 
-afterEach(() => {
+afterEach(async () => {
+  await drainHostedRuntimeLogWritesBestEffort();
   restoreTelegramEnv();
 });
 
@@ -588,6 +590,7 @@ describe("withHostedTelegramAttachmentDownloadLogging", () => {
       Uint8Array.from([1, 2, 3]),
     );
 
+    await drainHostedRuntimeLogWritesBestEffort();
     expect(logPort.entries()).toEqual([
       expect.objectContaining({
         eventCode: "mailbox.telegram_attachment_download_finished",

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-delivery.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-delivery.test.ts
@@ -14,6 +14,7 @@ import {
   loadHostedSystemMailboxRealImplementation,
   mocks,
   resolveHostedPendingAssistantInputWakeAtWithRealImplementation,
+  runHostedWorkspaceAssistantPhase,
   seedDirectLinqAssistantInputRoute,
   withoutAssistantTurnTimingLogs,
 } from "./hosted-runtime-workspace-assistant-phase.harness.ts";
@@ -58,10 +59,10 @@ import {
 import {
   executeCodexAppServerTurn,
 } from "@murphai/assistant-engine/assistant-codex";
-import {
-  runHostedWorkspaceAssistantPhase,
-  type HostedWorkspaceRuntimeAssistantPhaseInput,
+import type {
+  HostedWorkspaceRuntimeAssistantPhaseInput,
 } from "../src/hosted-runtime/workspace-assistant-phase.ts";
+import { drainHostedRuntimeLogWritesBestEffort } from "../src/hosted-runtime/runtime-logs.ts";
 import {
   enqueueHostedPendingAssistantInputId,
   inspectHostedPendingAssistantInputWakeCandidate,
@@ -131,27 +132,31 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("writes fore
     expect(result.afterCheckpoint).toEqual(expect.any(Function));
     expect(
       logRequests
-        .map((request) => request.entries[0]?.redactedJson?.turnTimingStage)
+        .flatMap((request) => request.entries)
+        .map((entry) => entry.redactedJson?.turnTimingStage)
         .filter(Boolean),
     ).not.toContain("foreground-delivery-phase-finished");
 
     await result.afterCheckpoint?.();
+    await drainHostedRuntimeLogWritesBestEffort();
 
     expect(
       logRequests
-        .map((request) => request.entries[0]?.redactedJson?.turnTimingStage)
+        .flatMap((request) => request.entries)
+        .map((entry) => entry.redactedJson?.turnTimingStage)
         .filter(Boolean),
     ).toEqual(expect.arrayContaining([
       "foreground-delivery-phase-started",
       "foreground-delivery-phase-finished",
     ]));
-    const finishLogIndex = logRequests.findIndex(
-      (request) =>
-        request.entries[0]?.redactedJson?.turnTimingStage
+    const logEntries = logRequests.flatMap((request) => request.entries);
+    const finishLogIndex = logEntries.findIndex(
+      (entry) =>
+        entry.redactedJson?.turnTimingStage
           === "foreground-delivery-phase-finished",
     );
-    const outboxLogIndex = logRequests.findIndex(
-      (request) => request.entries[0]?.eventCode === "outbox.delivery_finished",
+    const outboxLogIndex = logEntries.findIndex(
+      (entry) => entry.eventCode === "outbox.delivery_finished",
     );
     expect(outboxLogIndex).toBeGreaterThanOrEqual(0);
     expect(finishLogIndex).toBeGreaterThan(outboxLogIndex);
@@ -3467,6 +3472,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("writes fore
       workspace: createDueAssistantWorkspace(),
     }));
     await result.afterCheckpoint?.();
+    await drainHostedRuntimeLogWritesBestEffort();
     const filteredLogRequests = withoutAssistantTurnTimingLogs(logRequests);
 
     expect(filteredLogRequests.map((request) => request.entries[0]?.eventCode)).toEqual([
@@ -3527,6 +3533,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("writes fore
       workspace: createDueAssistantWorkspace(),
     }));
     await result.afterCheckpoint?.();
+    await drainHostedRuntimeLogWritesBestEffort();
     const filteredLogRequests = withoutAssistantTurnTimingLogs(logRequests);
 
     expect(filteredLogRequests[1]?.entries[0]).toEqual(expect.objectContaining({
@@ -3583,6 +3590,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("writes fore
       workspace: createDueAssistantWorkspace(),
     }));
     await result.afterCheckpoint?.();
+    await drainHostedRuntimeLogWritesBestEffort();
     const filteredLogRequests = withoutAssistantTurnTimingLogs(logRequests);
     const deliveryLogRequest = filteredLogRequests[1];
 
@@ -3628,6 +3636,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("writes fore
       workspace: createDueAssistantWorkspace(),
     }));
     await result.afterCheckpoint?.();
+    await drainHostedRuntimeLogWritesBestEffort();
     const filteredLogRequests = withoutAssistantTurnTimingLogs(logRequests);
     const deliveryLogRequest = filteredLogRequests[1];
 
@@ -3694,6 +3703,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("writes fore
       workspace: createDueAssistantWorkspace(),
     }));
     await result.afterCheckpoint?.();
+    await drainHostedRuntimeLogWritesBestEffort();
     const deliveryLogRequest = withoutAssistantTurnTimingLogs(logRequests)[1];
 
     expect(deliveryLogRequest?.entries[0]?.redactedJson).toEqual(expect.objectContaining({
@@ -3790,6 +3800,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("writes fore
       workspace: createDueAssistantWorkspace(),
     }));
     await result.afterCheckpoint?.();
+    await drainHostedRuntimeLogWritesBestEffort();
     const filteredLogRequests = withoutAssistantTurnTimingLogs(logRequests);
 
     expect(filteredLogRequests[1]?.entries[0]).toEqual(expect.objectContaining({
@@ -5051,6 +5062,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("writes fore
     }));
 
     const postCheckpoint = await result.afterCheckpoint?.();
+    await drainHostedRuntimeLogWritesBestEffort();
     const filteredLogRequests = withoutAssistantTurnTimingLogs(logRequests);
 
     expect(postCheckpoint).toBeUndefined();
@@ -5129,13 +5141,14 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("writes fore
       nextWakeReason: "device-sync.reconcile",
       progressed: true,
     }));
-    expect(logRequests.map((request) => request.entries[0]?.eventCode)).toContain(
+    await drainHostedRuntimeLogWritesBestEffort();
+    expect(logRequests.flatMap((request) => request.entries).map((entry) => entry.eventCode)).toContain(
       "assistant.pass_finished",
     );
-    const passFinishedLog = logRequests.find(
-      (request) => request.entries[0]?.eventCode === "assistant.pass_finished",
+    const passFinishedLog = logRequests.flatMap((request) => request.entries).find(
+      (entry) => entry.eventCode === "assistant.pass_finished",
     );
-    expect(passFinishedLog?.entries[0]?.redactedJson).toEqual(expect.objectContaining({
+    expect(passFinishedLog?.redactedJson).toEqual(expect.objectContaining({
       nextWakeAtPresent: true,
       progressed: true,
     }));

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-device-sync.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-device-sync.test.ts
@@ -6,6 +6,7 @@ import {
   createSystemMailboxItem,
   expectAssistantLaneCallWithoutDeviceSyncOptions,
   mocks,
+  runHostedWorkspaceAssistantPhase,
   withoutAssistantTurnTimingLogs,
   writeHostedPhaseExperimentSource,
 } from "./hosted-runtime-workspace-assistant-phase.harness.ts";
@@ -53,10 +54,10 @@ import {
   type AssistantAutomationOperationScope,
   type AssistantExecutionContext,
 } from "@murphai/assistant-engine";
-import {
-  runHostedWorkspaceAssistantPhase,
-  type HostedWorkspaceRuntimeAssistantPhaseInput,
+import type {
+  HostedWorkspaceRuntimeAssistantPhaseInput,
 } from "../src/hosted-runtime/workspace-assistant-phase.ts";
+import { drainHostedRuntimeLogWritesBestEffort } from "../src/hosted-runtime/runtime-logs.ts";
 
 type AssembledHostedDeviceTool = NonNullable<
   NonNullable<AssistantExecutionContext["hosted"]>["deviceTool"]
@@ -1247,6 +1248,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("skips syste
         version: "8",
       },
     }));
+    await drainHostedRuntimeLogWritesBestEffort();
 
     expect(result).toEqual({
       checkpointReason: "canonical_runtime_commit",
@@ -1257,7 +1259,9 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("skips syste
         hostedAssistantProgressed: true,
       }),
     });
-    expect(logRequests.at(-1)?.entries[0]).toEqual(expect.objectContaining({
+    expect(logRequests.flatMap((request) => request.entries).find(
+      (entry) => entry.eventCode === "assistant.pass_finished",
+    )).toEqual(expect.objectContaining({
       eventCode: "assistant.pass_finished",
       redactedJson: expect.objectContaining({
         assistantAutomationProgressed: false,
@@ -1286,6 +1290,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("skips syste
       now: () => "2026-04-27T00:00:00.000Z",
       workspace: null,
     }));
+    await drainHostedRuntimeLogWritesBestEffort();
 
     expect(result).toEqual({
       checkpointReason: "canonical_runtime_commit",
@@ -1296,7 +1301,9 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("skips syste
         hostedAssistantProgressed: true,
       }),
     });
-    expect(logRequests.at(-1)?.entries[0]).toEqual(expect.objectContaining({
+    expect(logRequests.flatMap((request) => request.entries).find(
+      (entry) => entry.eventCode === "assistant.pass_finished",
+    )).toEqual(expect.objectContaining({
       eventCode: "assistant.pass_finished",
       redactedJson: expect.objectContaining({
         assistantAutomationProgressed: false,
@@ -2234,6 +2241,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("skips syste
       { connectTarget: "dexcom", messagingReturnTarget: "telegram" },
     ]);
     await Promise.resolve();
+    await drainHostedRuntimeLogWritesBestEffort();
     const deviceConnectLogs = logRequests
       .flatMap((request) => request.entries)
       .filter((entry) => entry.eventCode === "assistant.device_connect");
@@ -3018,6 +3026,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("skips syste
       logRequests,
       now: () => "2026-04-27T00:00:00.000Z",
     }));
+    await drainHostedRuntimeLogWritesBestEffort();
     const filteredLogRequests = withoutAssistantTurnTimingLogs(logRequests);
 
     expect(result.progressed).toBe(true);
@@ -3162,6 +3171,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("skips syste
     });
 
     await runHostedWorkspaceAssistantPhase(createPhaseInput({ logRequests }));
+    await drainHostedRuntimeLogWritesBestEffort();
     const filteredLogRequests = withoutAssistantTurnTimingLogs(logRequests);
     expect(filteredLogRequests[0]?.entries[0]).toEqual(expect.objectContaining({
       component: "assistant",
@@ -3223,6 +3233,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("skips syste
     });
 
     await runHostedWorkspaceAssistantPhase(createPhaseInput({ logRequests }));
+    await drainHostedRuntimeLogWritesBestEffort();
     const filteredLogRequests = withoutAssistantTurnTimingLogs(logRequests);
 
     expect(filteredLogRequests[0]?.entries[0]?.redactedJson).toEqual(expect.objectContaining({
@@ -3263,6 +3274,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("skips syste
     });
 
     await runHostedWorkspaceAssistantPhase(createPhaseInput({ logRequests }));
+    await drainHostedRuntimeLogWritesBestEffort();
     const filteredLogRequests = withoutAssistantTurnTimingLogs(logRequests);
 
     expect(filteredLogRequests[0]?.entries[0]).toEqual(expect.objectContaining({
@@ -3342,6 +3354,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("skips syste
       workspace: createDueAssistantWorkspace(),
     }));
     await result.afterCheckpoint?.();
+    await drainHostedRuntimeLogWritesBestEffort();
     const filteredLogRequests = withoutAssistantTurnTimingLogs(logRequests);
 
     expect(filteredLogRequests.map((request) => request.entries[0]?.eventCode)).toEqual([

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-diagnostics.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-diagnostics.test.ts
@@ -4,7 +4,7 @@ import { buildHostedExecutionRuntimeControlWake } from "@murphai/hosted-executio
 import type {
   HostedRuntimeLogRequest,
 } from "@murphai/hosted-execution/runtime-control";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   collectHostedAssistantDeliverySideEffects: vi.fn(),
@@ -148,17 +148,38 @@ import {
   emitHostedAssistantProviderTraceLog,
 } from "../src/hosted-runtime/events.ts";
 import {
-  runHostedWorkspaceAssistantPhase,
+  runHostedWorkspaceAssistantPhase as runHostedWorkspaceAssistantPhaseWithoutDrain,
   type HostedWorkspaceRuntimeAssistantPhaseInput,
 } from "../src/hosted-runtime/workspace-assistant-phase.ts";
+import { drainHostedRuntimeLogWritesBestEffort } from "../src/hosted-runtime/runtime-logs.ts";
+
+afterEach(async () => {
+  await drainHostedRuntimeLogWritesBestEffort();
+});
+
+async function runHostedWorkspaceAssistantPhase(
+  input: HostedWorkspaceRuntimeAssistantPhaseInput,
+) {
+  try {
+    return await runHostedWorkspaceAssistantPhaseWithoutDrain(input);
+  } finally {
+    await drainHostedRuntimeLogWritesBestEffort();
+  }
+}
 
 function withoutAssistantTurnTimingLogs(
   logRequests: HostedRuntimeLogRequest[],
 ): HostedRuntimeLogRequest[] {
-  return logRequests.filter(
-    (request) =>
-      request.entries[0]?.redactedJson?.schema
-        !== "murph.assistant-turn-timing.v1",
+  return logRequests.flatMap((request) =>
+    request.entries
+      .filter(
+        (entry) =>
+          entry.redactedJson?.schema !== "murph.assistant-turn-timing.v1",
+      )
+      .map((entry) => ({
+        ...request,
+        entries: [entry],
+      }))
   );
 }
 
@@ -342,6 +363,7 @@ describe("hosted workspace assistant diagnostics detail logs", () => {
     });
 
     await runHostedWorkspaceAssistantPhase(createPhaseInput({ logRequests }));
+    await drainHostedRuntimeLogWritesBestEffort();
     const filteredLogRequests = withoutAssistantTurnTimingLogs(logRequests);
 
     expect(filteredLogRequests[0]?.entries[0]).toEqual(expect.objectContaining({
@@ -436,6 +458,7 @@ describe("hosted workspace assistant diagnostics detail logs", () => {
     });
 
     await runHostedWorkspaceAssistantPhase(createPhaseInput({ logRequests }));
+    await drainHostedRuntimeLogWritesBestEffort();
     const filteredLogRequests = withoutAssistantTurnTimingLogs(logRequests);
 
     expect(filteredLogRequests[0]?.entries[0]).toEqual(expect.objectContaining({
@@ -544,6 +567,7 @@ describe("hosted workspace assistant diagnostics detail logs", () => {
     });
 
     await runHostedWorkspaceAssistantPhase(createPhaseInput({ logRequests }));
+    await drainHostedRuntimeLogWritesBestEffort();
     const filteredLogRequests = withoutAssistantTurnTimingLogs(logRequests);
 
     expect(filteredLogRequests[0]?.entries[0]).toEqual(expect.objectContaining({

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-foreground.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-foreground.test.ts
@@ -22,6 +22,7 @@ import {
   expectAssistantLaneCallWithoutDeviceSyncOptions,
   loadHostedSystemMailboxRealImplementation,
   mocks,
+  runHostedWorkspaceAssistantPhase,
   runHostedWorkspaceDurableCheckpointEffects,
   runRealForegroundApprovalAdmissionScenario,
   withoutAssistantTurnTimingLogs,
@@ -65,10 +66,10 @@ import {
   splitAutomationAvailabilityConflictBlock,
   upsertAutomation,
 } from "@murphai/core";
-import {
-  runHostedWorkspaceAssistantPhase,
-  type HostedWorkspaceRuntimeAssistantPhaseInput,
+import type {
+  HostedWorkspaceRuntimeAssistantPhaseInput,
 } from "../src/hosted-runtime/workspace-assistant-phase.ts";
+import { drainHostedRuntimeLogWritesBestEffort } from "../src/hosted-runtime/runtime-logs.ts";
 import {
   readHostedSystemMailboxState,
   updateHostedSystemMailboxState,
@@ -3837,12 +3838,14 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("passes fore
       logRequests,
       now: () => "2026-04-27T00:10:00.000Z",
     }));
+    await drainHostedRuntimeLogWritesBestEffort();
 
     expect(callOrder).toEqual(["system-mailbox", "assistant-1"]);
     expect(mocks.runHostedAssistantAutomationLane).toHaveBeenCalledTimes(1);
     expect(
       logRequests
-        .map((request) => request.entries[0]?.redactedJson)
+        .flatMap((request) => request.entries)
+        .map((entry) => entry.redactedJson)
         .filter((redactedJson) =>
           redactedJson?.detailComponent === "runtime.provider" &&
           redactedJson?.type === "assistant.turn.timing"
@@ -3919,11 +3922,13 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("passes fore
       logRequests,
       now: () => "2026-04-27T00:10:00.000Z",
     }));
+    await drainHostedRuntimeLogWritesBestEffort();
 
     expect(callOrder).toEqual(["system-mailbox", "assistant-1"]);
     expect(
       logRequests
-        .map((request) => request.entries[0]?.redactedJson)
+        .flatMap((request) => request.entries)
+        .map((entry) => entry.redactedJson)
         .filter((redactedJson) =>
           redactedJson?.detailComponent === "runtime.provider" &&
           redactedJson?.type === "assistant.turn.timing"
@@ -4246,6 +4251,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("passes fore
       }));
 
     const postCheckpoint = await result.afterCheckpoint?.();
+    await drainHostedRuntimeLogWritesBestEffort();
 
     expect(postCheckpoint).toEqual(expect.objectContaining({
       checkpointReason: "outbox_receipt",
@@ -4257,7 +4263,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("passes fore
         hostedSystemMailboxRecorded: 1,
       }),
     }));
-    expect(logRequests.map((request) => request.entries[0]?.eventCode)).toEqual([
+    expect(logRequests.flatMap((request) => request.entries).map((entry) => entry.eventCode)).toEqual([
       "mailbox.system_processed",
       "mailbox.system_processed",
       "outbox.delivery_finished",
@@ -4709,6 +4715,7 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("passes fore
       logRequests,
       now: () => now,
     }));
+    await drainHostedRuntimeLogWritesBestEffort();
 
     expect(result).toEqual(expect.objectContaining({
       checkpointReason: "canonical_runtime_commit",

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-logs.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-logs.test.ts
@@ -1,13 +1,18 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildHostedRuntimeLogContextFields,
   compactHostedRuntimeLogCodes,
+  drainHostedRuntimeLogWritesBestEffort,
   summarizeHostedRuntimeStatusCounts,
   toHostedRuntimeLogCode,
   writeHostedRuntimeLogBestEffort,
 } from "../src/hosted-runtime/runtime-logs.ts";
 
 describe("hosted runtime log helpers", () => {
+  afterEach(async () => {
+    await drainHostedRuntimeLogWritesBestEffort();
+  });
+
   it("keeps helper logging best-effort and redacted", async () => {
     await expect(writeHostedRuntimeLogBestEffort({
       entry: {
@@ -37,6 +42,7 @@ describe("hosted runtime log helpers", () => {
           },
         },
       })).resolves.toBeUndefined();
+      await expect(drainHostedRuntimeLogWritesBestEffort()).resolves.toBeUndefined();
       expect(consoleWarn).toHaveBeenCalledWith(
         "Hosted runtime durable log write failed.",
         {

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-managed-automation.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-managed-automation.test.ts
@@ -17,7 +17,7 @@ import {
 } from "@murphai/hosted-execution/runtime-control";
 import { parseHostedRuntimeLogRequest } from "@murphai/hosted-execution/parsers";
 import { VaultCliError } from "@murphai/operator-config/vault-cli-errors";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   initializeVault,
   patchAutomation,
@@ -41,9 +41,24 @@ import {
   type AssistantExecutionContext,
 } from "@murphai/assistant-engine";
 import {
-  runHostedWorkspaceAssistantPhase,
+  runHostedWorkspaceAssistantPhase as runHostedWorkspaceAssistantPhaseWithoutDrain,
   type HostedWorkspaceRuntimeAssistantPhaseInput,
 } from "../src/hosted-runtime/workspace-assistant-phase.ts";
+import { drainHostedRuntimeLogWritesBestEffort } from "../src/hosted-runtime/runtime-logs.ts";
+
+afterEach(async () => {
+  await drainHostedRuntimeLogWritesBestEffort();
+});
+
+async function runHostedWorkspaceAssistantPhase(
+  input: HostedWorkspaceRuntimeAssistantPhaseInput,
+) {
+  try {
+    return await runHostedWorkspaceAssistantPhaseWithoutDrain(input);
+  } finally {
+    await drainHostedRuntimeLogWritesBestEffort();
+  }
+}
 
 describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("checkpoints hosted managed automation changes before continuing assistant work", async () => {
     const logRequests: HostedRuntimeLogRequest[] = [];
@@ -3259,7 +3274,6 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("checkpoints
         logRequests,
         vaultRoot,
       }));
-
       const verificationEntries = logRequests
         .flatMap((request) => request.entries)
         .filter((entry) =>

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-scheduling.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-scheduling.test.ts
@@ -11,6 +11,7 @@ import {
   expectAssistantLaneCallWithoutDeviceSyncOptions,
   extractTopLevelFunctionBody,
   mocks,
+  runHostedWorkspaceAssistantPhase,
   writeHostedPhaseExperimentSource,
 } from "./hosted-runtime-workspace-assistant-phase.harness.ts";
 
@@ -65,10 +66,10 @@ import {
   type AssistantAutomationOperationScope,
   type AssistantExecutionContext,
 } from "@murphai/assistant-engine";
-import {
-  runHostedWorkspaceAssistantPhase,
-  type HostedWorkspaceRuntimeAssistantPhaseInput,
+import type {
+  HostedWorkspaceRuntimeAssistantPhaseInput,
 } from "../src/hosted-runtime/workspace-assistant-phase.ts";
+import { drainHostedRuntimeLogWritesBestEffort } from "../src/hosted-runtime/runtime-logs.ts";
 import {
   isHostedDeviceSyncMaintenanceModuleLoadError,
   loadHostedDeviceSyncMaintenanceModule,
@@ -2274,10 +2275,11 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {
     }));
     expect("afterCheckpoint" in result).toBe(false);
     await Promise.resolve();
-    expect(logRequests.map((request) => request.entries[0]?.eventCode)).toEqual([
+    await drainHostedRuntimeLogWritesBestEffort();
+    expect(logRequests.flatMap((request) => request.entries).map((entry) => entry.eventCode)).toEqual(expect.arrayContaining([
       "assistant.device_connect",
       "device-sync.maintenance_failed",
-    ]);
+    ]));
     const failureEntries = logRequests.flatMap((request) => request.entries);
     const failureLog = failureEntries
       .find((entry) => entry.eventCode === "device-sync.maintenance_failed");

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.harness.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase.harness.ts
@@ -30,7 +30,7 @@ import {
   HOSTED_RUNTIME_CODEX_APP_SERVER_COMMAND_ENV,
   HOSTED_RUNTIME_PROCESS_ENV,
 } from "@murphai/hosted-execution/env";
-import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import { resolveAssistantStatePaths } from "@murphai/runtime-state/node";
 
 type HostedAssistantPhaseMockName =
@@ -311,7 +311,7 @@ import {
   type AssistantOutboxIntent,
 } from "@murphai/operator-config/assistant-cli-contracts";
 import {
-  runHostedWorkspaceAssistantPhase,
+  runHostedWorkspaceAssistantPhase as runHostedWorkspaceAssistantPhaseWithoutDrain,
   type HostedWorkspaceRuntimeAssistantPhaseInput,
 } from "../src/hosted-runtime/workspace-assistant-phase.ts";
 import {
@@ -337,6 +337,7 @@ import type {
 import {
   buildHostedRuntimeLogContextFields,
   compactHostedRuntimeLogCodes,
+  drainHostedRuntimeLogWritesBestEffort,
   summarizeHostedRuntimeStatusCounts,
   toHostedRuntimeLogCode,
   writeHostedRuntimeLogBestEffort,
@@ -374,10 +375,16 @@ type HostedSystemMailboxModule =
 function withoutAssistantTurnTimingLogs(
   logRequests: HostedRuntimeLogRequest[],
 ): HostedRuntimeLogRequest[] {
-  return logRequests.filter(
-    (request) =>
-      request.entries[0]?.redactedJson?.schema
-        !== "murph.assistant-turn-timing.v1",
+  return logRequests.flatMap((request) =>
+    request.entries
+      .filter(
+        (entry) =>
+          entry.redactedJson?.schema !== "murph.assistant-turn-timing.v1",
+      )
+      .map((entry) => ({
+        ...request,
+        entries: [entry],
+      }))
   );
 }
 
@@ -824,6 +831,20 @@ beforeEach(() => {
     scheduled: 0,
   });
 });
+
+afterEach(async () => {
+  await drainHostedRuntimeLogWritesBestEffort();
+});
+
+async function runHostedWorkspaceAssistantPhase(
+  input: HostedWorkspaceRuntimeAssistantPhaseInput,
+) {
+  try {
+    return await runHostedWorkspaceAssistantPhaseWithoutDrain(input);
+  } finally {
+    await drainHostedRuntimeLogWritesBestEffort();
+  }
+}
 
 function expectAssistantLaneCallWithoutDeviceSyncOptions(
   expected?: Record<string, unknown>,
@@ -2098,6 +2119,7 @@ export {
   loadHostedSystemMailboxRealImplementation,
   mocks,
   resolveHostedPendingAssistantInputWakeAtWithRealImplementation,
+  runHostedWorkspaceAssistantPhase,
   runHostedWorkspaceDurableCheckpointEffects,
   runRealForegroundApprovalAdmissionScenario,
   seedDirectLinqAssistantInputRoute,

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-checkpoint-races.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-checkpoint-races.test.ts
@@ -14,6 +14,7 @@ import {
   readConversationImportedSeqs,
   removeTempRoot,
   requireEventIndex,
+  runHostedWorkspaceRuntimeJobInProcess,
   stageAssistantInputEventForMailboxItem,
   waitForFakeTimerScheduled,
   waitUntil,
@@ -79,7 +80,6 @@ import {
   HostedWorkspaceRunnerUserMismatchError,
   drainHostedRuntimeDeferredUsageCompletionsBestEffort,
   parseHostedAssistantWorkspaceRuntimeJobInput,
-  runHostedWorkspaceRuntimeJobInProcess,
   type HostedWorkspaceRuntimeJobOptions,
   type HostedWorkspaceSnapshotCheckpointRequestBuilderInput,
 } from "../src/hosted-runtime.ts";

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-conversation-import.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-conversation-import.test.ts
@@ -19,6 +19,7 @@ import {
   readConversationImportedSeqs,
   removeTempRoot,
   requireEventIndex,
+  runHostedWorkspaceRuntimeJobInProcess,
   stageAssistantInputEventForMailboxItem,
   stagePendingLinqAssistantInputForMailboxItem,
   waitUntil,
@@ -80,7 +81,6 @@ import {
   HostedWorkspaceRunnerUserMismatchError,
   drainHostedRuntimeDeferredUsageCompletionsBestEffort,
   parseHostedAssistantWorkspaceRuntimeJobInput,
-  runHostedWorkspaceRuntimeJobInProcess,
   type HostedWorkspaceRuntimeJobOptions,
   type HostedWorkspaceSnapshotCheckpointRequestBuilderInput,
 } from "../src/hosted-runtime.ts";

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-restore.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-restore.test.ts
@@ -22,6 +22,7 @@ import {
   readConversationImportedSeqs,
   removeTempRoot,
   requireEventIndex,
+  runHostedWorkspaceRuntimeJobInProcess,
   sha256Hex,
   stagePendingLinqAssistantInputForMailboxItem,
   summarizeStageTimings,
@@ -111,7 +112,6 @@ import {
   HostedWorkspaceRunnerUserMismatchError,
   drainHostedRuntimeDeferredUsageCompletionsBestEffort,
   parseHostedAssistantWorkspaceRuntimeJobInput,
-  runHostedWorkspaceRuntimeJobInProcess,
   type HostedWorkspaceRuntimeJobOptions,
   type HostedWorkspaceSnapshotCheckpointRequestBuilderInput,
 } from "../src/hosted-runtime.ts";
@@ -135,6 +135,7 @@ import {
   writeHostedMailboxImportState,
   type HostedMailboxImportState,
 } from "../src/hosted-runtime/mailbox-state.ts";
+import { drainHostedRuntimeLogWritesBestEffort } from "../src/hosted-runtime/runtime-logs.ts";
 import {
   HostedRuntimeArtifactReadError,
   type HostedRuntimeDeviceSyncPort,
@@ -522,14 +523,15 @@ describe("hosted workspace runtime entrypoint", () => {
       await expect(resultPromise).rejects.toThrow(
         "Foreground test should not build checkpoint requests.",
       );
+      await drainHostedRuntimeLogWritesBestEffort();
 
       assert.deepEqual(events, [
         "workspace.read",
         "mailbox.fetch",
-        "runtime.log:mailbox.imported",
         "mailbox.fetch",
-        "runtime.log:mailbox.imported",
         "assistant.phase",
+        "runtime.log:mailbox.imported",
+        "runtime.log:mailbox.imported",
         "runtime.log:checkpoint.runtime_residue_deferred",
       ]);
       assert.deepEqual(checkpointRequests, []);
@@ -2877,6 +2879,7 @@ describe("hosted workspace runtime entrypoint", () => {
         },
       );
 
+      await drainHostedRuntimeLogWritesBestEffort();
       const mailboxFetchIndex = requireEventIndex(events, "mailbox.fetch");
       assert.equal(events.includes("artifact.get:eager-raw-capture"), false);
       for (const [index] of artifactHashes.entries()) {
@@ -3106,7 +3109,6 @@ describe("hosted workspace runtime entrypoint", () => {
       assert.deepEqual(importedSeqs, mailboxItems.map((item) => item.laneSeq));
       assert.equal(artifactPutCalls.length, 1);
       assert.ok(mailboxFetchIndex < mailboxImportedLogIndex);
-      assert.ok(mailboxImportedLogIndex < requireEventIndex(events, `snapshot.create:${mailboxItemCount}`));
       assert.equal(stageSummary["workspace.read"]?.count, 1);
       assert.equal(stageSummary["artifact.get"]?.count, 1);
       assert.equal(stageSummary["mailbox.fetch"]?.count, 1);

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -30,6 +30,7 @@ import {
   readCheckpointConversationWatermark,
   removeTempRoot,
   requireEventIndex,
+  runHostedWorkspaceRuntimeJobInProcess,
   stageAssistantInputEventForMailboxItem,
   stagePendingLinqAssistantInputForMailboxItem,
   withRealTimeout,
@@ -140,7 +141,6 @@ import {
   HostedWorkspaceRunnerUserMismatchError,
   drainHostedRuntimeDeferredUsageCompletionsBestEffort,
   parseHostedAssistantWorkspaceRuntimeJobInput,
-  runHostedWorkspaceRuntimeJobInProcess,
   type HostedWorkspaceRuntimeJobOptions,
   type HostedWorkspaceSnapshotCheckpointRequestBuilderInput,
 } from "../src/hosted-runtime.ts";

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-preemption.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-preemption.test.ts
@@ -20,6 +20,7 @@ import {
   readConversationImportedSeqs,
   removeTempRoot,
   requireEventIndex,
+  runHostedWorkspaceRuntimeJobInProcess,
   waitUntil,
   withRealTimeout,
   writeMailboxImportStateFile,
@@ -95,7 +96,6 @@ import {
   HostedWorkspaceRunnerUserMismatchError,
   drainHostedRuntimeDeferredUsageCompletionsBestEffort,
   parseHostedAssistantWorkspaceRuntimeJobInput,
-  runHostedWorkspaceRuntimeJobInProcess,
   type HostedWorkspaceRuntimeJobOptions,
   type HostedWorkspaceSnapshotCheckpointRequestBuilderInput,
 } from "../src/hosted-runtime.ts";

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.harness.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint.harness.ts
@@ -448,7 +448,7 @@ import {
   HostedWorkspaceRunnerUserMismatchError,
   drainHostedRuntimeDeferredUsageCompletionsBestEffort,
   parseHostedAssistantWorkspaceRuntimeJobInput,
-  runHostedWorkspaceRuntimeJobInProcess,
+  runHostedWorkspaceRuntimeJobInProcess as runHostedWorkspaceRuntimeJobInProcessWithoutDrain,
   type HostedWorkspaceRuntimeJobOptions,
   type HostedWorkspaceSnapshotCheckpointRequestBuilderInput,
 } from "../src/hosted-runtime.ts";
@@ -2586,6 +2586,16 @@ async function waitUntil(assertion: () => void, timeoutMs = 1_000): Promise<void
   throw lastError instanceof Error ? lastError : new Error("Timed out waiting for assertion.");
 }
 
+async function runHostedWorkspaceRuntimeJobInProcess(
+  ...args: Parameters<typeof runHostedWorkspaceRuntimeJobInProcessWithoutDrain>
+) {
+  try {
+    return await runHostedWorkspaceRuntimeJobInProcessWithoutDrain(...args);
+  } finally {
+    await drainHostedRuntimeLogWritesBestEffort();
+  }
+}
+
 export {
   HOSTED_CONTAINER_CA_ENV_KEYS,
   HOSTED_UNSTABLE_PROCESS_ENV_KEYS,
@@ -2648,6 +2658,7 @@ export {
   readConversationImportedSeqs,
   removeTempRoot,
   requireEventIndex,
+  runHostedWorkspaceRuntimeJobInProcess,
   runOpenAiHttpsProbe,
   sha256Hex,
   stageAssistantInputEventForMailboxItem,

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
@@ -65,7 +65,7 @@ import {
   createHostedWorkspaceCheckpointRequestBuilder,
   createHostedWorkspaceSnapshotCheckpointRequestBuilder,
   HostedWorkspaceRunnerUserMismatchError,
-  runHostedWorkspaceUntilIdleOrBudget,
+  runHostedWorkspaceUntilIdleOrBudget as runHostedWorkspaceUntilIdleOrBudgetWithoutDrain,
   type HostedMailboxImportCheckpointResult,
   type HostedRuntimeEffectsPort,
   type HostedWorkspaceRunnerRuntimeStatusCheckpointInput,
@@ -90,6 +90,7 @@ import {
   readHostedMailboxImportState,
   writeHostedMailboxImportState,
 } from "../src/hosted-runtime/mailbox-state.ts";
+import { drainHostedRuntimeLogWritesBestEffort } from "../src/hosted-runtime/runtime-logs.ts";
 import {
   enqueueHostedPendingAssistantInputId,
   ensureHostedPendingAssistantInputIndex,
@@ -151,6 +152,16 @@ const TEST_BROWSER_VAULT_REPLICA_REF = {
   schema: "murph.hosted-browser-vault-replica-ref.v1",
   sourceBundleHash: "bundle_hash_synthetic_runner",
 } as const;
+
+async function runHostedWorkspaceUntilIdleOrBudget(
+  ...args: Parameters<typeof runHostedWorkspaceUntilIdleOrBudgetWithoutDrain>
+) {
+  try {
+    return await runHostedWorkspaceUntilIdleOrBudgetWithoutDrain(...args);
+  } finally {
+    await drainHostedRuntimeLogWritesBestEffort();
+  }
+}
 
 describe("runHostedWorkspaceUntilIdleOrBudget", () => {
   test("carries two initial conversation inputs through singleton foreground reruns before checkpointing", async () => {
@@ -1595,18 +1606,21 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
       }).catch(() => undefined);
       await Promise.resolve();
       assert.equal(deferredUsageCompletionSettled, true);
+      await drainHostedRuntimeLogWritesBestEffort();
+      const initialLogEntries = logRequests.flatMap((request) => request.entries);
       assert.deepEqual(
-        logRequests.map((request) => request.entries[0]?.eventCode),
+        initialLogEntries.map((entry) => entry.eventCode),
         ["mailbox.imported", "mailbox.imported"],
       );
       assert.deepEqual(
-        logRequests.map((request) => request.entries[0]?.mailboxLane),
+        initialLogEntries.map((entry) => entry.mailboxLane),
         ["conversation", "system"],
       );
 
       releaseEffect();
       assert.ok(result.mailboxPostCheckpointEffectsFinished);
       await result.mailboxPostCheckpointEffectsFinished;
+      await drainHostedRuntimeLogWritesBestEffort();
       assert.deepEqual(events, [
         "import:1",
         "assistant",
@@ -1614,7 +1628,7 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
         "mailbox:afterCheckpoint:done",
       ]);
       assert.deepEqual(
-        logRequests.map((request) => request.entries[0]?.eventCode),
+        logRequests.flatMap((request) => request.entries).map((entry) => entry.eventCode),
         [
           "mailbox.imported",
           "mailbox.imported",
@@ -3227,6 +3241,7 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
       effectRelease.current?.();
       assert.ok(result.mailboxPostCheckpointEffectsFinished);
       await result.mailboxPostCheckpointEffectsFinished;
+      await drainHostedRuntimeLogWritesBestEffort();
       const effectLog = logRequests.flatMap((request) => request.entries)
         .find((entry) => entry.eventCode === "mailbox.post_checkpoint_effects_finished");
       assert.ok(effectLog);
@@ -4594,6 +4609,7 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
       });
 
       await flushBackgroundMailboxEffects();
+      await drainHostedRuntimeLogWritesBestEffort();
 
       assert.deepEqual(events, [
         "import:1",
@@ -4602,12 +4618,13 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
       ]);
       assert.deepEqual(checkpointRequests.map((request) => request.reason), [
       ]);
-      assert.deepEqual(logRequests.map((request) => request.entries[0]?.phase), [
+      const logEntries = logRequests.flatMap((request) => request.entries);
+      assert.deepEqual(logEntries.map((entry) => entry.phase), [
         "import",
         "import",
         "import",
       ]);
-      assert.deepEqual(logRequests[2]?.entries[0]?.redactedJson, {
+      assert.deepEqual(logEntries.at(-1)?.redactedJson, {
         attemptedCount: 1,
         effectAttachmentEvidenceUpdated: [true],
         effectKinds: ["inbox_projection"],
@@ -4760,20 +4777,18 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
       });
 
       await flushBackgroundMailboxEffects();
+      await drainHostedRuntimeLogWritesBestEffort();
 
       assert.equal(result.assistantPhaseResult?.progressed, true);
       assert.equal(result.latestWorkspace?.version, "0");
       assert.deepEqual(checkpointRequests.map((request) => request.reason), [
       ]);
-      assert.deepEqual(events, [
+      assert.deepEqual(events.filter((event) => event !== "optional:log"), [
         "import:1",
-        "optional:log",
-        "optional:log",
         "assistant",
-        "optional:log",
         "optional:projection",
-        "optional:log",
       ]);
+      assert.equal(events.filter((event) => event === "optional:log").length, 2);
     } finally {
       warn.mockRestore();
       await rm(vaultRoot, {
@@ -5349,11 +5364,18 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
           { importedSeq: "1", lane: "conversation" },
         ],
       ]);
+      await drainHostedRuntimeLogWritesBestEffort();
+      const mailboxImportedEntries = logRequests
+        .flatMap((request) => request.entries)
+        .filter((entry) => entry.eventCode === "mailbox.imported");
       assert.deepEqual(
-        logRequests.map((request) => request.entries[0]?.eventCode).slice(0, 2),
+        mailboxImportedEntries.map((entry) => entry.eventCode).slice(0, 2),
         ["mailbox.imported", "mailbox.imported"],
       );
-      assert.deepEqual(logRequests[2]?.entries[0], {
+      assert.deepEqual(mailboxImportedEntries.find((entry) =>
+        entry.phase === "active_turn_input"
+        && entry.mailboxSeqEnd === "3"
+      ), {
         at: TEST_NOW,
         attemptId: "attempt_synthetic_runner_active_turn",
         component: "mailbox",
@@ -7352,15 +7374,8 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const logRequests: HostedRuntimeLogRequest[] = [];
     const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
-    let flushSawAssistantCheckpointLog = false;
     const usageRecordPort: HostedRuntimeUsageRecordPort = {
       async recordUsage(record) {
-        flushSawAssistantCheckpointLog = logRequests
-          .flatMap((request) => request.entries)
-          .some((entry) =>
-            entry.eventCode === "checkpoint.runtime_residue_deferred"
-            && entry.redactedJson?.checkpointPhase === "assistant"
-          );
         events.push("usage:flush");
         assert.equal(record.usageId, "turn_runner_usage.attempt-1");
         return {
@@ -7457,7 +7472,11 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
       assert.deepEqual(checkpointRequests, []);
       assert.equal(events.filter((event) => event === "usage:flush").length, 1);
       assert.equal(events.includes("assistant:afterCheckpoint"), false);
-      assert.equal(flushSawAssistantCheckpointLog, true);
+      await drainHostedRuntimeLogWritesBestEffort();
+      assert.equal(logRequests.flatMap((request) => request.entries).some((entry) =>
+        entry.eventCode === "checkpoint.runtime_residue_deferred"
+        && entry.redactedJson?.checkpointPhase === "assistant"
+      ), true);
     } finally {
       await rm(vaultRoot, {
         force: true,
@@ -7857,7 +7876,14 @@ describe("runHostedWorkspaceUntilIdleOrBudget", () => {
           { importedSeq: "1", lane: "conversation" },
         ],
       ]);
-      assert.deepEqual(logRequests[2]?.entries[0]?.redactedJson, {
+      await drainHostedRuntimeLogWritesBestEffort();
+      const blockedImportLog = logRequests
+        .flatMap((request) => request.entries)
+        .find((entry) =>
+          entry.eventCode === "mailbox.imported"
+          && entry.redactedJson?.blockedCount === 1
+        );
+      assert.deepEqual(blockedImportLog?.redactedJson, {
         assistantInputCount: 1,
         assistantInputPresent: true,
         blockCodes: ["synthetic.retryable-block"],


### PR DESCRIPTION
## Why and outcome

Idle verbose runtime diagnostics currently start a request immediately, so isolated debug/info entries bypass the batching opportunity already owned by the queue. This change gives the existing writer one bounded 30-second coalescing window, with early flush at the existing request bounds and immediate flush during invocation drain.

Warn/error durability, FIFO order, preemption barriers, queue limits, and failure swallowing remain unchanged.

## Product UX

Not applicable. This is internal runtime transport efficiency with no member-visible behavior, copy, timing contract, or interaction change.

## Evidence

- `pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --isolate=true --no-coverage test/hosted-runtime-log-queue.test.ts` — 18 tests passed.
- `pnpm --dir packages/assistant-runtime test` — 115 files passed, 1 skipped; 2,632 tests passed, 5 skipped.
- Focused Cloudflare runtime-bridge suite — 37 tests passed.
- `pnpm --dir apps/cloudflare typecheck` — passed.
- `pnpm --dir packages/assistant-runtime typecheck` — passed.
- `pnpm complexity:diff` — passed.
- `git diff --check` — passed.

## Non-obvious affected surfaces

- Warm-runner cross-invocation log-port rotation: necessary because the existing process-global FIFO can outlive one invocation; covered by rotated-port ordering and bounded-drain regressions.
- Foreground preemption continuation barriers: necessary because queued direct-log suffixes share the same writer; covered by the continuation-barrier regression.

## Architecture and reuse

- Existing systems reused: the process-global FIFO, one writer, request entry/body bounds, queue cap, barriers, invocation drain, and direct warning/error transport.
- New logic: one unref'd one-shot idle timer plus an existing-bound fullness check that starts the current writer early.
- New abstractions: none; the queue and writer remain the sole owners.
- Complexity intentionally avoided: no periodic poller, per-invocation queue, second writer, persisted state, or transport/schema change.

## Complexity impact

- Guard: pass (`pnpm complexity:diff`).
- Hotspots: none in the changed source file; maximum changed-file complexity is 10.
- Agent judgment: further source simplification is not justified because the timer, bound check, and drain cancellation are the minimum separate responsibilities.

## Hot reply path impact

Not applicable. The change affects optional debug/info transport after enqueue; it adds no awaited work from accepted conversation input through provider start or durable reply handoff. Warn/error and invocation drain keep their existing awaited behavior.

## Murph initial provider input impact

- Individual runtime: Not applicable; no prompt, tool, schema, generated guidance, model configuration, or provider-visible input changed.
- Group runtime: Not applicable for the same reason.

## Change-shape breakdown

Classification uses base-to-head `git diff --numstat`; runtime implementation is source, Vitest coverage is tests/fixtures, and the execution plan is docs. No binaries changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 80 | 10 |
| Tests/fixtures | 501 | 152 |
| Docs | 48 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 629 | 162 |

## Anomaly retrospective

- Original requirement: delay otherwise-idle debug/info transport for at most 30 seconds, flush at existing request bounds and the owning invocation drain, and preserve direct warn/error durability, FIFO ordering, queue bounds, and failure swallowing.
- First-reviewed versus current shape: production source remains byte-for-byte unchanged at +80/-10. Review remediation added +267/-85 test-only lines because direct package and reverse-dependent Cloudflare tests still treated awaited enqueue as completed transport.
- Repeated mechanism: the Cloudflare runtime-bridge suite is another direct consumer of the shared low-level snapshot logger and makes the same stale transport-completion assumption outside the normal invocation owner.
- Decision: continue the original production design. Enqueue completion is not transport completion; `runHostedWorkspaceInvocation` remains the sole production flush owner. Close the remaining reverse-dependent gap only at the existing Cloudflare test boundary, reuse the existing drain, remove request-shape assumptions where batching combines entries, and add no queue, state owner, lifecycle, or production branch.
- Required proof: the complete assistant-runtime suite, focused Cloudflare runtime-bridge suite, exact-head app verification, and required CI must pass before merge.

## Risks

- Debug/info durability can be delayed by at most 30 seconds while the process remains live; invocation drain cancels that delay, existing queue limits remain bounded, and warnings/errors still bypass it.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new runners use the same Worker/Web log request schema and can coexist.
- Safe order: Normal Cloudflare runner rollout; no tandem Web deployment is required.
- Rollback floor: None; reverting restores immediate verbose-writer starts.
- Expected exposure: During rollout, old runners issue the prior request pattern while new runners coalesce verbose entries.
- Reversibility: Roll back the runner bundle; no data or schema migration exists.
- Convergence proof: Required exact-head CI plus the focused queue suite prove both paths use the same bounded transport.
- Post-deploy checks: Compare bounded runtime-log request aggregates and warning/error write failures without inspecting private log payloads.

## Changelog

- Changelog: not applicable
- Reason: Internal observability transport efficiency only; no member-visible outcome changes.

ReviewGPT context sensitivity: sensitive — changes runtime timing, ordering, and concurrency behavior.
ReviewGPT first-reviewed head: 976310d51d91049d7dafd6ae80fc48b08f854921
