### PR TITLE
Preserve exact standby allocation diagnostics

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -417,6 +417,11 @@ Last verified: 2026-09-01
   coordinator is the only shell-prewarm owner; the exact-user prewarm hint is
   skipped so it cannot reserve a competing target before a fresh claim. The
   ordinary exact-user start remains the fallback after a claim miss.
+  Every accepted fresh start records the bounded standby allocation outcome,
+  exact reason, and elapsed milliseconds in the existing latency phase
+  breakdown. The same metadata-only fields are emitted immediately in the
+  Worker structured log, including starts that exhaust the caller response
+  budget before an accepted runtime invocation exists.
   A coordinator transaction admits at most one winner, then replacement
   provisioning runs under `waitUntil`; alarms re-prove readiness, retry failed
   retirement, expire unbound claim tombstones, and drain stale releases. The

--- a/agent-docs/exec-plans/active/2026-09-03-standby-allocation-diagnostics.md
+++ b/agent-docs/exec-plans/active/2026-09-03-standby-allocation-diagnostics.md
@@ -1,0 +1,80 @@
+# Preserve standby allocation diagnostics
+
+Status: active
+Created: 2026-09-03
+Updated: 2026-09-03
+
+## Goal
+
+- Preserve the exact metadata-only reason and bounded timing for every accepted
+  fresh standby allocation decision in the existing hosted ingress latency
+  trace, with the same decision logged before later startup work.
+
+## Success criteria
+
+- Eligible fresh foreground starts distinguish a claimed slot, an empty ready
+  pool, a coordinator deadline or failure, missing deployment bindings, and a
+  post-claim bind failure without recording member or slot identifiers.
+- The diagnostic reaches the existing Web-owned latency trace alongside the
+  runtime invocation it describes.
+- Standby admission, fallback, retry, and container ownership behavior remain
+  unchanged.
+- Focused contract and Cloudflare tests plus both owning typechecks pass.
+
+## Scope
+
+- In scope: additive hosted-runtime orchestration diagnostic fields; fresh
+  allocation result attribution; focused parser, safety, and controller proof;
+  owning runtime documentation.
+- Out of scope: changing pool size, claim or bind deadlines, coordinator state,
+  retry behavior, scheduling, container lifecycle, or deployment variables.
+
+## Constraints
+
+- Reuse the existing latency phase-breakdown path and enum-string safety rules.
+- Record only bounded classifications, timestamps, and elapsed milliseconds;
+  never persist claim ids, slot names, member ids, error text, or raw provider
+  output.
+- Add no database schema, network call, state owner, dependency, or synchronous
+  logging callback.
+
+## Risks and mitigations
+
+1. Risk: diagnostics alter the hot start path.
+   Mitigation: derive fields from already-awaited results and existing clock
+   reads, then attach them to the already-propagated orchestration object.
+2. Risk: enum drift causes Web to discard the whole phase breakdown.
+   Mitigation: update the shared allowlist and parser tests in the same change.
+3. Risk: a claimed slot leaks an operational identifier.
+   Mitigation: expose only classification and elapsed time; keep slot and claim
+   identities within the current Cloudflare owner.
+
+## Tasks
+
+1. Map every ready and fallback exit from fresh standby resolution.
+2. Add the smallest diagnostic result shape and attach it to the accepted
+   invocation's orchestration phase.
+3. Add focused shared-contract and Cloudflare regression proof.
+4. Update the owning reliability/runtime documentation and record the internal
+   changelog decision.
+5. Run focused tests, typechecks, complexity and diff checks, parent review,
+   exact-head CI, and final ReviewGPT.
+
+## Decisions
+
+- Product UX effort: Patch. This changes only operator diagnostics; member
+  behavior and timing contracts are unchanged.
+- Persist in the existing Web-owned ingress trace because it already correlates
+  direct admission with the accepted runtime attempt and is available through
+  the documented read-only database path.
+- Keep Worker structured logs as a secondary signal; they are not sufficient
+  as the only diagnostic because local historical-log access may be unavailable.
+
+## Verification
+
+- Run focused hosted-execution contract/parser tests and Cloudflare standby
+  allocation tests.
+- Run `pnpm --dir packages/hosted-execution typecheck` and
+  `pnpm --dir apps/cloudflare typecheck`.
+- Run `pnpm complexity:diff` and `git diff --check`.
+- Let exact-head required CI own broad repository proof.

--- a/agent-docs/exec-plans/completed/2026-09-03-standby-allocation-diagnostics.md
+++ b/agent-docs/exec-plans/completed/2026-09-03-standby-allocation-diagnostics.md
@@ -1,6 +1,6 @@
 # Preserve standby allocation diagnostics
 
-Status: active
+Status: completed
 Created: 2026-09-03
 Updated: 2026-09-03
 
@@ -72,9 +72,16 @@ Updated: 2026-09-03
 
 ## Verification
 
-- Run focused hosted-execution contract/parser tests and Cloudflare standby
-  allocation tests.
-- Run `pnpm --dir packages/hosted-execution typecheck` and
-  `pnpm --dir apps/cloudflare typecheck`.
-- Run `pnpm complexity:diff` and `git diff --check`.
-- Let exact-head required CI own broad repository proof.
+- Cloudflare standby allocation tests: 32 passed.
+- Hosted-execution package tests: 54 files and 577 tests passed.
+- Cloudflare and hosted-execution typechecks passed.
+- `pnpm complexity:diff` and `git diff --check` passed.
+- Final ReviewGPT round 1 returned `ROUND_OUTCOME: PASS` with no findings for
+  exact head `74068d11015bb58fe2dd8c1eb542dcf10d7ce82d`.
+- Exact-head required CI owns broad repository proof after plan closure.
+
+## Changelog
+
+- Not applicable: this is internal operator diagnostic attribution with no
+  member-visible behavior change.
+Completed: 2026-09-03

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1657,9 +1657,12 @@ retained only by that same member under the ordinary conversation idle
 lifecycle and is never returned to ready. Slot invocation,
 provider-credential minting, withdrawal, account deletion, and retirement all
 re-read the exact durable binding; a member mismatch fails closed. A successful
-fresh-start acceptance records its closed standby allocation outcome alongside
-the orchestration and workspace attempt identifiers in the existing structured
-log. Failed, retried, or superseded starts do not emit an accepted attribution.
+fresh-start acceptance records the closed standby allocation outcome, bounded
+reason, and elapsed milliseconds in the existing orchestration latency phase
+breakdown and structured log. The selection log records the same metadata
+before fence or readiness work so a later caller-budget exit remains
+diagnosable without adding member or container identifiers. Failed, retried, or
+superseded starts do not emit an accepted attribution.
 
 The active-member replan durably
 appends the original conversation item. For an exact model-approved instant

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -1439,7 +1439,12 @@ Core execution tuning:
   `allocate` mode the standby coordinator is the sole shell-prewarm owner; the
   exact-user prewarm hint is skipped so it cannot reserve a competing target
   before the claim. An unsuccessful claim still uses the ordinary exact-user
-  fallback.
+  fallback. Accepted fresh starts persist the bounded allocation outcome,
+  reason, and elapsed milliseconds in the existing latency phase breakdown;
+  the Worker selection log emits the same metadata before fence and readiness
+  work. Deploy Web first so its strict telemetry parser accepts these additive
+  leaves, then deploy Cloudflare. Reversing that order affects diagnostics only:
+  old Web drops the unknown phase breakdown while retaining core milestones.
   Invalid values fail deploy/runtime parsing closed.
 - `HOSTED_EXECUTION_VERCEL_OIDC_ENVIRONMENT` defaults to `production` for
   direct/local artifact rendering. The manual deploy workflow derives it from

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -1445,6 +1445,10 @@ Core execution tuning:
   work. Deploy Web first so its strict telemetry parser accepts these additive
   leaves, then deploy Cloudflare. Reversing that order affects diagnostics only:
   old Web drops the unknown phase breakdown while retaining core milestones.
+  The fields remain in Worker-owned orchestration and do not change the
+  Worker/container invocation job, so this diagnostic itself needs no special
+  container rollout mode; obey any independently active production rollout
+  requirement.
   Invalid values fail deploy/runtime parsing closed.
 - `HOSTED_EXECUTION_VERCEL_OIDC_ENVIRONMENT` defaults to `production` for
   direct/local artifact rendering. The manual deploy workflow derives it from

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -147,11 +147,12 @@ type FreshRunnerContainerResolution =
   | {
       kind: "ready";
       runnerContainerName: string;
-      standbyAllocationOutcome:
-        | "claimed"
-        | "disabled"
-        | "fallback"
-        | "retained";
+      standbyAllocationOutcome: NonNullable<
+        RuntimeProcessingOrchestrationDiagnostics["standbyAllocationOutcome"]
+      >;
+      standbyAllocationReason: NonNullable<
+        RuntimeProcessingOrchestrationDiagnostics["standbyAllocationReason"]
+      >;
     }
   | {
       kind: "retry";
@@ -1040,6 +1041,7 @@ export class RuntimeProcessingController {
             kind: "ready",
             runnerContainerName: pendingRunnerContainerName,
             standbyAllocationOutcome: "retained",
+            standbyAllocationReason: "retained",
           };
         }
         if (retained === "retry") {
@@ -1050,6 +1052,7 @@ export class RuntimeProcessingController {
           kind: "ready",
           runnerContainerName: input.exactRunnerContainerName,
           standbyAllocationOutcome: "disabled",
+          standbyAllocationReason: "exact_user_pending",
         };
       } else if (!await this.destroyAndClearPendingRunnerContainer({
         runnerContainerName: pendingRunnerContainerName,
@@ -1059,15 +1062,28 @@ export class RuntimeProcessingController {
       }
     }
 
-    if (
-      readHostedStandbyMode(this.input.runnerRuntimeEnvSource) !== "allocate"
-      || normalizeRuntimeProcessingMode(input.input.processingMode) !== "default"
-      || !isTrustedWebDirectRuntimeProcessing(input.input)
-    ) {
+    if (readHostedStandbyMode(this.input.runnerRuntimeEnvSource) !== "allocate") {
       return {
         kind: "ready",
         runnerContainerName: input.exactRunnerContainerName,
         standbyAllocationOutcome: "disabled",
+        standbyAllocationReason: "mode_not_allocate",
+      };
+    }
+    if (normalizeRuntimeProcessingMode(input.input.processingMode) !== "default") {
+      return {
+        kind: "ready",
+        runnerContainerName: input.exactRunnerContainerName,
+        standbyAllocationOutcome: "disabled",
+        standbyAllocationReason: "processing_mode_not_default",
+      };
+    }
+    if (!isTrustedWebDirectRuntimeProcessing(input.input)) {
+      return {
+        kind: "ready",
+        runnerContainerName: input.exactRunnerContainerName,
+        standbyAllocationOutcome: "disabled",
+        standbyAllocationReason: "not_trusted_web_direct",
       };
     }
     const releaseId = readHostedStandbyReleaseId(this.input.runnerRuntimeEnvSource);
@@ -1078,6 +1094,7 @@ export class RuntimeProcessingController {
         kind: "ready",
         runnerContainerName: input.exactRunnerContainerName,
         standbyAllocationOutcome: "fallback",
+        standbyAllocationReason: "bindings_unavailable",
       };
     }
 
@@ -1134,11 +1151,20 @@ export class RuntimeProcessingController {
       standbyBudget,
       HOSTED_STANDBY_CLAIM_TIMEOUT_MS,
     );
-    if (claim.kind !== "completed" || claim.value.outcome !== "claimed") {
+    if (claim.kind !== "completed") {
       return {
         kind: "ready",
         runnerContainerName: exactRunnerContainerName,
         standbyAllocationOutcome: "fallback",
+        standbyAllocationReason: `claim_${claim.kind}`,
+      };
+    }
+    if (claim.value.outcome !== "claimed") {
+      return {
+        kind: "ready",
+        runnerContainerName: exactRunnerContainerName,
+        standbyAllocationOutcome: "fallback",
+        standbyAllocationReason: `claim_${claim.value.outcome}`,
       };
     }
 
@@ -1175,6 +1201,7 @@ export class RuntimeProcessingController {
         kind: "ready",
         runnerContainerName: slotName,
         standbyAllocationOutcome: "claimed",
+        standbyAllocationReason: "bind_completed",
       };
     }
     if (bind.kind === "timed_out") {
@@ -1200,6 +1227,7 @@ export class RuntimeProcessingController {
         kind: "ready",
         runnerContainerName: slotName,
         standbyAllocationOutcome: "claimed",
+        standbyAllocationReason: "bind_recovered",
       };
     }
     if (binding.state === "unbound") {
@@ -1223,6 +1251,7 @@ export class RuntimeProcessingController {
       kind: "ready",
       runnerContainerName: exactRunnerContainerName,
       standbyAllocationOutcome: "fallback",
+      standbyAllocationReason: "bind_rejected",
     };
   }
 
@@ -1364,6 +1393,7 @@ export class RuntimeProcessingController {
     if (!runnerContainerIdentity || runnerContainerIdentity.userId !== processingInput.userId) {
       throw new Error("Hosted runner container identity did not match the runtime start user.");
     }
+    const standbyAllocationStartedAtEpochMs = Date.now();
     const resolution = await this.resolveFreshRunnerContainer({
       commandBudget: input.commandBudget,
       exactRunnerContainerName: runnerContainerIdentity.runnerContainerName,
@@ -1373,11 +1403,22 @@ export class RuntimeProcessingController {
     if (resolution.kind === "retry") {
       return resolution.response;
     }
+    const standbyAllocationElapsedMs = Math.max(
+      0,
+      Date.now() - standbyAllocationStartedAtEpochMs,
+    );
+    processingInput = withRuntimeProcessingOrchestration(processingInput, {
+      standbyAllocationElapsedMs,
+      standbyAllocationOutcome: resolution.standbyAllocationOutcome,
+      standbyAllocationReason: resolution.standbyAllocationReason,
+    });
     const runnerContainerName = resolution.runnerContainerName;
     emitHostedExecutionStructuredLog({
       component: "hosted.runner",
       details: {
         standbyAllocationOutcome: resolution.standbyAllocationOutcome,
+        standbyAllocationReason: resolution.standbyAllocationReason,
+        standbyAllocationElapsedMs,
       },
       message: "Hosted runner selected a fresh container target.",
       phase: "runtime.starting",
@@ -1504,6 +1545,8 @@ export class RuntimeProcessingController {
         runtimePreparationWaitAfterContainerReadyMs:
           preparation.runtimePreparationWaitAfterContainerReadyMs,
         standbyAllocationOutcome: resolution.standbyAllocationOutcome,
+        standbyAllocationReason: resolution.standbyAllocationReason,
+        standbyAllocationElapsedMs,
         workspaceAttemptId: prepared.token.attemptId,
       },
       message: "Hosted runner runtime processing accepted.",

--- a/apps/cloudflare/test/hosted-runner-container-identity.test.ts
+++ b/apps/cloudflare/test/hosted-runner-container-identity.test.ts
@@ -44,6 +44,7 @@ import {
   HOSTED_STANDBY_CLAIM_TIMEOUT_MS,
   HOSTED_STANDBY_REGION,
   type HostedStandbyClaimRequest,
+  type HostedStandbyClaimResult,
   type HostedStandbyCoordinatorNamespaceLike,
   type HostedStandbyCoordinatorStubLike,
   type HostedStandbyRunnerContainerNamespaceLike,
@@ -229,7 +230,9 @@ describe("hosted runner container identity", () => {
       expect.objectContaining({
         details: expect.objectContaining({
           orchestrationAttemptId: "orchestration_attempt_1",
+          standbyAllocationElapsedMs: expect.any(Number),
           standbyAllocationOutcome: "disabled",
+          standbyAllocationReason: "mode_not_allocate",
           workspaceAttemptId: response.runtimeAttemptId,
         }),
         message: "Hosted runner runtime processing accepted.",
@@ -939,9 +942,10 @@ describe("hosted runner container identity", () => {
         };
       },
     };
+    const invocationService = new RecordingRuntimeInvocationService();
     const controller = new RuntimeProcessingController({
       env: createHostedExecutionEnvironment(),
-      invocationService: new RecordingRuntimeInvocationService(),
+      invocationService,
       runnerContainerNamespace,
       runnerRuntimeEnvSource: {
         CF_VERSION_METADATA: { id: "release_1" },
@@ -977,12 +981,19 @@ describe("hosted runner container identity", () => {
         details: expect.objectContaining({
           orchestrationAttemptId:
             "web-ingress-11111111-1111-4111-8111-111111111111",
+          standbyAllocationElapsedMs: expect.any(Number),
           standbyAllocationOutcome: "claimed",
+          standbyAllocationReason: "bind_completed",
           workspaceAttemptId: response.runtimeAttemptId,
         }),
         message: "Hosted runner runtime processing accepted.",
       }),
     );
+    expect(invocationService.invokedInputs[0]?.orchestration).toMatchObject({
+      standbyAllocationElapsedMs: expect.any(Number),
+      standbyAllocationOutcome: "claimed",
+      standbyAllocationReason: "bind_completed",
+    });
   });
 
   it.each([
@@ -991,6 +1002,7 @@ describe("hosted runner container identity", () => {
       {
         orchestrationAttemptId: "temporal-default-standby-ineligible",
       },
+      "not_trusted_web_direct",
     ],
     [
       "an untrusted direct flag",
@@ -998,6 +1010,7 @@ describe("hosted runner container identity", () => {
         orchestration: { triggeredByWebDirect: true },
         orchestrationAttemptId: "web-ingress-invalid",
       },
+      "not_trusted_web_direct",
     ],
     [
       "a direct-shaped id without Web authentication",
@@ -1005,6 +1018,7 @@ describe("hosted runner container identity", () => {
         orchestrationAttemptId:
           "web-ingress-22222222-2222-4222-8222-222222222222",
       },
+      "not_trusted_web_direct",
     ],
     [
       "trusted Web-direct system-mailbox work",
@@ -1014,6 +1028,7 @@ describe("hosted runner container identity", () => {
           "web-ingress-33333333-3333-4333-8333-333333333333",
         processingMode: "system_mailbox",
       },
+      "processing_mode_not_default",
     ],
     [
       "trusted Web-direct retention work",
@@ -1023,10 +1038,11 @@ describe("hosted runner container identity", () => {
           "web-ingress-44444444-4444-4444-8444-444444444444",
         processingMode: "inbox_media_retention",
       },
+      "processing_mode_not_default",
     ],
   ] as const)(
     "uses the exact-user container without claiming standby for %s",
-    async (_label, ensureInput) => {
+    async (_label, ensureInput, expectedReason) => {
       const durable = createRunnerDurableState();
       const stateStore = new RunnerStateStore(durable.state);
       const readyContainerNames: string[] = [];
@@ -1082,6 +1098,7 @@ describe("hosted runner container identity", () => {
         expect.objectContaining({
           details: expect.objectContaining({
             standbyAllocationOutcome: "disabled",
+            standbyAllocationReason: expectedReason,
           }),
           message: "Hosted runner selected a fresh container target.",
         }),
@@ -1096,33 +1113,40 @@ describe("hosted runner container identity", () => {
       "standby--v-release_1--0123456789abcdef0123456789abcdef";
     const createController = (
       claimReadyStandby: HostedStandbyCoordinatorStubLike["claimReadyStandby"],
-    ): RuntimeProcessingController => {
+    ): {
+      controller: RuntimeProcessingController;
+      invocationService: RecordingRuntimeInvocationService;
+    } => {
       const durable = createRunnerDurableState();
       const stateStore = new RunnerStateStore(durable.state);
-      return new RuntimeProcessingController({
-        env: createHostedExecutionEnvironment(),
-        invocationService: new RecordingRuntimeInvocationService(),
-        runnerContainerNamespace: createRunnerContainerNamespace({}),
-        runnerRuntimeEnvSource: {
-          CF_VERSION_METADATA: { id: "release_1" },
-          HOSTED_EXECUTION_STANDBY_MODE: "allocate",
-        },
-        standbyContainerNamespace: createStandbyNamespace({
-          slotName,
-          userId: TEST_USER_ID,
-        }),
-        standbyCoordinatorNamespace: {
-          getByName() {
-            return {
-              claimReadyStandby,
-              async ensureReadyStandby() {
-                return { accepted: true } as const;
-              },
-            };
+      const invocationService = new RecordingRuntimeInvocationService();
+      return {
+        controller: new RuntimeProcessingController({
+          env: createHostedExecutionEnvironment(),
+          invocationService,
+          runnerContainerNamespace: createRunnerContainerNamespace({}),
+          runnerRuntimeEnvSource: {
+            CF_VERSION_METADATA: { id: "release_1" },
+            HOSTED_EXECUTION_STANDBY_MODE: "allocate",
           },
-        },
-        stateStore,
-      });
+          standbyContainerNamespace: createStandbyNamespace({
+            slotName,
+            userId: TEST_USER_ID,
+          }),
+          standbyCoordinatorNamespace: {
+            getByName() {
+              return {
+                claimReadyStandby,
+                async ensureReadyStandby() {
+                  return { accepted: true } as const;
+                },
+              };
+            },
+          },
+          stateStore,
+        }),
+        invocationService,
+      };
     };
     const commandTimeoutMs =
       HOSTED_RUNTIME_PROCESSING_COMMAND_RESPONSE_MARGIN_MS + 100;
@@ -1130,7 +1154,8 @@ describe("hosted runner container identity", () => {
       async () => ({ outcome: "no_ready_slot" }),
     );
 
-    await createController(boundedClaim).ensureForUser({
+    const boundedController = createController(boundedClaim);
+    await boundedController.controller.ensureForUser({
       commandTimeoutMs,
       orchestration: { triggeredByWebDirect: true },
       orchestrationAttemptId:
@@ -1141,11 +1166,20 @@ describe("hosted runner container identity", () => {
     expect(boundedClaim).toHaveBeenCalledWith(expect.objectContaining({
       deadlineAtEpochMs: Date.now() + 100,
     }));
-
+    expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          standbyAllocationElapsedMs: 0,
+          standbyAllocationOutcome: "fallback",
+          standbyAllocationReason: "claim_no_ready_slot",
+        }),
+        message: "Hosted runner selected a fresh container target.",
+      }),
+    );
     const expiredClaim = vi.fn<HostedStandbyCoordinatorStubLike["claimReadyStandby"]>(
       async () => ({ outcome: "no_ready_slot" }),
     );
-    await createController(expiredClaim).ensureForUser({
+    await createController(expiredClaim).controller.ensureForUser({
       commandStartedAtEpochMs: Date.now() - 101,
       commandTimeoutMs,
       orchestration: { triggeredByWebDirect: true },
@@ -1155,6 +1189,65 @@ describe("hosted runner container identity", () => {
     });
 
     expect(expiredClaim).not.toHaveBeenCalled();
+    vi.useRealTimers();
+
+    const noReadyController = createController(async () => ({
+      outcome: "no_ready_slot",
+    }));
+    await noReadyController.controller.ensureForUser({
+      orchestration: { triggeredByWebDirect: true },
+      orchestrationAttemptId:
+        "web-ingress-99999999-9999-4999-8999-999999999999",
+      userId: TEST_USER_ID,
+    });
+    expect(noReadyController.invocationService.invokedInputs[0]?.orchestration)
+      .toMatchObject({
+        standbyAllocationOutcome: "fallback",
+        standbyAllocationReason: "claim_no_ready_slot",
+      });
+
+    const failedClaim = vi.fn<HostedStandbyCoordinatorStubLike["claimReadyStandby"]>(
+      async () => {
+        throw new Error("synthetic coordinator failure");
+      },
+    );
+    const failedController = createController(failedClaim);
+    await failedController.controller.ensureForUser({
+      orchestration: { triggeredByWebDirect: true },
+      orchestrationAttemptId:
+        "web-ingress-77777777-7777-4777-8777-777777777777",
+      userId: TEST_USER_ID,
+    });
+    expect(failedController.invocationService.invokedInputs[0]?.orchestration)
+      .toMatchObject({
+        standbyAllocationOutcome: "fallback",
+        standbyAllocationReason: "claim_failed",
+      });
+
+    const timedOutClaim = vi.fn<HostedStandbyCoordinatorStubLike["claimReadyStandby"]>(
+      async () => await new Promise<HostedStandbyClaimResult>(() => undefined),
+    );
+    const timedOutController = createController(timedOutClaim);
+    await expect(timedOutController.controller.ensureForUser({
+      orchestration: { triggeredByWebDirect: true },
+      orchestrationAttemptId:
+        "web-ingress-88888888-8888-4888-8888-888888888888",
+      userId: TEST_USER_ID,
+    })).resolves.toMatchObject({
+      action: "started",
+      kind: "runtime_processing_accepted",
+    });
+    expect(timedOutClaim).toHaveBeenCalledOnce();
+    expect(timedOutController.invocationService.invokedInputs[0]?.orchestration)
+      .toMatchObject({
+        standbyAllocationElapsedMs: expect.any(Number),
+        standbyAllocationOutcome: "fallback",
+        standbyAllocationReason: "claim_timed_out",
+      });
+    expect(
+      timedOutController.invocationService.invokedInputs[0]?.orchestration
+        ?.standbyAllocationElapsedMs,
+    ).toBeGreaterThanOrEqual(HOSTED_STANDBY_CLAIM_TIMEOUT_MS);
   });
 
   it("keeps a late standby bind as the exact retry target", async () => {
@@ -1331,6 +1424,7 @@ describe("hosted runner container identity", () => {
 
 class RecordingRuntimeInvocationService extends RuntimeInvocationService {
   readonly prepareTokens: RunnerWriteFenceToken[] = [];
+  readonly invokedInputs: PreparedRuntimeInvocation["input"][] = [];
 
   constructor() {
     const durable = createRunnerDurableState();
@@ -1373,7 +1467,12 @@ class RecordingRuntimeInvocationService extends RuntimeInvocationService {
     };
   }
 
-  override async invokePreparedWithFence(): Promise<HostedWorkspaceInvocationResult> {
+  override async invokePreparedWithFence(input: {
+    acceptedProcessingAttempt: boolean;
+    prepared: PreparedRuntimeInvocation;
+    runtimeWakeStartedAt: number;
+  }): Promise<HostedWorkspaceInvocationResult> {
+    this.invokedInputs.push(input.prepared.input);
     return {
       nextWakeAt: null,
       status: "idle",

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -40,6 +40,8 @@ import {
   HOSTED_RUNTIME_ASSISTANT_MILESTONES,
   HOSTED_RUNTIME_ASSISTANT_ASK_REQUEST_ID_MAX_CODE_POINTS,
   HOSTED_RUNTIME_SIDE_INPUT_UNAVAILABLE_CODES,
+  HOSTED_STANDBY_ALLOCATION_OUTCOMES,
+  HOSTED_STANDBY_ALLOCATION_REASONS,
   HOSTED_RUNTIME_LATENCY_TRACE_ASSISTANT_INPUT_MAX_IDS,
   HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_KEYS,
   HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_LEAF_KEYS,
@@ -102,6 +104,8 @@ import {
   type HostedRuntimeLatencyTraceProviderStartedEvent,
   type HostedRuntimeLatencyTraceRequest,
   type HostedRuntimeLatencyTraceResponse,
+  type HostedStandbyAllocationOutcome,
+  type HostedStandbyAllocationReason,
   type HostedRuntimeLogComponent,
   type HostedRuntimeLogEntry,
   type HostedRuntimeLogEventCode,
@@ -7507,6 +7511,10 @@ function parseHostedRuntimeLatencyPhaseBreakdown(
         "freshStartRequestedAtEpochMs",
         orchestrationLabel,
       ),
+      ...requireOptionalStandbyAllocationDiagnostics(
+        orchestration,
+        orchestrationLabel,
+      ),
       ...requireOptionalNonNegativeInteger(
         orchestration,
         "freshStartFenceBoundAtEpochMs",
@@ -8242,6 +8250,71 @@ function requireOptionalDirectEnsureOutcome(
     directEnsureResultKind,
     directEnsureRuntimeAttemptId,
   };
+}
+
+function requireOptionalStandbyAllocationDiagnostics(
+  record: Record<string, unknown>,
+  label: string,
+): {
+  standbyAllocationElapsedMs?: number;
+  standbyAllocationOutcome?: HostedStandbyAllocationOutcome;
+  standbyAllocationReason?: HostedStandbyAllocationReason;
+} {
+  const standbyAllocationElapsedMs = requireOptionalNonNegativeInteger(
+    record,
+    "standbyAllocationElapsedMs",
+    label,
+  );
+  const outcome = record.standbyAllocationOutcome;
+  const reason = record.standbyAllocationReason;
+  const elapsedMs = record.standbyAllocationElapsedMs;
+  if (elapsedMs === undefined && outcome === undefined && reason === undefined) {
+    return {};
+  }
+  if (elapsedMs === undefined || outcome === undefined || reason === undefined) {
+    throw new TypeError(
+      `${label} standby allocation elapsed time, outcome, and reason must be recorded together.`,
+    );
+  }
+  const parsedOutcome = parseAllowedString(
+    outcome,
+    `${label}.standbyAllocationOutcome`,
+    HOSTED_STANDBY_ALLOCATION_OUTCOMES,
+  );
+  const parsedReason = parseAllowedString(
+    reason,
+    `${label}.standbyAllocationReason`,
+    HOSTED_STANDBY_ALLOCATION_REASONS,
+  );
+  if (!standbyAllocationReasonMatchesOutcome(parsedOutcome, parsedReason)) {
+    throw new TypeError(`${label} standby allocation outcome and reason are inconsistent.`);
+  }
+  return {
+    ...standbyAllocationElapsedMs,
+    standbyAllocationOutcome: parsedOutcome,
+    standbyAllocationReason: parsedReason,
+  };
+}
+
+function standbyAllocationReasonMatchesOutcome(
+  outcome: HostedStandbyAllocationOutcome,
+  reason: HostedStandbyAllocationReason,
+): boolean {
+  switch (outcome) {
+    case "claimed":
+      return reason === "bind_completed" || reason === "bind_recovered";
+    case "disabled":
+      return reason === "exact_user_pending"
+        || reason === "mode_not_allocate"
+        || reason === "not_trusted_web_direct"
+        || reason === "processing_mode_not_default";
+    case "fallback":
+      return reason === "bind_rejected"
+        || reason === "bindings_unavailable"
+        || reason.startsWith("claim_");
+    case "retained":
+      return reason === "retained";
+  }
 }
 
 function parseHostedRuntimeLatencyTraceProviderStartedEvent(

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -2329,6 +2329,37 @@ export type HostedRuntimeAssistantMilestone =
 export type HostedRuntimeLatencyTraceMilestone =
   (typeof HOSTED_RUNTIME_LATENCY_TRACE_MILESTONES)[number];
 
+export const HOSTED_STANDBY_ALLOCATION_OUTCOMES = [
+  "claimed",
+  "disabled",
+  "fallback",
+  "retained",
+] as const;
+
+export type HostedStandbyAllocationOutcome =
+  (typeof HOSTED_STANDBY_ALLOCATION_OUTCOMES)[number];
+
+export const HOSTED_STANDBY_ALLOCATION_REASONS = [
+  "bind_completed",
+  "bind_recovered",
+  "bind_rejected",
+  "bindings_unavailable",
+  "claim_deadline_expired",
+  "claim_disabled",
+  "claim_failed",
+  "claim_no_ready_slot",
+  "claim_stale_release",
+  "claim_timed_out",
+  "exact_user_pending",
+  "mode_not_allocate",
+  "not_trusted_web_direct",
+  "processing_mode_not_default",
+  "retained",
+] as const;
+
+export type HostedStandbyAllocationReason =
+  (typeof HOSTED_STANDBY_ALLOCATION_REASONS)[number];
+
 export interface HostedRuntimeLatencyPhaseBreakdown {
   schemaVersion: number;
   // Control-plane orchestration diagnostics before the runner-container DO
@@ -2392,6 +2423,9 @@ export interface HostedRuntimeLatencyPhaseBreakdown {
     replacementFenceClearElapsedMs?: number;
     replacedStaleFence?: boolean;
     freshStartRequestedAtEpochMs?: number;
+    standbyAllocationElapsedMs?: number;
+    standbyAllocationOutcome?: HostedStandbyAllocationOutcome;
+    standbyAllocationReason?: HostedStandbyAllocationReason;
     freshStartFenceBoundAtEpochMs?: number;
     freshStartContainerReadinessRequestedAtEpochMs?: number;
     freshStartContainerLifecycleLockAcquiredAtEpochMs?: number;
@@ -2802,6 +2836,9 @@ export const HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_LEAF_KEYS: Record<
     "replacementFenceClearElapsedMs",
     "replacedStaleFence",
     "freshStartRequestedAtEpochMs",
+    "standbyAllocationElapsedMs",
+    "standbyAllocationOutcome",
+    "standbyAllocationReason",
     "freshStartFenceBoundAtEpochMs",
     "freshStartContainerReadinessRequestedAtEpochMs",
     "freshStartContainerLifecycleLockAcquiredAtEpochMs",
@@ -2966,6 +3003,10 @@ const HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_STRING_LEAF_VALUES:
       "woken",
       "already_running",
     ],
+    "orchestration.standbyAllocationOutcome":
+      HOSTED_STANDBY_ALLOCATION_OUTCOMES,
+    "orchestration.standbyAllocationReason":
+      HOSTED_STANDBY_ALLOCATION_REASONS,
   };
 
 export type HostedRuntimeLatencyPhaseBreakdownLeafRule =

--- a/packages/hosted-execution/test/hosted-runtime-control.test.ts
+++ b/packages/hosted-execution/test/hosted-runtime-control.test.ts
@@ -1685,6 +1685,9 @@ describe("hosted runtime control contracts", () => {
         replacementFenceClearElapsedMs: 5,
         replacedStaleFence: true,
         freshStartRequestedAtEpochMs: 1_777_000_000_070,
+        standbyAllocationElapsedMs: 250,
+        standbyAllocationOutcome: "fallback",
+        standbyAllocationReason: "claim_no_ready_slot",
         freshStartFenceBoundAtEpochMs: 1_777_000_000_080,
         freshStartContainerReadinessRequestedAtEpochMs: 1_777_000_000_081,
         freshStartContainerLifecycleLockAcquiredAtEpochMs: 1_777_000_000_082,
@@ -1981,6 +1984,19 @@ describe("hosted runtime control contracts", () => {
       { directEnsureResultKind: "retry_later", directEnsureRetryReason: "container_rpc_timeout" }, // retry reasons remain in structured logs only
       { directEnsureResultKind: "retry_later", directEnsureAction: "woken" }, // accepted metadata must match the result
       { directEnsureResultKind: "runtime_processing_accepted", directEnsureAction: "woken" }, // accepted results require a runtime id
+      { standbyAllocationOutcome: "fallback" }, // allocation timing, outcome, and reason are one diagnostic fact
+      { standbyAllocationReason: "claim_no_ready_slot" }, // allocation timing, outcome, and reason are one diagnostic fact
+      { standbyAllocationElapsedMs: 87 }, // allocation timing, outcome, and reason are one diagnostic fact
+      {
+        standbyAllocationElapsedMs: 87,
+        standbyAllocationOutcome: "fallback",
+        standbyAllocationReason: "raw_coordinator_error",
+      }, // allocation reasons are a bounded enum
+      {
+        standbyAllocationElapsedMs: 87,
+        standbyAllocationOutcome: "claimed",
+        standbyAllocationReason: "claim_no_ready_slot",
+      }, // allocation reasons must match their outcome
       {
         directEnsureResultKind: "runtime_processing_accepted",
         directEnsureAction: "woken",
@@ -2327,6 +2343,9 @@ describe("hosted runtime control contracts", () => {
       extraLeaf: 1,
       freshStartRequestedAtEpochMs: -1,
       replacedStaleFence: "true",
+      standbyAllocationElapsedMs: 87,
+      standbyAllocationOutcome: "fallback",
+      standbyAllocationReason: "claim_no_ready_slot",
       runtimeControlAuthFinishedAtEpochMs: 1_777_000_000_110,
       runtimeControlAuthStartedAtEpochMs: 1_777_000_000_090,
       runtimeInvocationPreparationElapsedMs: 120,
@@ -2351,6 +2370,9 @@ describe("hosted runtime control contracts", () => {
       directEnsureRuntimeAttemptId: "runtime-attempt-direct",
       runtimeControlAuthFinishedAtEpochMs: 1_777_000_000_110,
       runtimeControlAuthStartedAtEpochMs: 1_777_000_000_090,
+      standbyAllocationElapsedMs: 87,
+      standbyAllocationOutcome: "fallback",
+      standbyAllocationReason: "claim_no_ready_slot",
       runtimeInvocationPreparationElapsedMs: 120,
       runtimeStoreEnsureElapsedMs: 80,
       tokenAcquiredAtEpochMs: 1_777_000_000_010,


### PR DESCRIPTION
## Why and outcome

Fresh hosted starts currently collapse every unsuccessful standby allocation into `fallback`, so an accepted cold start cannot distinguish an empty pool, a coordinator deadline/failure, missing bindings, or a rejected bind. Preserve the bounded outcome, exact reason, and elapsed milliseconds in the existing Worker structured log and Web-owned ingress latency trace without changing allocation behavior.

## Product UX

- Effort: Patch
- Result: Not applicable. This is internal operator diagnostics; member behavior, eligibility, replies, and timing contracts are unchanged.

## Evidence

- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/hosted-runner-container-identity.test.ts` — 32 passed.
- `pnpm --filter @murphai/cloudflare-runner typecheck` — passed.
- `pnpm --filter @murphai/hosted-execution test` — 54 files and 577 tests passed.
- `pnpm --filter @murphai/hosted-execution typecheck` — passed.
- `pnpm complexity:diff` and `git diff --check` — passed.
- Direct proof covers claimed, disabled/ineligible, no-ready, coordinator failure, deadline expiry, and timeout attribution at the structured-log and accepted-invocation boundaries.
- Final ReviewGPT round 1 returned `ROUND_OUTCOME: PASS` with no findings for the immutable first-reviewed head.

## Non-obvious affected surfaces

- Shared hosted-runtime latency parsing: required so Web accepts and stores the new bounded orchestration leaves; parser safety and skew behavior are covered by the hosted-execution contract suite.
- Cloudflare deployment guidance: required because Web is the independently deployed telemetry consumer; the Worker/container invocation job is unchanged.

## Architecture and reuse

- Existing systems reused: the existing orchestration phase breakdown, structured logs, and Web-owned ingress latency trace remain the only diagnostic owners.
- New logic: each already-resolved allocation exit receives a bounded reason; the controller measures the existing resolution span and propagates the three fields.
- New abstractions: no service, state owner, schema, dependency, or network boundary was added; shared readonly enum constants keep the producer and parser aligned.
- Complexity intentionally avoided: no new log store, coordinator read, retry, migration, identifier, or synchronous callback was introduced.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` completed with unchanged debt and unchanged per-file maxima.
- Hotspots: existing `startRuntimeProcessing` remains 22 and existing parser hotspots remain unchanged; the new reason matcher stays below the threshold.
- Agent judgment: further splitting would add indirection without reducing behavior or state, so no additional simplification is justified.

## Hot reply path impact

This touches fresh foreground startup diagnostics. It adds two clock reads, one local metadata merge, and fields on two existing log/trace payloads once per fresh allocation. Added or moved database, network, provider, transaction, timeout, retry, and awaited operations: zero. Allocation ordering, the shared 250 ms claim/bind deadline, exact-user fallback, and runtime acceptance remain unchanged; focused controller tests prove those branches.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompt, tool, schema, generated guidance, or provider-visible request changes.
- Codex runtime: Not applicable; the diagnostics stay in Worker-owned orchestration and do not enter the Worker/container invocation job or provider request.

## Change-shape breakdown

Classification is path-based: runtime TypeScript is source, test files are tests/fixtures, Markdown and the execution plan are docs, and no generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 168 | 11 |
| Tests/fixtures | 151 | 30 |
| Docs | 108 | 4 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 427 | 45 |

## Deployment concerns

- Deployment: applicable
- Supported skew: New Web accepts old Worker events with absent optional fields. Old Web retains core milestones but drops a new Worker phase breakdown containing unknown leaves. New Worker diagnostics do not enter the runner job, so old warm runners remain compatible.
- Safe order: Deploy Web first, then Cloudflare; obey any independently active immediate-container-rollout requirement.
- Rollback floor: None. The new fields are optional and do not create durable product state.
- Expected exposure: Reversing the order causes a telemetry-only gap during the mixed-version window; processing remains unchanged.
- Reversibility: Roll back the Cloudflare writer before the compatible Web reader.
- Convergence proof: Exact-version Worker health and managed-container smoke prove the deployed Worker and runner bundle; a bounded accepted fresh-start trace proves the new fields reached Web storage.
- Post-deploy checks: Verify Worker version and standby mode, then inspect bounded fresh-start trace aggregates for non-null allocation outcome/reason/elapsed fields and absence of strict latency parser failures.

## Changelog

- Changelog: not applicable
- Reason: Members cannot see this internal diagnostic attribution and no product behavior changes.

ReviewGPT context sensitivity: sensitive — this changes a cross-owner runtime telemetry protocol on the foreground startup path.

ReviewGPT first-reviewed head: 74068d11015bb58fe2dd8c1eb542dcf10d7ce82d


