### PR TITLE
fix(hosted-local): migrate legacy KMS key versions

### DIFF
--- a/.agents/friction-log/20260902230155-hosted-local-preserves/friction.md
+++ b/.agents/friction-log/20260902230155-hosted-local-preserves/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Hosted-local preserves legacy invalid KMS key-version state'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Starting the hosted-local stack migrates persisted local authority state from legacy non-numeric key-version names to the current exact KMS resource-name format while preserving verification compatibility.
+
+## Current Behavior
+
+A persisted legacy local key-version name remains active after the repository adopts numeric KMS key versions. The first operation that signs a hosted domain-root envelope then fails, and local native admission cannot complete until the ignored crypto-state file is manually removed.
+
+## Possible Solution
+
+Derive the active local key version deterministically from the preserved public key on every startup, while retaining the legacy keyring entry as verify-only. Continue reading externally supplied key versions only when remote hosted crypto keys are explicitly enabled.
+
+## Minimal Reproducible Example
+
+Persist a matching local authority private/public key pair with an active key-version name ending in a non-numeric legacy suffix. Pass that state to mergeCloudflareLocalEnv, then call the local KMS signer with the returned active version.
+
+## Context
+
+This blocks a clean hosted-local signup after upgrading an existing development checkout and forces deletion of otherwise valid local crypto state.

--- a/packages/hosted-local-harness/src/dev-hosted-local/environment.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/environment.ts
@@ -298,12 +298,11 @@ export function mergeCloudflareLocalEnv(input: {
   const authoritySignPublicKeyPem =
     authoritySigningKey.publicKeyPem
     ?? readRequiredRemoteHostedCryptoKey("HOSTED_CRYPTO_GCP_AUTHORITY_SIGN_PUBLIC_KEY_PEM");
-  const authoritySignKeyVersion =
-    readHostedLocalKey("HOSTED_CRYPTO_GCP_AUTHORITY_SIGN_KEY_VERSION")
-    ?? readHostedLocalKey("HOSTED_CRYPTO_AUTHORITY_SIGN_KEY_VERSION")
-    ?? (useRemoteHostedCryptoKeys
-      ? readRequiredRemoteHostedCryptoKey("HOSTED_CRYPTO_GCP_AUTHORITY_SIGN_KEY_VERSION")
-      : buildHostedLocalAuthoritySignKeyVersion(authoritySignPublicKeyPem));
+  const authoritySignKeyVersion = useRemoteHostedCryptoKeys
+    ? readHostedLocalKey("HOSTED_CRYPTO_GCP_AUTHORITY_SIGN_KEY_VERSION")
+      ?? readHostedLocalKey("HOSTED_CRYPTO_AUTHORITY_SIGN_KEY_VERSION")
+      ?? readRequiredRemoteHostedCryptoKey("HOSTED_CRYPTO_GCP_AUTHORITY_SIGN_KEY_VERSION")
+    : buildHostedLocalAuthoritySignKeyVersion(authoritySignPublicKeyPem);
   const authorityVerifyKeyringJson = buildHostedAuthorityVerifyKeyringJson({
     currentKeyVersionName: authoritySignKeyVersion,
     currentPublicKeyPem: authoritySignPublicKeyPem,

--- a/packages/hosted-local-harness/test/dev-hosted-local/environment.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/environment.test.ts
@@ -569,13 +569,20 @@ describe("mergeCloudflareLocalEnv", () => {
     expect(merged.HOSTED_WEB_CALLBACK_SIGNING_PRIVATE_JWK).toBe(generatedPrivateJwkJson);
   });
 
-  it("preserves matching persisted local authority signing keys and key version", () => {
+  it("migrates matching persisted local authority keys from a legacy version name", () => {
+    const legacyKeyVersionName =
+      "projects/murph-local/locations/global/keyRings/hosted-local/cryptoKeys/authority-sign/cryptoKeyVersions/legacy-local";
     const merged = mergeCloudflareLocalEnv({
       config: localConfig,
       existing: {
         HOSTED_CRYPTO_ENV: "local",
-        HOSTED_CRYPTO_GCP_AUTHORITY_SIGN_KEY_VERSION:
-          "projects/murph-local/locations/global/keyRings/hosted-local/cryptoKeys/authority-sign/cryptoKeyVersions/legacy-local",
+        HOSTED_CRYPTO_AUTHORITY_VERIFY_KEYRING_JSON: JSON.stringify({
+          [legacyKeyVersionName]: {
+            publicKeyPem: existingAuthorityPublicPem.trim(),
+            status: "active",
+          },
+        }),
+        HOSTED_CRYPTO_GCP_AUTHORITY_SIGN_KEY_VERSION: legacyKeyVersionName,
         HOSTED_CRYPTO_GCP_AUTHORITY_SIGN_PUBLIC_KEY_PEM: existingAuthorityPublicPem,
         HOSTED_CRYPTO_LOCAL_AUTHORITY_SIGN_PRIVATE_JWK: existingAuthorityPrivateJwkJson,
         HOSTED_CRYPTO_LOCAL_KMS_WRAP_KEY: "existing-wrap-key",
@@ -592,8 +599,11 @@ describe("mergeCloudflareLocalEnv", () => {
       }),
     });
 
-    expect(merged.HOSTED_CRYPTO_GCP_AUTHORITY_SIGN_KEY_VERSION).toBe(
-      "projects/murph-local/locations/global/keyRings/hosted-local/cryptoKeys/authority-sign/cryptoKeyVersions/legacy-local",
+    expect(merged.HOSTED_CRYPTO_GCP_AUTHORITY_SIGN_KEY_VERSION).toMatch(
+      /^projects\/murph-local\/locations\/global\/keyRings\/hosted-local\/cryptoKeys\/authority-sign\/cryptoKeyVersions\/[1-9][0-9]*$/u,
+    );
+    expect(merged.HOSTED_CRYPTO_AUTHORITY_SIGN_KEY_VERSION).toBe(
+      merged.HOSTED_CRYPTO_GCP_AUTHORITY_SIGN_KEY_VERSION,
     );
     expect(merged.HOSTED_CRYPTO_GCP_AUTHORITY_SIGN_PUBLIC_KEY_PEM).toBe(
       existingAuthorityPublicPem.trim(),
@@ -601,6 +611,16 @@ describe("mergeCloudflareLocalEnv", () => {
     expect(merged.HOSTED_CRYPTO_LOCAL_AUTHORITY_SIGN_PRIVATE_JWK).toBe(
       existingAuthorityPrivateJwkJson,
     );
+    expect(JSON.parse(merged.HOSTED_CRYPTO_AUTHORITY_VERIFY_KEYRING_JSON)).toEqual({
+      [legacyKeyVersionName]: {
+        publicKeyPem: existingAuthorityPublicPem.trim(),
+        status: "verify_only",
+      },
+      [merged.HOSTED_CRYPTO_GCP_AUTHORITY_SIGN_KEY_VERSION]: {
+        publicKeyPem: existingAuthorityPublicPem.trim(),
+        status: "active",
+      },
+    });
   });
 
   it("rejects mismatched persisted local authority signing keys instead of regenerating", () => {


### PR DESCRIPTION
## Why and outcome

Existing hosted-local checkouts can retain a legacy non-numeric authority key-version name after the local KMS signer began enforcing exact GCP CryptoKeyVersion resource names. The first signed onboarding envelope then fails and native dev admission returns 400.

Local startup now derives the active numeric version deterministically from the preserved authority public key. Existing signing material is retained, the legacy version remains verification-only, and explicitly remote hosted-crypto configuration continues using its supplied version.

## Product UX

- Effort: Not applicable — this changes internal hosted-local environment migration only.
- Result: Not applicable
- Walkthrough: The affected developer can restart an existing checkout and complete the same native admission path without manually deleting local crypto state. Production and hosted member UX are excluded.

## Evidence

- Direct: The new regression failed before the source change because the merged active version ended in the legacy suffix; it passes with an exact numeric resource name and a verification-only legacy keyring entry after the fix. A real hosted-local stack also starts with an exact numeric active version after recovery; physical-phone admission replay remains a draft-PR follow-up.
- Coverage: `pnpm --dir packages/hosted-local-harness typecheck`; `pnpm --dir packages/hosted-local-harness test` (29 files passed, 454 tests passed, 1 skipped); focused environment suite (96 tests passed); `git diff --check`; `pnpm complexity:diff`.

## Non-obvious affected surfaces

- Local authority verification keyring: the prior active version is retained as `verify_only`, covered by the migration regression.
- Remote hosted-crypto setup: it still reads the externally supplied version only when remote keys are explicitly enabled, covered by the existing environment suite.

## Architecture and reuse

- Existing systems reused: the deterministic local key-version builder and existing authority keyring migration logic.
- New logic: local mode always derives its active version from the preserved public key; remote mode keeps its configured version lookup.
- New abstractions: None; the existing local/remote branch and keyring builder own the behavior.
- Complexity intentionally avoided: no state reset, one-off migration file, compatibility service, or second source of truth was added.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: `mergeCloudflareLocalEnv` remains at 31 and `buildHostedLocalDevOverrides` remains at 26; both are unchanged legacy hotspots and the diff adds no complexity debt.
- Agent judgment: no further behavior-preserving simplification is justified; the local/remote conditional directly expresses which source owns the active version.

## Hot reply path impact

- Path status: Not applicable — this changes hosted-local environment assembly before services start, not message acceptance or reply handoff.
- Database calls: None
- Network/provider calls: None
- Other awaited latency: None
- Before/after proof: Environment unit regression and full package suite.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged; no assistant instruction builder changed.
- Tool/schema/generated guidance: Unchanged; no provider-visible tool or schema surface changed.
- Other provider-visible input: Unchanged; this is local startup configuration only.
- Measurement method: Not run — no provider-input surface changed.

## Risks

- Local persisted envelopes signed under a legacy version continue to verify because the old entry is retained as `verify_only`; the regression asserts both keyring entries and statuses.

<!-- ReviewGPT context sensitivity: sensitive -->
<!-- Classification reason: Local cryptographic key-version selection and auth admission are sensitive even though the change cannot deploy to production. -->

## Deployment concerns

- Deployment: not applicable
- Reason: The changed package assembles local development environment state only and is not part of a production deploy artifact.

## Change-shape breakdown

Classification rule: TypeScript runtime code is source, Vitest code is tests/fixtures, and the Frog entry is docs. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 5 | 6 |
| Tests / fixtures | 25 | 5 |
| Docs | 24 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **54** | **11** |

## Changelog

- Changelog: not applicable
- Reason: Internal development-harness recovery only; no member-visible production behavior changes.

ReviewGPT first-reviewed head: 7a0994d8401ed2249991e8462ab5479f308a6751