### PR TITLE
fix(assistant): preserve group input order

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-01-group-reply-coalescing-race.md
+++ b/agent-docs/exec-plans/active/2026-09-01-group-reply-coalescing-race.md
@@ -2,7 +2,7 @@
 
 Status: active
 Created: 2026-09-01
-Updated: 2026-09-01
+Updated: 2026-09-02
 
 ## Goal
 
@@ -27,6 +27,8 @@ Updated: 2026-09-01
   the invocation-local recovered prefix, and a fully missed multi-message
   prefix drains in the same admission rather than one message per provider
   request.
+- Exact-conversation and room-route discoveries share one global cursor order,
+  so a later same-actor message cannot leapfrog an earlier group participant.
 - Focused runtime/engine tests, package typechecks, a production-derived
   synthetic real-Codex group journey, privacy/diff checks, exact-head
   ReviewGPT, and required CI pass.
@@ -74,6 +76,8 @@ Updated: 2026-09-01
 4. Inspect complexity, privacy, docs/changelog, final diff, and close the plan.
 5. Commit, push, open the PR, then run exact-head ReviewGPT concurrently with
    required CI and resolve any accepted findings.
+6. Follow up the merged change by proving the store-backed A1-B1-A2 ordering
+   gap and removing the strict-first composition path.
 
 ## Decisions
 
@@ -88,6 +92,10 @@ Updated: 2026-09-01
   source, retain its authoritative conversation prefix, add only notified or
   route candidates not already discovered, order once, and accept the complete
   valid prefix within the existing cumulative cap.
+- Exact-conversation discovery remains the eligibility authority for its
+  results, but those results enter the same sorted selector as notification and
+  route discoveries. This preserves compatibility without a second ordering
+  path or another frontier.
 
 ## Verification
 
@@ -98,16 +106,20 @@ Updated: 2026-09-01
   commit test pass; the assistant-runtime package typecheck passes.
 - Review regression proof: both the missed-predecessor notification case and a
   fully missed three-message room prefix failed before the admission collapse
-  and now pass; the full assistant auto-reply runtime suite passes 189/189 and
-  both assistant package typechecks pass.
+  and now pass. A production-faithful store-backed A1-B1-A2 regression then
+  failed because A2 was admitted ahead of B1; it passes after globally ordering
+  all discovery results. The full assistant auto-reply runtime suite passes
+  190/190.
 - Real-Codex journey: passed against the production group prompt/tool surface.
   After the admission collapse, the synthetic rapid clarification again
   produced one final response that plainly said the resistance type and level
   were unknown. Product UX verdict: Ready.
-- Candidate checks: full assistant auto-reply runtime suite 189/189, hosted
+- Candidate checks: full assistant auto-reply runtime suite 190/190, hosted
   turn-input suite 39/39, workspace foreground handoff suite 86/86, held-group
   single-commit regression, both package typechecks, complexity guard, and
-  privacy/diff checks all pass.
+  privacy/diff checks all pass. The follow-up assistant-engine package suite
+  also passes 4,296 tests across 268 files, alongside its package typecheck,
+  complexity guard, docs drift, and diff hygiene checks.
 - Remaining: exact-head ReviewGPT, required CI, final parent diff review, and
   plan closure.
 
@@ -123,3 +135,6 @@ Updated: 2026-09-01
 - 2026-09-01: resolved the second review finding by composing recovered and
   notified inputs at the existing admission owner and draining the bounded
   valid prefix without adding state, a timer, or another queue.
+- 2026-09-02: after the original change merged, reproduced a remaining
+  strict-first ordering gap against the real store-backed input source and
+  collapsed strict, exact, and route discoveries into one ordered selector.

--- a/agent-docs/exec-plans/completed/2026-09-01-group-reply-coalescing-race.md
+++ b/agent-docs/exec-plans/completed/2026-09-01-group-reply-coalescing-race.md
@@ -1,6 +1,6 @@
 # Collapse group reply coalescing registration race
 
-Status: active
+Status: completed
 Created: 2026-09-01
 Updated: 2026-09-02
 
@@ -138,3 +138,4 @@ Updated: 2026-09-02
 - 2026-09-02: after the original change merged, reproduced a remaining
   strict-first ordering gap against the real store-backed input source and
   collapsed strict, exact, and route discoveries into one ordered selector.
+Completed: 2026-09-02

--- a/packages/assistant-engine/src/assistant/automation/reply.ts
+++ b/packages/assistant-engine/src/assistant/automation/reply.ts
@@ -2887,45 +2887,35 @@ async function listAutoReplyActiveTurnInputs(input: {
         sourceId: expectedChannel,
       })
     : { inputs: [], nextCursor: exact.nextCursor }
-  const lastStrictInput = strict.inputs.at(-1)
-  const additional = selectAutoReplyRouteInputs({
-    acceptedLiveInputIds: [
-      ...input.context.inputIds,
-      ...strict.inputs.map((candidate) => candidate.event.inputId),
-    ],
-    afterCursor: strict.nextCursor ?? input.afterCursor,
-    candidates: [...exact.inputs, ...route.inputs],
+  return selectAutoReplyActiveTurnInputs({
+    acceptedLiveInputIds: input.context.inputIds,
+    afterCursor: input.afterCursor,
+    candidates: [...strict.inputs, ...exact.inputs, ...route.inputs],
     conversation: input.conversation,
+    conversationInputIds: strict.inputs.map(
+      (candidate) => candidate.event.inputId,
+    ),
     deliveryTarget: bindingDeliveryTarget,
     expectedChannel,
     anchorSummary:
-      lastStrictInput
-        ? assistantAutomationInputSummaryFromCandidate(lastStrictInput)
-        : input.context.items.at(-1)?.summary ?? input.context.firstItem.summary,
-    knownProjectionCaptureIds: [
-      ...input.knownProjectionCaptureIds,
-      ...strict.inputs.flatMap((candidate) =>
-        candidate.projection.captureId ? [candidate.projection.captureId] : []
-      ),
-    ],
+      input.context.items.at(-1)?.summary ?? input.context.firstItem.summary,
+    knownProjectionCaptureIds: input.knownProjectionCaptureIds,
   })
-  return {
-    inputs: [...strict.inputs, ...additional.inputs],
-    nextCursor: additional.nextCursor,
-  }
 }
 
-function selectAutoReplyRouteInputs(input: {
+function selectAutoReplyActiveTurnInputs(input: {
   acceptedLiveInputIds: readonly string[]
   afterCursor: AssistantInputCandidate['event']['cursor']
   anchorSummary: AssistantAutomationInputSummary
   candidates: readonly AssistantInputCandidate[]
   conversation: AssistantInputConversationRef
+  conversationInputIds: readonly string[]
   deliveryTarget: string
   expectedChannel: string
   knownProjectionCaptureIds: readonly string[]
 }): AssistantInputCandidateBatch {
   const acceptedLiveInputIds = new Set(input.acceptedLiveInputIds)
+  const conversationInputIds = new Set(input.conversationInputIds)
   const knownProjectionCaptureIds = new Set(input.knownProjectionCaptureIds)
   const seenInputIds = new Set<string>()
   const selectedInputs: AssistantInputCandidate[] = []
@@ -2938,20 +2928,29 @@ function selectAutoReplyRouteInputs(input: {
       continue
     }
     seenInputIds.add(candidate.event.inputId)
-    if (!isSameAutoReplyDeliveryRoute({
-      accountId: input.conversation.accountId,
-      candidate,
-      expectedChannel: input.expectedChannel,
-      threadIsDirect: input.conversation.threadIsDirect,
-      threadId: input.deliveryTarget,
-    })) {
+    const isConversationInput = conversationInputIds.has(
+      candidate.event.inputId,
+    )
+    if (
+      !isConversationInput &&
+      !isSameAutoReplyDeliveryRoute({
+        accountId: input.conversation.accountId,
+        candidate,
+        expectedChannel: input.expectedChannel,
+        threadIsDirect: input.conversation.threadIsDirect,
+        threadId: input.deliveryTarget,
+      })
+    ) {
       continue
     }
     const candidateSummary =
       assistantAutomationInputSummaryFromCandidate(candidate)
+    // Exact-conversation discovery already proves eligibility, but it still
+    // shares this ordered stream so an earlier route barrier cannot be skipped.
     // A trusted edit follows the exact accepted input it corrects rather than
     // the provider reply anchor. The admission gate revalidates the same link.
     if (
+      !isConversationInput &&
       !shouldGroupAdjacentConversationInput(
         input.anchorSummary,
         candidateSummary,

--- a/packages/assistant-engine/test/assistant-automation-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-automation-runtime.test.ts
@@ -23,6 +23,7 @@ import {
   type AssistantActiveTurnInputCheckpointInput,
 } from '../src/assistant/turn-input.ts'
 import {
+  assistantInputCandidateFromStoredEvent,
   createStoreBackedAssistantInputSource,
   type AssistantInputCandidate,
   type AssistantInputSource,
@@ -9732,6 +9733,136 @@ describe('assistant auto-reply runtime', () => {
     expect(evidenceMocks.writeAssistantAutoReplyReplyIntentEvidence)
       .toHaveBeenCalledWith(expect.objectContaining({
         inputIds: [initialInput.event.inputId],
+      }))
+  })
+
+  it('keeps a later exact-conversation input behind an earlier group actor from the store', async () => {
+    const context = await createTempVaultContext(
+      'assistant-reply-store-group-order-',
+    )
+    tempRoots.push(context.parentRoot)
+    const stageInput = async (input: {
+      actorId: string
+      laneSeq: string
+      messageId: string
+      occurredAt: string
+      text: string
+    }) => assistantInputCandidateFromStoredEvent(
+      await upsertAssistantInputEvent({
+        event: {
+          content: {
+            text: input.text,
+            userMessageContent: [{ text: input.text, type: 'text' }],
+          },
+          conversation: {
+            accountId: 'safe_acct_store_group_order',
+            actorId: input.actorId,
+            actorIsSelf: false,
+            source: 'linq',
+            threadId: 'hidden_store_group_order_thread',
+            threadIsDirect: false,
+          },
+          occurredAt: input.occurredAt,
+          receivedAt: input.occurredAt,
+          replyTarget: {
+            channel: 'linq',
+            messageId: input.messageId,
+            threadId: 'real_store_group_order_thread',
+          },
+          sourceRef: {
+            dedupeKey: `dedupe_store_group_order_${input.laneSeq}`,
+            eventId: `event_store_group_order_${input.laneSeq}`,
+            itemId: `item_store_group_order_${input.laneSeq}`,
+            kind: 'hosted-mailbox',
+            lane: 'conversation',
+            laneSeq: input.laneSeq,
+            payloadSchema: 'murph.hosted-mailbox-payload.v1',
+            payloadSource: 'inline',
+            source: 'hosted-mailbox',
+            wakeSchema: 'murph.hosted-execution-wake.v1',
+          },
+        },
+        vault: context.vaultRoot,
+      }),
+    )
+    const initial = await stageInput({
+      actorId: 'safe_actor_store_a',
+      laneSeq: '1',
+      messageId: 'store_group_order_message_a1',
+      occurredAt: '2026-04-08T00:03:00.000Z',
+      text: 'first message from actor A',
+    })
+    await stageInput({
+      actorId: 'safe_actor_store_b',
+      laneSeq: '2',
+      messageId: 'store_group_order_message_b1',
+      occurredAt: '2026-04-08T00:04:00.000Z',
+      text: 'intervening message from actor B',
+    })
+    await stageInput({
+      actorId: 'safe_actor_store_a',
+      laneSeq: '3',
+      messageId: 'store_group_order_message_a2',
+      occurredAt: '2026-04-08T00:05:00.000Z',
+      text: 'later message from actor A',
+    })
+    const inputSource = createStoreBackedAssistantInputSource({
+      vault: context.vaultRoot,
+    })
+    let admissionResult: unknown
+    replyMocks.sendAssistantMessage.mockImplementation(async (input: {
+      activeTurnInput?: (admission: {
+        availableInputIds?: readonly string[]
+        sessionId: string
+        turnId: string
+        vault: string
+      }) => Promise<unknown>
+    }) => {
+      admissionResult = await input.activeTurnInput?.({
+        availableInputIds: [],
+        sessionId: 'session-store-group-order',
+        turnId: 'turn-store-group-order',
+        vault: context.vaultRoot,
+      })
+      return {
+        delivery: {
+          channel: 'linq',
+          target: 'real_store_group_order_thread',
+          sentAt: '2026-04-08T00:10:00.000Z',
+        },
+        deliveryDeferred: false,
+        deliveryError: null,
+        deliveryIntentId: 'intent-store-group-order',
+        response: 'response to actor A',
+        session: { sessionId: 'session-store-group-order' },
+      }
+    })
+    const reply = await vi.importActual<typeof import('../src/assistant/automation/reply.ts')>(
+      '../src/assistant/automation/reply.ts',
+    )
+    const group = reply.createAssistantAutoReplyGroupContext([
+      createCapturelessReplyGroupItem(initial),
+    ])
+    if (!group) {
+      throw new Error('expected store-backed group context')
+    }
+
+    const result = await reply.processAssistantAutoReplyGroup({
+      allowSelfAuthored: false,
+      context: group,
+      enabledChannels: ['linq'],
+      inboxServices: createInboxServices({ show: vi.fn() }),
+      inputSource,
+      requestId: null,
+      sessionMaxAgeMs: null,
+      vault: context.vaultRoot,
+    })
+
+    expect(result.replied).toBe(1)
+    expect(admissionResult).toEqual({ kind: 'no-new-input' })
+    expect(evidenceMocks.writeAssistantAutoReplyReplyIntentEvidence)
+      .toHaveBeenCalledWith(expect.objectContaining({
+        inputIds: [initial.event.inputId],
       }))
   })
 


### PR DESCRIPTION
## Why and outcome

Follow-up to #2701. Exact-conversation discovery was concatenated ahead of room-route discovery, so a later same-actor message could leapfrog an earlier participant in the same group stream.

All strict conversation, exact notification, and room-route candidates now enter one deduplicated cursor-ordered selector. Exact-conversation results retain their existing eligibility proof, while earlier participant barriers remain authoritative.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Rapid group inputs remain one room-scoped batch when eligible; a later same-actor input can no longer bypass an earlier participant. Direct-message policy, provider lifecycle, and the existing 50-input cap are unchanged.

## Evidence

- Direct: The new store-backed A1-B1-A2 regression failed on the merged baseline by admitting A2 while omitting the earlier B1 barrier, then passed after the selection collapse.
- Coverage: The full assistant auto-reply runtime file passes 190/190. The complete assistant-engine package passes 4,296 tests across 268 files, and its package typecheck passes.

## Non-obvious affected surfaces

- Exact conversation compatibility remains source-authoritative, covered by the existing email, direct, reaction, correction, projection, causal-gap, and source-unavailable runtime cases in the exhaustive package pass.
- Cursor/frontier behavior is covered by the store-backed ordering regression and the existing missed-predecessor, fully missed prefix, replay, and 50-input-cap cases.

## Architecture and reuse

- Existing systems reused: Store-backed input source, active-turn admission owner, cursor comparator, route predicate, and adjacent-group selector.
- New logic: None; the existing discovery results are composed before the existing selection policy instead of splitting strict inputs into a privileged first path.
- New abstractions: None; the private selector is renamed for its broader existing responsibility.
- Complexity intentionally avoided: No queue, buffer, timer, state owner, schema, retry loop, or compatibility layer.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; changed-file debt remains 111 and maximum remains 47.
- Hotspots: Existing hotspots in `reply.ts` are unchanged; this patch adds no complexity debt and removes a separate ordering frontier.
- Agent judgment: No further production restructuring is justified. One selector now owns ordering and barrier enforcement, while the source retains eligibility ownership.

## Hot reply path impact

- Path status: Touched — active-turn candidate composition only.
- Database calls: None added or moved; the same strict, exact, and route reads remain.
- Network/provider calls: None added or moved.
- Other awaited latency: None; the change is an in-memory set lookup, dedupe, and existing cursor sort over the same bounded candidates.
- Before/after proof: The store-backed regression proves A2 was previously admitted ahead of B1 and is now held behind B1; exhaustive package tests preserve the existing query and delivery contracts.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Initial provider input is unchanged; this patch only governs later active-turn candidate ordering.
- Measurement method: Not run — no initial provider-input surface changed.

## Risks

- Ordering is safety-sensitive because incorrect composition can omit or misorder participant messages. The store-backed regression exercises the exact actor-sensitive query behavior that the prior mocked route test missed.

ReviewGPT context sensitivity: sensitive - Hosted group conversation ordering and reply delivery are changed.

## Deployment concerns

- Deployment: applicable
- Supported skew: No schema or persisted-format change; old and new runner versions can coexist, with each in-flight turn retaining its loaded code behavior.
- Safe order: Ordinary runner bundle rollout; no coordinated database or web deployment is required.
- Rollback floor: None beyond the current main schema; code can roll back without data migration.
- Expected exposure: During gradual rollout, old warm runners may retain the strict-first edge case until recycled.
- Reversibility: Revert the runner bundle; no new durable data exists.
- Convergence proof: Confirm the deployed runner version has converged, then exercise the synthetic rapid group journey.
- Post-deploy checks: Verify one reply for a rapid multi-participant group burst and inspect bounded reply-error and provider-to-delivery aggregates.

## Change-shape breakdown

Classification rule: Authored production TypeScript is source, runtime tests are tests/fixtures, and the execution-plan update is docs. No binary or generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 28 | 29 |
| Tests / fixtures | 131 | 0 |
| Docs | 22 | 6 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **181** | **35** |

## Changelog

- Changelog: not applicable
- Reason: This is a correctness follow-up to the existing `2026-09-01 · rapid-group-followups-stay-together` item already on main; no second member-visible announcement is warranted.


ReviewGPT first-reviewed head: 975255c7e3abd79924baa1ca490179ab311115ee



## ReviewGPT round 1

- Reviewed head: `975255c7e3abd79924baa1ca490179ab311115ee`
- Outcome: PASS — no qualifying findings.
- Model: `gpt-5.6-sol`


- Final PR head: `85d5ad52a9d288aae998874ddfaade491c919148` — docs-only plan closure after PASS; the production diff is identical to the reviewed head.


