### PR TITLE
Suppress expected hosted latency contention warnings

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-02-latency-trace-contention-warning.md
+++ b/agent-docs/exec-plans/active/2026-09-02-latency-trace-contention-warning.md
@@ -1,0 +1,55 @@
+# Latency trace contention warning
+
+Status: active
+Created: 2026-09-02
+Updated: 2026-09-02
+
+## Goal
+
+- Keep hosted latency trace writes non-blocking while warning only for rows that
+  fail trace ownership or eligibility, not rows skipped during expected lock
+  contention and recorded by the existing retry.
+
+## Evidence boundary
+
+- A bounded production trace completed staging, provider start, assistant
+  output, reply handoff, and delivery even though Web warned about one rejected
+  assistant milestone during the runtime retry window.
+- The existing real-PostgreSQL proof shows `FOR UPDATE SKIP LOCKED` returns the
+  same unmatched result for a contended row and records it after retry.
+- Production evidence remains private and identifier-free; repository proof
+  uses synthetic fixtures only.
+
+## Constraints
+
+- Do not wait on a contended trace row or put telemetry on the foreground reply
+  critical path.
+- Preserve the existing runtime retry and the three-field callback response.
+- Keep true source, user, attempt, and lease rejection warnings intact.
+- Add no state, dependency, queue, or database round trip.
+
+## Tasks
+
+1. Classify unmatched set-write rows that passed eligibility but were skipped
+   because their trace row was locked.
+2. Exclude those contended rows from Web's rejected-row warning count.
+3. Prove warning behavior with route coverage and classification with the
+   existing real-PostgreSQL contention scenario.
+4. Run focused tests, Web typecheck, final review, exact-head CI, and close the
+   plan through the normal scoped commit path.
+
+## Done when
+
+- A pure contention result emits no rejected-row warning and still returns the
+  unchanged callback response.
+- A genuine rejected row still warns with identifier-free counts.
+- Focused unit and real-PostgreSQL checks pass.
+
+## Validation
+
+- `pnpm exec vitest run --config apps/web/vitest.config.ts
+  apps/web/test/hosted-runtime-internal-routes.test.ts
+  apps/web/test/hosted-runtime-latency-store.test.ts`: 108 tests passed.
+- Dedicated migrated local PostgreSQL database with
+  `MURPH_TEST_POSTGRES_CONCURRENCY=1`: 5 contention tests passed.
+- `pnpm --dir apps/web typecheck`: passed.

--- a/agent-docs/exec-plans/active/2026-09-02-latency-trace-contention-warning.md
+++ b/agent-docs/exec-plans/active/2026-09-02-latency-trace-contention-warning.md
@@ -34,7 +34,9 @@ Updated: 2026-09-02
    because their trace row was locked.
 2. Exclude those contended rows from Web's rejected-row warning count.
 3. Prove warning behavior with route coverage and classification with the
-   existing real-PostgreSQL contention scenario.
+   existing real-PostgreSQL contention scenario. Revalidate write authority on
+   the live row at lock time, and prove a snapshot-to-lock ownership transfer
+   cannot admit a stale lifecycle or provider write.
 4. Run focused tests, Web typecheck, final review, exact-head CI, and close the
    plan through the normal scoped commit path.
 
@@ -43,6 +45,8 @@ Updated: 2026-09-02
 - A pure contention result emits no rejected-row warning and still returns the
   unchanged callback response.
 - A genuine rejected row still warns with identifier-free counts.
+- A row that changes attempt or lease ownership after the diagnostic snapshot
+  rejects the stale write while preserving the newer owner.
 - Focused unit and real-PostgreSQL checks pass.
 
 ## Validation
@@ -51,5 +55,10 @@ Updated: 2026-09-02
   apps/web/test/hosted-runtime-internal-routes.test.ts
   apps/web/test/hosted-runtime-latency-store.test.ts`: 108 tests passed.
 - Dedicated migrated local PostgreSQL database with
-  `MURPH_TEST_POSTGRES_CONCURRENCY=1`: 5 contention tests passed.
+  `MURPH_TEST_POSTGRES_CONCURRENCY=1`: 6 concurrency tests passed, including a
+  deterministic snapshot-to-lock transfer for lifecycle and provider writes.
+- The ownership-transfer test failed against the pre-remediation query because
+  the stale lifecycle write matched, then passed after lock-time eligibility
+  revalidation was restored.
 - `pnpm --dir apps/web typecheck`: passed.
+- Focused ESLint, `pnpm complexity:diff`, and `git diff --check`: passed.

--- a/agent-docs/exec-plans/completed/2026-09-02-latency-trace-contention-warning.md
+++ b/agent-docs/exec-plans/completed/2026-09-02-latency-trace-contention-warning.md
@@ -1,6 +1,6 @@
 # Latency trace contention warning
 
-Status: active
+Status: completed
 Created: 2026-09-02
 Updated: 2026-09-02
 
@@ -62,3 +62,7 @@ Updated: 2026-09-02
   revalidation was restored.
 - `pnpm --dir apps/web typecheck`: passed.
 - Focused ESLint, `pnpm complexity:diff`, and `git diff --check`: passed.
+- Final ReviewGPT round 2: `PASS`; the prior snapshot-to-lock ownership finding
+  is resolved with no new production owner, state, or round trip.
+- Required GitHub checks passed on the reviewed remediation head.
+Completed: 2026-09-02

--- a/apps/web/app/api/internal/hosted-runtime/latency/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/latency/route.ts
@@ -91,15 +91,18 @@ export const POST = withJsonError(async (request: Request) => {
           });
 
     // Assistant inputs the runtime created without an inbound messaging wake never
-    // get an ingress trace row, so reporting them is noise. Warn only when a row
-    // existed and the guarded write still declined it, which is the case an
-    // operator can act on.
+    // get an ingress trace row, so reporting them is noise. A row skipped while
+    // another callback holds its lock is also expected: the runtime retries that
+    // non-blocking write. Warn only when a traced row actually failed the guarded
+    // ownership or eligibility check.
+    const contendedCount = result.contendedCount ?? 0;
     const untracedCount = result.untracedCount ?? 0;
-    const rejectedCount = result.unmatchedCount - untracedCount;
+    const rejectedCount = result.unmatchedCount - untracedCount - contendedCount;
     if (rejectedCount > 0) {
       const eventType = traceRequest.event.type;
       const source = traceRequest.event.source;
       console.warn("Hosted runtime latency trace callback had rejected rows.", {
+        contendedCount,
         eventType,
         matchedCount: result.matchedCount,
         rejectedCount,

--- a/apps/web/src/lib/hosted-runtime-latency/store.ts
+++ b/apps/web/src/lib/hosted-runtime-latency/store.ts
@@ -453,9 +453,15 @@ export async function recordHostedIngressProviderStarted(input: {
     locked AS MATERIALIZED (
       SELECT scoped.assistant_input_id, trace.id
       FROM scoped
+      CROSS JOIN input
       JOIN hosted_ingress_latency_trace AS trace
         ON trace.id = scoped.trace_id
       WHERE scoped.eligible
+        AND (
+          trace.runtime_attempt_id IS NULL
+          OR input.runtime_attempt_id IS NULL
+          OR trace.runtime_attempt_id = input.runtime_attempt_id
+        )
       ORDER BY trace.id
       FOR UPDATE OF trace SKIP LOCKED
     ),
@@ -626,9 +632,21 @@ export async function recordHostedIngressAssistantMilestone(input: {
     locked AS MATERIALIZED (
       SELECT scoped.assistant_input_id, trace.id
       FROM scoped
+      CROSS JOIN input
       JOIN hosted_ingress_latency_trace AS trace
         ON trace.id = scoped.trace_id
       WHERE scoped.eligible
+        AND (
+          input.terminal_non_reply_projection
+          OR (
+            input.lifecycle_projection
+            AND ${buildHostedIngressLifecycleAssistantMilestoneEligibilitySql()}
+          )
+          OR (
+            NOT input.lifecycle_projection
+            AND trace.runtime_attempt_id = input.runtime_attempt_id
+          )
+        )
       ORDER BY trace.id
       FOR UPDATE OF trace SKIP LOCKED
     ),

--- a/apps/web/src/lib/hosted-runtime-latency/store.ts
+++ b/apps/web/src/lib/hosted-runtime-latency/store.ts
@@ -94,6 +94,10 @@ const HOSTED_INGRESS_LATENCY_PHASE_LEAF_RULES_JSON = JSON.stringify(
 );
 
 export interface HostedIngressLatencyWriteResult {
+  // Subset of unmatchedCount that passed ownership/eligibility but could not
+  // claim a trace row because another latency callback held its lock. The
+  // existing runtime retry owns convergence for these rows.
+  contendedCount?: number;
   matchedCount: number;
   recorded: boolean;
   /** True when a best-effort collection milestone deliberately bounded its write. */
@@ -430,8 +434,15 @@ export async function recordHostedIngressProviderStarted(input: {
     requested(assistant_input_id) AS (
       VALUES ${requestedIds}
     ),
-    scoped AS (
-      SELECT DISTINCT requested.assistant_input_id
+    scoped AS MATERIALIZED (
+      SELECT DISTINCT
+        requested.assistant_input_id,
+        trace.id AS trace_id,
+        (
+          trace.runtime_attempt_id IS NULL
+          OR input.runtime_attempt_id IS NULL
+          OR trace.runtime_attempt_id = input.runtime_attempt_id
+        ) AS eligible
       FROM requested
       CROSS JOIN input
       JOIN hosted_ingress_latency_trace AS trace
@@ -440,18 +451,11 @@ export async function recordHostedIngressProviderStarted(input: {
        AND trace.source = input.source
     ),
     locked AS MATERIALIZED (
-      SELECT requested.assistant_input_id, trace.id
-      FROM requested
-      CROSS JOIN input
+      SELECT scoped.assistant_input_id, trace.id
+      FROM scoped
       JOIN hosted_ingress_latency_trace AS trace
-        ON trace.assistant_input_id = requested.assistant_input_id
-       AND trace.user_id = input.user_id
-       AND trace.source = input.source
-       AND (
-         trace.runtime_attempt_id IS NULL
-         OR input.runtime_attempt_id IS NULL
-         OR trace.runtime_attempt_id = input.runtime_attempt_id
-       )
+        ON trace.id = scoped.trace_id
+      WHERE scoped.eligible
       ORDER BY trace.id
       FOR UPDATE OF trace SKIP LOCKED
     ),
@@ -496,6 +500,12 @@ export async function recordHostedIngressProviderStarted(input: {
         FROM scoped
         WHERE scoped.assistant_input_id = requested.assistant_input_id
       ) AS traced,
+      EXISTS (
+        SELECT 1
+        FROM scoped
+        WHERE scoped.assistant_input_id = requested.assistant_input_id
+          AND scoped.eligible
+      ) AS eligible,
       EXISTS (
         SELECT 1
         FROM locked
@@ -591,8 +601,21 @@ export async function recordHostedIngressAssistantMilestone(input: {
     requested(assistant_input_id) AS (
       VALUES ${requestedIds}
     ),
-    scoped AS (
-      SELECT DISTINCT requested.assistant_input_id
+    scoped AS MATERIALIZED (
+      SELECT DISTINCT
+        requested.assistant_input_id,
+        trace.id AS trace_id,
+        (
+          input.terminal_non_reply_projection
+          OR (
+            input.lifecycle_projection
+            AND ${buildHostedIngressLifecycleAssistantMilestoneEligibilitySql()}
+          )
+          OR (
+            NOT input.lifecycle_projection
+            AND trace.runtime_attempt_id = input.runtime_attempt_id
+          )
+        ) AS eligible
       FROM requested
       CROSS JOIN input
       JOIN hosted_ingress_latency_trace AS trace
@@ -601,24 +624,11 @@ export async function recordHostedIngressAssistantMilestone(input: {
        AND trace.source = input.source
     ),
     locked AS MATERIALIZED (
-      SELECT requested.assistant_input_id, trace.id
-      FROM requested
-      CROSS JOIN input
+      SELECT scoped.assistant_input_id, trace.id
+      FROM scoped
       JOIN hosted_ingress_latency_trace AS trace
-        ON trace.assistant_input_id = requested.assistant_input_id
-       AND trace.user_id = input.user_id
-       AND trace.source = input.source
-       AND (
-         input.terminal_non_reply_projection
-         OR (
-           input.lifecycle_projection
-           AND ${buildHostedIngressLifecycleAssistantMilestoneEligibilitySql()}
-         )
-         OR (
-           NOT input.lifecycle_projection
-           AND trace.runtime_attempt_id = input.runtime_attempt_id
-         )
-       )
+        ON trace.id = scoped.trace_id
+      WHERE scoped.eligible
       ORDER BY trace.id
       FOR UPDATE OF trace SKIP LOCKED
     ),
@@ -656,6 +666,12 @@ export async function recordHostedIngressAssistantMilestone(input: {
       ) AS traced,
       EXISTS (
         SELECT 1
+        FROM scoped
+        WHERE scoped.assistant_input_id = requested.assistant_input_id
+          AND scoped.eligible
+      ) AS eligible,
+      EXISTS (
+        SELECT 1
         FROM locked
         WHERE locked.assistant_input_id = requested.assistant_input_id
       ) AS matched
@@ -670,6 +686,7 @@ export async function recordHostedIngressAssistantMilestone(input: {
 
 type HostedIngressLatencySetWriteProjectionRow = {
   assistantInputId: string;
+  eligible: boolean;
   matched: boolean;
   traced: boolean;
 };
@@ -690,10 +707,15 @@ function buildHostedIngressLatencySetWriteResult(input: {
   const tracedIds = new Set(input.rows
     .filter((row) => row.traced)
     .map((row) => row.assistantInputId));
+  const eligibleIds = new Set(input.rows
+    .filter((row) => row.eligible)
+    .map((row) => row.assistantInputId));
   const unmatchedIds = input.assistantInputIds.filter((id) => !matchedIds.has(id));
   const untracedCount = unmatchedIds.filter((id) => !tracedIds.has(id)).length;
+  const contendedCount = unmatchedIds.filter((id) => eligibleIds.has(id)).length;
 
   return {
+    ...(contendedCount > 0 ? { contendedCount } : {}),
     matchedCount: matchedIds.size,
     recorded: matchedIds.size > 0,
     unmatchedCount: unmatchedIds.length,

--- a/apps/web/test/hosted-runtime-internal-routes.test.ts
+++ b/apps/web/test/hosted-runtime-internal-routes.test.ts
@@ -3027,6 +3027,35 @@ describe("hosted runtime internal web routes", () => {
       });
       expect(warn).not.toHaveBeenCalled();
 
+      mocks.recordHostedIngressAssistantMilestone.mockResolvedValue({
+        contendedCount: 1,
+        matchedCount: 0,
+        recorded: false,
+        unmatchedCount: 1,
+      });
+      const contendedResponse = await runtimeLatencyRoute.POST(jsonRequest(
+        "/api/internal/hosted-runtime/latency",
+        {
+          event: {
+            assistantInputIds: ["input_contended_1"],
+            at: FIXED_NOW,
+            milestone: "linq_typing_accepted",
+            runtimeAttemptId: "attempt_routes_1",
+            source: "linq",
+            type: "assistant_milestone",
+          },
+        },
+        runtimeWriteFenceHeaders(),
+      ));
+
+      expect(contendedResponse.status).toBe(200);
+      expect(await contendedResponse.json()).toEqual({
+        matchedCount: 0,
+        recorded: false,
+        unmatchedCount: 1,
+      });
+      expect(warn).not.toHaveBeenCalled();
+
       mocks.recordHostedIngressProviderStarted.mockResolvedValue({
         matchedCount: 1,
         recorded: true,
@@ -3053,6 +3082,7 @@ describe("hosted runtime internal web routes", () => {
       expect(warn).toHaveBeenCalledWith(
         "Hosted runtime latency trace callback had rejected rows.",
         {
+          contendedCount: 0,
           eventType: "provider_started",
           matchedCount: 1,
           rejectedCount: 1,

--- a/apps/web/test/hosted-runtime-latency-postgres-concurrency.test.ts
+++ b/apps/web/test/hosted-runtime-latency-postgres-concurrency.test.ts
@@ -408,6 +408,258 @@ describe.skipIf(!runPostgresProof)(
       }
     });
 
+    it("rechecks transferred ownership after taking its eligibility snapshot", async () => {
+      const suffix = randomUUID().replaceAll("-", "");
+      const memberId = `hbm_latency_owner_recheck_${suffix}`;
+      const lifecycleAssistantInputId =
+        `assistant_input_latency_owner_lifecycle_${suffix}`;
+      const providerAssistantInputId =
+        `assistant_input_latency_owner_provider_${suffix}`;
+      const lifecycleMailboxItemId = `hmi_latency_owner_lifecycle_${suffix}`;
+      const providerMailboxItemId = `hmi_latency_owner_provider_${suffix}`;
+      const lifecycleTraceId = `hil_latency_owner_lifecycle_${suffix}`;
+      const providerTraceId = `hil_latency_owner_provider_${suffix}`;
+      const staleLifecycleAttemptId = `runtime_latency_stale_lifecycle_${suffix}`;
+      const currentLifecycleAttemptId = `runtime_latency_current_lifecycle_${suffix}`;
+      const staleProviderAttemptId = `runtime_latency_stale_provider_${suffix}`;
+      const currentProviderAttemptId = `runtime_latency_current_provider_${suffix}`;
+      const applicationName = `latency_owner_recheck_${suffix.slice(0, 8)}`;
+      const observer = createPrismaClient({ databaseUrl, poolMax: 1 });
+      const barrier = createPrismaClient({ databaseUrl, poolMax: 1 });
+      const staleWriter = createPrismaClient({
+        databaseUrl: withPostgresApplicationName(databaseUrl, applicationName),
+        poolMax: 1,
+      });
+      const inFlight: Promise<unknown>[] = [];
+      let heldBarrierKey: bigint | null = null;
+
+      const armSnapshotBarrier = async (barrierKey: bigint): Promise<void> => {
+        await barrier.$executeRaw`
+          SELECT pg_advisory_lock(${barrierKey})
+        `;
+        heldBarrierKey = barrierKey;
+        await staleWriter.$queryRaw`
+          SELECT
+            set_config(
+              'murph.latency_snapshot_barrier_key',
+              ${barrierKey.toString()},
+              false
+            ),
+            set_config(
+              'murph.latency_snapshot_barrier_state',
+              'armed',
+              false
+            )
+        `;
+      };
+      const releaseSnapshotBarrier = async (): Promise<void> => {
+        if (heldBarrierKey === null) {
+          return;
+        }
+        const barrierKey = heldBarrierKey;
+        heldBarrierKey = null;
+        await barrier.$queryRaw`
+          SELECT pg_advisory_unlock(${barrierKey})
+        `;
+      };
+
+      try {
+        const acceptedAt = new Date("2026-08-09T12:20:00.000Z");
+        await observer.hostedMember.create({ data: { id: memberId } });
+        await observer.hostedMailboxItem.createMany({
+          data: [
+            {
+              dedupeKey: `latency-owner-lifecycle:${suffix}`,
+              id: lifecycleMailboxItemId,
+              kind: "conversation.message",
+              lane: "conversation",
+              laneSeq: 1n,
+              occurredAt: acceptedAt,
+              payloadSchema: "murph.hosted-execution.conversation-message.v1",
+              userId: memberId,
+            },
+            {
+              dedupeKey: `latency-owner-provider:${suffix}`,
+              id: providerMailboxItemId,
+              kind: "conversation.message",
+              lane: "conversation",
+              laneSeq: 2n,
+              occurredAt: acceptedAt,
+              payloadSchema: "murph.hosted-execution.conversation-message.v1",
+              userId: memberId,
+            },
+          ],
+        });
+        await observer.hostedIngressLatencyTrace.createMany({
+          data: [
+            {
+              acceptedAt,
+              assistantInputId: lifecycleAssistantInputId,
+              id: lifecycleTraceId,
+              mailboxItemId: lifecycleMailboxItemId,
+              mailboxLane: "conversation",
+              mailboxLaneSeq: 1n,
+              phaseBreakdownJson: {
+                assistant: { runtimeLeaseGeneration: "7" },
+                schemaVersion: 1,
+              },
+              runtimeAttemptId: staleLifecycleAttemptId,
+              source: "linq",
+              userId: memberId,
+            },
+            {
+              acceptedAt,
+              assistantInputId: providerAssistantInputId,
+              id: providerTraceId,
+              mailboxItemId: providerMailboxItemId,
+              mailboxLane: "conversation",
+              mailboxLaneSeq: 2n,
+              runtimeAttemptId: null,
+              source: "linq",
+              userId: memberId,
+            },
+          ],
+        });
+        await installHostedLatencySnapshotBarrier(staleWriter);
+
+        const lifecycleBarrierKey = BigInt(`0x${suffix.slice(0, 12)}`);
+        await armSnapshotBarrier(lifecycleBarrierKey);
+        const staleLifecycleWrite = recordHostedIngressAssistantMilestone({
+          assistantInputIds: [lifecycleAssistantInputId],
+          at: new Date("2026-08-09T12:20:10.000Z"),
+          authenticatedUserId: memberId,
+          milestone: "assistant_input_accepted_for_execution",
+          prisma: staleWriter,
+          runtimeAttemptId: staleLifecycleAttemptId,
+          runtimeLeaseGeneration: "7",
+          source: "linq",
+        });
+        inFlight.push(staleLifecycleWrite);
+        await waitForPostgresLock({ applicationName, observer });
+
+        const currentLifecycleAt = new Date("2026-08-09T12:20:20.000Z");
+        await expect(recordHostedIngressAssistantMilestone({
+          assistantInputIds: [lifecycleAssistantInputId],
+          at: currentLifecycleAt,
+          authenticatedUserId: memberId,
+          milestone: "assistant_input_accepted_for_execution",
+          prisma: observer,
+          runtimeAttemptId: currentLifecycleAttemptId,
+          runtimeLeaseGeneration: "8",
+          source: "linq",
+        })).resolves.toEqual({
+          matchedCount: 1,
+          recorded: true,
+          unmatchedCount: 0,
+        });
+        await releaseSnapshotBarrier();
+        await expect(staleLifecycleWrite).resolves.toEqual({
+          contendedCount: 1,
+          matchedCount: 0,
+          recorded: false,
+          unmatchedCount: 1,
+        });
+        await expect(recordHostedIngressAssistantMilestone({
+          assistantInputIds: [lifecycleAssistantInputId],
+          at: new Date("2026-08-09T12:20:30.000Z"),
+          authenticatedUserId: memberId,
+          milestone: "assistant_input_accepted_for_execution",
+          prisma: staleWriter,
+          runtimeAttemptId: staleLifecycleAttemptId,
+          runtimeLeaseGeneration: "7",
+          source: "linq",
+        })).resolves.toEqual({
+          matchedCount: 0,
+          recorded: false,
+          unmatchedCount: 1,
+        });
+
+        const lifecycleTrace =
+          await observer.hostedIngressLatencyTrace.findUniqueOrThrow({
+            select: { phaseBreakdownJson: true, runtimeAttemptId: true },
+            where: { id: lifecycleTraceId },
+          });
+        expect(lifecycleTrace.runtimeAttemptId).toBe(currentLifecycleAttemptId);
+        expect(
+          requireJsonRecord(
+            requireJsonRecord(lifecycleTrace.phaseBreakdownJson).assistant,
+          ),
+        ).toMatchObject({
+          assistantInputAcceptedForExecutionAtEpochMs:
+            currentLifecycleAt.getTime(),
+          runtimeLeaseGeneration: "8",
+        });
+
+        const providerBarrierKey = lifecycleBarrierKey + 1n;
+        await armSnapshotBarrier(providerBarrierKey);
+        const staleProviderWrite = recordHostedIngressProviderStarted({
+          assistantInputIds: [providerAssistantInputId],
+          at: new Date("2026-08-09T12:21:10.000Z"),
+          authenticatedUserId: memberId,
+          prisma: staleWriter,
+          providerRequestOrdinal: 0,
+          runtimeAttemptId: staleProviderAttemptId,
+          source: "linq",
+        });
+        inFlight.push(staleProviderWrite);
+        await waitForPostgresLock({ applicationName, observer });
+
+        await expect(recordHostedIngressAssistantMilestone({
+          assistantInputIds: [providerAssistantInputId],
+          at: new Date("2026-08-09T12:21:20.000Z"),
+          authenticatedUserId: memberId,
+          milestone: "pending_reply_admitted",
+          prisma: observer,
+          runtimeAttemptId: currentProviderAttemptId,
+          runtimeLeaseGeneration: "1",
+          source: "linq",
+        })).resolves.toEqual({
+          matchedCount: 1,
+          recorded: true,
+          unmatchedCount: 0,
+        });
+        await releaseSnapshotBarrier();
+        await expect(staleProviderWrite).resolves.toEqual({
+          contendedCount: 1,
+          matchedCount: 0,
+          recorded: false,
+          unmatchedCount: 1,
+        });
+        await expect(recordHostedIngressProviderStarted({
+          assistantInputIds: [providerAssistantInputId],
+          at: new Date("2026-08-09T12:21:30.000Z"),
+          authenticatedUserId: memberId,
+          prisma: staleWriter,
+          providerRequestOrdinal: 0,
+          runtimeAttemptId: staleProviderAttemptId,
+          source: "linq",
+        })).resolves.toEqual({
+          matchedCount: 0,
+          recorded: false,
+          unmatchedCount: 1,
+        });
+
+        await expect(
+          observer.hostedIngressLatencyTrace.findUniqueOrThrow({
+            select: { providerStartAt: true, runtimeAttemptId: true },
+            where: { id: providerTraceId },
+          }),
+        ).resolves.toEqual({
+          providerStartAt: null,
+          runtimeAttemptId: currentProviderAttemptId,
+        });
+      } finally {
+        await releaseSnapshotBarrier();
+        await Promise.allSettled(inFlight);
+        await observer.hostedMember.deleteMany({ where: { id: memberId } });
+        await Promise.all([
+          barrier.$disconnect(),
+          observer.$disconnect(),
+          staleWriter.$disconnect(),
+        ]);
+      }
+    });
+
     it("does not let an older checkpoint lease overwrite a newer lease after waiting", async () => {
       const suffix = randomUUID().replaceAll("-", "");
       const memberId = `hbm_latency_lease_race_${suffix}`;
@@ -1316,6 +1568,53 @@ function withPostgresSessionTimeZone(value: string, timeZone: string): string {
   const url = new URL(value);
   url.searchParams.set("options", `-c timezone=${timeZone}`);
   return url.toString();
+}
+
+function withPostgresApplicationName(value: string, applicationName: string): string {
+  const url = new URL(value);
+  url.searchParams.set("application_name", applicationName);
+  return url.toString();
+}
+
+async function installHostedLatencySnapshotBarrier(
+  prisma: ReturnType<typeof createPrismaClient>,
+): Promise<void> {
+  await prisma.$executeRaw`
+    CREATE TEMP TABLE hosted_latency_snapshot_barrier_session (
+      installed boolean NOT NULL
+    )
+  `;
+  await prisma.$executeRaw`
+    CREATE FUNCTION pg_temp.hosted_latency_snapshot_barrier()
+    RETURNS boolean
+    LANGUAGE plpgsql
+    VOLATILE
+    AS $function$
+    BEGIN
+      IF current_setting(
+        'murph.latency_snapshot_barrier_state',
+        true
+      ) = 'armed' THEN
+        PERFORM set_config(
+          'murph.latency_snapshot_barrier_state',
+          'passed',
+          false
+        );
+        PERFORM pg_advisory_xact_lock(
+          current_setting('murph.latency_snapshot_barrier_key')::bigint
+        );
+      END IF;
+      RETURN true;
+    END;
+    $function$
+  `;
+  await prisma.$executeRaw`
+    CREATE TEMP VIEW hosted_ingress_latency_trace
+    WITH (security_barrier = true) AS
+    SELECT *
+    FROM public.hosted_ingress_latency_trace
+    WHERE pg_temp.hosted_latency_snapshot_barrier()
+  `;
 }
 
 function withPostgresLockOrderProbe(value: string, applicationName: string): string {

--- a/apps/web/test/hosted-runtime-latency-postgres-concurrency.test.ts
+++ b/apps/web/test/hosted-runtime-latency-postgres-concurrency.test.ts
@@ -229,6 +229,7 @@ describe.skipIf(!runPostgresProof)(
           providerWhileLocked,
           "Expected provider-start row claim to skip a conflicting lock.",
         )).resolves.toEqual({
+          contendedCount: 1,
           matchedCount: 0,
           recorded: false,
           unmatchedCount: 1,
@@ -262,6 +263,7 @@ describe.skipIf(!runPostgresProof)(
           assistantWhileLocked,
           "Expected assistant-milestone row claim to skip a conflicting lock.",
         )).resolves.toEqual({
+          contendedCount: 1,
           matchedCount: 0,
           recorded: false,
           unmatchedCount: 1,
@@ -314,6 +316,7 @@ describe.skipIf(!runPostgresProof)(
           batchedProviderWhileLocked,
           "Expected provider-start to update free rows without waiting.",
         )).resolves.toEqual({
+          contendedCount: 1,
           matchedCount: 1,
           recorded: true,
           unmatchedCount: 1,
@@ -332,6 +335,7 @@ describe.skipIf(!runPostgresProof)(
           batchedAssistantWhileLocked,
           "Expected assistant milestone to update free rows without waiting.",
         )).resolves.toEqual({
+          contendedCount: 1,
           matchedCount: 1,
           recorded: true,
           unmatchedCount: 1,


### PR DESCRIPTION
## Why and outcome

Hosted latency callbacks use `FOR UPDATE SKIP LOCKED` and retry contended rows,
but Web logged every first skipped attempt as a rejected-row warning. Classify
rows that passed the existing eligibility predicate but lost the lock race so
expected contention stays quiet while true authority and eligibility rejections
still warn.

ReviewGPT context sensitivity: sensitive — this changes concurrency
classification inside the hosted Web latency callback query.

ReviewGPT first-reviewed head: 8921046a21f2b054ab2594a5366dd5e3b79985a2

## Product UX

Not applicable. This changes identifier-free operational diagnostics only; the
assistant turn, reply, delivery, retry, and member-visible behavior are
unchanged.

## Evidence

- 108 focused hosted Web route/store tests passed.
- 6 synthetic real-PostgreSQL concurrency tests passed against a dedicated
  migrated loopback database. The new deterministic snapshot-to-lock transfer
  proof fails on the unsafe query and passes with lock-time revalidation for
  both lifecycle and provider writes.
- `pnpm --dir apps/web typecheck` passed.
- Production diagnosis used bounded identifier-free aggregates and confirmed
  the affected turn reached provider start, assistant output, reply handoff,
  and delivery while the retried milestone was ultimately present.

## Non-obvious affected surfaces

- Hosted ingress provider-start and assistant-milestone set writes now project
  eligibility for diagnostics before their existing non-blocking row claim,
  then re-evaluate the original authority predicates on the live row before
  writing. The real-PostgreSQL suite proves free rows still update while locked
  rows remain retryable and ownership transfers reject stale callbacks.
- The internal latency callback warning subtracts contended and untraced rows
  from actual rejections. Its external three-field response is unchanged.

## Architecture and reuse

- Existing systems reused: the existing bounded set-write query,
  `FOR UPDATE SKIP LOCKED`, runtime retry, and internal callback result.
- New logic: one internal `contendedCount` derived from rows that passed the
  existing ownership/eligibility predicate but were not locked.
- New abstractions: none; the count stays on the existing Web-local write
  result and is stripped by the existing response parser.
- Complexity intentionally avoided: no blocking wait, new retry owner,
  persisted state, wire field, query round trip, queue, or dependency.

## Complexity impact

- Guard: pass (`pnpm complexity:diff`).
- Hotspots: `readHostedIngressLatencyDashboard` remains at 111 in the touched
  store file; it is unrelated existing dashboard complexity and did not change.
- Agent judgment: no further behavior-preserving simplification is justified;
  the query reuses one materialized scoped set for trace presence, eligibility,
  and the existing ordered row claim. Eligibility is repeated only at the lock
  boundary where PostgreSQL must revalidate current write authority.

## Hot reply path impact

Not applicable. Latency reporting remains diagnostic-only and queued outside
the foreground reply path. The callback keeps one bounded database statement,
adds no round trip, and retains the existing non-blocking lock and retry
behavior.

## Murph initial provider input impact

Not applicable for individual or group turns. No prompt, tool schema, generated
guidance, model configuration, or other provider-visible input changed.

## Change-shape breakdown

Classification uses authored base-to-head text lines; there are no binaries or
generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 77 | 34 |
| Tests/fixtures | 333 | 0 |
| Docs | 68 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 478 | 34 |

## Deployment concerns

- Deployment: not applicable
- Reason: This is a Web-only internal classification change; the callback
  request and response contracts are unchanged, so old and new runners behave
  identically during skew.

## Changelog

- Changelog: not applicable
- Reason: The change affects internal diagnostic warning accuracy only and has
  no member-visible behavior.
