### PR TITLE
fix(runtime): admit fresh device data through retained retry

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1233,10 +1233,11 @@ Last verified: 2026-09-01
   for another. A later due webhook for that same connection may admit the older
   exact retained mailbox item so newly dirty data can enter the local worker
   without waiting behind a historical retry. That webhook remains available for
-  an exact continuation when post-checkpoint acknowledgement reports a newer
-  coalesced dirty revision; once acknowledgement proves no newer revision
-  remains, the existing mailbox retention update atomically defers the webhook
-  to the retained retry, including when payload-only work is still in backoff.
+  an exact continuation only when post-checkpoint acknowledgement reports a
+  newer coalesced dirty revision and the retained job hints prove the next pass
+  has admission capacity. Otherwise, the existing mailbox retention update
+  atomically defers the webhook to the retained retry, including payload-only
+  backoff and a full retained queue that cannot yet admit distinct dirty work.
   The retained wake's job hints suppress provider scheduling,
   and each local job keeps its own `availableAt`, so these bounded passes neither
   run the later mailbox item out of order nor bypass provider backoff.

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1230,13 +1230,17 @@ Last verified: 2026-09-01
   runner rebuilds from those owners; it never projects local retry timing into
   `nextReconcileAt`. Per-connection mailbox ordering and scheduler scoping
   prevent a future retry for one connection from blocking or advancing due work
-  for another. A later due webhook for that same connection may admit one pass
-  through the older exact retained mailbox item so newly dirty data can enter
-  the local worker without waiting behind a historical retry. The retained
-  wake's job hints suppress provider scheduling, and each local job keeps its
-  own `availableAt`, so this admission neither runs the later mailbox item out
-  of order nor bypasses provider backoff. Scheduled-reconcile successors do not
-  grant that admission. Per-attempt `device-sync.job_failed` telemetry has one owner:
+  for another. A later due webhook for that same connection may admit the older
+  exact retained mailbox item so newly dirty data can enter the local worker
+  without waiting behind a historical retry. That webhook remains available for
+  an exact continuation when post-checkpoint acknowledgement reports a newer
+  coalesced dirty revision; once acknowledgement proves the connection clean,
+  the existing mailbox retention update atomically defers the webhook to the
+  historical retry. The retained wake's job hints suppress provider scheduling,
+  and each local job keeps its own `availableAt`, so these bounded passes neither
+  run the later mailbox item out of order nor bypass provider backoff.
+  Scheduled-reconcile successors do not grant admission. Per-attempt
+  `device-sync.job_failed` telemetry has one owner:
   assistant-runtime maintenance emits it from the failed local job diagnostic
   before Web state application. Web persists canonical failure state and never
   translates state application or a persistence failure into another provider or

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1230,7 +1230,13 @@ Last verified: 2026-09-01
   runner rebuilds from those owners; it never projects local retry timing into
   `nextReconcileAt`. Per-connection mailbox ordering and scheduler scoping
   prevent a future retry for one connection from blocking or advancing due work
-  for another. Per-attempt `device-sync.job_failed` telemetry has one owner:
+  for another. A later due webhook for that same connection may admit one pass
+  through the older exact retained mailbox item so newly dirty data can enter
+  the local worker without waiting behind a historical retry. The retained
+  wake's job hints suppress provider scheduling, and each local job keeps its
+  own `availableAt`, so this admission neither runs the later mailbox item out
+  of order nor bypasses provider backoff. Scheduled-reconcile successors do not
+  grant that admission. Per-attempt `device-sync.job_failed` telemetry has one owner:
   assistant-runtime maintenance emits it from the failed local job diagnostic
   before Web state application. Web persists canonical failure state and never
   translates state application or a persistence failure into another provider or

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1234,9 +1234,10 @@ Last verified: 2026-09-01
   exact retained mailbox item so newly dirty data can enter the local worker
   without waiting behind a historical retry. That webhook remains available for
   an exact continuation when post-checkpoint acknowledgement reports a newer
-  coalesced dirty revision; once acknowledgement proves the connection clean,
-  the existing mailbox retention update atomically defers the webhook to the
-  historical retry. The retained wake's job hints suppress provider scheduling,
+  coalesced dirty revision; once acknowledgement proves no newer revision
+  remains, the existing mailbox retention update atomically defers the webhook
+  to the retained retry, including when payload-only work is still in backoff.
+  The retained wake's job hints suppress provider scheduling,
   and each local job keeps its own `availableAt`, so these bounded passes neither
   run the later mailbox item out of order nor bypass provider backoff.
   Scheduled-reconcile successors do not grant admission. Per-attempt

--- a/agent-docs/exec-plans/completed/2026-09-02-device-sync-dirty-wake-recovery.md
+++ b/agent-docs/exec-plans/completed/2026-09-02-device-sync-dirty-wake-recovery.md
@@ -1,0 +1,95 @@
+# Recover fresh device data behind a retained retry
+
+Status: completed
+Created: 2026-09-02
+Updated: 2026-09-02
+
+## Goal
+
+- Let a fresh same-connection device webhook admit one bounded device-sync pass
+  even when an older exact continuation is waiting on its own local retry time.
+  Preserve the older job's provider backoff and exact mailbox ownership while
+  allowing newly arrived dirty data to be collected without waiting behind it.
+
+## Success criteria
+
+- A focused regression reproduces an older future retained device item followed
+  by a due webhook item for the same connection.
+- The older exact item owns the admitted pass; the later item is not executed
+  out of order, and the retained job's own availability remains unchanged.
+- A later scheduled-reconcile duplicate does not bypass provider backoff.
+- Different-connection concurrency and ordinary same-connection ordering stay
+  covered by the existing suite.
+- The fix is merged, the hosted runner is deployed, and the affected member
+  shows a new device pass plus forward sync progress.
+
+## Scope
+
+- In scope: assistant-runtime system-mailbox selection and wake projection,
+  focused synthetic coverage, durable retry documentation, and member-facing
+  recovery copy.
+- Out of scope: provider retry-delay policy, mailbox or workspace schemas,
+  Temporal wire changes, manual production database mutation, and new queues or
+  persisted owners.
+
+## Constraints
+
+- Technical constraints: preserve per-connection serialization and the local
+  device job store as the only retry-time owner; a newer webhook is admission
+  authority for a pass, not authority to make an older provider job due.
+- Product/process constraints: keep production evidence private, use only
+  synthetic fixtures in the repository, recheck public and private PR overlap
+  before push and merge, and follow the high-risk runtime PR/deploy gates.
+
+## Risks and mitigations
+
+1. Risk: a repeated scheduled reconciliation could accidentally hammer a
+   provider before its retained retry time.
+   Mitigation: allow only a due same-connection `webhook_hint` successor to
+   admit the older frontier, and prove scheduled duplicates remain blocked.
+2. Risk: executing the later webhook row directly could split local continuation
+   ownership across two mailbox items.
+   Mitigation: select the older exact frontier for the pass; leave the later row
+   durable and ordered behind it.
+3. Risk: wake projection and execution selection diverge again.
+   Mitigation: derive both from one helper and cover both the candidate resolver
+   and the end-to-end system-mailbox entrypoint.
+
+## Tasks
+
+1. Completed: added the failing same-connection retained-retry/webhook regression.
+2. Completed: implemented the smallest shared admission projection and updated the durable
+   reliability contract.
+3. Completed: ran focused tests, package typecheck, complexity, diff/privacy
+   checks, and the Product UX walkthrough; committed and opened draft PR #2723.
+4. Complete exact-head CI and ReviewGPT, merge, deploy the Cloudflare runner,
+   and verify live member recovery.
+
+## Decisions
+
+- Treat the previously merged mailbox-owner fix as necessary but insufficient:
+  it enabled the affected frontier to run and exposed a separate starvation
+  case caused by a legitimate 24-hour historical retry ahead of fresh dirty
+  webhook work.
+- Keep Temporal unchanged. Its repeated no-progress probes are downstream of
+  the hidden local retry, while the user-visible delay is owned by runtime
+  same-connection admission.
+- A due webhook admits the older exact retained item only when one of its
+  retained job hints owns the same future retry timestamp. This excludes outer
+  transient failures and scheduled-reconcile duplicates from early admission.
+
+## Verification
+
+- Commands to run: focused mailbox-state and system-mailbox entrypoint Vitest
+  suites; assistant-runtime typecheck; `pnpm complexity:diff`; changelog checks;
+  `git diff --check`; identifier scan; exact-head GitHub checks and final
+  ReviewGPT.
+- Expected outcomes: the regression fails on the old selector, passes with the
+  shared admission rule, all neighboring ordering/backoff cases stay green, and
+  production records a new device pass followed by updated sync completion or
+  an explicit provider-level terminal diagnosis.
+- Local results: the focused regression failed with no selected item before the
+  change. After the change, 20 mailbox-state tests, 62 system-mailbox execution
+  tests, 53 entrypoint tests, and 46 changelog tests pass; assistant-runtime
+  typecheck, complexity, diff, and private-identifier checks pass.
+Completed: 2026-09-02

--- a/apps/web/changelog/entries/2026-09-01/background-work-recovers-in-order.json
+++ b/apps/web/changelog/entries/2026-09-01/background-work-recovers-in-order.json
@@ -6,9 +6,9 @@
     "kind": "improvement",
     "priority": 4,
     "title": "Background work recovers in order",
-    "summary": "Murph now resumes delayed connected-health and routine background work in order instead of repeatedly waking without making progress.",
-    "details": "Current conversations and approved actions still run first. A delayed item waits for its recovery time, then its queued follow-ups continue without needing an unrelated message to restart them.",
+    "summary": "Murph now resumes delayed connected-health and routine background work in order instead of repeatedly waking without progress or letting an older retry delay fresh device data.",
+    "details": "Current conversations and approved actions still run first. Existing provider retries keep their recovery timing, while a fresh device update can start a bounded sync pass without needing an unrelated message.",
     "relevanceTags": ["wearables", "assistant", "reliability"],
-    "sourcePullRequests": [2682, 2693, 2700, 2710]
+    "sourcePullRequests": [2682, 2693, 2700, 2710, 2723]
   }
 }

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox-state.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox-state.ts
@@ -409,14 +409,18 @@ function resolveHostedSystemMailboxWakeCandidatesFromState(input: {
   defaultOwned: HostedRuntimeWakeCandidate;
   next: HostedSystemMailboxWakeCandidate;
 } {
-  const { now, state } = input;
-  const remainingState = input.excludeItemId
+  const { now } = input;
+  const remainingStateBeforeAdmission = input.excludeItemId
     ? {
-        pending: state.pending.filter((item) =>
+        pending: input.state.pending.filter((item) =>
           item.itemId !== input.excludeItemId
         ),
       }
-    : state;
+    : input.state;
+  const remainingState = projectHostedSystemMailboxRetainedDeviceWebhookAdmission({
+    now,
+    state: remainingStateBeforeAdmission,
+  });
   const wakeOwnerState = projectHostedSystemMailboxWakeOwnerFrontier(
     remainingState,
   );
@@ -539,10 +543,13 @@ export function findNextHostedSystemMailboxQueueItem(input: {
   now: string;
   state: HostedSystemMailboxState;
 }): HostedSystemMailboxPendingItem | null {
-  const state = excludeExpiredHostedGroupContextHandoffSystemMailboxItems(
-    input.state,
-    input.now,
-  );
+  const state = projectHostedSystemMailboxRetainedDeviceWebhookAdmission({
+    now: input.now,
+    state: excludeExpiredHostedGroupContextHandoffSystemMailboxItems(
+      input.state,
+      input.now,
+    ),
+  });
   if (input.allowedRouteActions == null) {
     const approvedContinuation = state.pending.find((item) =>
       systemMailboxItemIsDue(item, input.now)
@@ -568,6 +575,70 @@ export function findNextHostedSystemMailboxQueueItem(input: {
     ...input,
     state,
   });
+}
+
+export function projectHostedSystemMailboxRetainedDeviceWebhookAdmission(input: {
+  now: string;
+  state: HostedSystemMailboxState;
+}): HostedSystemMailboxState {
+  const futureRetainedByConnection = new Map<
+    string,
+    HostedSystemMailboxPendingItem
+  >();
+  const admittedItemIds = new Set<string>();
+
+  for (const item of input.state.pending) {
+    if (
+      item.routeAction !== "run-device-sync-wake"
+      || item.wake.kind !== "device-sync.wake"
+      || !item.wake.connectionId
+    ) {
+      continue;
+    }
+    const connectionId = item.wake.connectionId;
+    const retained = futureRetainedByConnection.get(connectionId);
+    if (!retained) {
+      if (isHostedFutureRetainedDeviceJobRetry(item, input.now)) {
+        futureRetainedByConnection.set(connectionId, item);
+      }
+      continue;
+    }
+    if (
+      item.wake.reason === "webhook_hint"
+      && systemMailboxItemIsDue(item, input.now)
+    ) {
+      admittedItemIds.add(retained.itemId);
+    }
+  }
+
+  return admittedItemIds.size === 0
+    ? input.state
+    : {
+        pending: input.state.pending.map((item) =>
+          admittedItemIds.has(item.itemId)
+            ? { ...item, nextAttemptAt: null }
+            : item
+        ),
+      };
+}
+
+function isHostedFutureRetainedDeviceJobRetry(
+  item: HostedSystemMailboxPendingItem,
+  now: string,
+): boolean {
+  if (
+    item.status !== "pending"
+    || item.postCheckpointRecord !== null
+    || item.nextAttemptAt === null
+    || item.wake.kind !== "device-sync.wake"
+    || !item.wake.connectionId
+    || systemMailboxItemIsDue(item, now)
+  ) {
+    return false;
+  }
+  return item.wake.hint?.jobs?.some((job) =>
+    job.availableAt === item.nextAttemptAt
+  ) === true;
 }
 
 function findNextHostedSystemMailboxQueueItemByOrder(input: {

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox-state.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox-state.ts
@@ -586,6 +586,7 @@ export function projectHostedSystemMailboxRetainedDeviceWebhookAdmission(input: 
     HostedSystemMailboxPendingItem
   >();
   const admittedItemIds = new Set<string>();
+  const deferredWebhookRetryAtByItemId = new Map<string, string>();
 
   for (const item of input.state.pending) {
     if (
@@ -607,18 +608,29 @@ export function projectHostedSystemMailboxRetainedDeviceWebhookAdmission(input: 
       item.wake.reason === "webhook_hint"
       && systemMailboxItemIsDue(item, input.now)
     ) {
+      const retainedRetryAt = retained.nextAttemptAt;
+      if (retainedRetryAt === null) {
+        continue;
+      }
       admittedItemIds.add(retained.itemId);
+      deferredWebhookRetryAtByItemId.set(item.itemId, retainedRetryAt);
     }
   }
 
   return admittedItemIds.size === 0
     ? input.state
     : {
-        pending: input.state.pending.map((item) =>
-          admittedItemIds.has(item.itemId)
-            ? { ...item, nextAttemptAt: null }
-            : item
-        ),
+        pending: input.state.pending.map((item) => {
+          if (admittedItemIds.has(item.itemId)) {
+            return { ...item, nextAttemptAt: null };
+          }
+          const deferredRetryAt = deferredWebhookRetryAtByItemId.get(
+            item.itemId,
+          );
+          return deferredRetryAt
+            ? { ...item, nextAttemptAt: deferredRetryAt }
+            : item;
+        }),
       };
 }
 

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox-state.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox-state.ts
@@ -586,7 +586,6 @@ export function projectHostedSystemMailboxRetainedDeviceWebhookAdmission(input: 
     HostedSystemMailboxPendingItem
   >();
   const admittedItemIds = new Set<string>();
-  const deferredWebhookRetryAtByItemId = new Map<string, string>();
 
   for (const item of input.state.pending) {
     if (
@@ -608,29 +607,18 @@ export function projectHostedSystemMailboxRetainedDeviceWebhookAdmission(input: 
       item.wake.reason === "webhook_hint"
       && systemMailboxItemIsDue(item, input.now)
     ) {
-      const retainedRetryAt = retained.nextAttemptAt;
-      if (retainedRetryAt === null) {
-        continue;
-      }
       admittedItemIds.add(retained.itemId);
-      deferredWebhookRetryAtByItemId.set(item.itemId, retainedRetryAt);
     }
   }
 
   return admittedItemIds.size === 0
     ? input.state
     : {
-        pending: input.state.pending.map((item) => {
-          if (admittedItemIds.has(item.itemId)) {
-            return { ...item, nextAttemptAt: null };
-          }
-          const deferredRetryAt = deferredWebhookRetryAtByItemId.get(
-            item.itemId,
-          );
-          return deferredRetryAt
-            ? { ...item, nextAttemptAt: deferredRetryAt }
-            : item;
-        }),
+        pending: input.state.pending.map((item) =>
+          admittedItemIds.has(item.itemId)
+            ? { ...item, nextAttemptAt: null }
+            : item
+        ),
       };
 }
 
@@ -1375,7 +1363,7 @@ function resolveHostedSystemMailboxSerializationKey(
   return item.routeAction;
 }
 
-function systemMailboxItemIsDue(
+export function systemMailboxItemIsDue(
   item: HostedSystemMailboxPendingItem,
   now: string,
 ): boolean {

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
@@ -398,8 +398,16 @@ export async function prepareHostedSystemMailboxItemForCheckpoint(input: {
         };
       }
 
+      const originalPending = state.pending.find((item) =>
+        item.itemId === pending.itemId
+      ) ?? null;
+      const pendingState =
+        originalPending !== null
+        && originalPending.nextAttemptAt !== pending.nextAttemptAt
+          ? admissionState
+          : state;
       const collapsed = collapseConsecutiveHostedBrowserVaultRefreshItems({
-        pending: state.pending,
+        pending: pendingState.pending,
         selected: pending,
       });
 

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
@@ -53,6 +53,7 @@ import {
   removeHostedSystemMailboxPendingItemIfCurrent,
   resolveHostedSystemMailboxNextWakeAt,
   resolveHostedSystemMailboxNextWakeCandidate,
+  systemMailboxItemIsDue,
   updateHostedSystemMailboxPendingItem,
   updateHostedSystemMailboxState,
   type HostedSystemMailboxPendingItem,
@@ -398,16 +399,8 @@ export async function prepareHostedSystemMailboxItemForCheckpoint(input: {
         };
       }
 
-      const originalPending = state.pending.find((item) =>
-        item.itemId === pending.itemId
-      ) ?? null;
-      const pendingState =
-        originalPending !== null
-        && originalPending.nextAttemptAt !== pending.nextAttemptAt
-          ? admissionState
-          : state;
       const collapsed = collapseConsecutiveHostedBrowserVaultRefreshItems({
-        pending: pendingState.pending,
+        pending: state.pending,
         selected: pending,
       });
 
@@ -912,6 +905,7 @@ export async function recordHostedSystemMailboxItemAfterCheckpoint(input: {
     const retainUntil = resolveHostedDeviceSyncMailboxRetentionAt(input.item);
     if (retainUntil) {
       await retainHostedDeviceSyncSystemMailboxItem({
+        connectionStillDirty: recordResult.stillDirty,
         item: input.item,
         nextAttemptAt: retainUntil,
         vaultRoot: input.vaultRoot,
@@ -997,14 +991,27 @@ function resolveHostedDeviceSyncMailboxRetentionAt(
 }
 
 async function retainHostedDeviceSyncSystemMailboxItem(input: {
+  connectionStillDirty: boolean;
   item: HostedSystemMailboxPendingItem;
   nextAttemptAt: string;
   vaultRoot: string;
 }): Promise<void> {
-  await updateHostedSystemMailboxState(input.vaultRoot, (state) => ({
-    pending: state.pending.map((item) =>
+  await updateHostedSystemMailboxState(input.vaultRoot, (state) => {
+    const retainedIndex = state.pending.findIndex((item) =>
       hostedSystemMailboxPendingItemsMatchForClaim(item, input.item)
-        ? {
+    );
+    if (retainedIndex < 0) {
+      return state;
+    }
+
+    const admittedAt = input.item.lastAttemptAt;
+    const connectionId = input.item.wake.kind === "device-sync.wake"
+      ? input.item.wake.connectionId ?? null
+      : null;
+    return {
+      pending: state.pending.map((item, index) => {
+        if (index === retainedIndex) {
+          return {
             ...input.item,
             lastErrorCode: null,
             lastErrorMessage: null,
@@ -1014,10 +1021,25 @@ async function retainHostedDeviceSyncSystemMailboxItem(input: {
             wake: input.item.postCheckpointRecord?.kind === "device-sync.dirty-processed-batch"
               ? input.item.postCheckpointRecord.retainedWake ?? input.item.wake
               : input.item.wake,
-          }
-        : item
-    ),
-  }));
+          };
+        }
+        if (
+          input.connectionStillDirty
+          || admittedAt === null
+          || connectionId === null
+          || index < retainedIndex
+          || item.routeAction !== "run-device-sync-wake"
+          || item.wake.kind !== "device-sync.wake"
+          || item.wake.connectionId !== connectionId
+          || item.wake.reason !== "webhook_hint"
+          || !systemMailboxItemIsDue(item, admittedAt)
+        ) {
+          return item;
+        }
+        return { ...item, nextAttemptAt: input.nextAttemptAt };
+      }),
+    };
+  });
 }
 
 export async function deferHostedSystemMailboxItemAfterVaultShareProjectionFailure(input: {

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
@@ -20,6 +20,7 @@ import type {
   AssistantExecutionContext,
 } from "@murphai/assistant-engine";
 
+import { HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT } from "../hosted-device-sync-limits.ts";
 import {
   createHostedAssistantChannelTypingDependencies,
 } from "./channel-activity.ts";
@@ -904,10 +905,13 @@ export async function recordHostedSystemMailboxItemAfterCheckpoint(input: {
       vaultRoot: input.vaultRoot,
     });
     const retainUntil = resolveHostedDeviceSyncMailboxRetentionAt(input.item);
+    const immediateDirtyContinuationCanProgress = retainUntil !== null
+      && recordResult.newerRevisionPending
+      && hostedDeviceSyncRetainedWakeHasCapacity(input.item);
     if (retainUntil) {
       await retainHostedDeviceSyncSystemMailboxItem({
+        immediateDirtyContinuationCanProgress,
         item: input.item,
-        newerRevisionPending: recordResult.newerRevisionPending,
         nextAttemptAt: retainUntil,
         vaultRoot: input.vaultRoot,
       });
@@ -924,7 +928,9 @@ export async function recordHostedSystemMailboxItemAfterCheckpoint(input: {
         HOSTED_DEVICE_SYNC_RECONCILE_WAKE_REASON,
       ),
       createHostedRuntimeWakeCandidate(
-        recordResult.nextWakeAt,
+        retainUntil === null || immediateDirtyContinuationCanProgress
+          ? recordResult.nextWakeAt
+          : null,
         HOSTED_DEVICE_SYNC_RECONCILE_WAKE_REASON,
       ),
     ]);
@@ -991,9 +997,23 @@ function resolveHostedDeviceSyncMailboxRetentionAt(
   return item.postCheckpointRecord.retainMailboxItemUntil ?? null;
 }
 
+function hostedDeviceSyncRetainedWakeHasCapacity(
+  item: HostedSystemMailboxPendingItem,
+): boolean {
+  if (item.postCheckpointRecord?.kind !== "device-sync.dirty-processed-batch") {
+    return false;
+  }
+  const retainedWake = item.postCheckpointRecord.retainedWake ?? item.wake;
+  const retainedJobs = retainedWake.kind === "device-sync.wake"
+    ? retainedWake.hint?.jobs
+    : undefined;
+  return retainedJobs !== undefined
+    && retainedJobs.length < HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT;
+}
+
 async function retainHostedDeviceSyncSystemMailboxItem(input: {
+  immediateDirtyContinuationCanProgress: boolean;
   item: HostedSystemMailboxPendingItem;
-  newerRevisionPending: boolean;
   nextAttemptAt: string;
   vaultRoot: string;
 }): Promise<void> {
@@ -1025,7 +1045,7 @@ async function retainHostedDeviceSyncSystemMailboxItem(input: {
           };
         }
         if (
-          input.newerRevisionPending
+          input.immediateDirtyContinuationCanProgress
           || admittedAt === null
           || connectionId === null
           || index < retainedIndex

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
@@ -47,6 +47,7 @@ import {
   isHostedGroupContextHandoffSystemMailboxItem,
   mergeHostedSystemMailboxRollbackItems,
   projectHostedSystemMailboxModelFreeFrontier,
+  projectHostedSystemMailboxRetainedDeviceWebhookAdmission,
   projectHostedSystemMailboxWakeOwnerFrontier,
   readHostedSystemMailboxState,
   removeHostedSystemMailboxPendingItemIfCurrent,
@@ -326,6 +327,11 @@ export async function prepareHostedSystemMailboxItemForCheckpoint(input: {
   >(
     input.vaultRoot,
     (state) => {
+      const admissionState =
+        projectHostedSystemMailboxRetainedDeviceWebhookAdmission({
+          now: startedAt,
+          state,
+        });
       const modelFreeProjectedState =
         input.allowedRouteActions?.includes(
           "dispatch-assistant-notification",
@@ -337,10 +343,10 @@ export async function prepareHostedSystemMailboxItemForCheckpoint(input: {
         && input.allowedWakeKinds?.includes(
           "assistant.notification.requested",
         ) === true
-          ? projectHostedSystemMailboxModelFreeFrontier(state)
+          ? projectHostedSystemMailboxModelFreeFrontier(admissionState)
           : input.allowedRouteActions == null
-            ? projectHostedSystemMailboxWakeOwnerFrontier(state)
-            : state;
+            ? projectHostedSystemMailboxWakeOwnerFrontier(admissionState)
+            : admissionState;
       const selectionState = {
         pending: modelFreeProjectedState.pending.filter((item) =>
           (

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
@@ -237,6 +237,7 @@ export type HostedSystemMailboxRuntime = Pick<
 > & Partial<Pick<NormalizedHostedAssistantRuntimeConfig, "parserToolchain">>;
 
 interface HostedSystemMailboxPostCheckpointRecordResult {
+  newerRevisionPending: boolean;
   nextWakeAt: string | null;
   recorded: number;
   stillDirty: boolean;
@@ -905,8 +906,8 @@ export async function recordHostedSystemMailboxItemAfterCheckpoint(input: {
     const retainUntil = resolveHostedDeviceSyncMailboxRetentionAt(input.item);
     if (retainUntil) {
       await retainHostedDeviceSyncSystemMailboxItem({
-        connectionStillDirty: recordResult.stillDirty,
         item: input.item,
+        newerRevisionPending: recordResult.newerRevisionPending,
         nextAttemptAt: retainUntil,
         vaultRoot: input.vaultRoot,
       });
@@ -991,8 +992,8 @@ function resolveHostedDeviceSyncMailboxRetentionAt(
 }
 
 async function retainHostedDeviceSyncSystemMailboxItem(input: {
-  connectionStillDirty: boolean;
   item: HostedSystemMailboxPendingItem;
+  newerRevisionPending: boolean;
   nextAttemptAt: string;
   vaultRoot: string;
 }): Promise<void> {
@@ -1024,7 +1025,7 @@ async function retainHostedDeviceSyncSystemMailboxItem(input: {
           };
         }
         if (
-          input.connectionStillDirty
+          input.newerRevisionPending
           || admittedAt === null
           || connectionId === null
           || index < retainedIndex
@@ -1355,6 +1356,7 @@ async function recordHostedSystemMailboxPostCheckpointRecord(input: {
         );
       }
       return {
+        newerRevisionPending: false,
         nextWakeAt: null,
         recorded: result.outcome === "delivered" ? 1 : 0,
         stillDirty: false,
@@ -1373,6 +1375,7 @@ async function recordHostedSystemMailboxPostCheckpointRecord(input: {
         await port.recordOutcome(input.record.request);
       }
       return {
+        newerRevisionPending: false,
         nextWakeAt: null,
         recorded: 1,
         stillDirty: false,
@@ -1394,6 +1397,7 @@ async function recordHostedSystemMailboxPostCheckpointRecord(input: {
         await removeHostedCodexAuthJson(input.operatorHomeRoot);
       }
       return {
+        newerRevisionPending: false,
         nextWakeAt: null,
         recorded: response.status === "superseded" ? 0 : 1,
         stillDirty: false,
@@ -1409,6 +1413,7 @@ async function recordHostedSystemMailboxPostCheckpointRecord(input: {
       }
       await deleteEnvironmentVoice(input.record.audioKey);
       return {
+        newerRevisionPending: false,
         nextWakeAt: null,
         recorded: 1,
         stillDirty: false,
@@ -1426,6 +1431,7 @@ async function recordHostedSystemMailboxPostCheckpointRecord(input: {
         input.signal ? { signal: input.signal } : undefined,
       );
       return {
+        newerRevisionPending: false,
         nextWakeAt: null,
         recorded: 1,
         stillDirty: false,
@@ -1471,6 +1477,7 @@ async function recordHostedDeviceSyncDirtyProcessedRecords(input: {
   }
 
   let nextWakeAt = input.records.length === 0 ? input.nextWakeAt ?? null : null;
+  let newerRevisionPending = false;
   let recorded = 0;
   let stillDirty = false;
 
@@ -1493,6 +1500,12 @@ async function recordHostedDeviceSyncDirtyProcessedRecords(input: {
     if (response.recorded) {
       recorded += 1;
     }
+    newerRevisionPending = newerRevisionPending || (
+      response.stillDirty
+      && response.dirtyRevision !== null
+      && response.processedRevision !== null
+      && response.dirtyRevision !== response.processedRevision
+    );
     stillDirty = stillDirty || response.stillDirty;
     if (shouldUseHostedDirtyAckWake(index, input.records.length, response.stillDirty)) {
       const onlyRetainedPayloadsRemain = response.stillDirty
@@ -1506,6 +1519,7 @@ async function recordHostedDeviceSyncDirtyProcessedRecords(input: {
   }
 
   return {
+    newerRevisionPending,
     nextWakeAt,
     recorded,
     stillDirty,

--- a/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+++ b/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
@@ -72,11 +72,13 @@ import {
   syncHostedDeviceSyncControlPlaneState,
   type HostedDeviceSyncRuntimeSyncState,
 } from "../src/hosted-device-sync-runtime.ts";
+import { HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT } from "../src/hosted-device-sync-limits.ts";
 import {
   HostedRuntimeArtifactWriteError,
   type HostedRuntimeDeviceSyncPort,
 } from "../src/hosted-runtime/platform.ts";
 import {
+  prepareHostedSystemMailboxItemForCheckpoint,
   recordHostedDeviceSyncDirtyPostCheckpointRecord,
   recordHostedSystemMailboxItemAfterCheckpoint,
 } from "../src/hosted-runtime/system-mailbox.ts";
@@ -475,6 +477,7 @@ function buildDirtyState(input: {
   dirtyRevision?: string;
   dirtyResources?: HostedExecutionDeviceSyncDirtyStateResponse["dirtyResources"];
   eventCount?: string;
+  processedRevision?: string;
   provider?: string;
   resourceCategoryCounts?: Record<string, number>;
   sourceProviderCounts?: Record<string, number>;
@@ -487,7 +490,7 @@ function buildDirtyState(input: {
     dirtyResources: input.dirtyResources ?? [],
     eventCount: input.eventCount ?? "1",
     latestDirtyAt: "2026-04-04T10:00:00.000Z",
-    processedRevision: "0",
+    processedRevision: input.processedRevision ?? "0",
     provider: input.provider ?? "demo",
     resourceCategoryCounts: input.resourceCategoryCounts ?? {},
     sourceProviderCounts: input.sourceProviderCounts ?? {},
@@ -6199,6 +6202,240 @@ describe("hosted device-sync runtime", () => {
       closeHostedRuntimeDeviceSyncService(restoredService);
       await firstWorkspace.cleanup();
       await restoredWorkspace.cleanup();
+    }
+  });
+
+  test("a full retained queue defers its webhook edge until capacity can advance", async () => {
+    const workspace = await createHostedRuntimeWorkspace(
+      "hosted-device-sync-runtime-full-retained-queue-",
+    );
+    await mkdir(workspace.vaultRoot, { recursive: true });
+    const occurredAt = "2026-04-04T10:00:00.000Z";
+    const immediateWakeAt = "2026-04-04T10:00:01.000Z";
+    const beforeRetryAt = "2026-04-04T10:05:00.000Z";
+    const retryAt = "2026-04-04T10:10:00.000Z";
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(occurredAt));
+    const connectionId = "hosted_full_retained_queue";
+    const executeJob = vi.fn(async () => ({}));
+    const service = createDeviceSyncServiceForVault(
+      workspace.vaultRoot,
+      [createFakeProvider({ jobExecutor: { executeJob } })],
+    );
+    const retainedWake = buildDeviceSyncWake({
+      connectionId,
+      eventId: "device-sync.wake:full-retained-owner",
+      hint: {
+        jobs: Array.from({ length: HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT }, (_, index) => ({
+          availableAt: retryAt,
+          dedupeKey: `retained-future-job-${index}`,
+          kind: "reconcile",
+          maxAttempts: 2,
+          priority: 30,
+        })),
+        reason: "dirty",
+      },
+      occurredAt,
+      reason: "webhook_hint",
+    });
+    const snapshot = buildRuntimeSnapshot({
+      connectionId,
+      externalAccountId: "full-retained-queue",
+    });
+    const ackDirtyStateProcessed = vi.fn(async (
+      request: Parameters<HostedRuntimeDeviceSyncPort["ackDirtyStateProcessed"]>[0],
+    ) => ({
+      connectionId,
+      dirtyRevision: "2",
+      nextWakeAt: immediateWakeAt,
+      processedRevision: request.processedRevision,
+      recorded: true,
+      stillDirty: true,
+      userId: "member_123",
+    }));
+    const port: HostedRuntimeDeviceSyncPort = {
+      ackDirtyStateProcessed,
+      async applyUpdates() {
+        throw new Error("applyUpdates should not be called during sync");
+      },
+      async createConnectLink() {
+        throw new Error("createConnectLink should not be called during sync");
+      },
+      async fetchDirtyStates() {
+        return {
+          hasMore: false,
+          items: [buildDirtyState({
+            connectionId,
+            dirtyRevision: "2",
+            dirtyResources: [{
+              count: 1,
+              dirtyPayloadId: "dsp_full_retained_queue_fresh",
+              jobKind: "resource",
+              payload: {
+                resourceId: "full-retained-queue-fresh",
+                resourceType: "activity",
+              },
+              resource: "activity",
+              resourceCategory: "activity",
+              sourceProviderSlug: "demo",
+              windowEnd: null,
+              windowStart: null,
+            }],
+            processedRevision: "1",
+          })],
+          nextWakeAt: immediateWakeAt,
+          userId: "member_123",
+        };
+      },
+      async fetchSnapshot() {
+        return snapshot;
+      },
+    };
+
+    try {
+      const syncState = await syncHostedDeviceSyncControlPlaneState({
+        deviceSyncPort: port,
+        secret: DEVICE_SYNC_SECRET,
+        service,
+        wake: retainedWake,
+      });
+      const localAccountId = syncState.hostedToLocalAccountIds.get(connectionId);
+      assert.ok(localAccountId);
+      assert.equal(readJobsForAccount(service, localAccountId).length, 100);
+      assert.deepEqual(syncState.pendingDirtyAcks, [{
+        connectionId,
+        nextWakeAt: immediateWakeAt,
+        processedRevision: "1",
+      }]);
+      assert.deepEqual(syncState.pendingDirtyPayloadJobs, []);
+      assert.equal(await service.drainWorker(100, localAccountId), 0);
+      assert.equal(executeJob.mock.calls.length, 0);
+
+      const recovery = resolveHostedDeviceSyncWakeRecovery({
+        service,
+        state: syncState,
+        wake: retainedWake,
+      });
+      assert.ok(recovery);
+      assert.equal(recovery.retryAt, retryAt);
+      assert.equal(recovery.wake.hint?.jobs?.length, HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT);
+      const retainedItem: HostedSystemMailboxPendingItem = {
+        attemptCount: 1,
+        itemId: "mailbox_item_full_retained_owner",
+        lastAttemptAt: occurredAt,
+        lastErrorCode: null,
+        lastErrorMessage: null,
+        mailboxDedupeKey: "device-sync.wake:full-retained-owner",
+        mailboxLaneSeq: "1",
+        nextAttemptAt: null,
+        occurredAt,
+        postCheckpointRecord: {
+          kind: "device-sync.dirty-processed-batch",
+          nextWakeAt: immediateWakeAt,
+          records: syncState.pendingDirtyAcks,
+          retainedWake: recovery.wake,
+          retainMailboxItemUntil: retryAt,
+        },
+        preferenceCausalSeq: null,
+        requestId: null,
+        routeAction: "run-device-sync-wake",
+        status: "recording",
+        wake: retainedWake,
+      };
+      const laterWebhook = buildDirtyDeviceSyncWake(connectionId, occurredAt);
+      await updateHostedSystemMailboxState(workspace.vaultRoot, () => ({
+        pending: [
+          retainedItem,
+          {
+            attemptCount: 0,
+            itemId: "mailbox_item_full_retained_webhook",
+            lastAttemptAt: null,
+            lastErrorCode: null,
+            lastErrorMessage: null,
+            mailboxDedupeKey: "device-sync.wake:full-retained-webhook",
+            mailboxLaneSeq: "2",
+            nextAttemptAt: null,
+            occurredAt,
+            postCheckpointRecord: null,
+            preferenceCausalSeq: null,
+            requestId: null,
+            routeAction: "run-device-sync-wake",
+            status: "pending",
+            wake: laterWebhook,
+          },
+        ],
+      }));
+
+      assert.deepEqual(await recordHostedSystemMailboxItemAfterCheckpoint({
+        item: retainedItem,
+        runtime: createDeviceSyncPostCheckpointRuntime(port),
+        vaultRoot: workspace.vaultRoot,
+      }), {
+        failed: 0,
+        nextWakeAt: retryAt,
+        nextWakeReason: "device-sync.reconcile",
+        recorded: 1,
+      });
+      assert.deepEqual(
+        (await readHostedSystemMailboxState(workspace.vaultRoot)).pending.map((item) => ({
+          itemId: item.itemId,
+          nextAttemptAt: item.nextAttemptAt,
+        })),
+        [
+          { itemId: retainedItem.itemId, nextAttemptAt: retryAt },
+          { itemId: "mailbox_item_full_retained_webhook", nextAttemptAt: retryAt },
+        ],
+      );
+      assert.equal(ackDirtyStateProcessed.mock.calls.length, 1);
+      assert.equal(
+        await prepareHostedSystemMailboxItemForCheckpoint({
+          allowedRouteActions: ["run-device-sync-wake"],
+          executionContext: null,
+          now: () => beforeRetryAt,
+          retainProcessedItemUntilRecorded: true,
+          runtime: createDeviceSyncPostCheckpointRuntime(port),
+          runtimeEnv: {},
+          vaultRoot: workspace.vaultRoot,
+        }),
+        null,
+      );
+
+      const retainedJobs = readJobsForAccount(service, localAccountId);
+      assert.ok(retainedJobs.every((job) => job.availableAt === retryAt));
+      vi.setSystemTime(new Date(retryAt));
+      assert.equal(await service.drainWorker(100, localAccountId), 100);
+      assert.equal(executeJob.mock.calls.length, 100);
+
+      const continuedState = await syncHostedDeviceSyncControlPlaneState({
+        deviceSyncPort: port,
+        secret: DEVICE_SYNC_SECRET,
+        service,
+        wake: buildDeviceSyncWake({
+          connectionId,
+          hint: { reason: "retained_dirty_remainder" },
+          occurredAt: retryAt,
+          reason: "reconcile_due",
+        }),
+      });
+      assert.deepEqual(continuedState.pendingDirtyAcks, [{
+        connectionId,
+        nextWakeAt: immediateWakeAt,
+        processedRevision: "2",
+      }]);
+      assert.equal(continuedState.pendingDirtyPayloadJobs.length, 1);
+      assert.equal(
+        getStore(service).listPendingJobsForAccount(localAccountId, 2).length,
+        1,
+      );
+      assert.ok(
+        readJobsForAccount(service, localAccountId)
+          .slice(0, HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT)
+          .every((job) => job.availableAt === retryAt),
+      );
+    } finally {
+      vi.useRealTimers();
+      closeHostedRuntimeDeviceSyncService(service);
+      await workspace.cleanup();
     }
   });
 

--- a/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+++ b/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
@@ -6568,6 +6568,7 @@ describe("hosted device-sync runtime", () => {
         runtime: createDeviceSyncPostCheckpointRuntime(deviceSyncPort),
       });
       assert.deepEqual(recorded, {
+        newerRevisionPending: false,
         nextWakeAt: retryJob.availableAt,
         recorded: 1,
         stillDirty: true,
@@ -6619,6 +6620,7 @@ describe("hosted device-sync runtime", () => {
           runtime: createDeviceSyncPostCheckpointRuntime(deviceSyncPort),
         }),
         {
+          newerRevisionPending: false,
           nextWakeAt: null,
           recorded: 1,
           stillDirty: false,

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-state.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-state.test.ts
@@ -938,6 +938,122 @@ describe("hosted runtime system mailbox state", () => {
     }
   });
 
+  it("lets a fresh same-connection webhook admit the retained device frontier", async () => {
+    const vaultRoot = await mkdtemp(
+      path.join(tmpdir(), "murph-hosted-system-mailbox-state-"),
+    );
+    const now = "2026-04-27T00:00:00.000Z";
+    const retryAt = "2026-04-28T00:00:00.000Z";
+    const connectionId = "device_sync_connection_synthetic";
+    const retained: HostedSystemMailboxPendingItem = {
+      ...buildPendingDeviceSyncMailboxItem({
+        itemId: "pending_retained_device_retry",
+        mailboxLaneSeq: "1",
+      }),
+      attemptCount: 1,
+      lastAttemptAt: now,
+      nextAttemptAt: retryAt,
+      wake: {
+        connectionId,
+        eventId: "device-sync.wake:retained-retry",
+        hint: {
+          jobs: [{
+            availableAt: retryAt,
+            dedupeKey: "retained-historical-job",
+            kind: "resource",
+            maxAttempts: 1,
+            payload: {},
+            priority: 30,
+          }],
+        },
+        kind: "device-sync.wake",
+        occurredAt: now,
+        provider: "junction",
+        reason: "reconcile_due",
+        userId: "member_123",
+      },
+    };
+    const webhook: HostedSystemMailboxPendingItem = {
+      ...buildPendingDeviceSyncMailboxItem({
+        itemId: "pending_fresh_device_webhook",
+        mailboxLaneSeq: "2",
+      }),
+      occurredAt: "2026-04-27T00:00:01.000Z",
+      wake: {
+        connectionId,
+        eventId: "device-sync.wake:fresh-webhook",
+        kind: "device-sync.wake",
+        occurredAt: "2026-04-27T00:00:01.000Z",
+        provider: "junction",
+        reason: "webhook_hint",
+        userId: "member_123",
+      },
+    };
+
+    try {
+      await updateHostedSystemMailboxState(vaultRoot, () => ({
+        pending: [retained, webhook],
+      }));
+
+      expect(findNextHostedSystemMailboxQueueItem({
+        allowedRouteActions: ["run-device-sync-wake"],
+        now,
+        state: { pending: [retained, webhook] },
+      })).toEqual({
+        ...retained,
+        nextAttemptAt: null,
+      });
+      await expect(resolveHostedSystemMailboxWakeCandidates({
+        now: () => now,
+        vaultRoot,
+      })).resolves.toEqual({
+        defaultOwned: {
+          at: null,
+          reason: null,
+        },
+        next: {
+          at: now,
+          executionClass: "model_free",
+          reason: "device-sync.reconcile",
+        },
+      });
+
+      const scheduledSuccessor: HostedSystemMailboxPendingItem = {
+        ...webhook,
+        itemId: "pending_repeated_scheduled_reconcile",
+        mailboxDedupeKey: "device-sync.wake:repeated-scheduled-reconcile",
+        wake: {
+          connectionId,
+          eventId: "device-sync.wake:repeated-scheduled-reconcile",
+          kind: "device-sync.wake",
+          occurredAt: "2026-04-27T00:00:01.000Z",
+          provider: "junction",
+          reason: "reconcile_due",
+          userId: "member_123",
+        },
+      };
+      await updateHostedSystemMailboxState(vaultRoot, () => ({
+        pending: [retained, scheduledSuccessor],
+      }));
+      await expect(resolveHostedSystemMailboxWakeCandidates({
+        now: () => now,
+        vaultRoot,
+      })).resolves.toEqual({
+        defaultOwned: {
+          at: null,
+          reason: null,
+        },
+        next: {
+          at: retryAt,
+          executionClass: null,
+          reason: "device-sync.reconcile",
+        },
+      });
+    } finally {
+      await rm(vaultRoot, { force: true, recursive: true });
+    }
+  });
+
   it("keeps a distinct dense raw retention successor after dirty receipt recording", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-hosted-system-mailbox-state-"));
 

--- a/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
@@ -3600,10 +3600,11 @@ describe("hosted system mailbox notification execution context", () => {
     }
   });
 
-  it("consumes a fresh webhook admission edge for a retained device retry", async () => {
+  it("keeps a retained webhook admission edge until newer dirty work is clean", async () => {
     const workspace = await createHostedRuntimeWorkspace("murph-hosted-system-mailbox-");
     const retryAt = "2026-04-28T00:00:00.000Z";
     const beforeRetryAt = "2026-04-27T00:10:00.000Z";
+    const immediateWakeAt = "2026-04-27T00:00:03.000Z";
     const connectionId = "dsc_webhook_edge_once";
     const retainedWake = buildHostedExecutionDeviceSyncWake({
       connectionId,
@@ -3647,10 +3648,41 @@ describe("hosted system mailbox notification execution context", () => {
       reason: "webhook_hint",
       userId: "member_123",
     });
+    const ackDirtyStateProcessed = vi.fn()
+      .mockResolvedValueOnce({
+        connectionId,
+        dirtyRevision: "2",
+        nextWakeAt: immediateWakeAt,
+        processedRevision: "1",
+        recorded: true,
+        stillDirty: true,
+        userId: "member_123",
+      })
+      .mockResolvedValueOnce({
+        connectionId,
+        dirtyRevision: "2",
+        nextWakeAt: null,
+        processedRevision: "2",
+        recorded: true,
+        stillDirty: false,
+        userId: "member_123",
+      })
+      .mockResolvedValueOnce({
+        connectionId,
+        dirtyRevision: "3",
+        nextWakeAt: null,
+        processedRevision: "3",
+        recorded: true,
+        stillDirty: false,
+        userId: "member_123",
+      });
     const runtime = createRuntime({
-      deviceSyncPort: createDeviceSyncPortStub(),
+      deviceSyncPort: {
+        ...createDeviceSyncPortStub(),
+        ackDirtyStateProcessed,
+      },
     });
-    const mockRetainedPass = () => {
+    const mockRetainedPass = (processedRevision: string) => {
       mocks.executeHostedMailboxEvent.mockResolvedValueOnce({
         bootstrapResult: null,
         conversationMetrics: null,
@@ -3658,7 +3690,7 @@ describe("hosted system mailbox notification execution context", () => {
         nextWakeAt: retryAt,
         postCheckpointRecord: {
           kind: "device-sync.dirty-processed-batch",
-          records: [],
+          records: [{ connectionId, processedRevision }],
           retainMailboxItemUntil: retryAt,
           retainedWake,
         },
@@ -3715,7 +3747,7 @@ describe("hosted system mailbox notification execution context", () => {
         vaultRoot: workspace.vaultRoot,
         wake: webhookWake,
       });
-      mockRetainedPass();
+      mockRetainedPass("1");
 
       const firstPass = await prepareHostedSystemMailboxItemForCheckpoint({
         allowedRouteActions: ["run-device-sync-wake"],
@@ -3736,9 +3768,9 @@ describe("hosted system mailbox notification execution context", () => {
         vaultRoot: workspace.vaultRoot,
       })).resolves.toEqual({
         failed: 0,
-        nextWakeAt: retryAt,
+        nextWakeAt: immediateWakeAt,
         nextWakeReason: "device-sync.reconcile",
-        recorded: 0,
+        recorded: 1,
       });
 
       expect((await readHostedSystemMailboxState(workspace.vaultRoot)).pending)
@@ -3755,10 +3787,34 @@ describe("hosted system mailbox notification execution context", () => {
           }),
           expect.objectContaining({
             itemId: "mailbox_item_first_webhook_edge",
-            nextAttemptAt: retryAt,
+            nextAttemptAt: null,
             wake: webhookWake,
           }),
         ]);
+
+      mockRetainedPass("2");
+      const remainingDirtyPass = await prepareHostedSystemMailboxItemForCheckpoint({
+        allowedRouteActions: ["run-device-sync-wake"],
+        executionContext: null,
+        now: () => beforeRetryAt,
+        retainProcessedItemUntilRecorded: true,
+        runtime,
+        runtimeEnv: {},
+        vaultRoot: workspace.vaultRoot,
+      });
+      assert.equal(remainingDirtyPass?.status, "processed");
+      assert.equal(remainingDirtyPass.itemId, "mailbox_item_retained_retry_once");
+
+      await expect(recordHostedSystemMailboxItemAfterCheckpoint({
+        item: remainingDirtyPass.item,
+        runtime,
+        vaultRoot: workspace.vaultRoot,
+      })).resolves.toEqual({
+        failed: 0,
+        nextWakeAt: retryAt,
+        nextWakeReason: "device-sync.reconcile",
+        recorded: 1,
+      });
 
       const repeatBeforeRetry = await prepareHostedSystemMailboxItemForCheckpoint({
         allowedRouteActions: ["run-device-sync-wake"],
@@ -3779,7 +3835,7 @@ describe("hosted system mailbox notification execution context", () => {
         vaultRoot: workspace.vaultRoot,
         wake: laterWebhookWake,
       });
-      mockRetainedPass();
+      mockRetainedPass("3");
 
       const secondPass = await prepareHostedSystemMailboxItemForCheckpoint({
         allowedRouteActions: ["run-device-sync-wake"],
@@ -3801,7 +3857,7 @@ describe("hosted system mailbox notification execution context", () => {
         failed: 0,
         nextWakeAt: retryAt,
         nextWakeReason: "device-sync.reconcile",
-        recorded: 0,
+        recorded: 1,
       });
 
       expect((await readHostedSystemMailboxState(workspace.vaultRoot)).pending)
@@ -3839,7 +3895,11 @@ describe("hosted system mailbox notification execution context", () => {
       )).toEqual([
         "device-sync.wake:retained-retry-once",
         "device-sync.wake:retained-retry-once",
+        "device-sync.wake:retained-retry-once",
       ]);
+      expect(ackDirtyStateProcessed.mock.calls.map((call) =>
+        call[0]?.processedRevision
+      )).toEqual(["1", "2", "3"]);
     } finally {
       await workspace.cleanup();
     }

--- a/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
@@ -3510,6 +3510,96 @@ describe("hosted system mailbox notification execution context", () => {
     }
   });
 
+  it("uses a fresh webhook to admit the older exact local device retry", async () => {
+    const workspace = await createHostedRuntimeWorkspace("murph-hosted-system-mailbox-");
+    const retryAt = "2026-04-28T00:00:00.000Z";
+    const connectionId = "dsc_webhook_admits_retained_retry";
+    const retainedWake = buildHostedExecutionDeviceSyncWake({
+      connectionId,
+      eventId: "device-sync.wake:retained-local-retry",
+      hint: {
+        jobs: [{
+          availableAt: retryAt,
+          dedupeKey: "retained-historical-job",
+          kind: "resource",
+          maxAttempts: 1,
+          payload: {},
+          priority: 30,
+        }],
+      },
+      occurredAt: FIXED_NOW,
+      provider: "junction",
+      reason: "reconcile_due",
+      userId: "member_123",
+    });
+    const webhookWake = buildHostedExecutionDeviceSyncWake({
+      connectionId,
+      eventId: "device-sync.wake:fresh-webhook",
+      occurredAt: "2026-04-27T00:00:01.000Z",
+      provider: "junction",
+      reason: "webhook_hint",
+      userId: "member_123",
+    });
+
+    try {
+      await enqueueHostedSystemMailboxItem({
+        item: createResolvedDeviceSyncItem({
+          id: "mailbox_item_retained_local_retry",
+          laneSeq: "1",
+        }),
+        vaultRoot: workspace.vaultRoot,
+        wake: retainedWake,
+      });
+      await enqueueHostedSystemMailboxItem({
+        item: createResolvedDeviceSyncItem({
+          id: "mailbox_item_fresh_webhook",
+          laneSeq: "2",
+        }),
+        vaultRoot: workspace.vaultRoot,
+        wake: webhookWake,
+      });
+      await updateHostedSystemMailboxState(workspace.vaultRoot, (state) => ({
+        pending: state.pending.map((item) =>
+          item.itemId === "mailbox_item_retained_local_retry"
+            ? {
+                ...item,
+                attemptCount: 1,
+                lastAttemptAt: FIXED_NOW,
+                nextAttemptAt: retryAt,
+              }
+            : item
+        ),
+      }));
+
+      const prepared = await prepareHostedSystemMailboxItemForCheckpoint({
+        allowedRouteActions: ["run-device-sync-wake"],
+        executionContext: null,
+        now: () => FIXED_NOW,
+        runtime: createRuntime({}),
+        runtimeEnv: {},
+        vaultRoot: workspace.vaultRoot,
+      });
+
+      assert.equal(prepared?.status, "processed");
+      assert.equal(prepared.itemId, "mailbox_item_retained_local_retry");
+      assert.equal(prepared.item.nextAttemptAt, null);
+      expect(mocks.executeHostedMailboxEvent).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          wake: retainedWake,
+        }),
+      );
+      expect((await readHostedSystemMailboxState(workspace.vaultRoot)).pending)
+        .toEqual([
+          expect.objectContaining({
+            itemId: "mailbox_item_fresh_webhook",
+            wake: webhookWake,
+          }),
+        ]);
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
   it("lets another connection run around a retained device-sync retry", async () => {
     const workspace = await createHostedRuntimeWorkspace("murph-hosted-system-mailbox-");
     const olderWake = buildHostedExecutionDeviceSyncWake({

--- a/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
@@ -1764,6 +1764,7 @@ describe("hosted system mailbox notification execution context", () => {
       },
       runtime,
     })).resolves.toEqual({
+      newerRevisionPending: true,
       nextWakeAt: immediateWakeAt,
       recorded: 1,
       stillDirty: true,
@@ -3600,11 +3601,13 @@ describe("hosted system mailbox notification execution context", () => {
     }
   });
 
-  it("keeps a retained webhook admission edge until newer dirty work is clean", async () => {
+  it("keeps a retained webhook admission edge only while a newer revision remains", async () => {
     const workspace = await createHostedRuntimeWorkspace("murph-hosted-system-mailbox-");
     const retryAt = "2026-04-28T00:00:00.000Z";
     const beforeRetryAt = "2026-04-27T00:10:00.000Z";
     const immediateWakeAt = "2026-04-27T00:00:03.000Z";
+    const beforePayloadRetryAt = "2026-04-27T00:15:00.000Z";
+    const payloadRetryAt = "2026-04-27T00:20:00.000Z";
     const connectionId = "dsc_webhook_edge_once";
     const retainedWake = buildHostedExecutionDeviceSyncWake({
       connectionId,
@@ -3623,6 +3626,22 @@ describe("hosted system mailbox notification execution context", () => {
       provider: "junction",
       reason: "reconcile_due",
       userId: "member_123",
+    });
+    const payloadRetainedWake = buildHostedExecutionDeviceSyncWake({
+      ...retainedWake,
+      hint: {
+        jobs: [
+          ...(retainedWake.hint?.jobs ?? []),
+          {
+            availableAt: payloadRetryAt,
+            dedupeKey: "retained-payload-job",
+            kind: "resource",
+            maxAttempts: 1,
+            payload: {},
+            priority: 30,
+          },
+        ],
+      },
     });
     const scheduledWake = buildHostedExecutionDeviceSyncWake({
       connectionId,
@@ -3665,6 +3684,15 @@ describe("hosted system mailbox notification execution context", () => {
         processedRevision: "2",
         recorded: true,
         stillDirty: false,
+        userId: "member_123",
+      })
+      .mockResolvedValueOnce({
+        connectionId,
+        dirtyRevision: "3",
+        nextWakeAt: immediateWakeAt,
+        processedRevision: "3",
+        recorded: true,
+        stillDirty: true,
         userId: "member_123",
       })
       .mockResolvedValueOnce({
@@ -3835,9 +3863,25 @@ describe("hosted system mailbox notification execution context", () => {
         vaultRoot: workspace.vaultRoot,
         wake: laterWebhookWake,
       });
-      mockRetainedPass("3");
+      mocks.executeHostedMailboxEvent.mockResolvedValueOnce({
+        bootstrapResult: null,
+        conversationMetrics: null,
+        mailboxLane: "device-sync",
+        nextWakeAt: payloadRetryAt,
+        postCheckpointRecord: {
+          kind: "device-sync.dirty-processed-batch",
+          records: [{
+            connectionId,
+            nextWakeAt: payloadRetryAt,
+            processedRevision: "3",
+          }],
+          retainMailboxItemUntil: payloadRetryAt,
+          retainedWake: payloadRetainedWake,
+        },
+        redactedLogEntries: [],
+      });
 
-      const secondPass = await prepareHostedSystemMailboxItemForCheckpoint({
+      const payloadBackoffPass = await prepareHostedSystemMailboxItemForCheckpoint({
         allowedRouteActions: ["run-device-sync-wake"],
         executionContext: null,
         now: () => beforeRetryAt,
@@ -3846,16 +3890,16 @@ describe("hosted system mailbox notification execution context", () => {
         runtimeEnv: {},
         vaultRoot: workspace.vaultRoot,
       });
-      assert.equal(secondPass?.status, "processed");
-      assert.equal(secondPass.itemId, "mailbox_item_retained_retry_once");
+      assert.equal(payloadBackoffPass?.status, "processed");
+      assert.equal(payloadBackoffPass.itemId, "mailbox_item_retained_retry_once");
 
       await expect(recordHostedSystemMailboxItemAfterCheckpoint({
-        item: secondPass.item,
+        item: payloadBackoffPass.item,
         runtime,
         vaultRoot: workspace.vaultRoot,
       })).resolves.toEqual({
         failed: 0,
-        nextWakeAt: retryAt,
+        nextWakeAt: payloadRetryAt,
         nextWakeReason: "device-sync.reconcile",
         recorded: 1,
       });
@@ -3864,7 +3908,8 @@ describe("hosted system mailbox notification execution context", () => {
         .toEqual([
           expect.objectContaining({
             itemId: "mailbox_item_retained_retry_once",
-            nextAttemptAt: retryAt,
+            nextAttemptAt: payloadRetryAt,
+            wake: payloadRetainedWake,
           }),
           expect.objectContaining({
             itemId: "mailbox_item_scheduled_successor",
@@ -3876,30 +3921,66 @@ describe("hosted system mailbox notification execution context", () => {
           }),
           expect.objectContaining({
             itemId: "mailbox_item_later_webhook_edge",
-            nextAttemptAt: retryAt,
+            nextAttemptAt: payloadRetryAt,
           }),
         ]);
 
-      const repeatAfterLaterWebhook = await prepareHostedSystemMailboxItemForCheckpoint({
+      const repeatBeforePayloadRetry = await prepareHostedSystemMailboxItemForCheckpoint({
         allowedRouteActions: ["run-device-sync-wake"],
         executionContext: null,
-        now: () => beforeRetryAt,
+        now: () => beforePayloadRetryAt,
         retainProcessedItemUntilRecorded: true,
         runtime,
         runtimeEnv: {},
         vaultRoot: workspace.vaultRoot,
       });
-      assert.equal(repeatAfterLaterWebhook, null);
+      assert.equal(repeatBeforePayloadRetry, null);
+
+      mockRetainedPass("3");
+      const payloadRetryPass = await prepareHostedSystemMailboxItemForCheckpoint({
+        allowedRouteActions: ["run-device-sync-wake"],
+        executionContext: null,
+        now: () => payloadRetryAt,
+        retainProcessedItemUntilRecorded: true,
+        runtime,
+        runtimeEnv: {},
+        vaultRoot: workspace.vaultRoot,
+      });
+      assert.equal(payloadRetryPass?.status, "processed");
+      assert.deepEqual(payloadRetryPass.item.wake, payloadRetainedWake);
+
+      await expect(recordHostedSystemMailboxItemAfterCheckpoint({
+        item: payloadRetryPass.item,
+        runtime,
+        vaultRoot: workspace.vaultRoot,
+      })).resolves.toEqual({
+        failed: 0,
+        nextWakeAt: retryAt,
+        nextWakeReason: "device-sync.reconcile",
+        recorded: 1,
+      });
+
+      const repeatAfterPayloadRetry = await prepareHostedSystemMailboxItemForCheckpoint({
+        allowedRouteActions: ["run-device-sync-wake"],
+        executionContext: null,
+        now: () => beforePayloadRetryAt,
+        retainProcessedItemUntilRecorded: true,
+        runtime,
+        runtimeEnv: {},
+        vaultRoot: workspace.vaultRoot,
+      });
+      assert.equal(repeatAfterPayloadRetry, null);
       expect(mocks.executeHostedMailboxEvent.mock.calls.map((call) =>
         call[0]?.wake?.eventId
       )).toEqual([
         "device-sync.wake:retained-retry-once",
         "device-sync.wake:retained-retry-once",
         "device-sync.wake:retained-retry-once",
+        "device-sync.wake:retained-retry-once",
       ]);
       expect(ackDirtyStateProcessed.mock.calls.map((call) =>
         call[0]?.processedRevision
-      )).toEqual(["1", "2", "3"]);
+      )).toEqual(["1", "2", "3", "3"]);
     } finally {
       await workspace.cleanup();
     }

--- a/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
@@ -3600,6 +3600,251 @@ describe("hosted system mailbox notification execution context", () => {
     }
   });
 
+  it("consumes a fresh webhook admission edge for a retained device retry", async () => {
+    const workspace = await createHostedRuntimeWorkspace("murph-hosted-system-mailbox-");
+    const retryAt = "2026-04-28T00:00:00.000Z";
+    const beforeRetryAt = "2026-04-27T00:10:00.000Z";
+    const connectionId = "dsc_webhook_edge_once";
+    const retainedWake = buildHostedExecutionDeviceSyncWake({
+      connectionId,
+      eventId: "device-sync.wake:retained-retry-once",
+      hint: {
+        jobs: [{
+          availableAt: retryAt,
+          dedupeKey: "retained-historical-job",
+          kind: "resource",
+          maxAttempts: 1,
+          payload: {},
+          priority: 30,
+        }],
+      },
+      occurredAt: FIXED_NOW,
+      provider: "junction",
+      reason: "reconcile_due",
+      userId: "member_123",
+    });
+    const scheduledWake = buildHostedExecutionDeviceSyncWake({
+      connectionId,
+      eventId: "device-sync.wake:scheduled-successor",
+      occurredAt: "2026-04-27T00:00:01.000Z",
+      provider: "junction",
+      reason: "reconcile_due",
+      userId: "member_123",
+    });
+    const webhookWake = buildHostedExecutionDeviceSyncWake({
+      connectionId,
+      eventId: "device-sync.wake:first-webhook-edge",
+      occurredAt: "2026-04-27T00:00:02.000Z",
+      provider: "junction",
+      reason: "webhook_hint",
+      userId: "member_123",
+    });
+    const laterWebhookWake = buildHostedExecutionDeviceSyncWake({
+      connectionId,
+      eventId: "device-sync.wake:later-webhook-edge",
+      occurredAt: beforeRetryAt,
+      provider: "junction",
+      reason: "webhook_hint",
+      userId: "member_123",
+    });
+    const runtime = createRuntime({
+      deviceSyncPort: createDeviceSyncPortStub(),
+    });
+    const mockRetainedPass = () => {
+      mocks.executeHostedMailboxEvent.mockResolvedValueOnce({
+        bootstrapResult: null,
+        conversationMetrics: null,
+        mailboxLane: "device-sync",
+        nextWakeAt: retryAt,
+        postCheckpointRecord: {
+          kind: "device-sync.dirty-processed-batch",
+          records: [],
+          retainMailboxItemUntil: retryAt,
+          retainedWake,
+        },
+        redactedLogEntries: [],
+      });
+    };
+
+    try {
+      await enqueueHostedSystemMailboxItem({
+        item: createResolvedDeviceSyncItem({
+          id: "mailbox_item_retained_retry_once",
+          laneSeq: "1",
+        }),
+        vaultRoot: workspace.vaultRoot,
+        wake: retainedWake,
+      });
+      await enqueueHostedSystemMailboxItem({
+        item: createResolvedDeviceSyncItem({
+          id: "mailbox_item_scheduled_successor",
+          laneSeq: "2",
+        }),
+        vaultRoot: workspace.vaultRoot,
+        wake: scheduledWake,
+      });
+      await updateHostedSystemMailboxState(workspace.vaultRoot, (state) => ({
+        pending: state.pending.map((item) =>
+          item.itemId === "mailbox_item_retained_retry_once"
+            ? {
+                ...item,
+                attemptCount: 1,
+                lastAttemptAt: FIXED_NOW,
+                nextAttemptAt: retryAt,
+              }
+            : item
+        ),
+      }));
+
+      const scheduledOnly = await prepareHostedSystemMailboxItemForCheckpoint({
+        allowedRouteActions: ["run-device-sync-wake"],
+        executionContext: null,
+        now: () => FIXED_NOW,
+        retainProcessedItemUntilRecorded: true,
+        runtime,
+        runtimeEnv: {},
+        vaultRoot: workspace.vaultRoot,
+      });
+      assert.equal(scheduledOnly, null);
+
+      await enqueueHostedSystemMailboxItem({
+        item: createResolvedDeviceSyncItem({
+          id: "mailbox_item_first_webhook_edge",
+          laneSeq: "3",
+        }),
+        vaultRoot: workspace.vaultRoot,
+        wake: webhookWake,
+      });
+      mockRetainedPass();
+
+      const firstPass = await prepareHostedSystemMailboxItemForCheckpoint({
+        allowedRouteActions: ["run-device-sync-wake"],
+        executionContext: null,
+        now: () => FIXED_NOW,
+        retainProcessedItemUntilRecorded: true,
+        runtime,
+        runtimeEnv: {},
+        vaultRoot: workspace.vaultRoot,
+      });
+      assert.equal(firstPass?.status, "processed");
+      assert.equal(firstPass.itemId, "mailbox_item_retained_retry_once");
+      assert.equal(firstPass.item.nextAttemptAt, null);
+
+      await expect(recordHostedSystemMailboxItemAfterCheckpoint({
+        item: firstPass.item,
+        runtime,
+        vaultRoot: workspace.vaultRoot,
+      })).resolves.toEqual({
+        failed: 0,
+        nextWakeAt: retryAt,
+        nextWakeReason: "device-sync.reconcile",
+        recorded: 0,
+      });
+
+      expect((await readHostedSystemMailboxState(workspace.vaultRoot)).pending)
+        .toEqual([
+          expect.objectContaining({
+            itemId: "mailbox_item_retained_retry_once",
+            nextAttemptAt: retryAt,
+            wake: retainedWake,
+          }),
+          expect.objectContaining({
+            itemId: "mailbox_item_scheduled_successor",
+            nextAttemptAt: null,
+            wake: scheduledWake,
+          }),
+          expect.objectContaining({
+            itemId: "mailbox_item_first_webhook_edge",
+            nextAttemptAt: retryAt,
+            wake: webhookWake,
+          }),
+        ]);
+
+      const repeatBeforeRetry = await prepareHostedSystemMailboxItemForCheckpoint({
+        allowedRouteActions: ["run-device-sync-wake"],
+        executionContext: null,
+        now: () => beforeRetryAt,
+        retainProcessedItemUntilRecorded: true,
+        runtime,
+        runtimeEnv: {},
+        vaultRoot: workspace.vaultRoot,
+      });
+      assert.equal(repeatBeforeRetry, null);
+
+      await enqueueHostedSystemMailboxItem({
+        item: createResolvedDeviceSyncItem({
+          id: "mailbox_item_later_webhook_edge",
+          laneSeq: "4",
+        }),
+        vaultRoot: workspace.vaultRoot,
+        wake: laterWebhookWake,
+      });
+      mockRetainedPass();
+
+      const secondPass = await prepareHostedSystemMailboxItemForCheckpoint({
+        allowedRouteActions: ["run-device-sync-wake"],
+        executionContext: null,
+        now: () => beforeRetryAt,
+        retainProcessedItemUntilRecorded: true,
+        runtime,
+        runtimeEnv: {},
+        vaultRoot: workspace.vaultRoot,
+      });
+      assert.equal(secondPass?.status, "processed");
+      assert.equal(secondPass.itemId, "mailbox_item_retained_retry_once");
+
+      await expect(recordHostedSystemMailboxItemAfterCheckpoint({
+        item: secondPass.item,
+        runtime,
+        vaultRoot: workspace.vaultRoot,
+      })).resolves.toEqual({
+        failed: 0,
+        nextWakeAt: retryAt,
+        nextWakeReason: "device-sync.reconcile",
+        recorded: 0,
+      });
+
+      expect((await readHostedSystemMailboxState(workspace.vaultRoot)).pending)
+        .toEqual([
+          expect.objectContaining({
+            itemId: "mailbox_item_retained_retry_once",
+            nextAttemptAt: retryAt,
+          }),
+          expect.objectContaining({
+            itemId: "mailbox_item_scheduled_successor",
+            nextAttemptAt: null,
+          }),
+          expect.objectContaining({
+            itemId: "mailbox_item_first_webhook_edge",
+            nextAttemptAt: retryAt,
+          }),
+          expect.objectContaining({
+            itemId: "mailbox_item_later_webhook_edge",
+            nextAttemptAt: retryAt,
+          }),
+        ]);
+
+      const repeatAfterLaterWebhook = await prepareHostedSystemMailboxItemForCheckpoint({
+        allowedRouteActions: ["run-device-sync-wake"],
+        executionContext: null,
+        now: () => beforeRetryAt,
+        retainProcessedItemUntilRecorded: true,
+        runtime,
+        runtimeEnv: {},
+        vaultRoot: workspace.vaultRoot,
+      });
+      assert.equal(repeatAfterLaterWebhook, null);
+      expect(mocks.executeHostedMailboxEvent.mock.calls.map((call) =>
+        call[0]?.wake?.eventId
+      )).toEqual([
+        "device-sync.wake:retained-retry-once",
+        "device-sync.wake:retained-retry-once",
+      ]);
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+
   it("lets another connection run around a retained device-sync retry", async () => {
     const workspace = await createHostedRuntimeWorkspace("murph-hosted-system-mailbox-");
     const olderWake = buildHostedExecutionDeviceSyncWake({


### PR DESCRIPTION
ReviewGPT context sensitivity: sensitive
ReviewGPT first-reviewed head: 5425ce242c4349c9acb71426aa630084f6845e8a

Sensitivity reason: This changes hosted runtime mailbox admission and device retry behavior.

## Why and outcome

A retained same-connection historical device job can legitimately wait on a long provider backoff. Fresh webhook rows already durable behind that item could not admit any pass, so newly dirty health data waited behind unrelated historical work.

A due same-connection webhook admits the older exact mailbox owner while every local job keeps its own availability. Post-checkpoint acknowledgement preserves that admission edge only when a newer dirty revision exists and the retained hints prove another pass has queue capacity. Otherwise, the existing atomic retention update defers the owner and granting webhook to the retained retry.

## Product UX

- Effort: Patch
- Walkthrough: Ready
- Affected people: Members whose fresh connected-health data arrives while an older historical retry is waiting.
- Result: Fresh dirty data gets the earliest bounded pass that can make progress, without bypassing provider backoff or spinning while the retained queue is full.
- Exclusions: No UI, prompt, provider cadence, schema, or member action changes.

## Evidence

- Red: with 100 future retained jobs, the real runtime fetched one distinct newer dirty resource, admitted zero jobs, performed no provider request, acknowledged unequal revisions, and the mailbox incorrectly returned an immediate wake.
- Green: that composed path now atomically defers the exact owner and granting webhook to the retained retry; preparation before the retry returns no work. At capacity release, all original availability timestamps remain unchanged and the fresh resource is admitted.
- Existing R1→R2 coalescing with capacity still preserves one useful immediate continuation; equal-revision payload backoff still sleeps until its retry.
- 63 notification/system-mailbox tests, 119 hosted device-sync runtime tests, and 73 mailbox-state plus system-mailbox entrypoint tests pass.
- Assistant-runtime typecheck, diff check, complexity guard, 7 changelog-fragment tests, and 39 changelog archive tests pass.
- CI metadata failure diagnosed: the architecture guard required a concrete explanation for the no-new-abstraction decision; this body now provides it.
- Live post-deploy recovery remains the completion gate.

## Non-obvious affected surfaces

- System-mailbox wake projection and execution selection share the same admission derivation.
- Scheduled-reconcile duplicates cannot grant early admission.
- Different-connection concurrency and generic transient retry ordering are unchanged.
- Payload-only dirty state retains its normal retry wake.
- A full retained queue cannot reuse a webhook as an immediate edge until capacity releases.

## Architecture and reuse

- Existing systems reused: the exact retained mailbox item, per-connection serialization, dirty-state acknowledgement, complete retained job hints, shared per-pass job limit, and pending item `nextAttemptAt`.
- New logic: one transient `immediateDirtyContinuationCanProgress` decision combines the acknowledgement revision fact with retained-hint capacity at the existing post-checkpoint owner.
- New abstractions: No new abstraction was added because the existing acknowledgement result and retained wake already own the two facts needed for the decision.
- Complexity intentionally avoided: no queue, scheduler, persisted field, schema, dependency, lease, state machine, or Temporal change.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` reports no debt or maximum increase.
- Hotspots: `prepareHostedSystemMailboxItemForCheckpoint` remains 30, `recordHostedSystemMailboxPostCheckpointRecord` remains 30, and `parseHostedSystemMailboxRecordRequest` remains 25; no existing hotspot grows.
- Agent judgment: one small capacity helper keeps the source-of-truth job limit shared and the scheduling decision readable; broader retry machinery would duplicate existing owners.

## Hot reply path impact

Not applicable. This affects background device-sync mailbox work only and adds no database, network, or provider operation to the current-message path.

## Murph initial provider input impact

- Murph: Not applicable. Prompts, tools, schemas, and provider-visible model input are unchanged.
- Codex: Not applicable. No provider invocation surface changed.

## Deployment concerns

- Deployment: applicable
- Supported skew: No wire or persisted shape changes; old and new runners read the same snapshots.
- Safe order: Merge, then deploy Cloudflare with immediate hosted-container rollout. No Vercel or private Temporal tandem deploy is required.
- Rollback floor: The currently deployed runner remains data-compatible; reverting restores fresh-webhook starvation behind retained retries.
- Reversibility: No persisted or wire shape changes; redeploying the prior runner safely reverses the selector change.
- Convergence proof: Confirm the deployed source commit and runner rollout, then observe the affected runtime record a new device pass and advance sync completion or emit a concrete provider terminal result.
- Expected exposure: Warm old containers keep the prior selector until rollout replacement.
- Post-deploy checks: Confirm the affected runtime records a device pass, mailbox progress, and updated sync completion or a concrete provider-level terminal result.

## Changelog

- Changelog: updated
- Items: 2026-09-01 · background-work-recovers-in-order
- Proof: the routed changelog fragment and archive suites pass 7 and 39 tests respectively; content-only changelog entry, no rendered UI change.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 161 | 20 |
| Tests/fixtures | 832 | 1 |
| Docs | 111 | 4 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 1104 | 25 |
