### PR TITLE
test(cloudflare): target standby runtime shutdown owner

### DIFF
--- a/.agents/friction-log/20260902211542-hosted-local-graceful/friction.md
+++ b/.agents/friction-log/20260902211542-hosted-local-graceful/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Hosted-local graceful shutdown control ignores standby-owned runtime fences'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The hosted-local graceful shutdown control should signal the Container instance named by the active UserRunner write fence, whether the owner is the exact-user container or a claimed standby container.
+
+## Current Behavior
+
+The control always resolves the exact-user container name. After foreground work claims a standby container, the control starts and stops an unused exact-user container while the active standby invocation and durable fence remain live until the test times out.
+
+## Possible Solution
+
+Resolve the active fence through the UserRunner test control, route its stored container name through the existing exact-user/standby namespace router, and keep the production Container classes unchanged.
+
+## Minimal Reproducible Example
+
+Run the focused Cloudflare route test with an active fence whose container name is an opaque standby slot, then request the shutdown checkpoint publication barrier with `action=shutdown`. The standby RPC is not called.
+
+## Context
+
+This blocks the private foreground-reply-priority admission scenario after standby allocation is enabled.

--- a/apps/cloudflare/src/hosted-local-test/standby-runner-container.ts
+++ b/apps/cloudflare/src/hosted-local-test/standby-runner-container.ts
@@ -11,6 +11,13 @@ import {
 const HOSTED_LOCAL_STANDBY_REGION = "REGN";
 
 export class HostedLocalTestStandbyRunnerContainer extends StandbyRunnerContainer {
+  async beginShutdownCheckpointGracefulStopForTest(
+    _input: { userId: string },
+  ): Promise<{ ok: true }> {
+    await this.stop("SIGTERM");
+    return { ok: true };
+  }
+
   protected override resolveExpectedStandbyHealthRegion(
     _region: typeof HOSTED_STANDBY_REGION,
   ): string {

--- a/apps/cloudflare/src/worker/route-handlers/test-runner.ts
+++ b/apps/cloudflare/src/worker/route-handlers/test-runner.ts
@@ -13,6 +13,9 @@ import type {
 import {
   resolveHostedExecutionRunnerContainerName,
 } from "../../runner-container.ts";
+import {
+  createHostedRunnerContainerNamespaceRouter,
+} from "../../standby-runner-contract.ts";
 import type {
   HostedRunnerActiveFenceTestResult,
   HostedRunnerStuckInvocationTestResult,
@@ -162,6 +165,46 @@ function hasHostedLocalTestRunnerContainerShutdownCheckpointPublicationBarrierCo
     && typeof stub.readShutdownCheckpointPublicationBarrierForTest === "function"
     && "releaseShutdownCheckpointPublicationBarrierForTest" in stub
     && typeof stub.releaseShutdownCheckpointPublicationBarrierForTest === "function";
+}
+
+function hasHostedLocalTestRunnerContainerGracefulStopControl(
+  stub: object,
+): stub is HostedLocalTestRunnerContainerStubLike & Required<Pick<
+  HostedLocalTestRunnerContainerStubLike,
+  "beginShutdownCheckpointGracefulStopForTest"
+>> {
+  return "beginShutdownCheckpointGracefulStopForTest" in stub
+    && typeof stub.beginShutdownCheckpointGracefulStopForTest === "function";
+}
+
+async function beginActiveHostedLocalTestRunnerGracefulStop(input: {
+  context: WorkerRouteContext;
+  fallbackRunnerContainerName: string;
+  userId: string;
+}): Promise<{ ok: true }> {
+  const userRunner = input.context.env.USER_RUNNER.getByName(input.userId) as
+    HostedLocalTestUserRunnerStubLike;
+  const activeFence = await userRunner.readActiveRuntimeFenceForTest({
+    userId: input.userId,
+  });
+  const runnerContainerNamespace = createHostedRunnerContainerNamespaceRouter({
+    exactUser: input.context.env.RUNNER_CONTAINER,
+    standby: input.context.env.STANDBY_RUNNER_CONTAINER ?? null,
+  });
+  if (!runnerContainerNamespace) {
+    throw new Error("Hosted runner container binding is unavailable.");
+  }
+  const activeStub = runnerContainerNamespace.getByName(
+    activeFence?.runnerContainerName ?? input.fallbackRunnerContainerName,
+  );
+  if (!hasHostedLocalTestRunnerContainerGracefulStopControl(activeStub)) {
+    throw new Error(
+      "Hosted runner container graceful shutdown test RPC is unavailable.",
+    );
+  }
+  return await activeStub.beginShutdownCheckpointGracefulStopForTest({
+    userId: input.userId,
+  });
 }
 
 function hasHostedLocalTestRunnerContainerActiveOperationControl(
@@ -746,6 +789,13 @@ export async function handleTestShutdownCheckpointPublicationBarrierRoute(
     source: context.env,
     userId,
   });
+  if (action === "shutdown") {
+    return json(await beginActiveHostedLocalTestRunnerGracefulStop({
+      context,
+      fallbackRunnerContainerName: runnerContainerName,
+      userId,
+    }));
+  }
   const stub = context.env.RUNNER_CONTAINER.getByName(runnerContainerName);
   if (!hasHostedLocalTestRunnerContainerShutdownCheckpointPublicationBarrierControl(stub)) {
     throw new Error(
@@ -760,8 +810,6 @@ export async function handleTestShutdownCheckpointPublicationBarrierRoute(
       return json(await stub.armIdleSnapshotStartBarrierForTest({ userId }));
     case "arm":
       return json(await stub.armShutdownCheckpointPublicationBarrierForTest({ userId }));
-    case "shutdown":
-      return json(await stub.beginShutdownCheckpointGracefulStopForTest({ userId }));
     case "status":
       return json(await stub.readShutdownCheckpointPublicationBarrierForTest({ userId }));
     case "release":

--- a/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
@@ -290,8 +290,6 @@ describe.sequential("hosted local foreground reply priority e2e", () => {
     const recoveryEvidenceStartedAt = new Date();
     const providerStartObservations: Array<{
       activeFence: Awaited<ReturnType<typeof readActiveRuntimeFenceForTest>>;
-      barrierState:
-        HostedLocalForegroundPriorityOrderingObservationState["barrierState"];
       deviceMailboxItem: Awaited<ReturnType<typeof readHostedMailboxItemForTest>>;
       systemLane: {
         importedSeq: string;
@@ -307,16 +305,8 @@ describe.sequential("hosted local foreground reply priority e2e", () => {
         inboundText,
         label: "system mailbox exact replacement",
         onAssistantProviderStart: async () => {
-          await requireScenario().harness
-            .recordForegroundPriorityAssistantProviderStartForTest(
-              systemMailboxProbe.userId,
-            );
-          const [ordering, activeFence, status, deviceMailboxItem] =
+          const [activeFence, status, deviceMailboxItem] =
             await Promise.all([
-              readForegroundPriorityOrderingObservation(
-                requireScenario(),
-                systemMailboxProbe.userId,
-              ),
               readActiveRuntimeFenceForTest(systemMailboxProbe.userId),
               requireScenario().harness.readUserStatus(
                 systemMailboxProbe.userId,
@@ -332,7 +322,6 @@ describe.sequential("hosted local foreground reply priority e2e", () => {
           );
           providerStartObservations.push({
             activeFence,
-            barrierState: ordering.barrierState,
             deviceMailboxItem,
             systemLane: systemLane
               ? {
@@ -353,6 +342,10 @@ describe.sequential("hosted local foreground reply priority e2e", () => {
         systemAttemptId: systemFence.attemptId,
         userId: systemMailboxProbe.userId,
       });
+      // Releasing the exact-user owner lets it finish and shut down before the
+      // foreground provider starts on the claimed standby. The provider-start
+      // callback therefore uses durable handoff evidence below instead of
+      // reaching back into volatile instrumentation on the retired owner.
       await expect(releaseForegroundPriorityOrderingBarrier({
         scenario: requireScenario(),
         userId: systemMailboxProbe.userId,
@@ -369,7 +362,6 @@ describe.sequential("hosted local foreground reply priority e2e", () => {
           ["Assistant provider started without an active runtime write fence."],
         ));
       }
-      expect(providerStart.barrierState).toBe("released");
       expect(providerStart.activeFence.processingMode).toBe("default");
       expect(providerStart.activeFence.attemptId).not.toBe(
         systemFence.attemptId,

--- a/apps/cloudflare/test/index.test.ts
+++ b/apps/cloudflare/test/index.test.ts
@@ -51,6 +51,12 @@ import type {
   HostedExecutionContainerNamespaceLike,
   HostedExecutionContainerStubLike,
 } from "../src/runner-container.ts";
+import {
+  HOSTED_STANDBY_LOCATION_HINT,
+  HOSTED_STANDBY_REGION,
+  createHostedStandbySlotName,
+  type HostedStandbyRunnerContainerStubLike,
+} from "../src/standby-runner-contract.ts";
 import type {
   DurableObjectStateLike,
   DurableObjectStorageLike,
@@ -2022,6 +2028,92 @@ describe("cloudflare worker routes", () => {
       env,
     );
     expect(invalidResponse.status).toBe(400);
+  });
+
+  it("stops the standby container that owns the active runtime fence", async () => {
+    const standbyContainerName = createHostedStandbySlotName("release_1");
+    const beginExactShutdown = vi.fn(async () => ({ ok: true as const }));
+    const beginStandbyShutdown = vi.fn(async () => ({ ok: true as const }));
+    const baseRunnerContainerNamespace = createRunnerContainerNamespace();
+    const exactStub = {
+      ...baseRunnerContainerNamespace.getByName("member_123"),
+      beginShutdownCheckpointGracefulStopForTest: beginExactShutdown,
+    };
+    const standbyStub = {
+      ...baseRunnerContainerNamespace.getByName(standbyContainerName),
+      bindStandbySlot: vi.fn(async (input) => ({
+        ...input,
+        bound: true as const,
+      })),
+      beginShutdownCheckpointGracefulStopForTest: beginStandbyShutdown,
+      prepareStandbySlot: vi.fn(async (input) => ({
+        ...input,
+        prepared: true as const,
+      })),
+      readStandbySlotBinding: vi.fn(async () => ({
+        claimId: "standby-claim-00000000-0000-4000-8000-000000000000",
+        releaseId: "release_1",
+        region: HOSTED_STANDBY_REGION,
+        slotName: standbyContainerName,
+        state: "bound" as const,
+        userId: "member_123",
+      })),
+      readStandbySlotCoordinatorState: vi.fn(async () => ({
+        coordinatorOwned: false,
+        releaseId: "release_1",
+        slotName: standbyContainerName,
+        state: "bound" as const,
+      })),
+      retireStandbySlot: vi.fn(async () => ({ retired: true as const })),
+    } satisfies HostedStandbyRunnerContainerStubLike & {
+      beginShutdownCheckpointGracefulStopForTest(
+        input: { userId: string },
+      ): Promise<{ ok: true }>;
+    };
+    const exactGetByName = vi.fn(() => exactStub);
+    const standbyGetByName = vi.fn(() => standbyStub);
+    const readActiveRuntimeFenceForTest = vi.fn(async () => ({
+      attemptId: "runtime-attempt-standby",
+      processingMode: "default" as const,
+      runnerContainerName: standbyContainerName,
+    }));
+    const env = createWorkerEnv(createUserRunnerStub({
+      readActiveRuntimeFenceForTest,
+    }), {
+      MURPH_HOSTED_LOCAL_TEST_ROUTES: "1",
+      NODE_ENV: "test",
+      RUNNER_CONTAINER: {
+        getByName: exactGetByName,
+      },
+      STANDBY_RUNNER_CONTAINER: {
+        getByName: standbyGetByName,
+      },
+    });
+
+    const response = await hostedLocalTestWorker.fetch(
+      await signControlRequest(new Request(
+        "https://runner.example.test/__test/users/member_123"
+          + "/shutdown-checkpoint-publication-barrier?action=shutdown",
+        { method: "POST" },
+      ), {
+        boundUserId: "member_123",
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(readActiveRuntimeFenceForTest).toHaveBeenCalledWith({
+      userId: "member_123",
+    });
+    expect(standbyGetByName).toHaveBeenCalledWith(standbyContainerName, {
+      locationHint: HOSTED_STANDBY_LOCATION_HINT,
+    });
+    expect(beginStandbyShutdown).toHaveBeenCalledWith({
+      userId: "member_123",
+    });
+    expect(exactGetByName).not.toHaveBeenCalled();
+    expect(beginExactShutdown).not.toHaveBeenCalled();
   });
 
   it("maps the user-scoped foreground-priority ordering controls", async () => {

--- a/apps/cloudflare/test/standby-runner.test.ts
+++ b/apps/cloudflare/test/standby-runner.test.ts
@@ -84,6 +84,20 @@ describe("hosted standby contract", () => {
 });
 
 describe("StandbyRunnerContainer", () => {
+  it("uses SIGTERM for the hosted-local shutdown checkpoint control", async () => {
+    const stop = vi.fn(async () => undefined);
+    const container: HostedLocalTestStandbyRunnerContainer = Object.create(
+      HostedLocalTestStandbyRunnerContainer.prototype,
+    );
+    Object.defineProperty(container, "stop", { value: stop });
+
+    await expect(container.beginShutdownCheckpointGracefulStopForTest({
+      userId: "member_shutdown_checkpoint_signal",
+    })).resolves.toEqual({ ok: true });
+    expect(stop).toHaveBeenCalledOnce();
+    expect(stop).toHaveBeenCalledWith("SIGTERM");
+  });
+
   it("keeps Wrangler's synthetic region override isolated to the local test class", async () => {
     const localHarness = createStandbyContainerHarness({
       containerClass: HostedLocalTestStandbyRunnerContainer,


### PR DESCRIPTION
## Why and outcome

PR #2738 made the foreground-priority journey exercise a claimed standby container. The hosted-local graceful-shutdown control still selected the exact-user container, so it stopped an unused instance while the real standby invocation and durable fence remained active.

This routes that test-only shutdown through the container named by the active UserRunner fence, exposes the same SIGTERM control on the hosted-local standby class, and keeps the exact-to-standby E2E assertion on durable handoff evidence after the original owner retires.

## Product UX

Not applicable. This corrects internal integration-test controls and evidence only; member-visible behavior, UI, copy, and workflows are unchanged.

## Evidence

- New focused route regression failed before the fix because the standby shutdown RPC was never called.
- `pnpm --dir apps/cloudflare typecheck`
- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/index.test.ts apps/cloudflare/test/standby-runner.test.ts` — 135 passed.
- `pnpm hosted-local e2e foreground-reply-priority --profile e2e:stub` with the private-main Temporal worker — main process 9 passed / 2 skipped; ordering process 2 passed / 9 skipped. The exact-to-standby system-mailbox case and stale-fence recovery both passed under their 30-second deadlines.
- `pnpm complexity:diff`
- Current-base `git merge-tree --write-tree` against `origin/main` completed cleanly.

## Non-obvious affected surfaces

- Hosted-local Cloudflare test routes and the local-only standby subclass now target the active runtime owner for graceful shutdown.
- The foreground-priority E2E no longer reaches into volatile instrumentation on the retired exact-user owner after the standby handoff; it still proves the pre-release ordering barrier and validates the new owner through the durable fence and mailbox state.
- Production Worker routes, the production `StandbyRunnerContainer`, runtime admission, and completion behavior are unchanged.

## Architecture and reuse

- **Existing systems reused:** The active UserRunner fence and existing exact-user/standby namespace router remain the two sources of routing truth.
- **New logic:** One local-test shutdown path reads the fence and invokes SIGTERM on the named container, with exact-user fallback when no fence exists.
- **New abstractions:** One narrow route helper and capability guard contain the test-only owner resolution; no new shared service or persisted state was added.
- **Complexity intentionally avoided:** The change does not alter production container ownership, duplicate fence state, or add lifecycle machinery.

## Complexity impact

- **Guard:** pass — `pnpm complexity:diff`.
- **Hotspots:** No changed source function exceeds 20; changed-file debt remains 0 and the route-handler maximum remains 18.
- **Agent judgment:** No further behavior-preserving simplification is justified; the helper isolates the owner lookup while reusing the canonical router.

## Hot reply path impact

Not applicable. The production Foreground Reply Critical Path is unchanged; all runtime code changes are compiled only into the hosted-local test Worker.

## Murph initial provider input impact

- **Murph:** Not applicable; no prompt, tool schema, generated guidance, or provider-visible assembly changed.
- **Codex:** Not applicable; no prompt, tool schema, generated guidance, or provider-visible assembly changed.

## Change-shape breakdown

Classification uses base-to-head `git diff --numstat`: files under Cloudflare `src` are source, test files are tests/fixtures, and the Frog entry is docs. There are no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 57 | 2 |
| Tests/fixtures | 111 | 13 |
| Docs | 24 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **192** | **15** |

## Deployment concerns

- Deployment: not applicable
- Reason: The affected classes and routes are hosted-local test-only surfaces and do not change a runtime deploy boundary.

## Changelog

- Changelog: not applicable
- Reason: This is an internal integration-test control correction with no member-visible change.
