### PR TITLE
Make onboarding archive proof durable

### DIFF
--- a/apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts
@@ -2,7 +2,10 @@ import { createHmac } from "node:crypto";
 import {
   buildHostedExecutionMemberActivatedWake,
 } from "@murphai/hosted-execution";
-import { readHostedLinqFirstContactMemberState } from "#hosted-web-testing";
+import {
+  listHostedRuntimeLogsForTest,
+  readHostedLinqFirstContactMemberState,
+} from "#hosted-web-testing";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import {
@@ -98,6 +101,7 @@ describe("hosted local onboarding follow-up e2e", () => {
       }),
       { matchInputContains: "I finished onboarding." },
     );
+    const archiveProofStartedAt = new Date();
     const completionWebhookResponse = await postSignedLinqWebhook(buildHostedLinqInboundEvent(
       userId,
       materializedChatId,
@@ -121,18 +125,27 @@ describe("hosted local onboarding follow-up e2e", () => {
     });
     expect(requireLinqStub().readObservedMessageText(completionReply))
       .toBe(onboardingCompleteReplyText);
-    let completionStatus = await requireScenario().waitForHostedCompletion(userId);
+    const completionStatus = await requireScenario().waitForHostedCompletion(userId);
     expect(completionStatus.lastErrorCode ?? null).toBeNull();
-    // The follow-up archive commits in a post-checkpoint managed-automation
-    // pass that may land one checkpoint (or one deferred wake) after the
-    // completion reply, so re-sample completions until the sticky
-    // murphManagedAutomationUpdated counter appears.
-    while (completionStatus.workspace?.redactedStatus?.murphManagedAutomationUpdated !== 1) {
-      completionStatus = await requireScenario().waitForHostedCompletion(userId);
-      expect(completionStatus.lastErrorCode ?? null).toBeNull();
-    }
-    expect(completionStatus.workspace?.redactedStatus).toMatchObject({
-      murphManagedAutomationUpdated: 1,
+    await vi.waitFor(async () => {
+      const logs = await listHostedRuntimeLogsForTest({
+        environment: requireScenario().runtimeEnv,
+        fromAt: archiveProofStartedAt,
+        limit: 1_500,
+        userId,
+      });
+      expect(logs).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          eventCode: "assistant.onboarding_followup_reconciled",
+          redactedJson: expect.objectContaining({
+            onboardingFollowupAction: "archived",
+            onboardingStateStatus: "completed",
+          }),
+        }),
+      ]));
+    }, {
+      interval: 250,
+      timeout: 180_000,
     });
   }, 720_000);
 });

--- a/apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-onboarding-followup-e2e.test.ts
@@ -138,7 +138,7 @@ describe("hosted local onboarding follow-up e2e", () => {
         expect.objectContaining({
           eventCode: "assistant.onboarding_followup_reconciled",
           redactedJson: expect.objectContaining({
-            onboardingFollowupAction: "archived",
+            onboardingFollowupAction: "archived_completed",
             onboardingStateStatus: "completed",
           }),
         }),


### PR DESCRIPTION
## Why and outcome

The hosted onboarding follow-up E2E now proves archival from the existing persisted redacted reconciliation event. It no longer treats a replaceable per-checkpoint diagnostic counter as sticky or waits for runtime work that has already finished.

## Product UX

- Effort: Not applicable — test-only reliability proof.
- Result: Ready.
- Walkthrough: No product behavior or UI changes. Completing onboarding still archives the finite follow-up.

## Evidence

- Direct: repeated private integration failures ended with the runtime checkpointed and both mailbox lanes drained while the old test waited on a replaced diagnostic field.
- Coverage: `pnpm --dir apps/cloudflare typecheck`, `pnpm complexity:diff`, and `git diff --check` pass. ReviewGPT round 2 passes the corrected exact head with no remaining findings. Exact-head private compatibility CI owns the production-shaped scenario because local execution is blocked before the test body by existing issue #2513.

ReviewGPT first-reviewed head: 7e2488917614d0dbca99ae2da758658c4149b782

## Non-obvious affected surfaces

Hosted-local Linq onboarding follow-up E2E only. The test reuses the existing runtime-log reader and `assistant.onboarding_followup_reconciled` event.

## Architecture and reuse

- Existing systems reused: the persisted redacted runtime event emitted by the automation archive owner and the existing runtime-log test reader.
- New logic: the test waits for the exact `archived_completed` event for its member and run window.
- New abstractions: none; the test composes the existing event reader directly, so another helper or state owner would be redundant.
- Complexity intentionally avoided: no production state, helper, retry layer, timeout increase, or second correctness owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` reported no authored production source to analyze and passed.
- Hotspots: no changed production-source function remains above the threshold; the patch is one bounded test wait.
- Agent judgment: no further simplification is justified because extracting the direct event assertion would add a redundant helper.

## Hot reply path impact

- Path status: Not applicable — test-only; no production reply path changes.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Not applicable — no hot-path behavior changed.

## Murph initial provider input impact

Not applicable — no assistant prompt, tool schema, runtime wrapper, history, or provider-visible input changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Test-only; no deployed production artifact or cross-surface skew.

## Change-shape breakdown

Classification rule: the only changed file is a hosted-local E2E test; there are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 25 | 12 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **25** | **12** |

## Changelog

- Changelog: not applicable
- Reason: Test-only; no member-visible change.
