### PR TITLE
fix(runtime): drain reported metrics in system mailbox mode

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-01-reported-daily-metric-model-free.md
+++ b/agent-docs/exec-plans/active/2026-09-01-reported-daily-metric-model-free.md
@@ -1,0 +1,35 @@
+# Reported daily metric mailbox ownership
+
+Status: active
+Created: 2026-09-01
+Updated: 2026-09-01
+
+## Goal
+
+- Stop a later reported daily metric from publishing a default-processing wake while earlier model-free device-sync work owns the durable system-mailbox frontier.
+
+## Product UX
+
+- Effort: Patch.
+- Outcome: delayed connected-health work resumes without a hot no-progress loop.
+- Reaches: members whose runtime imports device-sync work followed by a reported daily metric.
+- Proof: a production-shaped mixed-mailbox regression plus post-deploy system-mode, device-pass, and frontier-advance evidence.
+
+## Root-cause evidence
+
+- `health.daily-metric.reported` is currently classified as `default_owned` even though import already performs its canonical write and execution is a deterministic no-op plus projection record.
+- In a mixed frontier, that later row publishes a due default-processing wake while the earlier device-sync row remains the model-free execution frontier.
+- Default invocations hand the earlier device row back to system mode, then checkpoint the unchanged due default wake, producing repeated no-progress invocations.
+
+## Plan
+
+1. Add a failing contract regression for the reported metric execution class and a failing mixed-frontier regression matching production ordering.
+2. Move the deterministic reported-metric item into the existing model-free ownership set and allow its existing import route in system-mailbox mode.
+3. Add runtime-entrypoint proof that system mode consumes the item without entering the assistant lane.
+4. Run focused tests, package typechecks, complexity, changelog validation, diff/privacy review, exact-head CI, and ReviewGPT.
+5. Merge, deploy with immediate hosted-container rollout, and verify the affected production frontier advances and the loop stops.
+
+## Deployment concerns
+
+- Cloudflare hosted runtime first, with immediate container replacement; then deploy Web only if the merged shared classifier is consumed by its reconciliation build.
+- No schema, wire, Temporal workflow, provider-input, or persisted-state migration is expected.

--- a/agent-docs/exec-plans/completed/2026-09-01-reported-daily-metric-model-free.md
+++ b/agent-docs/exec-plans/completed/2026-09-01-reported-daily-metric-model-free.md
@@ -1,6 +1,6 @@
 # Reported daily metric mailbox ownership
 
-Status: active
+Status: completed
 Created: 2026-09-01
 Updated: 2026-09-01
 
@@ -33,3 +33,17 @@ Updated: 2026-09-01
 
 - Cloudflare hosted runtime first, with immediate container replacement; then deploy Web only if the merged shared classifier is consumed by its reconciliation build.
 - No schema, wire, Temporal workflow, provider-input, or persisted-state migration is expected.
+
+## Verification
+
+- Red proof: the mixed device-plus-metric frontier published a due default `assistant` wake, the shared classifier returned `default_owned`, and the real system-mode entrypoint left the metric pending.
+- Green proof: the same boundaries now classify both rows as model-free, publish no default wake, drain the metric through its projection boundary, clear the pending item, and avoid the assistant lane.
+- Passed 84 focused hosted runtime and contract tests and 58 hosted Web reconciliation tests.
+- Passed hosted-execution, assistant-runtime, and hosted Web typechecks plus the 207-scenario integrity check.
+
+## Product UX walkthrough
+
+- A member with earlier device-sync work and a later reported metric now stays on the background system owner until both items can advance.
+- A member sending a current message retains foreground priority because no conversation or approved-continuation ordering changed.
+- Recovery remains automatic and silent; the fix adds no duplicate message, new prompt, or member action.
+Completed: 2026-09-01

--- a/apps/web/changelog/entries/2026-09-01/background-work-recovers-from-stale-timers.json
+++ b/apps/web/changelog/entries/2026-09-01/background-work-recovers-from-stale-timers.json
@@ -5,10 +5,10 @@
     "id": "background-work-recovers-from-stale-timers",
     "kind": "improvement",
     "priority": 4,
-    "title": "Background work recovers from stale timers",
-    "summary": "Murph now recovers when connected-device work overlaps an outdated assistant timer or the behind-the-scenes cleanup after a reply.",
-    "details": "Current conversations, reminders, and pending deliveries keep priority. Completed replies finish cleanup without sending duplicate text, while interrupted scheduled work receives its own recovery check.",
+    "title": "Background work keeps moving",
+    "summary": "Murph now recovers when connected-device work overlaps an outdated assistant timer, the behind-the-scenes cleanup after a reply, or newly reported health data.",
+    "details": "Current conversations, reminders, and pending deliveries keep priority. Completed replies finish cleanup without sending duplicate text, while queued connected-health updates continue in order without needing an unrelated message to restart them.",
     "relevanceTags": ["assistant", "wearables", "reliability"],
-    "sourcePullRequests": [2682, 2693]
+    "sourcePullRequests": [2682, 2693, 2702]
   }
 }

--- a/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
+++ b/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
@@ -727,6 +727,11 @@ describe("hosted orchestration reconciliation facts", () => {
   it.each([
     ["device-sync.wake", "device-sync.wake:item", "model_free"],
     [
+      "health.daily-metric.reported",
+      "health.daily-metric.reported:item",
+      "model_free",
+    ],
+    [
       "environment-interview.completed",
       "environment-interview.completed:item",
       "model_free",

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -1345,6 +1345,18 @@ function recordHostedRuntimeLatencyMilestoneBestEffort(input: {
   }
 }
 
+function resolveHostedSystemMailboxProjectionMode(
+  item: HostedSystemMailboxPendingItem,
+): HostedVaultShareProjectionMode | undefined {
+  if (
+    item.postCheckpointRecord?.kind !== "vault-share.projection"
+    || item.wake.kind !== "runtime.maintenance-requested"
+  ) {
+    return undefined;
+  }
+  return HOSTED_VAULT_SHARE_FIRST_MATERIALIZATION_MODE;
+}
+
 export async function runHostedWorkspaceRuntimeJobInProcess(
   input: HostedAssistantWorkspaceRuntimeJobInput,
   options: HostedWorkspaceRuntimeJobOptions,
@@ -3529,9 +3541,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
             recordItem.postCheckpointRecord?.kind === "vault-share.projection";
           const projectionOpportunity =
             await offerVaultShareProjectionBeforeRecording(
-              isVaultShareProjectionRecord
-                ? HOSTED_VAULT_SHARE_FIRST_MATERIALIZATION_MODE
-                : undefined,
+              resolveHostedSystemMailboxProjectionMode(recordItem),
             );
           if (projectionOpportunity.outcome === "preempted") {
             return { preempted: true, prepared: true };

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -441,6 +441,7 @@ const HOSTED_FOREGROUND_MAILBOX_PREFETCH_LANES = ["conversation", "system"] as c
 const HOSTED_SYSTEM_MAILBOX_MODEL_FREE_ROUTE_ACTIONS = [
   "apply-runtime-control-request",
   "dispatch-assistant-notification",
+  "import-reported-daily-metric",
   "run-device-sync-wake",
   "run-environment-interview",
 ] as const;

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -1345,6 +1345,18 @@ function recordHostedRuntimeLatencyMilestoneBestEffort(input: {
   }
 }
 
+function resolveHostedSystemMailboxProjectionMode(
+  item: HostedSystemMailboxPendingItem,
+): HostedVaultShareProjectionMode | undefined {
+  if (
+    item.postCheckpointRecord?.kind !== "vault-share.projection"
+    || item.wake.kind !== "runtime.maintenance-requested"
+  ) {
+    return undefined;
+  }
+  return HOSTED_VAULT_SHARE_FIRST_MATERIALIZATION_MODE;
+}
+
 export async function runHostedWorkspaceRuntimeJobInProcess(
   input: HostedAssistantWorkspaceRuntimeJobInput,
   options: HostedWorkspaceRuntimeJobOptions,
@@ -3530,9 +3542,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
             recordItem.postCheckpointRecord?.kind === "vault-share.projection";
           const projectionOpportunity =
             await offerVaultShareProjectionBeforeRecording(
-              isVaultShareProjectionRecord
-                ? HOSTED_VAULT_SHARE_FIRST_MATERIALIZATION_MODE
-                : undefined,
+              resolveHostedSystemMailboxProjectionMode(recordItem),
             );
           if (projectionOpportunity.outcome === "preempted") {
             return { preempted: true, prepared: true };

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-state.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-state.test.ts
@@ -676,6 +676,60 @@ describe("hosted runtime system mailbox state", () => {
     }
   });
 
+  it("keeps a reported daily metric in the model-free device frontier", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-hosted-system-mailbox-state-"));
+    const deviceWake = buildPendingDeviceSyncMailboxItem({
+      itemId: "pending_device_sync_before_reported_metric",
+      mailboxLaneSeq: "1",
+    });
+    const reportedMetric = buildPendingReportedDailyMetricMailboxItem({
+      itemId: "pending_reported_metric_after_device_sync",
+      mailboxLaneSeq: "2",
+    });
+
+    try {
+      await updateHostedSystemMailboxState(vaultRoot, () => ({
+        pending: [deviceWake, reportedMetric],
+      }));
+
+      await expect(resolveHostedSystemMailboxWakeCandidates({
+        now: () => "2026-04-27T00:00:00.000Z",
+        vaultRoot,
+      })).resolves.toEqual({
+        defaultOwned: {
+          at: null,
+          reason: null,
+        },
+        next: {
+          at: "2026-04-27T00:00:00.000Z",
+          executionClass: "model_free",
+          reason: "device-sync.reconcile",
+        },
+      });
+
+      await removeHostedSystemMailboxPendingItemIfCurrent({
+        item: deviceWake,
+        vaultRoot,
+      });
+      await expect(resolveHostedSystemMailboxWakeCandidates({
+        now: () => "2026-04-27T00:00:00.000Z",
+        vaultRoot,
+      })).resolves.toEqual({
+        defaultOwned: {
+          at: null,
+          reason: null,
+        },
+        next: {
+          at: "2026-04-27T00:00:00.000Z",
+          executionClass: "model_free",
+          reason: "mailbox",
+        },
+      });
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
   it("keeps a distinct dense raw retention successor after dirty receipt recording", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-hosted-system-mailbox-state-"));
 
@@ -1106,6 +1160,40 @@ function buildPendingDeviceSyncMailboxItem(input: {
       kind: "device-sync.wake",
       occurredAt: "2026-04-27T00:00:00.000Z",
       reason: "reconcile_due",
+      userId: "member_123",
+    },
+  };
+}
+
+function buildPendingReportedDailyMetricMailboxItem(input: {
+  itemId: string;
+  mailboxLaneSeq: string;
+}): HostedSystemMailboxPendingItem {
+  return {
+    attemptCount: 0,
+    itemId: input.itemId,
+    lastAttemptAt: null,
+    lastErrorCode: null,
+    lastErrorMessage: null,
+    mailboxDedupeKey: `health.daily-metric.reported:${input.itemId}`,
+    mailboxLaneSeq: input.mailboxLaneSeq,
+    nextAttemptAt: null,
+    occurredAt: "2026-04-27T00:00:00.000Z",
+    postCheckpointRecord: null,
+    preferenceCausalSeq: null,
+    requestId: null,
+    routeAction: "import-reported-daily-metric",
+    status: "pending",
+    wake: {
+      dailyMetric: {
+        date: "2026-04-27",
+        metric: "steps",
+        unit: "count",
+        value: 8_000,
+      },
+      eventId: `health.daily-metric.reported:${input.itemId}`,
+      kind: "health.daily-metric.reported",
+      occurredAt: "2026-04-27T00:00:00.000Z",
       userId: "member_123",
     },
   };

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-state.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-state.test.ts
@@ -767,6 +767,60 @@ describe("hosted runtime system mailbox state", () => {
     }
   });
 
+  it("keeps a reported daily metric in the model-free device frontier", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-hosted-system-mailbox-state-"));
+    const deviceWake = buildPendingDeviceSyncMailboxItem({
+      itemId: "pending_device_sync_before_reported_metric",
+      mailboxLaneSeq: "1",
+    });
+    const reportedMetric = buildPendingReportedDailyMetricMailboxItem({
+      itemId: "pending_reported_metric_after_device_sync",
+      mailboxLaneSeq: "2",
+    });
+
+    try {
+      await updateHostedSystemMailboxState(vaultRoot, () => ({
+        pending: [deviceWake, reportedMetric],
+      }));
+
+      await expect(resolveHostedSystemMailboxWakeCandidates({
+        now: () => "2026-04-27T00:00:00.000Z",
+        vaultRoot,
+      })).resolves.toEqual({
+        defaultOwned: {
+          at: null,
+          reason: null,
+        },
+        next: {
+          at: "2026-04-27T00:00:00.000Z",
+          executionClass: "model_free",
+          reason: "device-sync.reconcile",
+        },
+      });
+
+      await removeHostedSystemMailboxPendingItemIfCurrent({
+        item: deviceWake,
+        vaultRoot,
+      });
+      await expect(resolveHostedSystemMailboxWakeCandidates({
+        now: () => "2026-04-27T00:00:00.000Z",
+        vaultRoot,
+      })).resolves.toEqual({
+        defaultOwned: {
+          at: null,
+          reason: null,
+        },
+        next: {
+          at: "2026-04-27T00:00:00.000Z",
+          executionClass: "model_free",
+          reason: "mailbox",
+        },
+      });
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
   it("keeps a distinct dense raw retention successor after dirty receipt recording", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-hosted-system-mailbox-state-"));
 
@@ -1197,6 +1251,40 @@ function buildPendingDeviceSyncMailboxItem(input: {
       kind: "device-sync.wake",
       occurredAt: "2026-04-27T00:00:00.000Z",
       reason: "reconcile_due",
+      userId: "member_123",
+    },
+  };
+}
+
+function buildPendingReportedDailyMetricMailboxItem(input: {
+  itemId: string;
+  mailboxLaneSeq: string;
+}): HostedSystemMailboxPendingItem {
+  return {
+    attemptCount: 0,
+    itemId: input.itemId,
+    lastAttemptAt: null,
+    lastErrorCode: null,
+    lastErrorMessage: null,
+    mailboxDedupeKey: `health.daily-metric.reported:${input.itemId}`,
+    mailboxLaneSeq: input.mailboxLaneSeq,
+    nextAttemptAt: null,
+    occurredAt: "2026-04-27T00:00:00.000Z",
+    postCheckpointRecord: null,
+    preferenceCausalSeq: null,
+    requestId: null,
+    routeAction: "import-reported-daily-metric",
+    status: "pending",
+    wake: {
+      dailyMetric: {
+        date: "2026-04-27",
+        metric: "steps",
+        unit: "count",
+        value: 8_000,
+      },
+      eventId: `health.daily-metric.reported:${input.itemId}`,
+      kind: "health.daily-metric.reported",
+      occurredAt: "2026-04-27T00:00:00.000Z",
       userId: "member_123",
     },
   };

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -61,6 +61,7 @@ import {
 } from "@murphai/core";
 import {
   buildHostedExecutionAssistantNotificationRequestedWake,
+  buildHostedExecutionDailyMetricReportedWake,
   buildHostedExecutionEnvironmentInterviewCompletedWake,
   buildHostedExecutionLinqConversationMessageWake,
   buildHostedExecutionMemberActivatedWake,
@@ -4709,7 +4710,8 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
   test.each([
     "runtime.maintenance-requested",
     "runtime.browser-vault-refresh-requested",
-  ] as const)("system mailbox mode drains model-free %s control work", async (kind) => {
+    "health.daily-metric.reported",
+  ] as const)("system mailbox mode drains model-free %s work", async (kind) => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const events: string[] = [];
@@ -4726,15 +4728,34 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
     try {
       vi.setSystemTime(new Date(TEST_NOW));
       await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      const resolvedItem = createResolvedRuntimeControlSystemMailboxItem(maintenanceItem);
       await enqueueHostedSystemMailboxItem({
-        item: createResolvedRuntimeControlSystemMailboxItem(maintenanceItem),
+        item: kind === "health.daily-metric.reported"
+          ? {
+              ...resolvedItem,
+              route: {
+                ...resolvedItem.route,
+                action: "import-reported-daily-metric",
+              },
+            }
+          : resolvedItem,
         vaultRoot,
-        wake: buildHostedExecutionRuntimeControlWake({
-          eventId: maintenanceItem.dedupeKey,
-          kind,
-          occurredAt: maintenanceItem.occurredAt,
-          userId: TEST_USER_ID,
-        }),
+        wake: kind === "health.daily-metric.reported"
+          ? buildHostedExecutionDailyMetricReportedWake({
+              date: "2026-04-27",
+              eventId: maintenanceItem.dedupeKey,
+              memberId: TEST_USER_ID,
+              metric: "steps",
+              occurredAt: maintenanceItem.occurredAt,
+              unit: "count",
+              value: 8_000,
+            })
+          : buildHostedExecutionRuntimeControlWake({
+              eventId: maintenanceItem.dedupeKey,
+              kind,
+              occurredAt: maintenanceItem.occurredAt,
+              userId: TEST_USER_ID,
+            }),
       });
       const importState = createEmptyHostedMailboxImportState();
       importState.watermarks.system = "1";
@@ -4770,6 +4791,20 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
             artifactBytesByHash: new Map([[restoredWorkspace.hash, restoredWorkspace.bytes]]),
             deviceSyncPort,
             mailboxPort: createMailboxPort({ events, items: [] }),
+            vaultSharePort: {
+              async listActiveProjectionScopes(input) {
+                return {
+                  ...(input?.projectionMode
+                    ? { projectionMode: input.projectionMode }
+                    : {}),
+                  projectionKinds: [],
+                  projectionScopes: [],
+                };
+              },
+              async deliver() {
+                throw new Error("No inactive vault-share projection should be delivered.");
+              },
+            },
             workspacePort: createWorkspacePort({
               checkpointRequests,
               events,

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -68,6 +68,9 @@ import {
   deriveHostedExecutionErrorCode,
 } from "@murphai/hosted-execution";
 import {
+  HOSTED_VAULT_SHARE_FIRST_MATERIALIZATION_MODE,
+} from "@murphai/hosted-execution/vault-share";
+import {
   appendAssistantTranscriptEntries,
   createAssistantOutboxIntent,
   ensureAutomaticMealCloseoutAutomation,
@@ -4708,16 +4711,33 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
   });
 
   test.each([
-    "runtime.maintenance-requested",
-    "runtime.browser-vault-refresh-requested",
-    "health.daily-metric.reported",
-  ] as const)("system mailbox mode drains model-free %s work", async (kind) => {
+    {
+      dedupeKey: "runtime-control:group-share-projection:synthetic",
+      expectedProjectionMode: HOSTED_VAULT_SHARE_FIRST_MATERIALIZATION_MODE,
+      kind: "runtime.maintenance-requested",
+    },
+    {
+      dedupeKey: "runtime.browser-vault-refresh-requested:synthetic",
+      expectedProjectionMode: null,
+      kind: "runtime.browser-vault-refresh-requested",
+    },
+    {
+      dedupeKey: "health.daily-metric.reported:synthetic",
+      expectedProjectionMode: null,
+      kind: "health.daily-metric.reported",
+    },
+  ] as const)("system mailbox mode drains model-free $kind work", async ({
+    dedupeKey,
+    expectedProjectionMode,
+    kind,
+  }) => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const events: string[] = [];
     const deviceSyncPort = createEmptyDeviceSyncPort();
+    const projectionModes: Array<string | null> = [];
     const maintenanceItem = createMailboxItem({
-      dedupeKey: "runtime.maintenance-requested:device-recovery-owner",
+      dedupeKey,
       id: "mailbox_item_system_mailbox_operator_maintenance",
       kind,
       lane: "system",
@@ -4793,6 +4813,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
             mailboxPort: createMailboxPort({ events, items: [] }),
             vaultSharePort: {
               async listActiveProjectionScopes(input) {
+                projectionModes.push(input?.projectionMode ?? null);
                 return {
                   ...(input?.projectionMode
                     ? { projectionMode: input.projectionMode }
@@ -4827,6 +4848,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       assert.equal(result.nextWakeAt, null);
       assert.equal(result.nextWakeReason ?? null, null);
       assert.equal(result.status, "idle");
+      assert.deepEqual(projectionModes, [expectedProjectionMode]);
       assert.equal(
         checkpointRequests.at(-1)?.redactedStatus?.hostedMailboxSystemHandledThroughSeq,
         "1",

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -69,6 +69,9 @@ import {
   deriveHostedExecutionErrorCode,
 } from "@murphai/hosted-execution";
 import {
+  HOSTED_VAULT_SHARE_FIRST_MATERIALIZATION_MODE,
+} from "@murphai/hosted-execution/vault-share";
+import {
   appendAssistantTranscriptEntries,
   createAssistantOutboxIntent,
   ensureAutomaticMealCloseoutAutomation,
@@ -4708,16 +4711,33 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
   });
 
   test.each([
-    "runtime.maintenance-requested",
-    "runtime.browser-vault-refresh-requested",
-    "health.daily-metric.reported",
-  ] as const)("system mailbox mode drains model-free %s work", async (kind) => {
+    {
+      dedupeKey: "runtime-control:group-share-projection:synthetic",
+      expectedProjectionMode: HOSTED_VAULT_SHARE_FIRST_MATERIALIZATION_MODE,
+      kind: "runtime.maintenance-requested",
+    },
+    {
+      dedupeKey: "runtime.browser-vault-refresh-requested:synthetic",
+      expectedProjectionMode: null,
+      kind: "runtime.browser-vault-refresh-requested",
+    },
+    {
+      dedupeKey: "health.daily-metric.reported:synthetic",
+      expectedProjectionMode: null,
+      kind: "health.daily-metric.reported",
+    },
+  ] as const)("system mailbox mode drains model-free $kind work", async ({
+    dedupeKey,
+    expectedProjectionMode,
+    kind,
+  }) => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const events: string[] = [];
     const deviceSyncPort = createEmptyDeviceSyncPort();
+    const projectionModes: Array<string | null> = [];
     const maintenanceItem = createMailboxItem({
-      dedupeKey: "runtime.maintenance-requested:device-recovery-owner",
+      dedupeKey,
       id: "mailbox_item_system_mailbox_operator_maintenance",
       kind,
       lane: "system",
@@ -4793,6 +4813,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
             mailboxPort: createMailboxPort({ events, items: [] }),
             vaultSharePort: {
               async listActiveProjectionScopes(input) {
+                projectionModes.push(input?.projectionMode ?? null);
                 return {
                   ...(input?.projectionMode
                     ? { projectionMode: input.projectionMode }
@@ -4827,6 +4848,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       assert.equal(result.nextWakeAt, null);
       assert.equal(result.nextWakeReason ?? null, null);
       assert.equal(result.status, "idle");
+      assert.deepEqual(projectionModes, [expectedProjectionMode]);
       assert.equal(
         checkpointRequests.at(-1)?.redactedStatus?.hostedMailboxSystemHandledThroughSeq,
         "1",

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -70,6 +70,7 @@ import {
 } from "@murphai/hosted-execution";
 import {
   HOSTED_VAULT_SHARE_FIRST_MATERIALIZATION_MODE,
+  type HostedVaultShareDeliverRequest,
 } from "@murphai/hosted-execution/vault-share";
 import {
   appendAssistantTranscriptEntries,
@@ -175,6 +176,9 @@ import type {
 import {
   enqueueHostedSystemMailboxItem,
 } from "../src/hosted-runtime/system-mailbox.ts";
+import {
+  importHostedReportedDailyMetricMailboxItem,
+} from "../src/hosted-runtime/reported-daily-metric-import.ts";
 import {
   findNextHostedSystemMailboxQueueItem,
   isHostedSystemMailboxModelFreeExactNotificationItem,
@@ -4735,8 +4739,10 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const events: string[] = [];
     const deviceSyncPort = createEmptyDeviceSyncPort();
+    const deliveredProjectionRequests: HostedVaultShareDeliverRequest[] = [];
     const projectionModes: Array<string | null> = [];
     const maintenanceItem = createMailboxItem({
+      causalSeq: "1",
       dedupeKey,
       id: "mailbox_item_system_mailbox_operator_maintenance",
       kind,
@@ -4749,34 +4755,51 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       vi.setSystemTime(new Date(TEST_NOW));
       await initializeVault({ createdAt: TEST_NOW, vaultRoot });
       const resolvedItem = createResolvedRuntimeControlSystemMailboxItem(maintenanceItem);
-      await enqueueHostedSystemMailboxItem({
-        item: kind === "health.daily-metric.reported"
-          ? {
-              ...resolvedItem,
-              route: {
-                ...resolvedItem.route,
-                action: "import-reported-daily-metric",
-              },
-            }
-          : resolvedItem,
-        vaultRoot,
-        wake: kind === "health.daily-metric.reported"
-          ? buildHostedExecutionDailyMetricReportedWake({
-              date: "2026-04-27",
-              eventId: maintenanceItem.dedupeKey,
-              memberId: TEST_USER_ID,
-              metric: "steps",
-              occurredAt: maintenanceItem.occurredAt,
-              unit: "count",
-              value: 8_000,
-            })
-          : buildHostedExecutionRuntimeControlWake({
-              eventId: maintenanceItem.dedupeKey,
-              kind,
-              occurredAt: maintenanceItem.occurredAt,
-              userId: TEST_USER_ID,
-            }),
-      });
+      if (kind === "health.daily-metric.reported") {
+        const dailyMetricItem: HostedMailboxResolvedImportItem = {
+          ...resolvedItem,
+          route: {
+            ...resolvedItem.route,
+            action: "import-reported-daily-metric",
+          },
+        };
+        const dailyMetricWake = buildHostedExecutionDailyMetricReportedWake({
+          date: "2026-04-26",
+          eventId: maintenanceItem.dedupeKey,
+          memberId: TEST_USER_ID,
+          metric: "steps",
+          occurredAt: maintenanceItem.occurredAt,
+          unit: "count",
+          value: 8_000,
+        });
+        assert.deepEqual(
+          await importHostedReportedDailyMetricMailboxItem({
+            item: dailyMetricItem,
+            vaultRoot,
+            wake: dailyMetricWake,
+          }),
+          {
+            reasonCode: "daily_metric_report.imported",
+            status: "imported",
+          },
+        );
+        await enqueueHostedSystemMailboxItem({
+          item: dailyMetricItem,
+          vaultRoot,
+          wake: dailyMetricWake,
+        });
+      } else {
+        await enqueueHostedSystemMailboxItem({
+          item: resolvedItem,
+          vaultRoot,
+          wake: buildHostedExecutionRuntimeControlWake({
+            eventId: maintenanceItem.dedupeKey,
+            kind,
+            occurredAt: maintenanceItem.occurredAt,
+            userId: TEST_USER_ID,
+          }),
+        });
+      }
       const importState = createEmptyHostedMailboxImportState();
       importState.watermarks.system = "1";
       await writeMailboxImportStateFile(vaultRoot, importState);
@@ -4814,6 +4837,18 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
             vaultSharePort: {
               async listActiveProjectionScopes(input) {
                 projectionModes.push(input?.projectionMode ?? null);
+                if (
+                  kind === "health.daily-metric.reported"
+                  && input?.projectionMode === undefined
+                ) {
+                  return {
+                    generationTokensByProjectionScopeKey: {
+                      "steps-days.v0": "a".repeat(43),
+                    },
+                    projectionKinds: ["steps-days.v0" as const],
+                    projectionScopes: [{ projectionKind: "steps-days.v0" as const }],
+                  };
+                }
                 return {
                   ...(input?.projectionMode
                     ? { projectionMode: input.projectionMode }
@@ -4822,8 +4857,12 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
                   projectionScopes: [],
                 };
               },
-              async deliver() {
-                throw new Error("No inactive vault-share projection should be delivered.");
+              async deliver(request) {
+                if (kind !== "health.daily-metric.reported") {
+                  throw new Error("No inactive vault-share projection should be delivered.");
+                }
+                deliveredProjectionRequests.push(request);
+                return { status: "delivered" };
               },
             },
             workspacePort: createWorkspacePort({
@@ -4850,9 +4889,34 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       assert.equal(result.status, "idle");
       assert.deepEqual(projectionModes, [expectedProjectionMode]);
       assert.equal(
+        deliveredProjectionRequests.length,
+        kind === "health.daily-metric.reported" ? 1 : 0,
+      );
+      if (kind === "health.daily-metric.reported") {
+        const delivery = deliveredProjectionRequests[0];
+        assert.ok(delivery);
+        assert.equal(delivery.projectionMode, undefined);
+        assert.equal(delivery.projectionKind, "steps-days.v0");
+        assert.equal(delivery.expectedGenerationToken, "a".repeat(43));
+        expect(delivery.records).toEqual([
+          expect.objectContaining({
+            data: expect.objectContaining({
+              date: "2026-04-26",
+              metricKey: "steps",
+              unit: "count",
+              value: 8_000,
+            }),
+            recordKey: "2026-04-26.manual",
+            source: { label: "Manual", source: "manual" },
+          }),
+        ]);
+      }
+      assert.equal(
         checkpointRequests.at(-1)?.redactedStatus?.hostedMailboxSystemHandledThroughSeq,
         "1",
       );
+      assert.equal(checkpointRequests.at(-1)?.nextDefaultProcessingWakeAt, null);
+      assert.equal(checkpointRequests.at(-1)?.nextDefaultProcessingWakeReason, null);
     } finally {
       vi.useRealTimers();
       await removeTempRoot(vaultRoot);

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -60,6 +60,7 @@ import {
 } from "@murphai/core";
 import {
   buildHostedExecutionAssistantNotificationRequestedWake,
+  buildHostedExecutionDailyMetricReportedWake,
   buildHostedExecutionEnvironmentInterviewCompletedWake,
   buildHostedExecutionLinqConversationMessageWake,
   buildHostedExecutionMemberActivatedWake,
@@ -4709,7 +4710,8 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
   test.each([
     "runtime.maintenance-requested",
     "runtime.browser-vault-refresh-requested",
-  ] as const)("system mailbox mode drains model-free %s control work", async (kind) => {
+    "health.daily-metric.reported",
+  ] as const)("system mailbox mode drains model-free %s work", async (kind) => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const events: string[] = [];
@@ -4726,15 +4728,34 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
     try {
       vi.setSystemTime(new Date(TEST_NOW));
       await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      const resolvedItem = createResolvedRuntimeControlSystemMailboxItem(maintenanceItem);
       await enqueueHostedSystemMailboxItem({
-        item: createResolvedRuntimeControlSystemMailboxItem(maintenanceItem),
+        item: kind === "health.daily-metric.reported"
+          ? {
+              ...resolvedItem,
+              route: {
+                ...resolvedItem.route,
+                action: "import-reported-daily-metric",
+              },
+            }
+          : resolvedItem,
         vaultRoot,
-        wake: buildHostedExecutionRuntimeControlWake({
-          eventId: maintenanceItem.dedupeKey,
-          kind,
-          occurredAt: maintenanceItem.occurredAt,
-          userId: TEST_USER_ID,
-        }),
+        wake: kind === "health.daily-metric.reported"
+          ? buildHostedExecutionDailyMetricReportedWake({
+              date: "2026-04-27",
+              eventId: maintenanceItem.dedupeKey,
+              memberId: TEST_USER_ID,
+              metric: "steps",
+              occurredAt: maintenanceItem.occurredAt,
+              unit: "count",
+              value: 8_000,
+            })
+          : buildHostedExecutionRuntimeControlWake({
+              eventId: maintenanceItem.dedupeKey,
+              kind,
+              occurredAt: maintenanceItem.occurredAt,
+              userId: TEST_USER_ID,
+            }),
       });
       const importState = createEmptyHostedMailboxImportState();
       importState.watermarks.system = "1";
@@ -4770,6 +4791,20 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
             artifactBytesByHash: new Map([[restoredWorkspace.hash, restoredWorkspace.bytes]]),
             deviceSyncPort,
             mailboxPort: createMailboxPort({ events, items: [] }),
+            vaultSharePort: {
+              async listActiveProjectionScopes(input) {
+                return {
+                  ...(input?.projectionMode
+                    ? { projectionMode: input.projectionMode }
+                    : {}),
+                  projectionKinds: [],
+                  projectionScopes: [],
+                };
+              },
+              async deliver() {
+                throw new Error("No inactive vault-share projection should be delivered.");
+              },
+            },
             workspacePort: createWorkspacePort({
               checkpointRequests,
               events,

--- a/packages/hosted-execution/src/orchestration-control.ts
+++ b/packages/hosted-execution/src/orchestration-control.ts
@@ -77,6 +77,7 @@ export const HOSTED_SYSTEM_MAILBOX_MODEL_FREE_KINDS = [
   "assistant.notification.requested",
   "device-sync.wake",
   "environment-interview.completed",
+  "health.daily-metric.reported",
   "runtime.browser-vault-refresh-requested",
   "runtime.maintenance-requested",
 ] as const satisfies readonly HostedMailboxKind[];

--- a/packages/hosted-execution/test/hosted-orchestration-control.test.ts
+++ b/packages/hosted-execution/test/hosted-orchestration-control.test.ts
@@ -328,6 +328,10 @@ describe("hosted orchestration control contracts", () => {
       dedupeKey: "assistant.notification.requested:generic",
       kind: "assistant.notification.requested",
     })).toBe("default_owned");
+    expect(classifyHostedSystemMailboxExecutionClass({
+      dedupeKey: "health.daily-metric.reported:synthetic",
+      kind: "health.daily-metric.reported",
+    })).toBe("model_free");
   });
 
   it("rejects raw payload-shaped fields in reconciliation facts contracts", () => {


### PR DESCRIPTION
## Outcome

Classify imported reported-daily-metric work under the deterministic system-mailbox owner so a later metric cannot keep publishing a default assistant wake behind earlier device-sync work. Preserve full active-share refreshes for those metrics while keeping grant-maintenance projection first-materialization-only.

## Product UX

Patch. Delayed connected-health work resumes without a hot no-progress loop; current conversations, reminders, deliveries, and already-materialized shared health views keep their existing behavior. Recovery stays automatic and silent.

## Direct evidence

- Red ownership proof on the unchanged base: the mixed device-plus-metric frontier published a due assistant default wake, the shared classifier returned `default_owned`, and the system-mode entrypoint left the metric pending.
- Red ReviewGPT regression on the first candidate: a reported metric incorrectly called projection with `first-materialization`.
- Green runtime proof on the rebased head: 85 focused runtime and contract tests pass; the entrypoint drains the metric, calls projection without a mode, clears the item, and avoids the assistant lane, while maintenance still calls `first-materialization`.
- Deterministic regression proof: the real in-process entrypoint imports a causal 8,000-step observation, exposes an already-materialized `steps-days.v0` grant only to full refresh, delivers the manual record exactly once, advances the handled frontier, and leaves no default wake. Temporarily restoring the buggy all-projection `first-materialization` selection makes this exact test fail red; all 52 system-mailbox entrypoint tests pass with the fix.
- Hosted Web reconciliation: 58 tests pass and project the metric as `model_free`.
- Hosted execution, assistant runtime, and hosted Web typechecks pass; the Cloudflare runner package build also passes.
- Changelog validation: 39 tests pass.
- Cyclomatic complexity diff passes with debt reduced by one and no maximum increase.
- The production-shaped hosted-local journey creates an active grant and reads back the prior device value plus the manual correction exactly once with no personal reply. A local run with the protected Temporal worker reached the test but its emulated runner container was killed with exit 137 during initial activation, before these assertions; no production invariant was weakened to bypass that host-resource failure.

## Affected surfaces

- Shared hosted mailbox execution-class projection.
- Cloudflare hosted runtime model-free route admission and vault-share projection-mode selection.
- Hosted Web reconciliation frontier classification.
- Public changelog item.
- No schema, wire, Temporal workflow, provider-input, or persisted-state changes.

## Architecture and reuse

- Existing systems reused: the shared mailbox classifier, system-mode route allowlist, deterministic event handler, and existing vault-share projection modes.
- New logic: one event kind and one route action join their existing allowlists; a small predicate selects first-materialization only for projection records created by maintenance wakes.
- New abstractions: one pure local projection-mode resolver; no new state owner, service, queue, retry path, dependency, or compatibility shim.
- Complexity intentionally avoided: no alternate scheduler, mailbox scan, special-case retry, duplicated projection path, or persisted migration.

## Complexity impact

- Guard: pass; `pnpm complexity:diff` reports complexity debt reduced by one and no maximum increase.
- Hotspots: the existing runtime entrypoint remains at 253; the local helper removes projection-mode selection from that hotspot and introduces no new hotspot.
- Agent judgment: the helper is the smallest explicit shape that preserves separate maintenance and reported-metric projection semantics without duplicating the projection path.
- Source: +15/-3
- Tests and fixtures: +165/-11
- Docs and changelog: +53/-4
- Config and tooling: +0/-0
- Generated and other: +0/-0

## Hot reply path

Foreground input priority is unchanged. The corrected item has already completed its canonical import and runs only its deterministic event and projection-record boundary.

## Provider-input impact

None. Provider payloads, parsing, and request behavior are unchanged.

## Deployment concerns

- Deployment: applicable
- Supported skew: Cloudflare must accept the new system owner before hosted Web begins projecting it; schema, state, and Temporal protocol remain compatible throughout the bounded rollout.
- Safe order: deploy the exact candidate to Cloudflare with immediate container replacement and certify its receipt, then allow the hosted Web production deployment for the merged head.
- Rollback floor: rolling either consumer back below this change reintroduces the no-progress loop for this mailbox shape.
- Expected exposure: any old warm container or old Web reconciliation build can retain the previous owner until both surfaces converge.
- Reversibility: no migration or state rewrite; code rollback is mechanically safe but restores the incident.
- Convergence proof: confirm `system_mailbox` execution, device-sync pass progress, handled-frontier advancement, default-wake clearance, and termination of repeated no-progress invocations.
- Post-deploy checks: verify the exact Cloudflare and hosted Web release receipts, then recheck bounded runtime logs and control state for frontier progress with no repeated no-progress attempts.

## Changelog

- Changelog: updated
- Items: 2026-09-01 · background-work-recovers-from-stale-timers
- Presentation: https://www.withmurph.ai/screenshots/ops#changelog-archive

ReviewGPT context sensitivity: sensitive
Sensitivity reason: hosted runtime ordering, projection refresh semantics, and cross-surface deployment skew change.
ReviewGPT first-reviewed head: b66fe81a1ed74d84055cf3e3e81ded673a3cd8c5
