### PR TITLE
fix(journal): remove empty activity details

### DIFF
--- a/apps/web/app/design/personal-patterns-study.tsx
+++ b/apps/web/app/design/personal-patterns-study.tsx
@@ -32,7 +32,7 @@ const POPULATED_REPORT: PersonalPatternReport = {
       observedDays: 6,
     },
     {
-      id: "blue-light-blocking-glasses",
+      id: "high-filtering-amber-red-or-orange-evening-glasses-with-spectral-data-when-available",
       kind: "intervention",
       label: "Blue-light blocking glasses",
       observedDays: 7,
@@ -108,7 +108,7 @@ const POPULATED_REPORT: PersonalPatternReport = {
       6,
     ),
     cell(
-      "blue-light-blocking-glasses",
+      "high-filtering-amber-red-or-orange-evening-glasses-with-spectral-data-when-available",
       "hrv",
       "new_clue",
       "higher",

--- a/apps/web/app/design/personal-patterns-study.tsx
+++ b/apps/web/app/design/personal-patterns-study.tsx
@@ -34,8 +34,14 @@ const POPULATED_REPORT: PersonalPatternReport = {
     {
       id: "high-filtering-amber-red-or-orange-evening-glasses-with-spectral-data-when-available",
       kind: "intervention",
-      label: "Blue-light blocking glasses",
+      label: "Red/amber evening glasses",
       observedDays: 7,
+    },
+    {
+      id: "blue-light-blocking-glasses",
+      kind: "intervention",
+      label: "Blue-light blocking glasses",
+      observedDays: 5,
     },
     { id: "strength", kind: "activity", label: "Strength", observedDays: 9 },
     {
@@ -116,6 +122,16 @@ const POPULATED_REPORT: PersonalPatternReport = {
       45.2,
       43.6,
       7,
+    ),
+    cell(
+      "blue-light-blocking-glasses",
+      "hrv",
+      "new_clue",
+      "lower",
+      -2.1,
+      42.7,
+      43.6,
+      5,
     ),
     cell("running", "spo2", "new_clue", "higher", 1, 97, 96, 8),
     cell(

--- a/apps/web/app/design/personal-patterns-study.tsx
+++ b/apps/web/app/design/personal-patterns-study.tsx
@@ -31,6 +31,12 @@ const POPULATED_REPORT: PersonalPatternReport = {
       label: "Bedroom temperature",
       observedDays: 6,
     },
+    {
+      id: "blue-light-blocking-glasses",
+      kind: "intervention",
+      label: "Blue-light blocking glasses",
+      observedDays: 7,
+    },
     { id: "strength", kind: "activity", label: "Strength", observedDays: 9 },
     {
       id: "late-meal",
@@ -100,6 +106,16 @@ const POPULATED_REPORT: PersonalPatternReport = {
       45.4,
       43.6,
       6,
+    ),
+    cell(
+      "blue-light-blocking-glasses",
+      "hrv",
+      "new_clue",
+      "higher",
+      3.6,
+      45.2,
+      43.6,
+      7,
     ),
     cell("running", "spo2", "new_clue", "higher", 1, 97, 96, 8),
     cell(

--- a/apps/web/changelog/entries/2026-09-01/journal-details-are-easier-to-scan.json
+++ b/apps/web/changelog/entries/2026-09-01/journal-details-are-easier-to-scan.json
@@ -5,10 +5,10 @@
     "id": "journal-details-are-easier-to-scan",
     "kind": "improvement",
     "priority": 3,
-    "title": "Journal is easier to scan",
-    "summary": "Journal now keeps seven-day context close to the timeline, marks entries with more detail, and removes repeated context.",
-    "details": "On phones, the seven-day summary appears before the timeline, calendars and metric trends open from the bottom, and pattern insights follow the period they describe. Workout, travel, laboratory, and experiment details stay one tap away.",
+    "title": "Journal and Patterns are easier to scan",
+    "summary": "Journal keeps seven-day context close to the timeline and hides empty or repeated activity details. Patterns uses shorter labels for recognized factors.",
+    "details": "On phones, the seven-day summary appears before the timeline, calendars and metric trends open from the bottom, and pattern insights follow the period they describe. Useful workout, travel, laboratory, and experiment details stay one tap away.",
     "relevanceTags": ["journal", "workouts", "experiments", "usability"],
-    "sourcePullRequests": []
+    "sourcePullRequests": [2705, 2731]
   }
 }

--- a/apps/web/src/components/journal/journal-view.tsx
+++ b/apps/web/src/components/journal/journal-view.tsx
@@ -1442,7 +1442,7 @@ function JournalEntryActions({
         <NotebookPen className="size-3" aria-hidden="true" />
       </span>
       <span className="text-xs leading-[19px] text-muted-foreground">
-        To add, correct, or remove an entry, tell Murph in your private chat.
+        Update your journal in private chat with Murph.
       </span>
     </span>
   );

--- a/apps/web/src/components/overview/pattern-factor-icon.ts
+++ b/apps/web/src/components/overview/pattern-factor-icon.ts
@@ -236,7 +236,10 @@ const RULES: ReadonlyArray<{ icon: string; tokens: readonly string[] }> = [
     icon: habitat("night-temp"),
     tokens: ["bedroom-temperature", "night-temperature"],
   },
-  { icon: habitat("redlight"), tokens: ["red-light"] },
+  {
+    icon: habitat("redlight"),
+    tokens: ["red-light", "blue-light-blocking-glasses"],
+  },
 ];
 
 export function resolvePatternFactorIcon(

--- a/apps/web/src/components/overview/pattern-factor-icon.ts
+++ b/apps/web/src/components/overview/pattern-factor-icon.ts
@@ -238,7 +238,11 @@ const RULES: ReadonlyArray<{ icon: string; tokens: readonly string[] }> = [
   },
   {
     icon: habitat("redlight"),
-    tokens: ["red-light", "blue-light-blocking-glasses"],
+    tokens: [
+      "red-light",
+      "blue-light-blocking-glasses",
+      "red-amber-evening-glasses",
+    ],
   },
 ];
 

--- a/apps/web/test/browser-vault-dashboard-pages.test.tsx
+++ b/apps/web/test/browser-vault-dashboard-pages.test.tsx
@@ -275,7 +275,7 @@ test("JournalPage renders the derived private health timeline", () => {
     assert.doesNotMatch(markup, /10–16 August 2026/u);
     assert.match(markup, /Morning walk/u);
     assert.match(markup, /Last 7 days/u);
-    assert.match(markup, /To add, correct, or remove an entry, tell Murph/u);
+    assert.match(markup, /Update your journal in private chat with Murph/u);
     assert.match(markup, /journal-day-2026-08-12/u);
     assert.doesNotMatch(markup, /journal-day-2026-08-13/u);
     assert.doesNotMatch(markup, /No data/u);

--- a/apps/web/test/browser-vault-dashboard-pages.test.tsx
+++ b/apps/web/test/browser-vault-dashboard-pages.test.tsx
@@ -749,7 +749,7 @@ test("Personal Patterns reveals factors after the first 15 on request", async ()
   try {
     assert.match(
       rendered.container.textContent ?? "",
-      /Showing 15 of 17 factors/u,
+      /Showing 15 of 19 factors/u,
     );
     assert.doesNotMatch(rendered.container.textContent ?? "", /Yoga/u);
     assert.doesNotMatch(rendered.container.textContent ?? "", /Reading/u);
@@ -764,7 +764,7 @@ test("Personal Patterns reveals factors after the first 15 on request", async ()
 
     assert.match(
       rendered.container.textContent ?? "",
-      /Showing 17 of 17 factors/u,
+      /Showing 19 of 19 factors/u,
     );
     assert.match(rendered.container.textContent ?? "", /Yoga/u);
     assert.match(rendered.container.textContent ?? "", /Reading/u);

--- a/apps/web/test/pattern-factor-icon.test.ts
+++ b/apps/web/test/pattern-factor-icon.test.ts
@@ -186,6 +186,10 @@ test("specific local factors resolve to their intended Quiver illustrations", ()
     ),
     /redlight\.svg$/u,
   );
+  assert.match(
+    resolvePatternFactorIcon(factor("Red/amber evening glasses", "intervention")),
+    /redlight\.svg$/u,
+  );
 });
 
 test("unknown provider values use the neutral fallback illustration", () => {

--- a/apps/web/test/pattern-factor-icon.test.ts
+++ b/apps/web/test/pattern-factor-icon.test.ts
@@ -180,6 +180,12 @@ test("specific local factors resolve to their intended Quiver illustrations", ()
     resolvePatternFactorIcon(factor("Bedroom temperature", "intervention")),
     /night-temp\.svg$/u,
   );
+  assert.match(
+    resolvePatternFactorIcon(
+      factor("Blue-light blocking glasses", "intervention"),
+    ),
+    /redlight\.svg$/u,
+  );
 });
 
 test("unknown provider values use the neutral fallback illustration", () => {

--- a/packages/contracts/src/browser-vault.ts
+++ b/packages/contracts/src/browser-vault.ts
@@ -7,7 +7,7 @@ export const BROWSER_VAULT_TRAINING_SESSION_SCHEMA =
  * Increment when a projection-shape or projection-interpretation change makes
  * an otherwise source-current browser replica incomplete for current readers.
  */
-export const BROWSER_VAULT_REPLICA_CURRENT_GENERATION = 14 as const;
+export const BROWSER_VAULT_REPLICA_CURRENT_GENERATION = 15 as const;
 
 export const BROWSER_VAULT_METRIC_BUCKET_IDS = [
   "00",

--- a/packages/contracts/test/browser-vault.test.ts
+++ b/packages/contracts/test/browser-vault.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../src/browser-vault.ts";
 
 test("browser vault generation rebuilds replicas for the bucketed metrics layout", () => {
-  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 14);
+  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 15);
 });
 
 test("browser vault owns one fixed 32-bucket lowercase hexadecimal namespace", () => {

--- a/packages/hosted-execution/test/hosted-execution.test.ts
+++ b/packages/hosted-execution/test/hosted-execution.test.ts
@@ -470,7 +470,7 @@ describe("hosted execution coverage gaps", () => {
   });
 
   it("centralizes browser-vault replica source hash and refresh decisions", () => {
-    expect(BROWSER_VAULT_REPLICA_CURRENT_GENERATION).toBe(14);
+    expect(BROWSER_VAULT_REPLICA_CURRENT_GENERATION).toBe(15);
     const base = {
       hash: "a".repeat(64),
       key: "cloudflare-workspace-snapshots/base.bundle",

--- a/packages/query/src/journal-view.ts
+++ b/packages/query/src/journal-view.ts
@@ -711,7 +711,7 @@ function mealSummary(attributes: Record<string, unknown>): string | null {
 
 function journalEventDetailItems(event: CanonicalEntity): string[] {
   if (event.kind === "activity_session") {
-    return activityDetailItems(event.attributes);
+    return activityDetailItems(event.attributes, eventLabel(event));
   }
 
   if (event.kind === "experiment_context") {
@@ -808,7 +808,10 @@ function experimentJournalSummary(
   return progress;
 }
 
-function activityDetailItems(attributes: Record<string, unknown>): string[] {
+function activityDetailItems(
+  attributes: Record<string, unknown>,
+  title: string,
+): string[] {
   const workout = readRecord(attributes.workout);
   const metrics = readRecord(workout?.metrics);
   const distanceKm = firstJournalNumber(
@@ -847,9 +850,9 @@ function activityDetailItems(attributes: Record<string, unknown>): string[] {
   const energy = activeCalories === null ? totalCalories : activeCalories;
 
   return uniqueStrings([
-    readString(workout?.routineName),
-    readString(workout?.sportName),
-    formatJournalDetail("Distance", distanceKm, "km"),
+    usefulActivityDetail(workout?.routineName, title),
+    usefulActivityDetail(workout?.sportName, title),
+    formatPositiveJournalDetail("Distance", distanceKm, "km"),
     formatJournalDetail("Average heart rate", averageHeartRate, "bpm"),
     formatJournalDetail("Maximum heart rate", maxHeartRate, "bpm"),
     formatJournalDetail("Strain", strain),
@@ -862,6 +865,14 @@ function activityDetailItems(attributes: Record<string, unknown>): string[] {
     formatJournalDetail("Average power", averagePower, "W"),
     exercises.length > 0 ? `Exercises: ${exercises.join(", ")}` : null,
   ]);
+}
+
+function usefulActivityDetail(value: unknown, title: string): string | null {
+  const detail = readString(value);
+  if (!detail || detail.toLocaleLowerCase() === "unknown") return null;
+  return detail.localeCompare(title, undefined, { sensitivity: "accent" }) === 0
+    ? null
+    : detail;
 }
 
 function firstJournalNumber(...values: readonly unknown[]): number | null {
@@ -891,6 +902,16 @@ function formatJournalDetail(
 ): string | null {
   if (value === null) return null;
   return `${label}: ${formatDetailNumber(value)}${unit ? ` ${unit}` : ""}`;
+}
+
+function formatPositiveJournalDetail(
+  label: string,
+  value: number | null,
+  unit?: string,
+): string | null {
+  return value !== null && value > 0
+    ? formatJournalDetail(label, value, unit)
+    : null;
 }
 
 function formatDetailNumber(value: number): string {

--- a/packages/query/src/personal-patterns.ts
+++ b/packages/query/src/personal-patterns.ts
@@ -1410,12 +1410,14 @@ function canonicalFactorToken(value: string | null): string | null {
 }
 
 function humanizeToken(value: string): string {
-  if (
-    value === "blue-light-blocking-glasses" ||
-    value ===
-      "high-filtering-amber-red-or-orange-evening-glasses-with-spectral-data-when-available"
-  ) {
+  if (value === "blue-light-blocking-glasses") {
     return "Blue-light blocking glasses";
+  }
+  if (
+    value ===
+    "high-filtering-amber-red-or-orange-evening-glasses-with-spectral-data-when-available"
+  ) {
+    return "Red/amber evening glasses";
   }
   const readableValue =
     value === "yardwork"

--- a/packages/query/src/personal-patterns.ts
+++ b/packages/query/src/personal-patterns.ts
@@ -1385,6 +1385,8 @@ function readFiniteNumber(value: unknown): number | null {
 
 function canonicalFactorToken(value: string | null): string | null {
   switch (value) {
+    case "high-filtering-amber-red-or-orange-evening-glasses-with-spectral-data-when-available":
+      return "blue-light-blocking-glasses";
     case "run":
       return "running";
     case "walk":
@@ -1410,6 +1412,9 @@ function canonicalFactorToken(value: string | null): string | null {
 }
 
 function humanizeToken(value: string): string {
+  if (value === "blue-light-blocking-glasses") {
+    return "Blue-light blocking glasses";
+  }
   const readableValue =
     value === "yardwork"
       ? "yard-work"

--- a/packages/query/src/personal-patterns.ts
+++ b/packages/query/src/personal-patterns.ts
@@ -1385,8 +1385,6 @@ function readFiniteNumber(value: unknown): number | null {
 
 function canonicalFactorToken(value: string | null): string | null {
   switch (value) {
-    case "high-filtering-amber-red-or-orange-evening-glasses-with-spectral-data-when-available":
-      return "blue-light-blocking-glasses";
     case "run":
       return "running";
     case "walk":
@@ -1412,7 +1410,11 @@ function canonicalFactorToken(value: string | null): string | null {
 }
 
 function humanizeToken(value: string): string {
-  if (value === "blue-light-blocking-glasses") {
+  if (
+    value === "blue-light-blocking-glasses" ||
+    value ===
+      "high-filtering-amber-red-or-orange-evening-glasses-with-spectral-data-when-available"
+  ) {
     return "Blue-light blocking glasses";
   }
   const readableValue =

--- a/packages/query/test/browser-vault-lab-results.test.ts
+++ b/packages/query/test/browser-vault-lab-results.test.ts
@@ -99,7 +99,7 @@ test("browser vault projects all live lab history without widening the wearable 
     sourceBundleHash: "f".repeat(64),
     vault,
   });
-  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 14);
+  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 15);
   assert.equal(replica.generation, BROWSER_VAULT_REPLICA_CURRENT_GENERATION);
   const client = createBrowserVaultQueryClient(
     parseBrowserVaultReplica(replica),

--- a/packages/query/test/browser-vault-replica-shards.test.ts
+++ b/packages/query/test/browser-vault-replica-shards.test.ts
@@ -362,7 +362,7 @@ test("browser vault shard parsers validate schemas, bucket placement, and genera
 test("browser vault metric bucket assignment has stable SHA-256 test vectors", async () => {
   // Changing any vector requires a generation bump so old refs are never read
   // with a new canonical-key placement rule.
-  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 14);
+  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 15);
   assert.equal(await getBrowserVaultMetricBucketId("spo2"), "02");
   assert.equal(await getBrowserVaultMetricBucketId("lowest-spo2"), "19");
   assert.equal(await getBrowserVaultMetricBucketId("estimated-vo2-max"), "0d");

--- a/packages/query/test/browser-vault-training-projection.test.ts
+++ b/packages/query/test/browser-vault-training-projection.test.ts
@@ -311,7 +311,7 @@ test("browser vault replicas expose a bounded sanitized training projection with
   assert.equal(liveTraining.state, "in_progress");
   assert.equal("sourceApp" in liveTraining, false);
   assert.deepEqual(liveTraining.exercises, []);
-  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 14);
+  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 15);
 });
 
 test("browser training projection preserves completed next-local-day sessions before UTC midnight", async () => {

--- a/packages/query/test/journal-view.test.ts
+++ b/packages/query/test/journal-view.test.ts
@@ -374,6 +374,38 @@ test("Journal keeps useful workout detail in the activity popover", () => {
   ]);
 });
 
+test("Journal omits missing and repeated activity details", () => {
+  const view = buildJournalView(
+    createVaultReadModel({
+      entities: [
+        event(
+          "yard_work",
+          "activity_session",
+          "2026-08-25T12:37:00.000Z",
+          {
+            activityType: "yardwork",
+            source: "oura",
+            workout: {
+              metrics: { activeCalories: 925 },
+              routineName: "Unknown",
+              sportName: "Yard work",
+            },
+            distanceKm: 0,
+          },
+          "Yard work",
+        ),
+      ],
+      vaultRoot: "test://journal-activity-detail-cleanup",
+    }),
+    [],
+    { asOf: "2026-08-25T22:00:00.000Z" },
+  );
+
+  assert.deepEqual(view.days[0]?.events[0]?.details, [
+    "Active energy: 925 kcal",
+  ]);
+});
+
 test("Journal keeps source note summaries and experiment results without tag rules", () => {
   const lateCaffeine = {
     ...event(

--- a/packages/query/test/personal-patterns.test.ts
+++ b/packages/query/test/personal-patterns.test.ts
@@ -1429,6 +1429,40 @@ test("Personal Patterns keeps recognized factors when matched history is insuffi
   assert.equal(report.testedCellCount, 0);
 });
 
+test("Personal Patterns uses the concise label for evening light-filtering glasses", () => {
+  const start = "2026-03-02";
+  const entities: CanonicalEntity[] = [
+    ...Array.from({ length: 5 }, (_, index) => ({
+      ...event(`glasses_${index}`, addDays(start, index), "note", {}),
+      tags: [
+        "key-high-filtering-amber-red-or-orange-evening-glasses-with-spectral-data-when-available",
+      ],
+      attributes: { noteType: "journal-factor" },
+    })),
+    ...Array.from({ length: 6 }, (_, index) =>
+      observation(
+        `sleep_${index}`,
+        addDays(start, index + 1),
+        "sleep-score",
+        80,
+        "score",
+      ),
+    ),
+  ];
+  const report = buildPersonalPatternReport(
+    createVaultReadModel({
+      entities,
+      vaultRoot: "test://personal-pattern-light-filtering-glasses",
+    }),
+    { asOf: "2026-03-08T12:00:00.000Z" },
+  );
+
+  assert.deepEqual(
+    report.factors.map((factor) => [factor.id, factor.label]),
+    [["blue-light-blocking-glasses", "Blue-light blocking glasses"]],
+  );
+});
+
 test("Personal Patterns suppresses outcome-like activity and intervention factors", () => {
   const start = "2026-01-05";
   const factorDates = Array.from({ length: 8 }, (_, index) =>

--- a/packages/query/test/personal-patterns.test.ts
+++ b/packages/query/test/personal-patterns.test.ts
@@ -1439,6 +1439,11 @@ test("Personal Patterns uses the concise label for evening light-filtering glass
       ],
       attributes: { noteType: "journal-factor" },
     })),
+    ...Array.from({ length: 5 }, (_, index) => ({
+      ...event(`generic_glasses_${index}`, addDays(start, index + 1), "note", {}),
+      tags: ["key-blue-light-blocking-glasses"],
+      attributes: { noteType: "journal-factor" },
+    })),
     ...Array.from({ length: 6 }, (_, index) =>
       observation(
         `sleep_${index}`,
@@ -1459,7 +1464,13 @@ test("Personal Patterns uses the concise label for evening light-filtering glass
 
   assert.deepEqual(
     report.factors.map((factor) => [factor.id, factor.label]),
-    [["blue-light-blocking-glasses", "Blue-light blocking glasses"]],
+    [
+      [
+        "high-filtering-amber-red-or-orange-evening-glasses-with-spectral-data-when-available",
+        "Blue-light blocking glasses",
+      ],
+      ["blue-light-blocking-glasses", "Blue-light blocking glasses"],
+    ],
   );
 });
 

--- a/packages/query/test/personal-patterns.test.ts
+++ b/packages/query/test/personal-patterns.test.ts
@@ -1465,11 +1465,11 @@ test("Personal Patterns uses the concise label for evening light-filtering glass
   assert.deepEqual(
     report.factors.map((factor) => [factor.id, factor.label]),
     [
+      ["blue-light-blocking-glasses", "Blue-light blocking glasses"],
       [
         "high-filtering-amber-red-or-orange-evening-glasses-with-spectral-data-when-available",
-        "Blue-light blocking glasses",
+        "Red/amber evening glasses",
       ],
-      ["blue-light-blocking-glasses", "Blue-light blocking glasses"],
     ],
   );
 });


### PR DESCRIPTION
ReviewGPT context sensitivity: sensitive
ReviewGPT first-reviewed head: 773ad890d4c2833ead40936f2cf5f2940a989b1f

## Outcome

Journal activity details now omit zero distance, unknown labels, and descriptions that repeat the activity title. Patterns uses concise, distinct labels and the existing Quiver illustration for evening light-filtering glasses. Existing Browser Vault history refreshes into the corrected projections.

## Product UX

- Outcome: sparse provider data no longer creates empty or repeated detail rows. Two supported glasses factors remain clear when they coexist.
- Reaches: existing members opening Journal activity details and Patterns.
- Proof: focused query and Web tests, desktop and mobile renders, and the previous-generation replica refresh path.

## Evidence

- Query projection tests: 93 passed.
- Web Journal, Patterns, and refresh-path tests: 107 passed.
- Contracts and hosted-execution tests: 12 passed.
- Query, Web, contracts, and hosted-execution typechecks passed.
- Complexity guard passed.

## Design proof

- Design page: https://www.withmurph.ai/design?tab=components#journal-study
- Evidence: local desktop and mobile renders inspected for Journal and Personal Patterns.
- Coverage: zero-distance activity, repeated activity label, concise helper copy, both glasses factors together, distinct labels, and the Quiver illustration.

## Architecture and reuse

- Existing systems reused: Journal query projection, Personal Patterns display labels, Quiver asset registry, and Browser Vault generation refresh.
- New logic: omit non-positive distance, unknown activity text, and text equal to the activity title; shorten two supported factor labels without changing their stable IDs; advance the projection generation from 14 to 15.
- New abstractions: none. Existing owners already cover this behavior.
- Complexity intentionally avoided: no factor-ID migration, model call, provider-specific UI branch, dependency, backfill, or new state owner.

## Complexity impact

- Guard: pass, pnpm complexity:diff.
- Hotspots: none above threshold 20.
- Agent judgment: existing query and replica-generation owners cover the complete correction without new machinery.

## Affected surfaces

- Journal activity detail popovers
- Journal private-chat helper copy
- Personal Patterns factor labels and illustrations
- Existing Browser Vault history through generation-15 refresh

## Hot reply path

No change.

## Provider input

No provider schema change. Missing Oura distance remains missing instead of rendering as zero.

## Deployment concerns

- Deployment: applicable
- Supported skew: The new Web reads existing vault history, while the old Web can stay live during the hold.
- Safe order: Keep the rollback live until messaging recovers. Then deploy Cloudflare first, Web second, and run the Web migration step.
- Rollback floor: Keep the known-good Web deployment and Cloudflare version available until all post-deploy checks pass.
- Expected exposure: Members stay on the known-good release during the hold, followed by one normal rollout window.
- Reversibility: Cancel the new Web deployment or restore the known-good alias, then roll Cloudflare back to the saved version.
- Convergence proof: Confirm Cloudflare sends all traffic to the intended version and www points to the intended Vercel deployment.
- Post-deploy checks: Run the Linq canary, open Journal and Patterns with existing history, and confirm the generation-15 Browser Vault refresh completes.

## Changelog

- Changelog: updated
- Items: 2026-09-01 · journal-details-are-easier-to-scan

## LOC

- Source: +45 / -8
- Tests and fixtures: +95 / -8
- Design proof: +32 / -0
- Docs: +4 / -4
- Config and tooling: +0 / -0
- Generated and other: +0 / -0
