### PR TITLE
Correlate standby allocation outcomes with accepted runtime attempts

### DIFF
--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1640,7 +1640,10 @@ stale-release drain run outside the accepted-message path. A bound slot can
 be retained only by that same member under the ordinary conversation idle
 lifecycle and is never returned to ready. Slot invocation,
 provider-credential minting, withdrawal, account deletion, and retirement all
-re-read the exact durable binding; a member mismatch fails closed.
+re-read the exact durable binding; a member mismatch fails closed. A successful
+fresh-start acceptance records its closed standby allocation outcome alongside
+the orchestration and workspace attempt identifiers in the existing structured
+log. Failed, retried, or superseded starts do not emit an accepted attribution.
 
 The active-member replan durably
 appends the original conversation item. For an exact model-approved instant

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -1487,6 +1487,7 @@ export class RuntimeProcessingController {
         runtimeProcessingAction: input.action,
         runtimePreparationWaitAfterContainerReadyMs:
           preparation.runtimePreparationWaitAfterContainerReadyMs,
+        standbyAllocationOutcome: resolution.standbyAllocationOutcome,
         workspaceAttemptId: prepared.token.attemptId,
       },
       message: "Hosted runner runtime processing accepted.",

--- a/apps/cloudflare/test/hosted-runner-container-identity.test.ts
+++ b/apps/cloudflare/test/hosted-runner-container-identity.test.ts
@@ -93,12 +93,28 @@ import {
   createTestSqlStorage,
 } from "./sql-storage.js";
 
+const mocks = vi.hoisted(() => ({
+  emitHostedExecutionStructuredLog: vi.fn(),
+}));
+
+vi.mock("@murphai/hosted-execution", async () => {
+  const actual = await vi.importActual<typeof import("@murphai/hosted-execution")>(
+    "@murphai/hosted-execution",
+  );
+
+  return {
+    ...actual,
+    emitHostedExecutionStructuredLog: mocks.emitHostedExecutionStructuredLog,
+  };
+});
+
 const FIXED_NOW = "2026-06-03T00:00:00.000Z";
 const TEST_USER_ID = "member_123";
 describe("hosted runner container identity", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
+    mocks.emitHostedExecutionStructuredLog.mockReset();
   });
 
   it("round-trips a versioned runner container identity", () => {
@@ -186,13 +202,17 @@ describe("hosted runner container identity", () => {
       stateStore,
     });
 
-    await expect(controller.ensureForUser({
+    const response = await controller.ensureForUser({
       orchestrationAttemptId: "orchestration_attempt_1",
       userId: TEST_USER_ID,
-    })).resolves.toMatchObject({
+    });
+    expect(response).toMatchObject({
       action: "started",
       kind: "runtime_processing_accepted",
     });
+    if (response.kind !== "runtime_processing_accepted") {
+      throw new Error("Expected runtime processing acceptance.");
+    }
 
     const expectedRunnerContainerName = "member_123--v-worker-version-current";
     expect(invocationService.prepareTokens).toHaveLength(1);
@@ -203,6 +223,16 @@ describe("hosted runner container identity", () => {
       expect.objectContaining({
         runnerContainerName: expectedRunnerContainerName,
         userId: TEST_USER_ID,
+      }),
+    );
+    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          orchestrationAttemptId: "orchestration_attempt_1",
+          standbyAllocationOutcome: "disabled",
+          workspaceAttemptId: response.runtimeAttemptId,
+        }),
+        message: "Hosted runner runtime processing accepted.",
       }),
     );
   });
@@ -922,13 +952,17 @@ describe("hosted runner container identity", () => {
       stateStore,
     });
 
-    await expect(controller.ensureForUser({
+    const response = await controller.ensureForUser({
       orchestrationAttemptId: "orchestration_attempt_standby",
       userId: TEST_USER_ID,
-    })).resolves.toMatchObject({
+    });
+    expect(response).toMatchObject({
       action: "started",
       kind: "runtime_processing_accepted",
     });
+    if (response.kind !== "runtime_processing_accepted") {
+      throw new Error("Expected runtime processing acceptance.");
+    }
 
     expect(standby.bindStandbySlot).toHaveBeenCalledTimes(1);
     expect(claimReadyStandby).toHaveBeenCalledTimes(1);
@@ -936,6 +970,16 @@ describe("hosted runner container identity", () => {
     await expect(stateStore.readState()).resolves.toMatchObject({
       writeFence: { runnerContainerName: slotName },
     });
+    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          orchestrationAttemptId: "orchestration_attempt_standby",
+          standbyAllocationOutcome: "claimed",
+          workspaceAttemptId: response.runtimeAttemptId,
+        }),
+        message: "Hosted runner runtime processing accepted.",
+      }),
+    );
   });
 
   it("caps standby claim dispatch at the foreground command budget", async () => {


### PR DESCRIPTION
## Outcome

Successful fresh runtime starts now record the closed standby allocation outcome on the same structured acceptance record that already carries the orchestration and workspace attempt IDs. This makes claimed-standby latency causally attributable without logging a member, slot, or container identifier.

Retries, failed preparation, and superseded starts still do not emit an accepted attribution.

## Product UX

- Product UX: not applicable.
- Reason: This is internal production observability only; it changes no member-visible behavior, copy, timing, or recovery path.

## Evidence

- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/hosted-runner-container-identity.test.ts` — 27 tests passed, including exact `claimed` and standby-off attempt correlation.
- `pnpm --dir apps/cloudflare typecheck` — passed.
- `pnpm complexity:diff` — passed with no complexity movement.
- `git diff --check` — passed.

## Non-obvious affected surfaces

- Hosted runner structured logs: the existing successful acceptance record gains one additive closed-enum detail. Focused controller tests prove both claimed and standby-off values beside the exact attempt IDs.
- Hosted runtime protocol documentation: records that accepted attribution is emitted only for successful fresh starts.

## Architecture and reuse

- Existing systems reused: The existing standby resolution enum and existing hosted-runner acceptance log remain the only owners.
- New logic: One existing enum value is copied into the accepted record's details.
- New abstractions: None; the existing resolution result and structured-log contract are sufficient.
- Complexity intentionally avoided: No second telemetry stream, trace state, join table, identifier, network call, database call, or awaited work was added.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` passed; source complexity debt stayed 9 to 9 and maximum stayed 27 to 27.
- Hotspots: Existing `ensureExistingRuntimeProcessing` (27) and `startRuntimeProcessing` (22) remain above 20 with no complexity increase from this patch.
- Agent judgment: Further simplification is not justified; the production change is one property on its existing owner record.

## Hot reply path impact

- Not applicable: This decorates an already-emitted post-handoff structured log. It adds no database, network, provider, awaited, retry, timeout, or fallback operation.

## Murph initial provider input impact

- Murph: Not applicable; no prompt, instruction, tool, schema, or generated guidance changes.
- Codex: Not applicable; no provider-visible input surface changes.

## Change-shape breakdown

Classification is by repository path; source is runtime TypeScript, tests/fixtures are test TypeScript, and docs are authored Markdown. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1 | 0 |
| Tests/fixtures | 48 | 4 |
| Docs | 4 | 1 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 53 | 5 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Old Worker versions omit the additive field; new Worker versions emit it. Existing log consumers tolerate both shapes. Web and active warm runner-container bundles do not consume this field.
- Safe order: Deploy the Cloudflare Worker normally; no Web, database, or container-bundle tandem deploy is required.
- Rollback floor: The Worker can be rolled back at any time; rolled-back versions simply resume omitting the field.
- Expected exposure: During Worker rollout, accepted records may temporarily contain a mix of old and new log shapes.
- Reversibility: Roll back the Worker; no persisted product state or schema needs repair.
- Convergence proof: Protected deployment smoke and the live Worker version establish rollout completion.
- Post-deploy checks: Confirm the live Worker version, then observe a bounded successful standby claim and verify its accepted record contains the outcome plus both attempt IDs without elevated runtime-start failures.

## Changelog

- Changelog: not applicable
- Reason: Internal observability only; members cannot see this change.

ReviewGPT context sensitivity: sensitive — changes Cloudflare production hosted-execution observability on the runtime acceptance path.

ReviewGPT first-reviewed head: 0af68b1e8551ab92f3ab8e01170d0078676b7a90

