### PR TITLE
Fix exact hosted runtime owner-release forwarding

### DIFF
--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -671,9 +671,11 @@ cleared and may include the exact positive `immediateRecheckRequested` edge. A
 known future mailbox retry continuation skips the callback unless the result
 carries that edge. The edge means the invocation newly committed an unserviced
 default or retention schedule; it does not carry the schedule itself. Without
-the edge, Web signals Temporal only for current runnable mailbox lag and never
-turns a persisted due wake into a repeated level-triggered signal. Callback
-failure is logged and ignored with no retry or result mutation.
+the edge, Web still forwards an exact attempt release for Temporal to match at
+the accepted-owner boundary. Only legacy pointerless callbacks require current
+runnable mailbox lag, so a persisted due wake never becomes a repeated
+level-triggered signal. Callback failure is logged and ignored with no retry or
+result mutation.
 
 ## Deploy Artifacts
 

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -671,11 +671,12 @@ cleared and may include the exact positive `immediateRecheckRequested` edge. A
 known future mailbox retry continuation skips the callback unless the result
 carries that edge. The edge means the invocation newly committed an unserviced
 default or retention schedule; it does not carry the schedule itself. Without
-the edge, Web still forwards an exact attempt release for Temporal to match at
-the accepted-owner boundary. Only legacy pointerless callbacks require current
-runnable mailbox lag, so a persisted due wake never becomes a repeated
-level-triggered signal. Callback failure is logged and ignored with no retry or
-result mutation.
+the edge, Web signals only when current runnable mailbox lag or a live system
+mailbox item beyond the handled-through frontier remains. Exact callbacks use
+the attempt-bound owner-release signal; legacy pointerless callbacks use the
+facts-only recheck. A persisted due wake alone therefore never becomes a
+repeated level-triggered signal. Callback failure is logged and ignored with no
+retry or result mutation.
 
 ## Deploy Artifacts
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1328,16 +1328,17 @@ Callback auth contract:
   completion handoff. Web accepts a zero-byte body and a signed query containing
   the opaque released `runtimeAttemptId`, plus the optional exact
   `immediateRecheckRequested=1` positive edge. It binds the user through the
-  signed request plus normal nonce protection and emits
-  `runtime_owner_released` only for actionable work. Temporal matches the
-  attempt before releasing an accepted-owner horizon. Legacy callbacks without
-  the pointer remain facts-only `runtime_recheck_requested` signals during
-  rollout. A persisted default or retention wake is not itself signal authority.
-  The positive edge means the completed invocation newly committed an
-  unserviced schedule and carries no wake data. Known future mailbox retry
-  continuations remain deferred. Cloudflare calls the route at most once, with
-  a timeout capped at two seconds, only after exact write-fence completion;
-  failure is non-fatal and has no callback retry.
+  signed request plus normal nonce protection and emits one exact
+  `runtime_owner_released`; Temporal matches the attempt before releasing an
+  accepted-owner horizon. Legacy callbacks without the pointer remain
+  facts-only `runtime_recheck_requested` signals during rollout and are emitted
+  only for current runnable mailbox lag or the positive edge. A persisted
+  default or retention wake is not itself legacy signal authority. The positive
+  edge means the completed invocation newly committed an unserviced schedule
+  and carries no wake data. Known future mailbox retry continuations remain
+  deferred. Cloudflare calls the route at most once, with a timeout capped at
+  two seconds, only after exact write-fence completion; failure is non-fatal and
+  has no callback retry.
 
 When you set `DEVICE_SYNC_PUBLIC_BASE_URL`, use the same stable production
 hostname as every first-party hosted app-session URL that can serve the OAuth

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1328,17 +1328,18 @@ Callback auth contract:
   completion handoff. Web accepts a zero-byte body and a signed query containing
   the opaque released `runtimeAttemptId`, plus the optional exact
   `immediateRecheckRequested=1` positive edge. It binds the user through the
-  signed request plus normal nonce protection and emits one exact
-  `runtime_owner_released`; Temporal matches the attempt before releasing an
-  accepted-owner horizon. Legacy callbacks without the pointer remain
-  facts-only `runtime_recheck_requested` signals during rollout and are emitted
-  only for current runnable mailbox lag or the positive edge. A persisted
-  default or retention wake is not itself legacy signal authority. The positive
-  edge means the completed invocation newly committed an unserviced schedule
-  and carries no wake data. Known future mailbox retry continuations remain
-  deferred. Cloudflare calls the route at most once, with a timeout capped at
-  two seconds, only after exact write-fence completion; failure is non-fatal and
-  has no callback retry.
+  signed request plus normal nonce protection. Without the positive edge, Web
+  emits a signal only when current runnable mailbox lag or a live system mailbox
+  item beyond the handled-through frontier remains. Exact callbacks use
+  `runtime_owner_released`, which Temporal matches before releasing an
+  accepted-owner horizon; legacy pointerless callbacks use the facts-only
+  `runtime_recheck_requested` signal during rollout. A persisted default or
+  retention wake alone is not signal authority. The positive edge means the
+  completed invocation newly committed an unserviced schedule and carries no
+  wake data. Known future mailbox retry continuations remain deferred.
+  Cloudflare calls the route at most once, with a timeout capped at two seconds,
+  only after exact write-fence completion; failure is non-fatal and has no
+  callback retry.
 
 When you set `DEVICE_SYNC_PUBLIC_BASE_URL`, use the same stable production
 hostname as every first-party hosted app-session URL that can serve the OAuth

--- a/apps/web/app/api/internal/hosted-runtime/owner-released/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/owner-released/route.ts
@@ -21,6 +21,14 @@ export const POST = withJsonError(async (request: Request) => {
   });
   const ownerRelease = readOwnerRelease(request);
 
+  if (ownerRelease.runtimeAttemptId !== null) {
+    await signalHostedRuntimeOwnerReleasedRuntime({
+      runtimeAttemptId: ownerRelease.runtimeAttemptId,
+      userId,
+    });
+    return jsonOk({ signaled: true });
+  }
+
   if (
     !ownerRelease.immediateRecheckRequested
     && !(await readHostedRuntimeOwnerReleaseMailboxLagActionable({ userId }))
@@ -28,15 +36,7 @@ export const POST = withJsonError(async (request: Request) => {
     return jsonOk({ signaled: false });
   }
 
-  if (ownerRelease.runtimeAttemptId === null) {
-    await signalHostedRuntimeRecheckRuntime({ userId });
-  } else {
-    await signalHostedRuntimeOwnerReleasedRuntime({
-      runtimeAttemptId: ownerRelease.runtimeAttemptId,
-      userId,
-    });
-  }
-
+  await signalHostedRuntimeRecheckRuntime({ userId });
   return jsonOk({ signaled: true });
 });
 

--- a/apps/web/app/api/internal/hosted-runtime/owner-released/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/owner-released/route.ts
@@ -6,7 +6,7 @@ import {
   requireHostedCloudflareCallbackRequest,
 } from "@/src/lib/hosted-execution/cloudflare-callback-auth";
 import {
-  readHostedRuntimeOwnerReleaseMailboxLagActionable,
+  readHostedRuntimeOwnerReleaseActionable,
 } from "@/src/lib/hosted-orchestration/runtime-reconciliation-facts";
 import {
   signalHostedRuntimeOwnerReleasedRuntime,
@@ -21,22 +21,21 @@ export const POST = withJsonError(async (request: Request) => {
   });
   const ownerRelease = readOwnerRelease(request);
 
-  if (ownerRelease.runtimeAttemptId !== null) {
-    await signalHostedRuntimeOwnerReleasedRuntime({
-      runtimeAttemptId: ownerRelease.runtimeAttemptId,
-      userId,
-    });
-    return jsonOk({ signaled: true });
-  }
-
   if (
     !ownerRelease.immediateRecheckRequested
-    && !(await readHostedRuntimeOwnerReleaseMailboxLagActionable({ userId }))
+    && !(await readHostedRuntimeOwnerReleaseActionable({ userId }))
   ) {
     return jsonOk({ signaled: false });
   }
 
-  await signalHostedRuntimeRecheckRuntime({ userId });
+  if (ownerRelease.runtimeAttemptId === null) {
+    await signalHostedRuntimeRecheckRuntime({ userId });
+  } else {
+    await signalHostedRuntimeOwnerReleasedRuntime({
+      runtimeAttemptId: ownerRelease.runtimeAttemptId,
+      userId,
+    });
+  }
   return jsonOk({ signaled: true });
 });
 

--- a/apps/web/changelog/entries/2026-09-01/messages-resume-after-background-handoffs.json
+++ b/apps/web/changelog/entries/2026-09-01/messages-resume-after-background-handoffs.json
@@ -9,6 +9,6 @@
     "summary": "When a message arrives as background work finishes, Murph now starts the reply as soon as that work releases instead of waiting for an older retry timer.",
     "details": "The handoff is matched to the exact finished runtime, so a delayed callback cannot interrupt newer work; durable reconciliation remains the recovery path if the handoff signal fails.",
     "relevanceTags": ["assistant", "messaging", "reliability"],
-    "sourcePullRequests": [2699]
+    "sourcePullRequests": [2699, 2730]
   }
 }

--- a/apps/web/src/lib/hosted-orchestration/runtime-reconciliation-facts.ts
+++ b/apps/web/src/lib/hosted-orchestration/runtime-reconciliation-facts.ts
@@ -98,7 +98,7 @@ const HOSTED_RUNTIME_RECONCILIATION_FACTS_LOG_SCHEMA =
 const HOSTED_RUNTIME_RECONCILIATION_ENGAGEMENT_PAUSE_RETRY_MS =
   24 * 60 * 60 * 1000;
 
-export async function readHostedRuntimeOwnerReleaseMailboxLagActionable(input: {
+export async function readHostedRuntimeOwnerReleaseActionable(input: {
   now?: Date | string;
   userId: string;
 }): Promise<boolean> {
@@ -121,18 +121,25 @@ export async function readHostedRuntimeOwnerReleaseMailboxLagActionable(input: {
       redactedStatusJson: redactedStatus,
     })
   );
-  if (!hasHostedMailboxLag(mailboxLag)) {
-    return false;
-  }
-
   const deferredMailboxContinuation =
     isHostedRuntimeFutureMailboxContinuation({
       nextWakeAt: workspace.nextWakeAt,
       nextWakeReason: workspace.nextWakeReason,
       redactedStatus,
     }, now.getTime());
+  if (hasHostedMailboxLag(mailboxLag) && !deferredMailboxContinuation) {
+    return true;
+  }
 
-  return !deferredMailboxContinuation;
+  return await readHostedRuntimeSystemMailboxFrontier({
+    at: now,
+    handledThroughSeq:
+      readHostedRuntimeSystemHandledThroughSeq(workspace.redactedStatusJson)
+        ?? "0",
+    maxSeqByLane,
+    prisma,
+    userId: input.userId,
+  }) !== null;
 }
 
 export async function readHostedRuntimeReconciliationFacts(

--- a/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
+++ b/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
@@ -223,6 +223,45 @@ describe("hosted orchestration reconciliation facts", () => {
       await expect(readOwnerReleaseActionable()).resolves.toBe(false);
     });
 
+    it("signals for an imported live system item beyond handled-through", async () => {
+      mocks.readHostedWorkspace.mockResolvedValue(buildWorkspaceRecord({
+        redactedStatusJson: {
+          hostedMailboxSystemHandledThroughSeq: "0",
+          systemImportedSeq: "1",
+        },
+      }));
+      mocks.readHostedMailboxMaxSeqByLane.mockResolvedValue([
+        { lane: "system", maxSeq: "1" },
+      ]);
+      mocks.readHostedMailboxFirstLiveSystemItemAfterSeq.mockResolvedValue({
+        dedupeKey: "device-sync.wake:owner-release-actionable",
+        kind: "device-sync.wake",
+        laneSeq: "1",
+      });
+
+      await expect(readOwnerReleaseActionable()).resolves.toBe(true);
+      expect(mocks.readHostedMailboxFirstLiveSystemItemAfterSeq).toHaveBeenCalledWith({
+        afterSeq: "0",
+        at: new Date(FIXED_NOW),
+        prisma: expect.any(Object),
+        userId: MEMBER_ID,
+      });
+    });
+
+    it("preserves the owner horizon when the system high-water has no live item", async () => {
+      mocks.readHostedWorkspace.mockResolvedValue(buildWorkspaceRecord({
+        redactedStatusJson: {
+          hostedMailboxSystemHandledThroughSeq: "0",
+          systemImportedSeq: "1",
+        },
+      }));
+      mocks.readHostedMailboxMaxSeqByLane.mockResolvedValue([
+        { lane: "system", maxSeq: "1" },
+      ]);
+
+      await expect(readOwnerReleaseActionable()).resolves.toBe(false);
+    });
+
     it("does not hot-loop lag with a future mailbox continuation", async () => {
       mocks.readHostedWorkspace.mockResolvedValue(buildWorkspaceRecord({
         nextWakeAt: "2026-05-20T12:00:15.000Z",
@@ -2014,10 +2053,10 @@ function routeContext(): { params: Promise<{ userId: string }> } {
 
 async function readOwnerReleaseActionable(): Promise<boolean> {
   const {
-    readHostedRuntimeOwnerReleaseMailboxLagActionable,
+    readHostedRuntimeOwnerReleaseActionable,
   } = await import("../src/lib/hosted-orchestration/runtime-reconciliation-facts");
 
-  return await readHostedRuntimeOwnerReleaseMailboxLagActionable({
+  return await readHostedRuntimeOwnerReleaseActionable({
     userId: MEMBER_ID,
   });
 }

--- a/apps/web/test/hosted-runtime-internal-routes.test.ts
+++ b/apps/web/test/hosted-runtime-internal-routes.test.ts
@@ -281,35 +281,10 @@ describe("hosted runtime internal web routes", () => {
   });
 
   it("signals an exact authenticated runtime owner release", async () => {
-    const request = new Request(
-      "https://join.example.test/api/internal/hosted-runtime/owner-released"
-        + "?runtimeAttemptId=runtime_attempt_routes_1",
-      { method: "POST" },
-    );
-
-    const response = await runtimeOwnerReleasedRoute.POST(request);
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ signaled: true });
-    expect(mocks.requireHostedCloudflareCallbackRequest).toHaveBeenCalledWith(
-      request,
-      { maxBodyBytes: 0 },
-    );
-    expect(mocks.readHostedRuntimeOwnerReleaseMailboxLagActionable).toHaveBeenCalledWith({
-      userId: "member_routes_1",
-    });
-    expect(mocks.signalHostedRuntimeOwnerReleasedRuntime).toHaveBeenCalledWith({
-      runtimeAttemptId: "runtime_attempt_routes_1",
-      userId: "member_routes_1",
-    });
-  });
-
-  it("signals an authenticated explicit immediate recheck without a mailbox read", async () => {
     mocks.readHostedRuntimeOwnerReleaseMailboxLagActionable.mockResolvedValue(false);
     const request = new Request(
       "https://join.example.test/api/internal/hosted-runtime/owner-released"
-        + "?runtimeAttemptId=runtime_attempt_routes_1"
-        + "&immediateRecheckRequested=1",
+        + "?runtimeAttemptId=runtime_attempt_routes_1",
       { method: "POST" },
     );
 
@@ -326,6 +301,29 @@ describe("hosted runtime internal web routes", () => {
       runtimeAttemptId: "runtime_attempt_routes_1",
       userId: "member_routes_1",
     });
+  });
+
+  it("signals an authenticated explicit immediate recheck without a mailbox read", async () => {
+    mocks.readHostedRuntimeOwnerReleaseMailboxLagActionable.mockResolvedValue(false);
+    const request = new Request(
+      "https://join.example.test/api/internal/hosted-runtime/owner-released"
+        + "?immediateRecheckRequested=1",
+      { method: "POST" },
+    );
+
+    const response = await runtimeOwnerReleasedRoute.POST(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ signaled: true });
+    expect(mocks.requireHostedCloudflareCallbackRequest).toHaveBeenCalledWith(
+      request,
+      { maxBodyBytes: 0 },
+    );
+    expect(mocks.readHostedRuntimeOwnerReleaseMailboxLagActionable).not.toHaveBeenCalled();
+    expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledWith({
+      userId: "member_routes_1",
+    });
+    expect(mocks.signalHostedRuntimeOwnerReleasedRuntime).not.toHaveBeenCalled();
   });
 
   it("keeps legacy owner releases on the facts-only recheck during rollout", async () => {
@@ -362,12 +360,11 @@ describe("hosted runtime internal web routes", () => {
     expect(mocks.signalHostedRuntimeOwnerReleasedRuntime).not.toHaveBeenCalled();
   });
 
-  it("preserves the owner horizon when no durable work is visible", async () => {
+  it("preserves the legacy owner horizon when no durable work is visible", async () => {
     mocks.readHostedRuntimeOwnerReleaseMailboxLagActionable.mockResolvedValue(false);
 
     const response = await runtimeOwnerReleasedRoute.POST(new Request(
-      "https://join.example.test/api/internal/hosted-runtime/owner-released"
-        + "?runtimeAttemptId=runtime_attempt_routes_1",
+      "https://join.example.test/api/internal/hosted-runtime/owner-released",
       { method: "POST" },
     ));
 

--- a/apps/web/test/hosted-runtime-internal-routes.test.ts
+++ b/apps/web/test/hosted-runtime-internal-routes.test.ts
@@ -34,7 +34,7 @@ const mocks = vi.hoisted(() => ({
   readHostedMemberAssistantModelPreference: vi.fn(),
   readHostedMemberCoreState: vi.fn(),
   readHostedActiveGroupRunningBit: vi.fn(),
-  readHostedRuntimeOwnerReleaseMailboxLagActionable: vi.fn(),
+  readHostedRuntimeOwnerReleaseActionable: vi.fn(),
   readHostedWorkspace: vi.fn(),
   recordHostedIngressAssistantInputStaged: vi.fn(),
   recordHostedIngressAssistantMilestone: vi.fn(),
@@ -139,8 +139,8 @@ vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({
 }));
 
 vi.mock("@/src/lib/hosted-orchestration/runtime-reconciliation-facts", () => ({
-  readHostedRuntimeOwnerReleaseMailboxLagActionable:
-    mocks.readHostedRuntimeOwnerReleaseMailboxLagActionable,
+  readHostedRuntimeOwnerReleaseActionable:
+    mocks.readHostedRuntimeOwnerReleaseActionable,
 }));
 
 type MailboxFetchRoute = typeof import("../app/api/internal/hosted-mailbox/fetch/route");
@@ -262,7 +262,7 @@ describe("hosted runtime internal web routes", () => {
     });
     mocks.readHostedActiveGroupRunningBit.mockResolvedValue(null);
     mocks.readHostedMemberCoreState.mockResolvedValue(buildActiveHostedMemberRecord());
-    mocks.readHostedRuntimeOwnerReleaseMailboxLagActionable.mockResolvedValue(true);
+    mocks.readHostedRuntimeOwnerReleaseActionable.mockResolvedValue(true);
     mocks.claimHostedAcceptedAttemptFailureRecheck.mockResolvedValue(false);
     mocks.resolveHostedRuntimeAiUsageGate.mockResolvedValue({
       status: "allowed",
@@ -281,7 +281,7 @@ describe("hosted runtime internal web routes", () => {
   });
 
   it("signals an exact authenticated runtime owner release", async () => {
-    mocks.readHostedRuntimeOwnerReleaseMailboxLagActionable.mockResolvedValue(false);
+    mocks.readHostedRuntimeOwnerReleaseActionable.mockResolvedValue(true);
     const request = new Request(
       "https://join.example.test/api/internal/hosted-runtime/owner-released"
         + "?runtimeAttemptId=runtime_attempt_routes_1",
@@ -296,7 +296,9 @@ describe("hosted runtime internal web routes", () => {
       request,
       { maxBodyBytes: 0 },
     );
-    expect(mocks.readHostedRuntimeOwnerReleaseMailboxLagActionable).not.toHaveBeenCalled();
+    expect(mocks.readHostedRuntimeOwnerReleaseActionable).toHaveBeenCalledWith({
+      userId: "member_routes_1",
+    });
     expect(mocks.signalHostedRuntimeOwnerReleasedRuntime).toHaveBeenCalledWith({
       runtimeAttemptId: "runtime_attempt_routes_1",
       userId: "member_routes_1",
@@ -304,7 +306,7 @@ describe("hosted runtime internal web routes", () => {
   });
 
   it("signals an authenticated explicit immediate recheck without a mailbox read", async () => {
-    mocks.readHostedRuntimeOwnerReleaseMailboxLagActionable.mockResolvedValue(false);
+    mocks.readHostedRuntimeOwnerReleaseActionable.mockResolvedValue(false);
     const request = new Request(
       "https://join.example.test/api/internal/hosted-runtime/owner-released"
         + "?immediateRecheckRequested=1",
@@ -319,7 +321,7 @@ describe("hosted runtime internal web routes", () => {
       request,
       { maxBodyBytes: 0 },
     );
-    expect(mocks.readHostedRuntimeOwnerReleaseMailboxLagActionable).not.toHaveBeenCalled();
+    expect(mocks.readHostedRuntimeOwnerReleaseActionable).not.toHaveBeenCalled();
     expect(mocks.signalHostedRuntimeRecheckRuntime).toHaveBeenCalledWith({
       userId: "member_routes_1",
     });
@@ -360,16 +362,25 @@ describe("hosted runtime internal web routes", () => {
     expect(mocks.signalHostedRuntimeOwnerReleasedRuntime).not.toHaveBeenCalled();
   });
 
-  it("preserves the legacy owner horizon when no durable work is visible", async () => {
-    mocks.readHostedRuntimeOwnerReleaseMailboxLagActionable.mockResolvedValue(false);
+  it.each([
+    ["exact", "?runtimeAttemptId=runtime_attempt_routes_1"],
+    ["legacy", ""],
+  ])("preserves the %s owner horizon when no durable work is visible", async (
+    _kind,
+    search,
+  ) => {
+    mocks.readHostedRuntimeOwnerReleaseActionable.mockResolvedValue(false);
 
     const response = await runtimeOwnerReleasedRoute.POST(new Request(
-      "https://join.example.test/api/internal/hosted-runtime/owner-released",
+      `https://join.example.test/api/internal/hosted-runtime/owner-released${search}`,
       { method: "POST" },
     ));
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ signaled: false });
+    expect(mocks.readHostedRuntimeOwnerReleaseActionable).toHaveBeenCalledWith({
+      userId: "member_routes_1",
+    });
     expect(mocks.signalHostedRuntimeRecheckRuntime).not.toHaveBeenCalled();
     expect(mocks.signalHostedRuntimeOwnerReleasedRuntime).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Outcome

Runtime owner releases now wake Temporal only when Web can prove runnable work remains: current non-deferred mailbox lag or a live system-mailbox item beyond the handled-through frontier. Exact callbacks keep the attempt-bound signal; legacy pointerless callbacks keep the facts-only recheck. The explicit positive `immediateRecheckRequested` edge still wakes without a read.

## Product UX result

- A member reply can preempt active background work, complete, and then hand an already-imported live item to the next runtime owner instead of leaving Murph silent.
- A no-work exact release stays inert, preventing the release callback from hot-looping an unchanged runtime.
- Future deferred mailbox work and persisted due wakes remain deferred unless current live work or the explicit positive edge exists.

## Direct evidence

- Red proof on the prior implementation: 3 focused failures showed the exact route skipped actionability, signaled with no work, and missed an imported live system frontier.
- Green focused Web proof: 128 passed across the internal route and reconciliation-facts suites.
- Real hosted-local handoff E2E: 1 passed in 105.22s. It exercised actual Web, the private Temporal worker, Cloudflare Worker/Durable Object/container, Postgres mailbox, assistant runtime, and outbound delivery; only external model and Linq transports were deterministic test servers.
- Web typecheck: passed.
- Scoped lint: zero errors; one unrelated pre-existing unused-test-helper warning.
- Complexity guard: passed with zero added debt; the changed route remains at complexity 4.

## Non-obvious affected surfaces

- Cloudflare runtime documentation changes because Cloudflare owns the signed owner-release callback producer and its bounded best-effort behavior.
- The existing September 1 handoff-recovery changelog item includes this completing PR instead of publishing a duplicate member outcome.
- No schema, dependency, environment variable, prompt, tool, provider-input, or persisted-state shape changes.

## Architecture and reuse

- Existing systems reused: the existing Web-owned mailbox high-water read, handled-through projection, live system-frontier read, exact Temporal owner-release signal, and legacy recheck signal.
- New logic: One shared actionability read governs exact and pointerless callbacks; the opaque attempt pointer only selects the signal after work is proven.
- New abstractions: none; no new state owner or seam was added.
- Complexity intentionally avoided: no queue, retry loop, reconciliation manager, state machine, compatibility shim, or new abstraction.

## Complexity impact

- Guard: pass; `pnpm complexity:diff` completed successfully with zero added debt.
- Hotspots: unchanged pre-existing reconciliation functions remain above threshold; the changed route stays at complexity 4 and adds no hotspot.
- Agent judgment: the direct guard followed by the two existing signal choices is the smallest behavior-preserving shape.

## Hot reply path impact

The callback runs after exact write-fence completion and durable reply handoff, outside durable inbound acceptance through user-visible reply. It adds one bounded Web-owned database actionability read to ordinary owner releases, then emits at most one existing Temporal signal. It adds no provider call, retry loop, or transaction around network work.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, instruction, tool/schema, model selection, or generated-guidance surface changed.
- Codex runtime: Not applicable; no provider-visible input surface changed.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: the existing production changelog item's copy and presentation are unchanged; only its source-PR provenance includes this completing fix.
- Coverage: no user-facing UI changed.

## Change-shape breakdown

Classification rule: runtime route and reconciliation logic are source; Vitest coverage is tests/fixtures; READMEs and the changelog provenance are docs; no config/tooling, generated, or binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 15 | 9 |
| Tests/fixtures | 64 | 17 |
| Docs | 19 | 14 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 98 | 40 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Web must deploy before the exact-match Temporal consumer and Cloudflare producer. The route remains compatible with pointerless callers during rollout.
- Safe order: deploy Web, make the exact-match Temporal worker Current with no ramp, then deploy Cloudflare immediately.
- Rollback floor: stop or roll back the Cloudflare producer before reverting Temporal; durable mailbox reconciliation remains the fallback.
- Expected exposure: the Web-only window accepts the existing callback shape; the final Cloudflare rollout is the only producer/consumer mixed-version window.
- Reversibility: roll back the Cloudflare producer first; Web and Temporal retain the existing pointerless reconciliation path and canonical mailbox truth.
- Convergence proof: require the exact Temporal build to be Current, then require exact Cloudflare deployment smoke and container convergence.
- Post-deploy checks: run the production conversation canary and inspect bounded owner-release, orchestration, mailbox-lag, and error aggregates without message content.

## Changelog

- Changelog: updated
- Items: 2026-09-01 · messages-resume-after-background-handoffs

ReviewGPT context sensitivity: sensitive — this changes the hosted Web-to-Temporal execution boundary and release ordering.

ReviewGPT first-reviewed head: c9f2d608753b39311f31ccfc3e25126af10d4875




