### PR TITLE
fix(runtime): unblock member channel frontiers

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-02-model-free-member-channel-frontier.md
+++ b/agent-docs/exec-plans/active/2026-09-02-model-free-member-channel-frontier.md
@@ -1,0 +1,45 @@
+# Model-free member-channel frontier recovery
+
+## Goal
+
+Allow a deterministic `member.channels.updated` system-mailbox item to be
+processed by the existing bounded model-free owner so it cannot strand newer
+device-sync work behind the handled frontier.
+
+## Root-cause proof
+
+- Production reconciliation classified the first live retained system item as
+  `default_owned` and repeatedly requested default processing.
+- Repeated default invocations imported the complete system prefix but ran no
+  device-sync work and did not advance the handled frontier.
+- The runtime routes `member.channels.updated` to the existing deterministic
+  `apply-member-channels-update` action, but that kind/action is absent from the
+  model-free classifier and executor allowlist.
+- Default processing applies channel updates only as a reply pre-dispatch
+  barrier, so an idle default pass cannot consume the frontier item.
+
+## Approach
+
+1. Add a focused classifier regression and a production-shaped system-mailbox
+   entrypoint test that fails before the correction.
+2. Add the existing kind and route action to the shared model-free contract.
+3. Keep the pre-dispatch channel barrier unchanged so a concurrent reply still
+   observes the newest imported channel authority before provider delivery.
+4. Update the hosted runtime protocol and changelog, run focused verification,
+   then complete the normal PR, ReviewGPT, CI, merge, and deploy gates.
+
+## Architecture and complexity
+
+This reuses the existing classifier, route, executor, checkpoint, and handled
+frontier. It adds no state, queue, scheduler, retry loop, mode, dependency, or
+new abstraction.
+
+## Verification
+
+- Hosted-execution classifier test.
+- Assistant-runtime system-mailbox entrypoint regression.
+- Affected package typechecks.
+- Required exact-head CI and ReviewGPT gates.
+
+Status: active
+Updated: 2026-09-02

--- a/agent-docs/exec-plans/completed/2026-09-02-model-free-member-channel-frontier.md
+++ b/agent-docs/exec-plans/completed/2026-09-02-model-free-member-channel-frontier.md
@@ -41,5 +41,6 @@ new abstraction.
 - Affected package typechecks.
 - Required exact-head CI and ReviewGPT gates.
 
-Status: active
+Status: completed
 Updated: 2026-09-02
+Completed: 2026-09-02

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -779,11 +779,12 @@ selection as well as during idle maintenance, so restored content cannot begin a
 reply after its deadline.
 `system_mailbox` runs one bounded model-free item only when that item is the
 exact first live durable system frontier. The shared classifier admits
-device-sync, operator maintenance, browser-vault refresh, Environment
-completion, and the narrow exact-notification cases; an earlier default-owned
-row remains a hard ordering barrier. Already committed Web updates remain
-authoritative, while an interrupted or not-yet-checkpointed unit stays
-recoverable from the durable mailbox and its existing continuation contract.
+device-sync, member-channel reconciliation, operator maintenance, browser-vault
+refresh, Environment completion, and the narrow exact-notification cases; an
+earlier default-owned row remains a hard ordering barrier. Already committed
+Web updates remain authoritative, while an interrupted or not-yet-checkpointed
+unit stays recoverable from the durable mailbox and its existing continuation
+contract.
 
 Default and `system_mailbox` remain separate bounded owners over one ordered
 mailbox. When the runnable mailbox owner is model-free, the checkpoint
@@ -1388,6 +1389,11 @@ the durable retained frontier. For inactive access, Web emits `null` without a
 mailbox read so Temporal can retire its pointer projection while the durable
 mailbox remains canonical and can be re-read after reactivation. Deploy the
 tolerant Temporal consumer before Web begins emitting the classification.
+When an existing mailbox kind moves from `default_owned` to `model_free`, deploy
+the Cloudflare runtime allowlist before the Web classifier. Old Web remains
+compatible with the expanded runtime; new Web paired with an old runtime keeps
+the item durable but cannot make progress until the runtime is upgraded. Reverse
+that order for rollback.
 Because explicit-null retirement removes Temporal's last local reason to wake,
 every Web owner that restores active access must append a deterministic
 `runtime.maintenance-requested` mailbox item in the same transaction as the
@@ -2796,9 +2802,10 @@ An expected managed AI usage denial observed by the workspace read is not a
 transport preparation failure. Cloudflare binds the denied allowance to the
 fresh write fence and narrows a default invocation to the existing
 `system_mailbox` path, which imports system work, may run one bounded
-model-free deterministic device-sync, operator-maintenance, or browser-vault
-refresh item, and exits before foreground assistant admission. Other system
-items retain their default owner and are not consumed by this recovery mode.
+model-free deterministic device-sync, member-channel reconciliation,
+operator-maintenance, browser-vault refresh, or reported-metric item, and exits
+before foreground assistant admission. Other system items retain their default
+owner and are not consumed by this recovery mode.
 It binds that effective processing mode into the same fence so controller
 priority, preemption, and the container job
 cannot diverge; the fence also rejects all metered provider egress if the runtime

--- a/agent-docs/references/hosted-temporal-orchestration.md
+++ b/agent-docs/references/hosted-temporal-orchestration.md
@@ -107,8 +107,9 @@ An exact system-mailbox pointer is admission, not completion. Web projects the
 authenticated `hostedMailboxSystemHandledThroughSeq` scalar from the existing
 redacted workspace checkpoint and classifies only the exact first live system
 row as `model_free` or `default_owned`. Environment completion is one generic
-model-free kind; Temporal does not know its product meaning or select a
-feature-specific processing mode. Temporal applies three distinct retirement
+model-free kind, as is deterministic member-channel reconciliation; Temporal
+does not know their product meaning or select a feature-specific processing
+mode. Temporal applies three distinct retirement
 rules: a handled-through frontier that reaches the pointer lane sequence retires
 it as completed; an explicit `systemMailboxFrontier: null` retires only
 Temporal's noncanonical pointer projection because the current facts admit no

--- a/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
@@ -546,18 +546,17 @@ describe.sequential("hosted local foreground reply priority e2e", () => {
     const providerRequestBaseline =
       requireScenario().assistantProviderRequests.length;
     const predecessorEventId =
-      `member.channels.updated:environment-ordering:${runId}`;
+      `member.preferences.updated:environment-ordering:${runId}`;
     const predecessor = await appendHostedExecutionWakeForTest({
       environment: requireScenario().runtimeEnv,
-      wake: buildHostedExecutionMemberChannelsUpdatedWake({
+      wake: buildHostedExecutionMemberPreferencesUpdatedWake({
         eventId: predecessorEventId,
-        memberChannels: {
-          email: false,
-          linq: true,
-          telegram: false,
-        },
         memberId: environmentOrderingProbe.userId,
         occurredAt: new Date().toISOString(),
+        preferences: {
+          personality: { detail: 6 },
+          tone: "casual",
+        },
       }),
     });
     expect(predecessor.inserted).toBe(true);
@@ -626,7 +625,7 @@ describe.sequential("hosted local foreground reply priority e2e", () => {
       environment: requireScenario().runtimeEnv,
       userId: environmentOrderingProbe.userId,
     })).resolves.toMatchObject({
-      kind: "member.channels.updated",
+      kind: "member.preferences.updated",
       lane: "system",
     });
     expect(requireScenario().assistantProviderRequests).toHaveLength(

--- a/apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts
@@ -10,6 +10,7 @@ import {
   buildHostedExecutionEnvironmentInterviewCompletedWake,
   buildHostedExecutionMemberActivatedWake,
   buildHostedExecutionMemberChannelsUpdatedWake,
+  buildHostedExecutionMemberPreferencesUpdatedWake,
 } from "@murphai/hosted-execution";
 import {
   startHostedLocalFullStackScenario,
@@ -234,18 +235,17 @@ describe("hosted local Temporal orchestration e2e", () => {
     const providerRequestBaseline = activeScenario.assistantProviderRequests.length;
 
     const retainedEventId =
-      `member.channels.updated:paused-retention:${Date.now()}`;
+      `member.preferences.updated:paused-retention:${Date.now()}`;
     const retainedAppend = await appendHostedExecutionWakeForTest({
       environment: activeScenario.runtimeEnv,
-      wake: buildHostedExecutionMemberChannelsUpdatedWake({
+      wake: buildHostedExecutionMemberPreferencesUpdatedWake({
         eventId: retainedEventId,
-        memberChannels: {
-          email: false,
-          linq: true,
-          telegram: false,
-        },
         memberId: pausedRetentionUserId,
         occurredAt: new Date().toISOString(),
+        preferences: {
+          personality: { detail: 6 },
+          tone: "casual",
+        },
       }),
     });
     const retainedSignal = await signalHostedMailboxAppendRuntimeForTest({
@@ -321,7 +321,7 @@ describe("hosted local Temporal orchestration e2e", () => {
       userId: pausedRetentionUserId,
     })).resolves.toMatchObject({
       consumedAt: null,
-      kind: "member.channels.updated",
+      kind: "member.preferences.updated",
       lane: "system",
     });
     expect(activeScenario.assistantProviderRequests).toHaveLength(
@@ -364,6 +364,47 @@ describe("hosted local Temporal orchestration e2e", () => {
       expectedSeq: modelFreeAppend.wake.seq,
       userId: modelFreeFrontierUserId,
     });
+
+    const memberChannelsEventId =
+      `member.channels.updated:temporal-frontier:${Date.now()}`;
+    const memberChannelsAppend = await appendHostedExecutionWakeForTest({
+      environment: activeScenario.runtimeEnv,
+      wake: buildHostedExecutionMemberChannelsUpdatedWake({
+        eventId: memberChannelsEventId,
+        memberChannels: {
+          email: false,
+          linq: true,
+          telegram: false,
+        },
+        memberId: modelFreeFrontierUserId,
+        occurredAt: new Date().toISOString(),
+      }),
+    });
+    const memberChannelsSignalStartedAt = new Date();
+    const memberChannelsSignal = await signalHostedMailboxAppendRuntimeForTest({
+      environment: activeScenario.runtimeEnv,
+      expectedUserId: modelFreeFrontierUserId,
+      mailboxItemId: memberChannelsAppend.wake.id,
+    });
+    const memberChannelsState = await waitForWorkflowExecutionState({
+      env: activeScenario.runtimeEnv,
+      executionNotBefore: memberChannelsSignalStartedAt,
+      workflowId: memberChannelsSignal.workflowId,
+    });
+    expect(memberChannelsState.lastExecutionErrorCode).toBeNull();
+    await waitForSystemMailboxHandledThrough({
+      expectedSeq: memberChannelsAppend.wake.seq,
+      userId: modelFreeFrontierUserId,
+    });
+    await expect(readHostedMailboxItemForTest({
+      dedupeKey: memberChannelsEventId,
+      environment: activeScenario.runtimeEnv,
+      userId: modelFreeFrontierUserId,
+    })).resolves.toMatchObject({
+      consumedAt: expect.any(String),
+      kind: "member.channels.updated",
+      lane: "system",
+    });
     expect(activeScenario.assistantProviderRequests).toHaveLength(
       modelFreeProviderBaseline,
     );
@@ -376,18 +417,17 @@ describe("hosted local Temporal orchestration e2e", () => {
     const defaultOwnedProviderBaseline =
       activeScenario.assistantProviderRequests.length;
     const defaultOwnedEventId =
-      `member.channels.updated:temporal-frontier:${Date.now()}`;
+      `member.preferences.updated:temporal-frontier:${Date.now()}`;
     const defaultOwnedAppend = await appendHostedExecutionWakeForTest({
       environment: activeScenario.runtimeEnv,
-      wake: buildHostedExecutionMemberChannelsUpdatedWake({
+      wake: buildHostedExecutionMemberPreferencesUpdatedWake({
         eventId: defaultOwnedEventId,
-        memberChannels: {
-          email: false,
-          linq: true,
-          telegram: false,
-        },
         memberId: defaultOwnedFrontierUserId,
         occurredAt: new Date().toISOString(),
+        preferences: {
+          personality: { detail: 6 },
+          tone: "casual",
+        },
       }),
     });
     const defaultOwnedSignal = await signalHostedMailboxAppendRuntimeForTest({
@@ -413,7 +453,7 @@ describe("hosted local Temporal orchestration e2e", () => {
       userId: defaultOwnedFrontierUserId,
     })).resolves.toMatchObject({
       consumedAt: null,
-      kind: "member.channels.updated",
+      kind: "member.preferences.updated",
       lane: "system",
     });
     const defaultOwnedStatus = await activeScenario.harness.readUserStatus(

--- a/apps/web/changelog/entries/2026-09-02/connected-health-sync-queues-recover.json
+++ b/apps/web/changelog/entries/2026-09-02/connected-health-sync-queues-recover.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-02",
+  "order": 200,
+  "item": {
+    "id": "connected-health-sync-queues-recover",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Connected health sync queues recover",
+    "summary": "Queued connected-health updates now resume when an account-channel refresh is waiting ahead of them.",
+    "details": "Both updates keep their durable ordering and retry behavior, while recovery no longer depends on sending Murph another message.",
+    "relevanceTags": ["wearables", "reliability"],
+    "sourcePullRequests": [2757]
+  }
+}

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -440,6 +440,7 @@ const HOSTED_INITIAL_CONVERSATION_MAILBOX_IMPORT_LANES = ["conversation"] as con
 const HOSTED_INITIAL_BOOTSTRAP_MAILBOX_IMPORT_LANES = ["system", "conversation"] as const;
 const HOSTED_FOREGROUND_MAILBOX_PREFETCH_LANES = ["conversation", "system"] as const;
 const HOSTED_SYSTEM_MAILBOX_MODEL_FREE_ROUTE_ACTIONS = [
+  "apply-member-channels-update",
   "apply-runtime-control-request",
   "dispatch-assistant-notification",
   "import-reported-daily-metric",

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -66,6 +66,7 @@ import {
   buildHostedExecutionEnvironmentInterviewCompletedWake,
   buildHostedExecutionLinqConversationMessageWake,
   buildHostedExecutionMemberActivatedWake,
+  buildHostedExecutionMemberChannelsUpdatedWake,
   buildHostedExecutionRuntimeControlWake,
   deriveHostedExecutionErrorCode,
 } from "@murphai/hosted-execution";
@@ -4788,6 +4789,11 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       expectedProjectionMode: null,
       kind: "health.daily-metric.reported",
     },
+    {
+      dedupeKey: "member.channels.updated:settings-change",
+      expectedProjectionMode: null,
+      kind: "member.channels.updated",
+    },
   ] as const)("system mailbox mode drains model-free $kind work", async ({
     dedupeKey,
     expectedProjectionMode,
@@ -4845,6 +4851,28 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
           item: dailyMetricItem,
           vaultRoot,
           wake: dailyMetricWake,
+        });
+      } else if (kind === "member.channels.updated") {
+        const memberChannelsItem: HostedMailboxResolvedImportItem = {
+          ...resolvedItem,
+          route: {
+            ...resolvedItem.route,
+            action: "apply-member-channels-update",
+          },
+        };
+        await enqueueHostedSystemMailboxItem({
+          item: memberChannelsItem,
+          vaultRoot,
+          wake: buildHostedExecutionMemberChannelsUpdatedWake({
+            eventId: maintenanceItem.dedupeKey,
+            memberChannels: {
+              email: false,
+              linq: false,
+              telegram: false,
+            },
+            memberId: TEST_USER_ID,
+            occurredAt: maintenanceItem.occurredAt,
+          }),
         });
       } else {
         await enqueueHostedSystemMailboxItem({

--- a/packages/hosted-execution/src/orchestration-control.ts
+++ b/packages/hosted-execution/src/orchestration-control.ts
@@ -83,6 +83,7 @@ export const HOSTED_SYSTEM_MAILBOX_MODEL_FREE_KINDS = [
   "device-sync.wake",
   "environment-interview.completed",
   "health.daily-metric.reported",
+  "member.channels.updated",
   "runtime.browser-vault-refresh-requested",
   "runtime.maintenance-requested",
 ] as const satisfies readonly HostedMailboxKind[];

--- a/packages/hosted-execution/test/hosted-orchestration-control.test.ts
+++ b/packages/hosted-execution/test/hosted-orchestration-control.test.ts
@@ -338,6 +338,10 @@ describe("hosted orchestration control contracts", () => {
       kind: "environment-interview.completed",
     })).toBe("model_free");
     expect(classifyHostedSystemMailboxExecutionClass({
+      dedupeKey: "member.channels.updated:settings-change",
+      kind: "member.channels.updated",
+    })).toBe("model_free");
+    expect(classifyHostedSystemMailboxExecutionClass({
       dedupeKey: "assistant.ask.completed:request",
       kind: "assistant.ask.completed",
     })).toBe("default_owned");


### PR DESCRIPTION
## Why and outcome

A deterministic member-channel update could remain the oldest live system-mailbox item indefinitely because orchestration classified it as assistant-owned while idle assistant passes only reconcile channels immediately before a reply. Every newer connected-health wake then remained ordered behind that unhandled frontier.

Classify the existing channel update as model-free and admit its existing route action to the bounded system-mailbox executor. The runtime now consumes it through the canonical mailbox/checkpoint path before continuing to newer device-sync work.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: An established member whose channel update precedes connected-health work recovers without sending a message or creating a second recovery mechanism. Concurrent reply delivery retains the existing pre-dispatch channel barrier. No UI changes.

## Evidence

- Direct: Production-shaped runtime entrypoint test restores a queued `member.channels.updated` item, runs `system_mailbox`, proves the assistant phase is never entered, consumes the item, and checkpoints handled-through sequence `1`.
- Coverage: Hosted-execution classifier coverage proves the exact first frontier is `model_free`; the full affected test files pass (54 assistant-runtime tests and 10 hosted-execution tests); assistant-runtime, hosted-execution, Cloudflare, and Web typechecks pass. The full hosted-local command was attempted with the current private Temporal worker but stopped before test assertions when the unrelated runner-container shell smoke repeatedly timed out; exact-head cross-repository CI owns that final integration proof.

## Non-obvious affected surfaces

- Web reconciliation facts now project `member.channels.updated` as `model_free`; classifier regression covers the shared contract.
- Cloudflare/assistant-runtime must accept `apply-member-channels-update` before Web emits that classification; the production-shaped entrypoint regression covers the consumer.
- Foreground reply channel authority remains protected by the unchanged pre-dispatch reconciliation barrier.
- Hosted-local Temporal and foreground-priority fixtures now use `member.preferences.updated` for genuine default-owner ordering and explicitly cover model-free channel consumption without provider work.

## Architecture and reuse

- Existing systems reused: Durable ordered system mailbox, shared execution-class classifier, existing `apply-member-channels-update` route, bounded system-mailbox executor, workspace checkpoint, and handled frontier.
- New logic: One existing mailbox kind is assigned to its deterministic owner, and one existing route action is admitted there.
- New abstractions: None; the current classifier and executor remain the two owning boundaries.
- Complexity intentionally avoided: No repair queue, background sweep, replay table, scheduler, compatibility layer, retry loop, or new state owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; both changed source files add zero complexity debt and zero maximum complexity.
- Hotspots: The existing `hosted-runtime.ts` hotspots are unchanged; `orchestration-control.ts` remains below the threshold.
- Agent judgment: No further behavior-preserving simplification is justified. Two explicit allowlist entries are the smallest representation across the producer classification and consumer authorization boundaries.

## Hot reply path impact

- Path status: Not applicable — this changes idle/system-mailbox ownership, not conversation acceptance through reply handoff.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved.
- Before/after proof: The regression forbids entry into the assistant phase; the existing pre-dispatch channel barrier is unchanged.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Risks

ReviewGPT context sensitivity: sensitive
Classification reason: This changes cross-deploy hosted-runtime scheduling and execution ownership for durable queued work.
ReviewGPT first-reviewed head: cc1ad9ce05d3a629ae8feb6cc45dfdcba7dd4817

## Deployment concerns

- Deployment: applicable
- Supported skew: Expanded Cloudflare consumer with old Web is safe. New Web with old Cloudflare keeps the item durable but cannot advance it until the consumer is upgraded.
- Safe order: Deploy Cloudflare/assistant-runtime first, then deploy Web's reconciliation classifier.
- Rollback floor: Roll Web back before Cloudflare so the old classifier never asks an old consumer to execute the newly model-free route.
- Expected exposure: During wrong-order skew, affected frontiers remain durable and temporarily stalled; no mailbox item is dropped.
- Reversibility: Both changes are allowlist additions and can be rolled back in reverse deployment order without data migration.
- Convergence proof: After both deploys, reconciliation selects `system_mailbox`; the existing executor consumes the first item and checkpoints a newer handled frontier.
- Post-deploy checks: Confirm the first live frontier class becomes `model_free`, processing mode becomes `system_mailbox`, handled-through advances, and queued device-sync work resumes.

## Change-shape breakdown

Classification rule: Runtime allowlists are source; Vitest changes are tests; the execution plan and protocol references are docs; no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 2 | 0 |
| Tests / fixtures | 95 | 24 |
| Docs | 78 | 10 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **175** | **34** |

## Changelog

- Changelog: updated
- Items: 2026-09-02 · connected-health-sync-queues-recover
