### PR TITLE
test(cloudflare): align foreground completion timeout

### DIFF
--- a/.agents/friction-log/20260902232000-hosted-foreground-completion-timeout/friction.md
+++ b/.agents/friction-log/20260902232000-hosted-foreground-completion-timeout/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Foreground-priority E2E times out before the configured idle checkpoint'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The foreground-priority E2E should allow the background Environment item to resume after the production-like idle-checkpoint boundary when no extra wake races in first.
+
+## Current Behavior
+
+The scenario configures a 180-second idle-checkpoint delay but waits only 120 seconds for the deferred Environment item. It passes when an incidental wake resumes work early and fails when the runtime follows the configured idle path.
+
+## Possible Solution
+
+Derive the completion deadline from the scenario's production-like idle-checkpoint delay and retain a bounded margin for the resumed invocation.
+
+## Minimal Reproducible Example
+
+Run the hosted-local `foreground-reply-priority` scenario without an extra wake after the foreground reply. The reply succeeds, the replacement invocation completes after the configured idle checkpoint, and the shorter Environment completion poll expires first.
+
+## Context
+
+The mismatch makes the private release-admission workflow intermittently reject an otherwise successful foreground-preemption journey.

--- a/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
@@ -2408,7 +2408,7 @@ async function waitForEnvironmentCompletion(input: {
       };
     }, {
       interval: 250,
-      timeout: 120_000,
+      timeout: productionIdleCheckpointDelayMs + 60_000,
     }).toEqual({
       handled: true,
       lastErrorCode: null,


### PR DESCRIPTION
## Why and outcome

The foreground-priority E2E configures the production-like 180-second idle-checkpoint delay but allowed only 120 seconds for a deferred Environment item to resume. The journey therefore passed when an incidental wake resumed work early and failed when the runtime followed the legitimate idle-checkpoint path.

This derives the completion wait from the configured idle delay and adds a bounded 60-second recovery margin. Runtime behavior is unchanged.

## Product UX

Not applicable. This changes internal release-admission test timing only; member-visible behavior, UI, copy, and workflows are unchanged.

## Evidence

- Private integration attempt 6 proved the failure path: foreground reply succeeded, the replacement invocation completed after 191.8 seconds (about 9.7 seconds of preemption plus the configured 180-second idle delay), and the system item then resumed; the old 120-second assertion expired first.
- Private integration attempt 5 proved the early-wake path: the same replacement invocation completed in 11.7 seconds and the test passed.
- `pnpm --dir apps/cloudflare typecheck` — pass.
- `pnpm hosted-local e2e foreground-reply-priority` with the exact private-main Temporal worker — all five scenarios through the changed Environment-priority assertion passed, including a run beyond the former 120-second bound. Four later unrelated local arm64/Docker harness cases failed after the stack degraded; those same cases were green in private integration attempt 6.
- `pnpm complexity:diff` — pass; no authored source change to analyze.
- `git diff --check` — pass.

## Non-obvious affected surfaces

- Both callers of the shared Environment completion helper now allow the configured production-like idle boundary plus recovery margin.
- The enclosing E2E tests remain bounded at 300 seconds.
- Production Cloudflare, Web, assistant runtime, mailbox, and Temporal code are unchanged.

## Architecture and reuse

- Existing systems reused: `productionIdleCheckpointDelayMs`.
- New logic: derive the shared Environment completion wait from that configured delay plus a bounded recovery margin.
- New abstractions: none are needed because the existing delay constant and completion helper already own this timing boundary.
- Complexity intentionally avoided: retries, lifecycle machinery, and another independent timeout constant.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: no production source or branching changes are introduced; only one test wait expression changes.
- Agent judgment: deriving the timeout from the existing configured delay reduces drift and is simpler than retries or a second lifecycle mechanism.
- Source complexity: unchanged.
- Test logic: one constant-derived timeout replaces one shorter literal.

## Hot reply path impact

Not applicable. The production Foreground Reply Critical Path is unchanged.

## Murph initial provider input impact

- Murph: not applicable; no prompt, tool schema, guidance, or provider-visible assembly changed.
- Codex: not applicable; no prompt, tool schema, guidance, or provider-visible assembly changed.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 1 | 1 |
| Docs | 24 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **25** | **1** |

## Deployment concerns

- Deployment: not applicable
- Reason: test-only change; no deployable artifact changes.

## Changelog

- Changelog: not applicable
- Reason: internal release-admission test correction with no member-visible change.
