### PR TITLE
fix(web): shorten database pool idle timeout

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-02-address-book-pool-idle-timeout.md
+++ b/agent-docs/exec-plans/active/2026-09-02-address-book-pool-idle-timeout.md
@@ -1,0 +1,93 @@
+# Shorten Vercel database pool idle tail
+
+Status: active
+Created: 2026-09-02
+Updated: 2026-09-02
+
+## Goal
+
+- Keep hosted companion address-book status reads from exhausting their Vercel
+  invocation budget after normal database work completes, while preserving the
+  shared PostgreSQL pool and its connection-retirement contract.
+
+## Success criteria
+
+- The hosted Web PostgreSQL pool retires idle clients after five seconds, which
+  bounds the `attachDatabasePool` request-lifetime tail to approximately 5.1
+  seconds instead of approximately 30.1 seconds.
+- The same module-scoped pool remains attached to Vercel and reusable by active
+  or concurrent requests.
+- Focused pool and companion address-book route tests pass, and the Web
+  TypeScript check passes.
+- The member-visible reliability improvement is represented in the current
+  changelog and the exact pushed PR head passes required CI and ReviewGPT.
+
+## Scope
+
+- In scope: hosted Web PostgreSQL idle retirement, focused pool assertions,
+  existing pool-lifecycle documentation, and the public reliability note.
+- Out of scope: authentication, address-book query behavior, pool-size policy,
+  database connection acquisition timeout, dependencies, schemas, and provider
+  ingestion behavior.
+
+## Product UX patch
+
+- Outcome: Connected members' routine companion status checks keep the same
+  result while avoiding an unnecessarily long idle cleanup tail.
+- Reaches: The existing authenticated companion address-book status journey;
+  no screen, action, audience, permission, or data meaning changes.
+- Proof: Existing composed-auth and route tests preserve successful and denied
+  responses, while the production-pool test proves the shorter attached-pool
+  idle boundary.
+
+Walkthrough: a connected member receives the same status JSON, an unauthorized
+request receives the same error, and other hosted Web requests retain the same
+shared-pool behavior while fully idle clients retire sooner. The focused route
+and pool tests cover those boundaries. No presentation state changes, so
+rendered evidence adds no proof. Result: Ready.
+
+## Constraints
+
+- Technical constraints: retain one globally reusable `pg` pool and
+  `attachDatabasePool`; do not replace the proven lifecycle mechanism with
+  route-local retries or a longer function timeout.
+- Product/process constraints: keep production evidence private, preserve all
+  existing authorization behavior, and ship through the isolated PR lane with
+  focused local proof plus exact-head gates.
+
+## Risks and mitigations
+
+1. Risk: A request arriving after more than five seconds of complete pool
+   inactivity may need to establish a new database connection.
+   Mitigation: Active traffic still reuses the shared pool, the five-second
+   value follows Vercel's current Fluid Compute guidance, and existing bounded
+   connection acquisition and failure diagnostics remain unchanged.
+
+## Tasks
+
+1. [x] Apply and inspect the ReviewGPT patch against current `origin/main`.
+2. [x] Add the required member-facing changelog fragment with public-safe claims.
+3. [x] Run focused pool and address-book tests, Web typecheck, changelog proof,
+   and complexity/diff checks.
+4. [ ] Commit, push, open the draft PR, and complete exact-head CI and final
+   ReviewGPT before merge.
+
+## Decisions
+
+- Preserve `attachDatabasePool` rather than deleting the connection-suspension
+  protection.
+- Keep the route's 60-second deadline as the failure boundary; reduce the
+  avoidable idle tail instead of masking it with more runtime.
+- Reuse the existing production-pool test instead of adding a duplicate test
+  for the same idle-timeout and attachment assertions.
+
+## Verification
+
+- Passed: `pnpm --dir apps/web test -- prisma-store-client.test.ts
+  device-sync-companion-address-book-route.test.ts
+  device-sync-companion-address-book-route-composed-auth.test.ts` (3 files, 70
+  tests); `pnpm --dir apps/web test -- changelog-page.test.tsx` (1 file, 9
+  tests); `pnpm --dir apps/web typecheck`; `pnpm complexity:diff`; and `git diff
+  --check`.
+- Pending: exact-head GitHub Actions, final ReviewGPT, parent final review, and
+  current-base merge-tree proof.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1667,11 +1667,12 @@ registers it with Vercel Fluid Compute, and passes that same pool to
 its existing cleanup contract. Keep session-persistent setup such as connection
 `SET` hooks out of this path because transaction pooling can move consecutive
 transactions between backend connections. The default pool limit is 15 clients
-per module runtime, with five seconds for connection acquisition and 30 seconds
-for idle retirement; tune those values only from measured pool and database
-pressure. Connection failure logs expose only fixed operation/source labels,
-retry attempt and disposition, the configured pool limit, and numeric
-pre-attempt and post-failure pool counts.
+per module runtime, with five seconds each for connection acquisition and idle
+retirement. Vercel's pool attachment extends the active invocation through that
+idle window, so keep it short and tune it only from measured invocation, pool,
+and database pressure. Connection failure logs expose only fixed
+operation/source labels, retry attempt and disposition, the configured pool
+limit, and numeric pre-attempt and post-failure pool counts.
 
 That module permits one jittered retry only for ambiguous transient failures
 that prove the database did no work. A `pool_checkout_timeout` means the

--- a/apps/web/changelog/entries/2026-09-02/connected-health-status-checks-finish-reliably.json
+++ b/apps/web/changelog/entries/2026-09-02/connected-health-status-checks-finish-reliably.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-02",
+  "order": 100,
+  "item": {
+    "id": "connected-health-status-checks-finish-reliably",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Connected health checks finish reliably",
+    "summary": "Routine connected-health status checks now release unused backend resources sooner, reducing avoidable delays.",
+    "details": "Active syncs and authenticated requests continue unchanged. The improvement only shortens cleanup after database activity becomes idle.",
+    "relevanceTags": ["wearables", "reliability"],
+    "sourcePullRequests": [2748]
+  }
+}

--- a/apps/web/src/lib/prisma.ts
+++ b/apps/web/src/lib/prisma.ts
@@ -19,7 +19,10 @@ const globalForPrisma = globalThis as typeof globalThis & {
 const DEFAULT_DATABASE_POOL_MAX = 15;
 const DATABASE_POOL_MAX = Number.parseInt(process.env.DATABASE_POOL_MAX ?? "", 10);
 const PG_CONNECTION_TIMEOUT_MS = 5_000;
-const PG_IDLE_TIMEOUT_MS = 30_000;
+// attachDatabasePool extends the active Vercel invocation until pg's idle
+// cleanup window closes. Keep that window short so idle connections do not
+// consume most of a 60-second route budget.
+const PG_IDLE_TIMEOUT_MS = 5_000;
 const PRISMA_TRANSACTION_MAX_WAIT_MS = 10_000;
 const PRISMA_TRANSACTION_TIMEOUT_MS = 15_000;
 const DATABASE_RETRY_ATTEMPTS = 2;

--- a/apps/web/test/prisma-store-client.test.ts
+++ b/apps/web/test/prisma-store-client.test.ts
@@ -179,7 +179,7 @@ describe("prisma module", () => {
     expect(mocks.Pool).toHaveBeenCalledWith({
       connectionString: "postgresql://example.invalid/db?sslmode=require",
       connectionTimeoutMillis: 5_000,
-      idleTimeoutMillis: 30_000,
+      idleTimeoutMillis: 5_000,
       max: 15,
     });
     expect(mocks.attachDatabasePool).toHaveBeenCalledOnce();
@@ -233,13 +233,13 @@ describe("prisma module", () => {
     expect(mocks.Pool).toHaveBeenNthCalledWith(1, {
       connectionString: "postgresql://example.invalid/first?sslmode=require",
       connectionTimeoutMillis: 5_000,
-      idleTimeoutMillis: 30_000,
+      idleTimeoutMillis: 5_000,
       max: 1,
     });
     expect(mocks.Pool).toHaveBeenNthCalledWith(2, {
       connectionString: "postgresql://example.invalid/second?sslmode=require",
       connectionTimeoutMillis: 5_000,
-      idleTimeoutMillis: 30_000,
+      idleTimeoutMillis: 5_000,
       max: 1,
     });
     expect(mocks.attachDatabasePool).toHaveBeenNthCalledWith(1, poolA);
@@ -294,7 +294,7 @@ describe("prisma module", () => {
     expect(mocks.Pool).toHaveBeenCalledWith({
       connectionString: "postgresql://example.invalid/db?sslmode=require",
       connectionTimeoutMillis: 5_000,
-      idleTimeoutMillis: 30_000,
+      idleTimeoutMillis: 5_000,
       max: 15,
     });
   });
@@ -335,7 +335,7 @@ describe("prisma module", () => {
     expect(mocks.Pool).toHaveBeenCalledWith({
       connectionString: "postgresql://example.invalid/db?sslmode=require",
       connectionTimeoutMillis: 5_000,
-      idleTimeoutMillis: 30_000,
+      idleTimeoutMillis: 5_000,
       max: 9,
     });
   });


### PR DESCRIPTION
## Why and outcome

The hosted Web PostgreSQL pool kept idle connections for 30 seconds. Vercel's
pool attachment extends an invocation through that idle window, which consumed
half of the companion address-book status route's 60-second budget after normal
database work.

This keeps the globally reused, Vercel-attached pool and shortens only its idle
retirement window to five seconds, following Vercel's Fluid Compute guidance.
Active requests continue to reuse connections; authentication, queries, pool
size, retries, and route deadlines are unchanged.

## Product UX

- Effort: Patch
- Outcome: Connected members' routine companion status checks keep the same
  result while avoiding an unnecessarily long idle cleanup tail.
- Reaches: The existing authenticated companion address-book status journey.
  No screen, action, audience, permission, or data meaning changes.
- Walkthrough: Successful and unauthorized companion requests preserve their
  existing responses; other hosted Web routes keep the same shared-pool
  behavior while fully idle clients retire sooner.
- Result: Ready

## Evidence

- `pnpm --dir apps/web test -- prisma-store-client.test.ts device-sync-companion-address-book-route.test.ts device-sync-companion-address-book-route-composed-auth.test.ts` (3 files, 70 tests passed)
- `pnpm --dir apps/web test -- changelog-page.test.tsx` (1 file, 9 tests passed)
- `pnpm --dir apps/web typecheck` (passed)
- `pnpm complexity:diff` (passed)
- `git diff --check` (passed)
- Direct code-path proof: the production pool test preserves one globally
  reused pool, verifies the five-second idle boundary, and verifies the same
  pool is passed to `attachDatabasePool`.

## Non-obvious affected surfaces

- Shared hosted Web database pool: every hosted Web route using the module pool
  receives the shorter fully idle retirement window. Active and borrowed
  clients are unaffected; existing pool-construction coverage protects default,
  configured, and independent factory pools.
- Vercel invocation lifecycle: `attachDatabasePool` remains the suspension-safe
  owner, but its request-lifetime tail falls from approximately 30.1 seconds to
  approximately 5.1 seconds.
- Existing pool documentation: updated to keep the implementation and deployed
  lifecycle contract aligned.

## Architecture and reuse

- Existing systems reused: The existing module-scoped `pg` pool,
  `PrismaPg` adapter, and Vercel `attachDatabasePool` lifecycle remain the only
  owners.
- New logic: One existing idle-timeout constant changes from 30 seconds to five
  seconds.
- New abstractions: None; the current shared pool and tests already own this
  behavior.
- Complexity intentionally avoided: No route-local retries, deadline increase,
  custom cleanup manager, dependency change, or duplicate regression test was
  added.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` completed successfully.
- Hotspots: Existing `resolveDatabasePoolFailureCategory` remains at complexity
  34 with no change; the edited pool construction adds no branch or function
  complexity.
- Agent judgment: No further behavior-preserving simplification is justified;
  the production change is one constant plus an explanatory comment.

## Hot reply path impact

- Not applicable: this changes idle retirement for the hosted Web database pool
  and adds no database, network, provider, retry, or fallback operation to the
  Foreground Reply Critical Path.

## Murph initial provider input impact

- Individual runtime: Not applicable; no prompt, tool schema, generated
  guidance, or provider-visible request assembly changed.
- Group runtime: Not applicable; no prompt, tool schema, generated guidance, or
  provider-visible request assembly changed.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: The only presentation change is one authored changelog fragment;
  production archive rendering and styling are unchanged. The changed copy was
  reviewed directly and the production archive component test passed.
- Coverage: The item schema, visible copy, provenance, and unchanged responsive
  archive rendering contract are covered; no new visual state exists.

## Change-shape breakdown

Classification rule: production TypeScript and runtime-loaded changelog content
are source; Vitest assertions are tests; the Web README and execution plan are
docs. There are no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 18 | 1 |
| Tests/fixtures | 5 | 5 |
| Docs | 105 | 5 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 128 | 11 |

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new Web instances use different idle-retirement
  windows against the same unchanged database and route contracts; both are
  compatible during a rolling deploy.
- Safe order: Normal Vercel Web rolling deployment; no Cloudflare or database
  deployment is required.
- Rollback floor: Reverting restores the longer idle window without changing
  stored data or API compatibility.
- Expected exposure: During rollout, some Web instances may retain idle
  connections longer until old instances drain.
- Reversibility: A normal Web rollback is sufficient.
- Convergence proof: Confirm the production deployment SHA and bounded
  address-book timeout aggregate after rollout.
- Post-deploy checks: Verify ordinary companion status reads succeed and inspect
  bounded Vercel hard-timeout and database-pool failure aggregates.

## Changelog

- Changelog: updated
- Items: 2026-09-02 · connected-health-status-checks-finish-reliably

ReviewGPT context sensitivity: sensitive

Reason: the patch changes shared hosted database-pool and Vercel invocation
lifecycle behavior.

ReviewGPT first-reviewed head: a561509e9605c439dd82601fc04fd739071d501a
