### PR TITLE
fix(cloudflare): allow operator task control proxy

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-01-hosted-operator-task-control-transport.md
+++ b/agent-docs/exec-plans/active/2026-09-01-hosted-operator-task-control-transport.md
@@ -1,0 +1,75 @@
+# Restore hosted operator-task control transport
+
+Status: active
+Created: 2026-09-01
+Updated: 2026-09-01
+
+## Goal
+
+- Let an already-admitted hosted operator notification reach its existing Web
+  authorization and completion owner instead of failing at Cloudflare's
+  outbound proxy boundary and retrying indefinitely.
+
+## Success criteria
+
+- The exact operator-task runtime control path is admitted only for `POST` by
+  the existing central Cloudflare Web-control policy.
+- A focused proxy regression proves the request is signed, member-bound, and
+  forwarded without caller credentials.
+- Cloudflare typecheck and the focused test pass.
+- Exact-head review, required CI, protected deployment, and live runtime proof
+  complete without changing mailbox, Temporal, or Web ownership.
+
+## Scope
+
+- In scope: one Cloudflare outbound policy entry, focused regression coverage,
+  and the existing public recovery changelog item's source provenance.
+- Out of scope: mailbox projection, retry policy, Temporal workflow behavior,
+  Web route semantics, schema, queues, schedulers, and new state.
+
+## Constraints
+
+- Technical constraints: reuse the exported route constant and the single
+  outbound policy owner; keep the existing runtime write-fence and callback
+  signing path unchanged.
+- Product/process constraints: do not expose production identifiers or private
+  runtime evidence; preserve foreground work and all current authority checks.
+
+## Risks and mitigations
+
+1. Risk: admitting a broader route or method weakens the proxy boundary.
+   Mitigation: map only the exact exported path in the existing POST policy and
+   prove GET and suffixed paths remain denied through the shared policy tests.
+2. Risk: a policy-only assertion misses transport behavior.
+   Mitigation: reuse the full outbound proxy table test, which checks signing,
+   member binding, credential stripping, body forwarding, and timeout policy.
+
+## Tasks
+
+1. Completed: added a failing full-proxy regression for the existing
+   operator-task route.
+2. Completed: added the exact route to the central Cloudflare POST policy.
+3. Completed locally: ran focused Cloudflare verification and typecheck.
+4. In progress: commit, open a draft PR, update changelog provenance, and run exact-head
+   ReviewGPT and required CI.
+5. Pending: merge, deploy through the protected Cloudflare workflow, and prove the
+   affected runtime converges without the prior allowlist failure.
+
+## Decisions
+
+- The current production blocker is the missing Cloudflare outbound policy
+  entry. Current `main` already contains the mailbox-owner correction from PR
+  2700, so this change does not alter mailbox ownership.
+- No new abstraction is warranted: the path, Web route, effects-port caller,
+  signing transport, and policy owner already exist.
+
+## Verification
+
+- Failed before the fix: focused `runner-outbound` proxy-table test, with the
+  exact operator-task POST policy resolving to `allowed: false`.
+- Passed after the fix: all 221 tests in
+  `apps/cloudflare/test/runner-outbound.test.ts`.
+- Passed: `pnpm --dir apps/cloudflare typecheck`.
+- Remaining: changelog fragment test if provenance changes, exact-head required
+  GitHub checks, ReviewGPT, merge-tree proof, protected deployment, and bounded
+  production runtime-log/control-row checks.

--- a/agent-docs/exec-plans/active/2026-09-01-hosted-operator-task-control-transport.md
+++ b/agent-docs/exec-plans/active/2026-09-01-hosted-operator-task-control-transport.md
@@ -50,8 +50,8 @@ Updated: 2026-09-01
    operator-task route.
 2. Completed: added the exact route to the central Cloudflare POST policy.
 3. Completed locally: ran focused Cloudflare verification and typecheck.
-4. In progress: commit, open a draft PR, update changelog provenance, and run exact-head
-   ReviewGPT and required CI.
+4. In progress: draft PR 2708 is open; update changelog provenance and run
+   exact-head ReviewGPT and required CI.
 5. Pending: merge, deploy through the protected Cloudflare workflow, and prove the
    affected runtime converges without the prior allowlist failure.
 

--- a/agent-docs/exec-plans/completed/2026-09-01-hosted-operator-task-control-transport.md
+++ b/agent-docs/exec-plans/completed/2026-09-01-hosted-operator-task-control-transport.md
@@ -1,6 +1,6 @@
 # Restore hosted operator-task control transport
 
-Status: active
+Status: completed
 Created: 2026-09-01
 Updated: 2026-09-01
 
@@ -50,10 +50,11 @@ Updated: 2026-09-01
    operator-task route.
 2. Completed: added the exact route to the central Cloudflare POST policy.
 3. Completed locally: ran focused Cloudflare verification and typecheck.
-4. In progress: draft PR 2708 is open; update changelog provenance and run
-   exact-head ReviewGPT and required CI.
-5. Pending: merge, deploy through the protected Cloudflare workflow, and prove the
-   affected runtime converges without the prior allowlist failure.
+4. Completed: draft PR 2708 is open and the existing recovery changelog item
+   names this PR as source provenance.
+5. Authorized follow-through: the user explicitly opted out of pre-merge
+   ReviewGPT and requested an immediate admin merge and protected Cloudflare
+   deploy, with ReviewGPT run retroactively.
 
 ## Decisions
 
@@ -70,6 +71,10 @@ Updated: 2026-09-01
 - Passed after the fix: all 221 tests in
   `apps/cloudflare/test/runner-outbound.test.ts`.
 - Passed: `pnpm --dir apps/cloudflare typecheck`.
-- Remaining: changelog fragment test if provenance changes, exact-head required
-  GitHub checks, ReviewGPT, merge-tree proof, protected deployment, and bounded
-  production runtime-log/control-row checks.
+- Passed: 9 focused changelog archive tests and
+  `pnpm --dir apps/web typecheck`.
+- Passed: `scripts/check-agent-docs-drift.sh` and `pnpm complexity:diff`.
+- Follow-through after plan closure: admin merge, protected deployment, bounded
+  production runtime-log/control-row checks, and the explicitly deferred
+  retroactive ReviewGPT audit.
+Completed: 2026-09-01

--- a/apps/cloudflare/src/runner-outbound/shared-web-control-policy.ts
+++ b/apps/cloudflare/src/runner-outbound/shared-web-control-policy.ts
@@ -55,6 +55,7 @@ import {
   HOSTED_RUNTIME_MAILBOX_PAYLOAD_FETCH_PATH,
   HOSTED_RUNTIME_MEMBER_ACTION_OUTCOME_PATH,
   HOSTED_RUNTIME_OUTBOUND_MESSAGE_VOLUME_RECEIPT_PATH,
+  HOSTED_RUNTIME_OPERATOR_TASK_CONTROL_PATH,
   HOSTED_RUNTIME_PRODUCT_FEEDBACK_RECORD_PATH,
   HOSTED_RUNTIME_PHONE_CALL_RESULT_DELIVERY_PATH,
   HOSTED_RUNTIME_THREAD_ROUTE_AUTHORITY_PATH,
@@ -117,6 +118,7 @@ export type HostedRunnerWebControlOperation =
   | "linq_delivery_outcome"
   | "linq_egress_engagement"
   | "outbound_message_volume_receipt"
+  | "operator_task_control"
   | "plan_usage_tool"
   | "subscription_tool"
   | "thread_route_authority"
@@ -182,6 +184,7 @@ const HOSTED_RUNNER_WEB_CONTROL_POST_POLICY = new Map<string, HostedRunnerWebCon
     HOSTED_RUNTIME_OUTBOUND_MESSAGE_VOLUME_RECEIPT_PATH,
     "outbound_message_volume_receipt",
   ],
+  [HOSTED_RUNTIME_OPERATOR_TASK_CONTROL_PATH, "operator_task_control"],
   [HOSTED_RUNTIME_WORKSPACE_CHECKPOINT_PATH, "workspace_checkpoint"],
   [HOSTED_RUNTIME_ISSUE_RECORD_PATH, "assistant_runtime_issue_export"],
   [HOSTED_RUNTIME_PRODUCT_FEEDBACK_RECORD_PATH, "product_feedback_recording"],

--- a/apps/cloudflare/test/runner-outbound.test.ts
+++ b/apps/cloudflare/test/runner-outbound.test.ts
@@ -89,6 +89,7 @@ import {
   HOSTED_RUNTIME_LINQ_EGRESS_DELIVERY_PATH,
   HOSTED_RUNTIME_LINQ_EGRESS_ENGAGEMENT_PATH,
   HOSTED_RUNTIME_OUTBOUND_MESSAGE_VOLUME_RECEIPT_PATH,
+  HOSTED_RUNTIME_OPERATOR_TASK_CONTROL_PATH,
   HOSTED_RUNTIME_PHONE_CALL_RESULT_DELIVERY_PATH,
   HOSTED_RUNTIME_PRODUCT_FEEDBACK_RECORD_PATH,
   HOSTED_RUNTIME_PLAN_USAGE_TOOL_PATH,
@@ -217,6 +218,16 @@ type HostedSystemProgressProjection = Required<Pick<
   | "systemMailboxProgressGeneration"
 >>;
 const ALLOWLISTED_WEB_CONTROL_CASES = [
+  {
+    body: {
+      action: "authorize",
+      expiresAt: "2036-08-25T18:10:00.000Z",
+      requestId: "assistant.notification.requested:operator-task:opt_synthetic",
+      taskId: "opt_synthetic",
+    },
+    name: "hosted operator task control",
+    path: HOSTED_RUNTIME_OPERATOR_TASK_CONTROL_PATH,
+  },
   {
     body: {
       action: "upgrade_edge",

--- a/apps/web/changelog/entries/2026-09-01/background-work-recovers-from-stale-timers.json
+++ b/apps/web/changelog/entries/2026-09-01/background-work-recovers-from-stale-timers.json
@@ -9,6 +9,6 @@
     "summary": "Murph now recovers when connected-device work overlaps an outdated assistant timer, the behind-the-scenes cleanup after a reply, or newly reported health data.",
     "details": "Current conversations, reminders, and pending deliveries keep priority. Completed replies finish cleanup without sending duplicate text, while queued connected-health updates continue in order without needing an unrelated message to restart them.",
     "relevanceTags": ["assistant", "wearables", "reliability"],
-    "sourcePullRequests": [2682, 2693, 2702]
+    "sourcePullRequests": [2682, 2693, 2702, 2708]
   }
 }


### PR DESCRIPTION
## Why and outcome

An existing hosted operator notification reaches the runtime, but Cloudflare rejects its existing Web control callback because the exact route is absent from the central outbound policy. The task then retries without progress.

This adds the already-exported route to the existing exact-path POST policy. The current Web route, runtime write fence, callback signing, task authorization, retry owner, and mailbox ownership stay unchanged.

## Product UX

- Effort: Patch.
- Walkthrough: Ready. A member with an already-admitted background notification gets the existing message after its Web-owned authorization succeeds. There is no new interaction or UI.
- Exclusions: No mailbox, Temporal, task semantics, provider prompt, or delivery policy changes.

## Evidence

- Before fix: the focused full-proxy regression resolved the exact operator-task POST path as disallowed.
- After fix: all 221 tests in apps/cloudflare/test/runner-outbound.test.ts pass.
- Passed: pnpm --dir apps/cloudflare typecheck.
- Passed: 9 focused changelog archive tests.
- Passed: pnpm --dir apps/web typecheck.
- Passed: scripts/check-agent-docs-drift.sh.
- Passed: pnpm complexity:diff.
- ReviewGPT: explicitly deferred by the user until after the immediate admin merge and deploy.

## Non-obvious affected surfaces

- Cloudflare runner outbound Web-control proxy: admits one existing exact POST path and retains the same runtime write-fence validation, member binding, callback signing, credential stripping, timeout, and body limits. Covered by the full proxy-table regression.
- Hosted operator notification recovery: the unchanged effects port can now reach its unchanged Web authorization and completion owner. Existing assistant-runtime and Web route tests cover those owners.
- No database, Temporal workflow, mailbox projection, provider input, or frontend surface changes.

## Architecture and reuse

- Existing systems reused: the exported hosted-execution route constant, central Cloudflare POST policy map, existing signed Web-control transport, runtime fence, and Web route.
- New logic: one exact route-to-operation policy mapping.
- New abstractions: none; the existing policy map is the canonical owner.
- Complexity intentionally avoided: no queue, scheduler, retry layer, compatibility shim, state field, route duplicate, or mailbox ownership change.

## Complexity impact

- Guard: pnpm complexity:diff passes.
- Hotspots: no changed-file functions above 20; policy max remains 10.
- Agent judgment: no further simplification is justified because the final behavior is one mapping in the existing source of truth.

## Hot reply path impact

Not applicable. The change only affects an already-admitted background operator notification at the Cloudflare outbound proxy; it does not alter durable conversation acceptance through provider start or reply handoff.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, instruction, tool schema, generated guidance, or provider-visible request assembly changed.
- Codex runtime: Not applicable; no prompt, instruction, tool schema, generated guidance, or provider-visible request assembly changed.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: The only hosted Web change is source provenance on an existing changelog item; archive rendering and copy are unchanged.
- Coverage: The focused archive test server-rendered all nine current changelog cases. No viewport or interaction changed.

## Change-shape breakdown

Classification: production TypeScript is source, Vitest code is tests/fixtures, the completed execution plan and changelog provenance are docs/content, and no generated or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 3 | 0 |
| Tests/fixtures | 11 | 0 |
| Docs | 76 | 1 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 90 | 1 |

## Deployment concerns

- Deployment: applicable
- Supported skew: The Web route and runtime caller already exist. Old Cloudflare Worker versions continue the prior retryable rejection; the new Worker forwards the same request. No record or payload shape changes.
- Safe order: Deploy Cloudflare only; no Vercel or Temporal deployment is required.
- Rollback floor: There is no schema or compatibility floor. Reverting only restores the prior blocked behavior.
- Expected exposure: During gradual Worker traffic movement, attempts handled by an old version can still retry until the new version owns traffic.
- Reversibility: The policy entry is independently reversible, with no state cleanup.
- Convergence proof: After full traffic, the affected task advances through its existing Web control owner and the prior allowlist failure stops.
- Post-deploy checks: Confirm the deployed Cloudflare version and traffic, then inspect bounded runtime-log aggregates and the affected control frontier for forward progress.

## Changelog

- Changelog: updated
- Items: 2026-09-01 · background-work-recovers-from-stale-timers

## Risks

- Trust boundary: admission remains exact-path and POST-only, behind the existing runtime fence and signed member-bound transport. The full proxy regression proves caller credentials are stripped and replaced by the Worker signature.

ReviewGPT context sensitivity: sensitive because the merged change affects a production outbound trust boundary.
ReviewGPT first-reviewed head: 4db37a8e5602ef72a72e2c3ec1e8ff2f9f2f6aa4
