### PR TITLE
fix(runtime): complete group Journal fact imports

### DIFF
--- a/apps/web/changelog/entries/2026-08-31/private-group-journal-capture.json
+++ b/apps/web/changelog/entries/2026-08-31/private-group-journal-capture.json
@@ -9,6 +9,6 @@
     "summary": "Murph can privately ask before saving a clear fact that comes up in an authenticated group.",
     "details": "The first clear fact asks for one global choice in private. Later clear facts can save quietly, unclear facts get one private question, and each group can be excluded. Nothing about another member's Journal appears in the group.",
     "relevanceTags": ["journal", "groups", "privacy", "personal-patterns"],
-    "sourcePullRequests": []
+    "sourcePullRequests": [2683]
   }
 }

--- a/apps/web/changelog/entries/2026-08-31/private-group-journal-capture.json
+++ b/apps/web/changelog/entries/2026-08-31/private-group-journal-capture.json
@@ -9,6 +9,6 @@
     "summary": "Murph can privately ask before saving a clear fact that comes up in an authenticated group.",
     "details": "The first clear fact asks for one global choice in private. Later clear facts can save quietly, unclear facts get one private question, and each group can be excluded. Nothing about another member's Journal appears in the group.",
     "relevanceTags": ["journal", "groups", "privacy", "personal-patterns"],
-    "sourcePullRequests": [2683]
+    "sourcePullRequests": [2683, 2747]
   }
 }

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -444,6 +444,7 @@ const HOSTED_SYSTEM_MAILBOX_MODEL_FREE_ROUTE_ACTIONS = [
   "apply-member-channels-update",
   "apply-runtime-control-request",
   "dispatch-assistant-notification",
+  "import-group-journal-fact",
   "import-reported-daily-metric",
   "run-device-sync-wake",
   "run-environment-interview",

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -49,6 +49,7 @@ import {
   buildIntegrationEvidencePart,
   buildIntegrationIngestRecord,
   findCaptureByLookup,
+  findEventByExternalRef,
   initializeVault,
   applyCanonicalWriteBatch,
   patchAutomation,
@@ -64,11 +65,13 @@ import {
   buildHostedExecutionAssistantNotificationRequestedWake,
   buildHostedExecutionDailyMetricReportedWake,
   buildHostedExecutionEnvironmentInterviewCompletedWake,
+  buildHostedExecutionGroupJournalFactRecordedWake,
   buildHostedExecutionLinqConversationMessageWake,
   buildHostedExecutionMemberActivatedWake,
   buildHostedExecutionMemberChannelsUpdatedWake,
   buildHostedExecutionRuntimeControlWake,
   deriveHostedExecutionErrorCode,
+  type HostedExecutionWake,
 } from "@murphai/hosted-execution";
 import {
   HOSTED_VAULT_SHARE_FIRST_MATERIALIZATION_MODE,
@@ -1516,6 +1519,234 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       expect(result.status).toBe("idle");
     } finally {
       mocks.refreshHostedBrowserVaultReplicaFromRuntime.mockClear();
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
+  test("blocked system mailbox mode imports a Group Journal fact and drains later model-free work", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
+    const artifactBytesByHash = new Map<string, Uint8Array>();
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const events: string[] = [];
+    const fetchRequests: HostedMailboxFetchRequest[] = [];
+    const groupFactItem = createMailboxItem({
+      causalSeq: "1",
+      dedupeKey: "group_journal_model_free_fact",
+      id: "mailbox_item_group_journal_model_free_fact",
+      kind: "journal.group-fact.recorded",
+      lane: "system",
+      laneSeq: "1",
+    });
+    const refreshItem = createMailboxItem({
+      causalSeq: "2",
+      dedupeKey: "runtime.browser-vault-refresh-requested:after-group-journal",
+      id: "mailbox_item_browser_vault_after_group_journal",
+      kind: "runtime.browser-vault-refresh-requested",
+      lane: "system",
+      laneSeq: "2",
+    });
+    const groupFactWake = buildHostedExecutionGroupJournalFactRecordedWake({
+      eventId: groupFactItem.dedupeKey,
+      journalFact: {
+        date: "2026-04-26",
+        factIndex: 1,
+        note: "Completed an afternoon walk.",
+        noteType: "journal-factor",
+        title: "Afternoon walk",
+      },
+      memberId: TEST_USER_ID,
+      occurredAt: groupFactItem.occurredAt,
+    });
+    const refreshWake = buildHostedExecutionRuntimeControlWake({
+      eventId: refreshItem.dedupeKey,
+      kind: "runtime.browser-vault-refresh-requested",
+      occurredAt: refreshItem.occurredAt,
+      userId: TEST_USER_ID,
+    });
+    const wakesByItemId = new Map<string, HostedExecutionWake>([
+      [groupFactItem.id, groupFactWake],
+      [refreshItem.id, refreshWake],
+    ]);
+    let browserPublishCalls = 0;
+    let browserWriteCalls = 0;
+    let currentWorkspace: HostedWorkspaceState | null = null;
+    let snapshotOrdinal = 0;
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      vi.setSystemTime(new Date(TEST_NOW));
+      mocks.prepareHostedCodexRuntimeEnvironment.mockClear();
+      mocks.prepareHostedCodexAssistantProcess.mockClear();
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      const restoredWorkspace = await createVaultSnapshotBundle({
+        key: "users/bundles/member-synthetic/group-journal-model-free-before.bundle.json",
+        vaultRoot,
+      });
+      artifactBytesByHash.set(restoredWorkspace.hash, restoredWorkspace.bytes);
+      currentWorkspace = createWorkspaceState({
+        snapshotRef: restoredWorkspace.snapshotRef,
+        version: "0",
+      });
+      const workspacePort: HostedRuntimeWorkspacePort = {
+        async checkpoint(request) {
+          events.push("workspace.checkpoint");
+          checkpointRequests.push(request);
+          currentWorkspace = createWorkspaceState({
+            browserVaultReplicaRef: currentWorkspace?.browserVaultReplicaRef ?? null,
+            inboxMediaRetentionWakeAt: request.inboxMediaRetentionWakeAt ?? null,
+            nextDefaultProcessingWakeAt:
+              request.nextDefaultProcessingWakeAt ?? null,
+            nextDefaultProcessingWakeReason:
+              request.nextDefaultProcessingWakeReason ?? null,
+            nextWakeAt: request.nextWakeAt ?? null,
+            nextWakeReason: request.nextWakeReason ?? null,
+            redactedStatus: request.redactedStatus ?? null,
+            snapshotRef: request.snapshotRef,
+            systemMailboxProgressGeneration:
+              request.systemMailboxProgressGeneration ?? null,
+            version: String(BigInt(request.expectedWorkspaceVersion) + 1n),
+          });
+          return {
+            checkpointed: true,
+            workspace: currentWorkspace,
+          };
+        },
+        async read() {
+          events.push("workspace.read");
+          return {
+            fetchedAt: TEST_NOW,
+            workspace: currentWorkspace,
+          };
+        },
+      };
+      const platform = createPlatform({
+        artifactBytesByHash,
+        browserVaultReplicaPort: {
+          async publishRef({ replicaRef }) {
+            browserPublishCalls += 1;
+            events.push(`browser-vault.publish:${browserPublishCalls}`);
+            assert.ok(currentWorkspace);
+            currentWorkspace = {
+              ...currentWorkspace,
+              browserVaultReplicaRef: replicaRef,
+            };
+            return {
+              published: true,
+              workspace: currentWorkspace,
+            };
+          },
+          async write({ replica }) {
+            browserWriteCalls += 1;
+            events.push(`browser-vault.write:${browserWriteCalls}`);
+            return createBrowserVaultReplicaRef(replica);
+          },
+        },
+        mailboxPort: createMailboxPort({
+          events,
+          fetchRequests,
+          items: [groupFactItem, refreshItem],
+        }),
+        workspacePort,
+      });
+      const runSystemPass = async (attemptId: string) => {
+        const runtimeJobInput = createWorkspaceRuntimeJobInput({
+          request: {
+            assistantExecutionBlocked: true,
+            attemptId,
+            processingMode: "system_mailbox",
+            workspaceVersion: currentWorkspace?.version ?? "0",
+          },
+        });
+        const runtime = runtimeJobInput.runtime;
+        assert.ok(runtime);
+        const bridgeOptions = createHostedWorkspaceRuntimeBridgeJobOptions({
+          decodeMailboxPayload: {
+            async decode({ itemRef }) {
+              const wake = wakesByItemId.get(itemRef.id);
+              assert.ok(wake);
+              return { status: "decoded", wake };
+            },
+          },
+          platform,
+          request: runtimeJobInput.request,
+          runtime,
+          snapshotArchiveBuilder: {
+            async buildEncryptedSnapshot() {
+              throw new Error("The focused bridge test overrides snapshot construction.");
+            },
+          },
+          vaultRoot,
+          async waitForBackgroundAssistantWork() {},
+        });
+        return await runHostedWorkspaceRuntimeJobInProcess(runtimeJobInput, {
+          ...bridgeOptions,
+          async createCheckpointSnapshot() {
+            snapshotOrdinal += 1;
+            const snapshot = await createVaultSnapshotBundle({
+              key: `users/bundles/member-synthetic/group-journal-model-free-${snapshotOrdinal}.bundle.json`,
+              vaultRoot,
+            });
+            artifactBytesByHash.set(snapshot.hash, snapshot.bytes);
+            return { snapshotRef: snapshot.snapshotRef };
+          },
+          async runAssistantPhase() {
+            throw new Error("Blocked Group Journal work must not enter assistant execution.");
+          },
+        });
+      };
+
+      const firstResult = await runSystemPass(
+        "attempt_group_journal_model_free_first",
+      );
+
+      await expect(findEventByExternalRef({
+        resourceId: groupFactItem.dedupeKey,
+        resourceType: "group-journal-fact",
+        system: "manual",
+        vaultRoot,
+      })).resolves.toMatchObject({
+        kind: "note",
+        note: "Completed an afternoon walk.",
+        title: "Afternoon walk",
+      });
+      assert.deepEqual(
+        fetchRequests.map((request) => request.lanes.map((lane) => lane.lane)),
+        [["system"]],
+      );
+      assert.deepEqual(
+        (await readHostedSystemMailboxState(vaultRoot)).pending.map((item) =>
+          item.itemId
+        ),
+        [refreshItem.id],
+      );
+      assert.equal(
+        checkpointRequests.at(-1)?.redactedStatus?.hostedMailboxSystemHandledThroughSeq,
+        "1",
+      );
+      assert.ok(browserWriteCalls >= 1);
+      assert.ok(browserPublishCalls >= 1);
+      assert.ok(
+        requireEventIndex(events, "workspace.checkpoint")
+          < requireEventIndex(events, "browser-vault.publish:1"),
+      );
+      assert.equal(firstResult.status, "scheduled");
+
+      const secondResult = await runSystemPass(
+        "attempt_group_journal_model_free_second",
+      );
+
+      assert.deepEqual((await readHostedSystemMailboxState(vaultRoot)).pending, []);
+      assert.equal(
+        checkpointRequests.at(-1)?.redactedStatus?.hostedMailboxSystemHandledThroughSeq,
+        "2",
+      );
+      expect(mocks.prepareHostedCodexRuntimeEnvironment).not.toHaveBeenCalled();
+      expect(mocks.prepareHostedCodexAssistantProcess).not.toHaveBeenCalled();
+      assert.equal(secondResult.status, "idle");
+      assert.equal(secondResult.nextWakeAt, null);
+      assert.equal(secondResult.nextWakeReason ?? null, null);
+    } finally {
+      vi.useRealTimers();
       await removeTempRoot(vaultRoot);
     }
   });

--- a/packages/hosted-execution/src/orchestration-control.ts
+++ b/packages/hosted-execution/src/orchestration-control.ts
@@ -83,6 +83,7 @@ export const HOSTED_SYSTEM_MAILBOX_MODEL_FREE_KINDS = [
   "device-sync.wake",
   "environment-interview.completed",
   "health.daily-metric.reported",
+  "journal.group-fact.recorded",
   "member.channels.updated",
   "runtime.browser-vault-refresh-requested",
   "runtime.maintenance-requested",

--- a/packages/hosted-execution/test/hosted-orchestration-control.test.ts
+++ b/packages/hosted-execution/test/hosted-orchestration-control.test.ts
@@ -357,6 +357,10 @@ describe("hosted orchestration control contracts", () => {
       dedupeKey: "health.daily-metric.reported:synthetic",
       kind: "health.daily-metric.reported",
     })).toBe("model_free");
+    expect(classifyHostedSystemMailboxExecutionClass({
+      dedupeKey: "journal.group-fact.recorded:synthetic",
+      kind: "journal.group-fact.recorded",
+    })).toBe("model_free");
   });
 
   it("rejects raw payload-shaped fields in reconciliation facts contracts", () => {


### PR DESCRIPTION
## Why and outcome

Public PR #2683 established the canonical Group Journal mailbox action and is now merged. This follow-up classifies that wake kind and route action through the existing model-free owners, so an authorized fact can finish importing even when assistant execution is unavailable.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: An authenticated group member who permits Journal capture gets the fact in that member's private Journal and browser view without requiring a model run. A member who has not consented, an excluded group, and every other group member remain outside this change.

## Evidence

- `pnpm exec vitest run packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts packages/hosted-execution/test/hosted-orchestration-control.test.ts` passed 66/66.
- The production-path test blocks assistant execution, imports the Journal note, checkpoints it before publishing the Browser Vault replica, removes the mailbox item, advances the handled sequence, and drains a later model-free refresh item without starting Codex.
- Both affected package typechecks passed.
- `pnpm complexity:diff --base origin/main --head HEAD` passed with no complexity debt or maximum-complexity regression.
- A current-base `git merge-tree --write-tree` proof passed before push.
- Exact-head CI passed at `e1805b29302d5199475b6d6dae1123b92ae6172e`; all required release, coverage, Web, Cloudflare, host, Temporal compatibility, and evidence checks are green. One transient GitHub Markdown-render 403 in `Release build/typecheck` passed on its exact-job rerun; the focused local test also passed.

## Non-obvious affected surfaces

- Model-free mailbox ownership: the persisted wake-kind classifier and runtime route-action classifier now assign Group Journal imports to the existing model-free owner. Classifier and blocked-entrypoint tests cover both boundaries.
- Snapshot and Browser Vault convergence: production-path proof shows the Journal write is checkpointed before the browser replica is published, then the mailbox sequence advances.
- Foreground-reply priority: no foreground path operation changed; the new classification only applies inside the existing background system-mailbox mode.
- Public changelog provenance: the existing #2683 item now names both PRs that complete the outcome.

## Architecture and reuse

- Existing systems reused: The canonical mailbox route, existing model-free ownership tables, persisted system-mailbox state, snapshot checkpoint owner, Browser Vault publisher, and current direct importer remain the owners.
- New logic: Two entries admit the already-canonical wake kind and route action to those existing model-free owners.
- New abstractions: None; the existing discriminated unions, classifiers, and mailbox lifecycle are sufficient.
- Complexity intentionally avoided: No second queue, retry manager, state owner, compatibility layer, dependency, or duplicated parser was added.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base origin/main --head HEAD` reported no debt or maximum-complexity regression.
- Hotspots: Existing hotspots in `hosted-runtime.ts` are unchanged; the production diff adds one table entry there and one in `orchestration-control.ts`, with no new function or branch.
- Agent judgment: No further behavior-preserving simplification is justified because the correction is exactly two entries in existing ownership tables.

## Hot reply path impact

- Path status: Not applicable — this admits a background system-mailbox route and adds no work between durable current-message acceptance, provider start, and durable reply handoff.
- Database calls: None added or moved onto the hot reply path.
- Network/provider calls: None added or moved onto the hot reply path.
- Other awaited latency: None added or moved onto the hot reply path.
- Before/after proof: The existing foreground scheduling path is unchanged; the focused test exercises only blocked-assistant system-mailbox mode.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged; no prompt, instruction builder, message assembly, or routing guidance changed.
- Tool/schema/generated guidance: Unchanged; no tool definition, schema, deferred metadata, or generated guidance changed.
- Other provider-visible input: Unchanged; the added fixture is local hosted-runtime input and is never sent to a model.
- Measurement method: Not run because no provider-input surface changed.

## Risks

ReviewGPT context sensitivity: sensitive

Classification reason: Hosted system-mailbox ownership and snapshot publication ordering affect private Journal delivery.

ReviewGPT first-reviewed head: 567939a5bca790626bd3a502eb87a89def95836b

Per explicit user instruction, no additional ReviewGPT round is being run after the behavior-preserving stack rebase and conflict resolution.

## Deployment concerns

- Deployment: applicable
- Supported skew: #2683 can remain deployed briefly without this model-free classification; the action remains retryable, but Group Journal capture may wait for ordinary assistant availability during that window.
- Safe order: Merge and deploy this public consumer support, then merge private PR #96, then land the public release-controller follow-up.
- Rollback floor: Keep this consumer support while #2683 can emit the action; remove the producer first if rollback is required.
- Expected exposure: Only authorized Group Journal fact imports are affected; ordinary foreground replies and other system-mailbox actions retain their existing paths.
- Reversibility: Revert the two ownership entries after the producing feature is disabled or rolled back.
- Convergence proof: The blocked-assistant production-path test proves the route advances and the Browser Vault converges without model execution.
- Post-deploy checks: Run the private hosted foreground-priority lane and confirm an authorized Group Journal fact reaches the private Journal/browser view while assistant execution is unavailable.

## Change-shape breakdown

Classification rule: Runtime files are source, Vitest changes are tests and fixtures, and the JSON release note is docs; there are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 2 | 0 |
| Tests / fixtures | 235 | 0 |
| Docs | 1 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **238** | **1** |

## Changelog

- Changelog: updated
- Items: 2026-08-31 · private-group-journal-capture


