### PR TITLE
fix(onboarding): use canonical voice preview URLs

### DIFF
--- a/.agents/friction-log/20260902235559-native-voice-preview/friction.md
+++ b/.agents/friction-log/20260902235559-native-voice-preview/friction.md
@@ -1,0 +1,26 @@
+---
+title: 'Native voice preview URLs inherit non-playable development origins'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Native companion onboarding should return voice preview URLs that AVFoundation can stream in every supported environment.
+
+## Current Behavior
+
+The onboarding projection derives voice asset URLs from the incoming request origin. A development tunnel can return the MP3 successfully over HTTP while AVPlayer rejects the same URL as unavailable, leaving the preview control apparently playing without sound.
+
+## Possible Solution
+
+Project immutable public voice assets from the canonical product origin and cover that contract independently from request-origin contact actions.
+
+## Minimal Reproducible Example
+
+1. Request the companion onboarding catalog through a development tunnel.
+2. Fetch a returned voice preview URL with an HTTP client and observe a valid ranged MP3 response.
+3. Give that URL to AVPlayer and observe a resource-unavailable failure before playback advances.
+
+## Context
+
+This makes HTTP-only route checks misleading and blocks physical-device voice selection testing.

--- a/apps/web/app/api/device-sync/companion/initial-onboarding/route.ts
+++ b/apps/web/app/api/device-sync/companion/initial-onboarding/route.ts
@@ -1,6 +1,7 @@
 import {
   assistantBasePersonaOptions,
   assistantVoiceOptions,
+  MURPH_PRODUCT_ORIGIN,
 } from "@murphai/contracts";
 
 import {
@@ -185,7 +186,7 @@ function projectPendingState(input: {
         description: option.description,
         id: option.id,
         label: option.label,
-        previewURL: new URL(option.previewPath, input.origin).toString(),
+        previewURL: new URL(option.previewPath, MURPH_PRODUCT_ORIGIN).toString(),
       })),
     },
     contactCard: supportsContactCard

--- a/apps/web/test/device-sync-companion-initial-onboarding-route.test.ts
+++ b/apps/web/test/device-sync-companion-initial-onboarding-route.test.ts
@@ -121,7 +121,7 @@ describe("companion initial onboarding routes", () => {
     expect(payload.catalog.personas).toHaveLength(6);
     expect(payload.catalog.voices.length).toBeGreaterThan(10);
     expect(payload.catalog.voices[0].previewURL).toMatch(
-      /^https:\/\/app\.example\.test\/audio\//u,
+      /^https:\/\/www\.withmurph\.ai\/audio\//u,
     );
     expect(mocks.requireActivePrivyMemberAuthFromBearerToken)
       .toHaveBeenCalledWith(request, expect.anything());


### PR DESCRIPTION
## Why and outcome

The native companion receives voice preview URLs from the initial-onboarding catalog. Those URLs previously inherited the request origin, so a development tunnel could serve a valid ranged MP3 to an HTTP client while AVFoundation rejected the same URL as unavailable.

Voice previews now use Murph's canonical public product origin. Contact-card assets and actions continue using the active environment origin because those routes remain environment-owned.

## Product UX

- Effort: Small — one broken control in the native onboarding path, with no visual redesign or schema change.
- Result: Voice choices resolve to a host the native media stack can stream in development; production returns the same URLs it already returned.
- Walkthrough: A native development user opens Choose a Voice, taps a preview, and hears the selected sample. Production onboarding and the contact-card flow remain unchanged.

## Evidence

- Direct: The MP3 served through the development tunnel was byte-identical to the local asset and non-silent, but AVPlayer failed that tunnel URL with a resource-unavailable error while the canonical production URL advanced through playback.
- Regression: The focused route test failed before the source correction because the response used the synthetic request origin; it passes after the correction and asserts the canonical audio origin.
- Coverage: focused companion initial-onboarding route suite (7 passed); hosted Web typecheck; `git diff --check`; `pnpm complexity:diff`.
- Review: exact-head ReviewGPT round 1 passed with no findings.

## Non-obvious affected surfaces

- Contact-card image URLs remain request/environment-relative.
- The response schema and voice IDs, labels, descriptions, and paths are unchanged.
- Existing production requests already resolve to the canonical origin, so this changes development behavior only.

## Architecture and reuse

- Existing systems reused: the contracts-owned `MURPH_PRODUCT_ORIGIN` constant and the existing onboarding catalog projection.
- New logic: immutable voice paths resolve against the canonical product origin; contact-card assets continue resolving against the environment origin.
- New abstractions: none; the existing catalog projector already owns absolute URL construction.
- Complexity intentionally avoided: no fallback host, environment branch, media proxy, dependency, or extra state was added.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: none introduced; route debt remains 0 and max complexity remains 5.
- Agent judgment: the one-source URL correction is the smallest complete fix.

## Hot reply path impact

- Path status: Not applicable — this projects onboarding metadata and does not accept or deliver messages.
- Database calls: unchanged
- Network/provider calls: unchanged
- Other awaited latency: unchanged

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: unchanged
- Tool/schema/generated guidance: unchanged
- Other provider-visible input: unchanged
- Measurement method: not run because no provider-input surface changed

## Risks

- The development app now depends on the same public static audio origin production already uses. A canonical asset outage would affect both environments rather than allowing the tunnel to mask it.

<!-- ReviewGPT context sensitivity: sensitive -->
<!-- Classification reason: The patch changes an absolute external URL in a public onboarding API response, so the public API and egress boundary makes it sensitive despite its narrow scope. -->

## Deployment concerns

- Deployment: not applicable
- Reason: Production already returns the canonical preview origin; after this normal hosted Web deploy, existing development apps refetch the corrected catalog without coordinated Cloudflare or iOS rollout.

## Change-shape breakdown

Classification rule: route TypeScript is source, Vitest is tests/fixtures, and the Frog entry is docs. No config or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 2 | 1 |
| Tests / fixtures | 1 | 1 |
| Docs | 26 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **29** | **2** |

## Changelog

- Changelog: not applicable
- Reason: Development-only recovery; production members already receive the same canonical preview URLs.

ReviewGPT first-reviewed head: cec4095769a2f4676ec9da8cc090b82999fab975