### PR TITLE
Protect standby shells for foreground starts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1587,6 +1587,11 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   readiness and atomic availability only; the per-member `UserRunner` persists
   the exact opaque stop target, binds it once, then owns the ordinary write
   fence, workspace restore, invocation, retention, and retirement. Standby
+  allocation is available only to a fresh, OIDC-authenticated Web-direct
+  `default` start with a validated direct-attempt identity. Background modes,
+  Temporal starts, and replacements of work already using the member's exact
+  container retain that exact target. A previously reserved standby is
+  reconciled before this eligibility check so retries cannot split ownership.
   readiness warms the image, heavy runtime, and a disposable content-free Codex
   initialization, while the member-specific resident Codex process remains
   post-restore. Claimed containers are never returned for another member.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1592,9 +1592,10 @@ Only five packages are published to npm: `@murphai/contracts`, `@murphai/hosted-
   Temporal starts, and replacements of work already using the member's exact
   container retain that exact target. A previously reserved standby is
   reconciled before this eligibility check so retries cannot split ownership.
-  readiness warms the image, heavy runtime, and a disposable content-free Codex
-  initialization, while the member-specific resident Codex process remains
-  post-restore. Claimed containers are never returned for another member.
+  Standby readiness warms the image, heavy runtime, and a disposable
+  content-free Codex initialization, while the member-specific resident Codex
+  process remains post-restore. Claimed containers are never returned for
+  another member.
 - The same Cloudflare app owns one production database-health singleton that is
   deliberately independent of hosted Web and Postgres. A five-minute Cron
   Trigger asks a SQLite-backed `DatabaseHealthDurableObject` to discover and

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -376,10 +376,13 @@ Last verified: 2026-09-01
 - Cloudflare standby allocation is an optional one-slot optimization, not a
   scheduler. `off` is the source-controlled default, `shadow` maintains and
   re-proves one current-release ENAM slot without allocating it, and `allocate`
-  uses one 250 ms claim/bind deadline. A miss before slot ownership uses the
-  ordinary exact-user fallback; an ambiguous bind after the per-member stop
-  target is durably reserved retries that exact target instead of risking two
-  live containers.
+  offers one 250 ms claim/bind deadline only to a fresh, authenticated
+  Web-direct `default` start. Temporal and background starts, plus foreground
+  replacement of work already using the member's exact container, keep the
+  ordinary exact-user target. A miss before slot ownership uses that same
+  fallback; an ambiguous bind after the per-member stop target is durably
+  reserved retries that exact target instead of risking two live containers.
+  Pending and retained targets are reconciled before fresh-claim eligibility.
   A coordinator transaction admits at most one winner, then replacement
   provisioning runs under `waitUntil`; alarms re-prove readiness, retry failed
   retirement, expire unbound claim tombstones, and drain stale releases. The

--- a/agent-docs/exec-plans/active/2026-09-02-foreground-standby-admission.md
+++ b/agent-docs/exec-plans/active/2026-09-02-foreground-standby-admission.md
@@ -54,6 +54,10 @@ Updated: 2026-09-02
 3. Risk: the direct foreground request can lose the existing race to Temporal.
    Mitigation: retain ordinary exact-user startup and measure the resulting
    claimed/fallback cohort before considering any pool expansion.
+4. Risk: background completion can clear the observed fence while foreground
+   preemption awaits its abort, making the continuation look like a fresh start.
+   Mitigation: keep fence-free clear loss on the existing `replaced` path; only
+   a returned live successor fence re-enters generic convergence.
 
 ## Tasks
 
@@ -79,6 +83,10 @@ Updated: 2026-09-02
   evidence.
 - Keep one ready shell. Raising `max_instances` alone does not create a pool and
   a multi-shell coordinator would not remove background priority inversion.
+- ReviewGPT round 1 found a valid replacement-completion race. The correction
+  changes no state or contract: both clear outcomes share the existing
+  replacement start, with replacement timing recorded only when this request
+  actually cleared the fence.
 
 ## Verification
 
@@ -91,3 +99,6 @@ Updated: 2026-09-02
   remains intact; no new hot-path await or provider-input change; live claimed
   events carry trusted direct identity and background work no longer drains the
   shared ready slot.
+- Review remediation proof: the combined controller and container-identity
+  suite passes 197 tests, including completion clearing the exact fence before
+  abort acceptance; Cloudflare typecheck and `git diff --check` pass.

--- a/agent-docs/exec-plans/active/2026-09-02-foreground-standby-admission.md
+++ b/agent-docs/exec-plans/active/2026-09-02-foreground-standby-admission.md
@@ -1,0 +1,93 @@
+# Protect standby shells for foreground starts
+
+Status: active
+Created: 2026-09-02
+Updated: 2026-09-02
+
+## Goal
+
+- Reserve fresh shared standby claims for trusted Web-direct foreground starts,
+  while preserving ordinary exact-user startup and existing-container reuse for
+  background work and retries.
+
+## Success criteria
+
+- A trusted Web-direct default request may claim the ready standby.
+- Temporal/default, `system_mailbox`, retention, and spoofed-direct requests do
+  not call the standby coordinator and instead use the exact-user container.
+- An already pending or bound standby remains the exact retry target regardless
+  of the retry caller, so late binding cannot split one member across targets.
+- Existing active exact-user or bound-standby containers continue to be reused.
+- Focused Cloudflare tests and typecheck pass, exact-head CI is green, final
+  ReviewGPT is resolved, and production proof shows claimed allocations are
+  trusted Web-direct default attempts only.
+
+## Scope
+
+- In scope: fresh standby admission in the Cloudflare runtime-processing
+  controller; focused admission and retry-race coverage; owning runtime docs;
+  a safe public changelog decision; protected Cloudflare rollout and bounded
+  live verification.
+- Out of scope: increasing the one-slot ready pool, changing the 100-instance
+  capacity ceiling, adding a scheduler or queue, changing Temporal contracts,
+  or guaranteeing standby use when Temporal wins the existing startup race.
+
+## Constraints
+
+- Technical constraints: reuse the OIDC-derived `triggeredByWebDirect` flag,
+  validated `web-ingress-<UUID>` identity, normalized default mode, existing
+  pending-target recovery, and ordinary exact-user fallback. Add no persisted
+  state, database work, network call, or deploy variable.
+- Product/process constraints: preserve foreground priority, background
+  recovery, member/container ownership, private evidence boundaries, exact-head
+  review/CI, and protected deploy verification.
+
+## Risks and mitigations
+
+1. Risk: a caller could assert foreground eligibility without trusted identity.
+   Mitigation: require both the route-authored direct flag and the existing
+   validated direct attempt id.
+2. Risk: a Temporal retry could abandon a late-bound standby and create a
+   duplicate exact-user target.
+   Mitigation: evaluate pending/retained targets before fresh-claim eligibility
+   and preserve the existing fence convergence path.
+3. Risk: the direct foreground request can lose the existing race to Temporal.
+   Mitigation: retain ordinary exact-user startup and measure the resulting
+   claimed/fallback cohort before considering any pool expansion.
+
+## Tasks
+
+1. Confirm exclusive ownership on current `origin/main` and map the exact
+   admission/race tests.
+2. Add the smallest trusted foreground eligibility rule after pending-target
+   recovery and before a new coordinator claim.
+3. Update focused tests, runtime documentation, and the changelog decision.
+4. Run focused proof, Product UX walkthrough, complexity guard, and parent diff
+   review.
+5. Commit, open the draft PR, mark the exact candidate Ready, and run CI plus
+   final ReviewGPT concurrently.
+6. Resolve gates, merge, deploy through the protected Cloudflare workflow, and
+   verify live claimed allocations before retiring the worktree.
+
+## Decisions
+
+- Product UX effort: Patch.
+- Outcome: foreground messages get first access to the existing ready shell.
+- Reaches: fresh hosted Linq and Assistant Ask Web-direct starts; members with
+  an existing exact-user or bound-standby container continue on that container.
+- Proof: focused admission/race tests plus post-deploy allocation and latency
+  evidence.
+- Keep one ready shell. Raising `max_instances` alone does not create a pool and
+  a multi-shell coordinator would not remove background priority inversion.
+
+## Verification
+
+- Commands to run: focused `hosted-runner-container-identity` tests, route
+  authorization tests already covering direct diagnostics, Cloudflare
+  typecheck, `pnpm complexity:diff`, `git diff --check`, exact-head required CI,
+  current-base merge-tree, protected deploy smoke, and a bounded live log tail.
+- Expected outcomes: only trusted Web-direct default fresh requests claim; all
+  ineligible fresh starts use the exact-user target; late-bound retry retention
+  remains intact; no new hot-path await or provider-input change; live claimed
+  events carry trusted direct identity and background work no longer drains the
+  shared ready slot.

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1627,17 +1627,23 @@ that typing hint. A memberless coordinator maintains at most one advertised
 pristine slot after exact release, image fingerprints, architecture,
 heavy-runtime, and content-free Codex App Server initialize/stop readiness all
 pass. In allocation mode, one storage transaction removes that slot from ready
-and records an opaque claim tombstone. The requesting `UserRunner` durably
-reserves the opaque stop target before immutable bind-once member attachment,
-then opens its normal write fence and restores the encrypted workspace. The
-real resident Codex App Server remains post-restore because its launch identity
-is member-specific. Coordinator claim and bind share one 250 ms deadline;
-no-ready, stale-release, or coordinator failure before slot ownership uses the
-unchanged exact-user cold target. An ambiguous bind after the opaque target is
-reserved yields for retry against that exact target instead of starting a
-second container. Replenishment, readiness re-proving, orphan retirement, and
-stale-release drain run outside the accepted-message path. A bound slot can
-be retained only by that same member under the ordinary conversation idle
+and records an opaque claim tombstone only for a fresh `started` action whose
+`default` work came from authenticated Web-direct ingress with a validated
+direct-attempt identity. Temporal starts, background processing modes, spoofed
+direct inputs, and replacement of work already using the member's exact
+container keep the unchanged exact-user target. The requesting `UserRunner`
+durably reserves the opaque stop target before immutable bind-once member
+attachment, then opens its normal write fence and restores the encrypted
+workspace. The real resident Codex App Server remains post-restore because its
+launch identity is member-specific. Coordinator claim and bind share one 250 ms
+deadline; no-ready, stale-release, or coordinator failure before slot ownership
+uses the unchanged exact-user cold target. A pending or retained standby target
+is reconciled before fresh-claim eligibility. An ambiguous bind after the
+opaque target is reserved therefore yields for retry against that exact target
+instead of starting a second container, even when the retry arrives through
+Temporal. Replenishment, readiness re-proving, orphan retirement, and
+stale-release drain run outside the accepted-message path. A bound slot can be
+retained only by that same member under the ordinary conversation idle
 lifecycle and is never returned to ready. Slot invocation,
 provider-credential minting, withdrawal, account deletion, and retirement all
 re-read the exact durable binding; a member mismatch fails closed. A successful

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -1422,9 +1422,12 @@ Core execution tuning:
 - `HOSTED_EXECUTION_RUNNER_IDLE_TTL_MS` defaults to `300000` (production sets `600000`) and controls the post-completion warm lease minted only by observed conversation activity. Reducing production from 20 minutes to 10 minutes means a follow-up in the former 11–20 minute warm window can take the existing cold-start path instead. `HOSTED_EXECUTION_RUNNER_LIFECYCLE_REEVALUATION_MS` defaults to the idle TTL when absent for rollback compatibility. Leave it unset for the additive code deploy and one legacy-TTL observation window, drain old containers, then set it to `60000` for a canary before widening the rollout. Device sync, system maintenance, replay, and generic runner activity do not extend conversation warmth. RunnerContainer derives the lease directly from the resident child process's private health watermark on every expiry, re-arms the platform timeout while the lease or active work remains, yields on uncertain cleanup state, and otherwise destroys the idle shell. An inactive old child without the watermark is cleanup-eligible; active old-child work remains protected by its independent active-work count. A replacement child starts without inheriting the old process's warmth. Dirty foreground runtime state is checkpointed by the runtime-owned idle-floor—or last-chance shutdown—`idle_shutdown` path before the invocation returns; RunnerContainer never records pending checkpoint intent.
 - `HOSTED_EXECUTION_STANDBY_MODE` defaults to `off`. `shadow` maintains one
   release-scoped ENAM standby and measures readiness without allocating it;
-  `allocate` lets `UserRunner` claim it with a 250 ms total coordinator/bind
-  deadline and uses the unchanged exact-user cold path when no ready slot is
-  available. Invalid values fail deploy/runtime parsing closed.
+  `allocate` lets only a fresh, authenticated Web-direct `default` start claim
+  it with a 250 ms total coordinator/bind deadline. Temporal starts, background
+  modes, and replacement of work already using the member's exact container use
+  the unchanged exact-user path. Pending or retained standby targets still
+  reconcile before that fresh-claim gate. Invalid values fail deploy/runtime
+  parsing closed.
 - `HOSTED_EXECUTION_VERCEL_OIDC_ENVIRONMENT` defaults to `production` for
   direct/local artifact rendering. The manual deploy workflow derives it from
   the selected `preview` or `production` target; do not configure a conflicting
@@ -1454,7 +1457,10 @@ effective standby mode, expected Worker release, and runner bundle/source
 fingerprints first. Then use `shadow` for at least one ordinary
 observation window and verify that exactly one current-release ENAM slot stays
 ready, failed/stale slots retire, and no processing reports a claimed standby.
-Only then set `allocate`; no Web or Temporal deploy is required.
+Only then set `allocate`; no Web or Temporal deploy is required. In the bounded
+post-deploy observation, require every claimed allocation to be a validated
+Web-direct `default` attempt and require Temporal or background starts to report
+the exact-user path instead of a claim.
 
 At the current 2-vCPU, 6-GiB-memory, 6-GB-disk shape, one continuously ready
 slot costs about $40.52 per average 730-hour month for allocated memory and

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -74,9 +74,11 @@ HTTP route. `HOSTED_EXECUTION_STANDBY_MODE` has three strict values:
 - `off` (the default) advertises no slot and retires any still-unclaimed slot.
 - `shadow` keeps one release-scoped ENAM slot ready but never gives it to real
   processing.
-- `allocate` atomically claims that one ready slot, immediately starts a
-  replacement in background work, and falls back to the ordinary exact-user
-  container when the claim does not finish within 250 ms.
+- `allocate` lets only a fresh, authenticated Web-direct `default` start claim
+  that one ready slot, immediately starts a replacement in background work, and
+  falls back to the ordinary exact-user container when the claim does not
+  finish within 250 ms. Temporal starts, background modes, and foreground
+  replacement of work already using the exact-user container do not claim it.
 
 The public banner and health response report the canonical effective mode.
 Deployment smoke pins the newly deployed Worker version and requires its live
@@ -96,7 +98,9 @@ slot as its exact stop target, then binds the slot once to that member and
 claim, opens the normal write fence, restores the workspace, and invokes the
 ordinary runner path. A claimed slot may remain warm only for that same member
 under the existing conversation idle lifecycle; it is retired and scrubbed,
-never returned to the standby for another member.
+never returned to the standby for another member. Pending and retained standby
+targets are resolved before fresh-claim eligibility, so a later Temporal retry
+continues the same reserved target rather than creating a second container.
 
 Hosted assistant delivery recovery comes from the encrypted local runtime outbox state inside the workspace checkpoint plus web-owned hosted-runtime logs/status.
 The runner container sends runtime internal Worker requests to normal virtual hosts such as `results.worker` and `web-control.worker`. Cloudflare Container outbound interception routes those requests back into Worker-owned handlers, using the runtime write-fence headers as authority.

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -528,10 +528,7 @@ export class RuntimeProcessingController {
 
     const requestedProcessingMode = normalizeRuntimeProcessingMode(input.input.processingMode);
     const triggeredByTrustedWebDirect =
-      input.input.orchestration?.triggeredByWebDirect === true
-      && isHostedRuntimeDirectEnsureOrchestrationAttemptId(
-        input.input.orchestrationAttemptId,
-      );
+      isTrustedWebDirectRuntimeProcessing(input.input);
     const cooperativeMailboxOwnerHandoff =
       activeFence.processingMode === "system_mailbox"
       && requestedProcessingMode === "default";
@@ -1009,6 +1006,7 @@ export class RuntimeProcessingController {
   }
 
   private async resolveFreshRunnerContainer(input: {
+    allowFreshStandbyClaim: boolean;
     commandBudget: RuntimeProcessingCommandBudget;
     exactRunnerContainerName: string;
     initialRecord: RunnerStateRecord;
@@ -1047,7 +1045,12 @@ export class RuntimeProcessingController {
       }
     }
 
-    if (readHostedStandbyMode(this.input.runnerRuntimeEnvSource) !== "allocate") {
+    if (
+      readHostedStandbyMode(this.input.runnerRuntimeEnvSource) !== "allocate"
+      || !input.allowFreshStandbyClaim
+      || normalizeRuntimeProcessingMode(input.input.processingMode) !== "default"
+      || !isTrustedWebDirectRuntimeProcessing(input.input)
+    ) {
       return {
         kind: "ready",
         runnerContainerName: input.exactRunnerContainerName,
@@ -1349,6 +1352,7 @@ export class RuntimeProcessingController {
       throw new Error("Hosted runner container identity did not match the runtime start user.");
     }
     const resolution = await this.resolveFreshRunnerContainer({
+      allowFreshStandbyClaim: input.action === "started",
       commandBudget: input.commandBudget,
       exactRunnerContainerName: runnerContainerIdentity.runnerContainerName,
       initialRecord,
@@ -1972,4 +1976,13 @@ function normalizeRuntimeProcessingMode(
       || value === "system_mailbox"
     ? value
     : "default";
+}
+
+function isTrustedWebDirectRuntimeProcessing(
+  input: RuntimeProcessingInput,
+): boolean {
+  return input.orchestration?.triggeredByWebDirect === true
+    && isHostedRuntimeDirectEnsureOrchestrationAttemptId(
+      input.orchestrationAttemptId,
+    );
 }

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -758,15 +758,13 @@ export class RuntimeProcessingController {
       generation: String(activeFence.generation),
       userId: record.userId,
     });
-    if (!cleared.cleared) {
+    if (!cleared.cleared && cleared.record.writeFence) {
       const convergedInput = withoutSupersededRuntimeFenceDiagnostics(inputAtClearStart);
       return await this.ensureExistingRuntimeProcessing({
         commandBudget: input.commandBudget,
-        input: cleared.record.writeFence
-          ? withRuntimeProcessingOrchestration(convergedInput, {
-              activeFenceObservedAtEpochMs: Date.now(),
-            })
-          : convergedInput,
+        input: withRuntimeProcessingOrchestration(convergedInput, {
+          activeFenceObservedAtEpochMs: Date.now(),
+        }),
         record: cleared.record,
         runtimeWakeStartedAt: input.runtimeWakeStartedAt,
       });
@@ -778,16 +776,17 @@ export class RuntimeProcessingController {
         userId: input.input.userId,
       });
     }
-
     const replacementFenceClearedAtEpochMs = Date.now();
-    const replacementInput = withRuntimeProcessingOrchestration(inputAtClearStart, {
-      replacedStaleFence: input.replacedStaleFence ?? true,
-      replacementFenceClearElapsedMs: Math.max(
-        0,
-        replacementFenceClearedAtEpochMs - replacementFenceClearStartedAtEpochMs,
-      ),
-      replacementFenceClearedAtEpochMs,
-    });
+    const replacementInput = cleared.cleared
+      ? withRuntimeProcessingOrchestration(inputAtClearStart, {
+          replacedStaleFence: input.replacedStaleFence ?? true,
+          replacementFenceClearElapsedMs: Math.max(
+            0,
+            replacementFenceClearedAtEpochMs - replacementFenceClearStartedAtEpochMs,
+          ),
+          replacementFenceClearedAtEpochMs,
+        })
+      : withoutSupersededRuntimeFenceDiagnostics(inputAtClearStart);
     return await this.startRuntimeProcessing({
       action: "replaced",
       commandBudget: input.commandBudget,

--- a/apps/cloudflare/test/hosted-runner-container-identity.test.ts
+++ b/apps/cloudflare/test/hosted-runner-container-identity.test.ts
@@ -953,7 +953,9 @@ describe("hosted runner container identity", () => {
     });
 
     const response = await controller.ensureForUser({
-      orchestrationAttemptId: "orchestration_attempt_standby",
+      orchestration: { triggeredByWebDirect: true },
+      orchestrationAttemptId:
+        "web-ingress-11111111-1111-4111-8111-111111111111",
       userId: TEST_USER_ID,
     });
     expect(response).toMatchObject({
@@ -973,7 +975,8 @@ describe("hosted runner container identity", () => {
     expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
       expect.objectContaining({
         details: expect.objectContaining({
-          orchestrationAttemptId: "orchestration_attempt_standby",
+          orchestrationAttemptId:
+            "web-ingress-11111111-1111-4111-8111-111111111111",
           standbyAllocationOutcome: "claimed",
           workspaceAttemptId: response.runtimeAttemptId,
         }),
@@ -981,6 +984,110 @@ describe("hosted runner container identity", () => {
       }),
     );
   });
+
+  it.each([
+    [
+      "Temporal default work",
+      {
+        orchestrationAttemptId: "temporal-default-standby-ineligible",
+      },
+    ],
+    [
+      "an untrusted direct flag",
+      {
+        orchestration: { triggeredByWebDirect: true },
+        orchestrationAttemptId: "web-ingress-invalid",
+      },
+    ],
+    [
+      "a direct-shaped id without Web authentication",
+      {
+        orchestrationAttemptId:
+          "web-ingress-22222222-2222-4222-8222-222222222222",
+      },
+    ],
+    [
+      "trusted Web-direct system-mailbox work",
+      {
+        orchestration: { triggeredByWebDirect: true },
+        orchestrationAttemptId:
+          "web-ingress-33333333-3333-4333-8333-333333333333",
+        processingMode: "system_mailbox",
+      },
+    ],
+    [
+      "trusted Web-direct retention work",
+      {
+        orchestration: { triggeredByWebDirect: true },
+        orchestrationAttemptId:
+          "web-ingress-44444444-4444-4444-8444-444444444444",
+        processingMode: "inbox_media_retention",
+      },
+    ],
+  ] as const)(
+    "uses the exact-user container without claiming standby for %s",
+    async (_label, ensureInput) => {
+      const durable = createRunnerDurableState();
+      const stateStore = new RunnerStateStore(durable.state);
+      const readyContainerNames: string[] = [];
+      const slotName =
+        "standby--v-release_1--0123456789abcdef0123456789abcdef";
+      const standby = createAllocatingStandbyHarness({ slotName, stateStore });
+      const claimReadyStandby = vi.fn(async () => ({
+        outcome: "claimed" as const,
+        slotName,
+      }));
+      const controller = new RuntimeProcessingController({
+        env: createHostedExecutionEnvironment(),
+        invocationService: new RecordingRuntimeInvocationService(),
+        runnerContainerNamespace: createHostedRunnerContainerNamespaceRouter({
+          exactUser: createRunnerContainerNamespace({ readyContainerNames }),
+          standby: standby.namespace,
+        }),
+        runnerRuntimeEnvSource: {
+          CF_VERSION_METADATA: { id: "release_1" },
+          HOSTED_EXECUTION_STANDBY_MODE: "allocate",
+        },
+        standbyContainerNamespace: standby.namespace,
+        standbyCoordinatorNamespace: {
+          getByName() {
+            return {
+              claimReadyStandby,
+              async ensureReadyStandby() {
+                return { accepted: true } as const;
+              },
+            };
+          },
+        },
+        stateStore,
+      });
+
+      await expect(controller.ensureForUser({
+        ...ensureInput,
+        userId: TEST_USER_ID,
+      })).resolves.toMatchObject({
+        action: "started",
+        kind: "runtime_processing_accepted",
+      });
+
+      expect(claimReadyStandby).not.toHaveBeenCalled();
+      expect(standby.bindStandbySlot).not.toHaveBeenCalled();
+      expect(readyContainerNames).toEqual([
+        resolveHostedExecutionRunnerContainerName({
+          source: { CF_VERSION_METADATA: { id: "release_1" } },
+          userId: TEST_USER_ID,
+        }),
+      ]);
+      expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: expect.objectContaining({
+            standbyAllocationOutcome: "disabled",
+          }),
+          message: "Hosted runner selected a fresh container target.",
+        }),
+      );
+    },
+  );
 
   it("caps standby claim dispatch at the foreground command budget", async () => {
     vi.useFakeTimers();
@@ -1025,7 +1132,9 @@ describe("hosted runner container identity", () => {
 
     await createController(boundedClaim).ensureForUser({
       commandTimeoutMs,
-      orchestrationAttemptId: "standby-budget-bounded",
+      orchestration: { triggeredByWebDirect: true },
+      orchestrationAttemptId:
+        "web-ingress-55555555-5555-4555-8555-555555555555",
       userId: TEST_USER_ID,
     });
 
@@ -1039,7 +1148,9 @@ describe("hosted runner container identity", () => {
     await createController(expiredClaim).ensureForUser({
       commandStartedAtEpochMs: Date.now() - 101,
       commandTimeoutMs,
-      orchestrationAttemptId: "standby-budget-expired",
+      orchestration: { triggeredByWebDirect: true },
+      orchestrationAttemptId:
+        "web-ingress-66666666-6666-4666-8666-666666666666",
       userId: TEST_USER_ID,
     });
 
@@ -1094,7 +1205,9 @@ describe("hosted runner container identity", () => {
     });
 
     const first = controller.ensureForUser({
-      orchestrationAttemptId: "standby-bind-late",
+      orchestration: { triggeredByWebDirect: true },
+      orchestrationAttemptId:
+        "web-ingress-77777777-7777-4777-8777-777777777777",
       userId: TEST_USER_ID,
     });
     await vi.waitFor(() => expect(claimReadyStandby).toHaveBeenCalledOnce());
@@ -1114,7 +1227,8 @@ describe("hosted runner container identity", () => {
       claimDelayMs + bindDelayMs - HOSTED_STANDBY_CLAIM_TIMEOUT_MS,
     );
     const retained = controller.ensureForUser({
-      orchestrationAttemptId: "standby-bind-retained",
+      orchestrationAttemptId: "temporal-standby-bind-retained",
+      processingMode: "system_mailbox",
       userId: TEST_USER_ID,
     });
     await vi.waitFor(() =>

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -4175,9 +4175,10 @@ describe("HostedUserRunner execution coordination", () => {
   });
 
   it.each([
-    ["retention-only", "default", "inbox_media_retention", undefined, false],
-    ["retention-only", "system-mailbox", "inbox_media_retention", "system_mailbox", false],
-    ["system-mailbox", "default", "system_mailbox", undefined, true],
+    ["retention-only", "default", "inbox_media_retention", undefined, false, false],
+    ["retention-only", "system-mailbox", "inbox_media_retention", "system_mailbox", false, false],
+    ["system-mailbox", "default", "system_mailbox", undefined, true, false],
+    ["completing system-mailbox", "default", "system_mailbox", undefined, true, true],
   ] as const)(
     "preempts active %s work before starting %s processing",
     async (
@@ -4186,6 +4187,7 @@ describe("HostedUserRunner execution coordination", () => {
       activeProcessingMode,
       processingMode,
       triggeredByWebDirect,
+      completeDuringAbort,
     ) => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
@@ -4303,6 +4305,15 @@ describe("HostedUserRunner execution coordination", () => {
     expect(ensureRuntimeProcessingSettled).toBe(false);
     expect(invoke).not.toHaveBeenCalled();
     expect(runnerContainerNames[0]).toBe(activeRunnerContainerName);
+    if (completeDuringAbort) {
+      await expect(runner.recordRuntimeCompletionFromContainer({
+        attemptId: token.attemptId,
+        generation: String(token.generation),
+        result: { nextWakeAt: null, status: "idle" },
+        userId: TEST_USER_ID,
+      })).resolves.toEqual({ completed: true });
+      expect(readRunnerMeta(sql).active_attempt_id).toBeNull();
+    }
     abortResult.resolve("accepted");
 
     await expect(ensureRuntimeProcessing).resolves.toMatchObject({
@@ -4327,7 +4338,7 @@ describe("HostedUserRunner execution coordination", () => {
       processingMode,
     );
     expect(invoke.mock.calls[0]?.[0].orchestration).toMatchObject({
-      replacedStaleFence: false,
+      ...(completeDuringAbort ? {} : { replacedStaleFence: false }),
       ...(triggeredByWebDirect
         ? {
             runtimeInvocationOrchestrationAttemptId: orchestrationAttemptId,
@@ -4335,6 +4346,11 @@ describe("HostedUserRunner execution coordination", () => {
           }
         : {}),
     });
+    if (completeDuringAbort) {
+      expect(invoke.mock.calls[0]?.[0].orchestration).not.toHaveProperty(
+        "replacedStaleFence",
+      );
+    }
     expect(readRunnerMeta(sql)).toMatchObject({
       active_attempt_id: expect.not.stringMatching(token.attemptId),
       active_expires_at: null,

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1154,7 +1154,9 @@ describe("HostedUserRunner execution coordination", () => {
     const ensure = harness.runner.ensureRuntimeProcessingForUser({
       commandTimeoutMs:
         HOSTED_RUNTIME_PROCESSING_COMMAND_RESPONSE_MARGIN_MS + foregroundBudgetMs,
-      orchestrationAttemptId: "standby-binding-timeout",
+      orchestration: { triggeredByWebDirect: true },
+      orchestrationAttemptId:
+        "web-ingress-99999999-9999-4999-8999-999999999999",
       userId: TEST_USER_ID,
     });
     await bindingReadStarted.promise;
@@ -4215,21 +4217,43 @@ describe("HostedUserRunner execution coordination", () => {
     const runnerRuntimeEnvSource = {
       ...TEST_RUNNER_RUNTIME_ENV_SOURCE,
       CF_VERSION_METADATA: { id: "current" },
+      HOSTED_EXECUTION_STANDBY_MODE: "allocate",
     };
     const priorRunnerContainerName = `${TEST_USER_ID}--v-prior`;
     const currentRunnerContainerName = `${TEST_USER_ID}--v-current`;
+    const activeRunnerContainerName = triggeredByWebDirect
+      ? currentRunnerContainerName
+      : priorRunnerContainerName;
+    const claimReadyStandby = vi.fn(async () => ({
+      outcome: "no_ready_slot" as const,
+    }));
     const { invoke, runner, runnerContainerNames, sql } = createRunnerHarness({
       abortWorkspaceInvocation,
       ensureProcessing,
       invocationResults: [invocationResult.promise],
       readActiveRuntimeUserFence,
       runnerRuntimeEnvSource,
+      standbyContainerNamespace: {
+        getByName() {
+          throw new Error("Background preemption must reuse the exact-user container.");
+        },
+      },
+      standbyCoordinatorNamespace: {
+        getByName() {
+          return {
+            claimReadyStandby,
+            async ensureReadyStandby() {
+              return { accepted: true } as const;
+            },
+          };
+        },
+      },
       workspace: createWorkspaceState({ version: "7" }),
     });
     await runner.bindUser(TEST_USER_ID);
     const token = writeRuntimeFenceForTest(sql, {
       processingMode: activeProcessingMode,
-      runnerContainerName: priorRunnerContainerName,
+      runnerContainerName: activeRunnerContainerName,
       workspaceVersion: "7",
     });
     activeAttemptId = token.attemptId;
@@ -4278,7 +4302,7 @@ describe("HostedUserRunner execution coordination", () => {
     expect(abortWorkspaceInvocation).toHaveBeenCalledOnce();
     expect(ensureRuntimeProcessingSettled).toBe(false);
     expect(invoke).not.toHaveBeenCalled();
-    expect(runnerContainerNames[0]).toBe(priorRunnerContainerName);
+    expect(runnerContainerNames[0]).toBe(activeRunnerContainerName);
     abortResult.resolve("accepted");
 
     await expect(ensureRuntimeProcessing).resolves.toMatchObject({
@@ -4295,6 +4319,7 @@ describe("HostedUserRunner execution coordination", () => {
       userId: TEST_USER_ID,
     });
     expect(ensureProcessing).not.toHaveBeenCalled();
+    expect(claimReadyStandby).not.toHaveBeenCalled();
     expect(ensureRuntimeProcessingSettled).toBe(true);
     expect(invoke).toHaveBeenCalledOnce();
     expect(runnerContainerNames).toContain(currentRunnerContainerName);

--- a/apps/web/changelog/entries/2026-08-30/replies-wake-sooner-after-idle-time.json
+++ b/apps/web/changelog/entries/2026-08-30/replies-wake-sooner-after-idle-time.json
@@ -6,9 +6,9 @@
     "kind": "improvement",
     "priority": 2,
     "title": "Replies recover cleanly after idle time",
-    "summary": "After an idle period, Murph now wakes sooner and keeps established conversations ready to continue.",
-    "details": "When a full workspace restore is needed, Murph opens the restored state with a fresh assistant process so replies do not wait on stale local state.",
+    "summary": "After an idle period, Murph now saves its ready-to-go assistant for your current conversation and keeps established conversations ready to continue.",
+    "details": "Background work keeps its ordinary startup and cannot take that ready assistant. If the faster path is unavailable, Murph falls back to the durable startup; a full workspace restore still opens with a fresh assistant process.",
     "relevanceTags": ["assistant", "performance", "reliability"],
-    "sourcePullRequests": [2584, 2617]
+    "sourcePullRequests": [2584, 2615, 2617, 2712]
   }
 }


### PR DESCRIPTION
## Outcome

Reserves fresh standby claims for trusted Web-direct foreground starts. Temporal work, background modes, spoofed direct inputs, and foreground replacement of work already using the member's exact container now keep the ordinary exact-user target instead of draining the shared ready shell.

Pending and retained standby targets still reconcile before eligibility, so a late bind or Temporal retry cannot split one member across two containers.

## Product UX

- Effort: Patch
- Affected people: Hosted members sending a foreground message after idle time, especially while background work is starting or already active.
- Result: Background work can no longer consume the one shared ready shell before an eligible current conversation. Existing exact-user and bound-standby conversations keep their current container.
- UI/copy: No interface change. The existing public reply-recovery changelog item is updated.

## Evidence

- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/hosted-runner-container-identity.test.ts apps/cloudflare/test/user-runner-alarm.test.ts` (197 passed)
- Focused Worker route proof for OIDC-derived direct attribution and fail-closed invalid credentials (3 passed)
- `pnpm --dir apps/cloudflare typecheck`
- `pnpm --dir apps/web test -- changelog-page.test.tsx` (9 passed)
- `pnpm --dir apps/web typecheck`
- `pnpm complexity:diff` (changed-file debt 9 to 7; max 27 to 25)
- `git diff --check`

## Non-obvious affected surfaces

- Fresh allocation only: an already reserved standby remains the same member's retry target regardless of whether the retry arrives directly or through Temporal.
- Replacement only: a foreground message preempting device-sync, system-mailbox, or retention work on the exact container reuses that exact container and does not claim standby, including when background completion wins the fence-clear race.
- No Durable Object schema, Temporal contract, request body, container capacity, or deployment-variable change.

## Architecture and reuse

- Existing systems reused: route-authored `triggeredByWebDirect`, validated `web-ingress-<UUID>` identity, normalized processing mode, pending-target reconciliation, and exact-user fallback.
- New logic: one local fresh-claim eligibility predicate before the existing coordinator call, plus one distinction between a live successor fence and completion-won fence clearing.
- New abstractions: None; the existing state-store result, controller branch, and replacement start path remain the only owners.
- Complexity intentionally avoided: no scheduler, persisted state, state owner, network call, Temporal contract, or pool redesign.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` reports changed-file debt reduced from 9 to 7 and maximum complexity reduced from 27 to 25.
- Hotspots: The admission predicate gates the existing standby coordinator call, while both fence-free replacement outcomes share the existing replacement start call.
- Agent judgment: The patch removes duplicate eligibility checks and adds no state, abstraction, lifecycle owner, network call, or protocol surface.

## Hot reply path impact

Eligible foreground starts retain the existing bounded 250 ms claim/bind path. Ineligible starts skip that coordinator RPC and go directly to the existing exact-user path. There is no new await.

## Provider-input impact

None. Assistant prompts, model input, credentials, and provider transport are unchanged.

## Deployment concerns

- Deployment: applicable
- Supported skew: Web and Temporal remain protocol-compatible, and either Worker revision can call the current runner because this patch does not change the runner RPC contract.
- Safe order: Deploy the Cloudflare Worker and container application through the protected workflow as one verified release; no Web or Temporal ordering is required.
- Rollback floor: Roll back only to a verified Cloudflare release with a matching Worker/container application pair; do not perform a Worker-only rollback across a container-version boundary.
- Expected exposure: During rollout, old Workers retain the prior broader standby eligibility while new Workers enforce foreground-only fresh claims; existing exact-user and retained standby targets remain valid.
- Reversibility: The protected workflow can restore the last verified compatible Cloudflare release without data migration because this patch adds no schema, persisted state, or protocol field.
- Convergence proof: Post-deploy live binding proof must show the Worker and container application are the versions published by the same protected workflow run.
- Post-deploy checks: Confirm trusted Web-direct default starts can claim standby, background and Temporal starts use the exact-user path, foreground replacement reuses the exact-user container, and admitted messages reach runner acceptance and assistant staging.

## Changelog

- Changelog: updated
- Items: 2026-08-30 · replies-wake-sooner-after-idle-time

## ReviewGPT

ReviewGPT context sensitivity: sensitive

Reason: this changes production hosted-runtime admission at an authentication-derived foreground boundary.

ReviewGPT first-reviewed head: cff892896dd9edb6f95d6bbd92ebb93a140fc935

Round 1 found one valid completion-before-abort-response race. The accepted correction is pushed at `ca523a136443484dfc1b53b8df88ca8efdb00a5f`; it adds no state or abstraction and preserves replacement provenance through that interleaving.

Round 2 fresh full audit at `ca523a136443484dfc1b53b8df88ca8efdb00a5f`: PASS with no findings. The reviewer verified the prior race is resolved, the regression exercises the real completion entry point, and the correction adds no state or lifecycle owner. [Review thread](https://chatgpt.com/c/6a98349a-4284-83ea-bee8-c82a347054e3).

## Change shape

- Source: +32 / -20
- Tests/fixtures: +168 / -13
- Docs: +158 / -29
- Config/tooling: +0 / -0
- Generated/other: +0 / -0
