### PR TITLE
test(cloudflare): await mailbox consumption

### DIFF
--- a/.agents/friction-log/20260903031030-hosted-temporal-e2e/friction.md
+++ b/.agents/friction-log/20260903031030-hosted-temporal-e2e/friction.md
@@ -1,0 +1,35 @@
+---
+title: 'Hosted Temporal E2E handled-through checkpoint races mailbox consumption'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The hosted Temporal orchestration E2E should wait for the system mailbox item
+to reach the consumed state before asserting consumption.
+
+## Current Behavior
+
+The test waits only for the workspace handled-through checkpoint and then
+immediately reads the mailbox row. That checkpoint can be published during
+prepare, before the later record checkpoint persists consumption, so a valid
+run can observe a null consumed timestamp.
+
+## Possible Solution
+
+Poll the mailbox item's consumed state directly while retaining the kind and
+lane assertions.
+
+## Minimal Reproducible Example
+
+1. Enqueue a synthetic `member.channels.updated` system mailbox item.
+2. Wait for the workspace handled-through checkpoint.
+3. Immediately read the mailbox item.
+4. Observe that the handled-through checkpoint may be visible before the
+   consumed timestamp.
+
+## Context
+
+The same assertion failed in two release integration attempts, forcing
+expensive reruns even though the runtime completed the later record checkpoint
+normally.

--- a/apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-temporal-orchestration-e2e.test.ts
@@ -396,12 +396,22 @@ describe("hosted local Temporal orchestration e2e", () => {
       expectedSeq: memberChannelsAppend.wake.seq,
       userId: modelFreeFrontierUserId,
     });
-    await expect(readHostedMailboxItemForTest({
-      dedupeKey: memberChannelsEventId,
-      environment: activeScenario.runtimeEnv,
-      userId: modelFreeFrontierUserId,
-    })).resolves.toMatchObject({
-      consumedAt: expect.any(String),
+    await expect.poll(async () => {
+      const item = await readHostedMailboxItemForTest({
+        dedupeKey: memberChannelsEventId,
+        environment: activeScenario.runtimeEnv,
+        userId: modelFreeFrontierUserId,
+      });
+      return {
+        consumed: item.consumedAt !== null,
+        kind: item.kind,
+        lane: item.lane,
+      };
+    }, {
+      interval: 250,
+      timeout: 120_000,
+    }).toEqual({
+      consumed: true,
       kind: "member.channels.updated",
       lane: "system",
     });


### PR DESCRIPTION
## Outcome

Make the hosted Temporal orchestration E2E wait for the mailbox-consumption boundary it actually asserts. The workspace handled-through checkpoint can publish during prepare, before the later record checkpoint persists consumption, so the prior immediate read could race a valid workflow.

## Product UX

Not applicable. This is an internal test synchronization fix and changes no member-visible behavior.

## Evidence

- `pnpm --dir apps/cloudflare typecheck`
- `pnpm complexity:diff`
- `git diff --check`
- Clean current-base `git merge-tree --write-tree HEAD origin/main`
- The prior assertion reproduced twice in downstream release integration; both failures observed the handled-through checkpoint before the later mailbox-consumption write.
- Final ReviewGPT is not applicable under the test-only exemption because this PR changes no production behavior.

## Non-obvious affected surfaces

None. Only the hosted-local Temporal E2E assertion and its repository friction record change.

## Architecture and reuse

- **Existing systems reused:** Existing `readHostedMailboxItemForTest` and Vitest `expect.poll` synchronization.
- **New logic:** The test polls the actual `consumedAt` condition while preserving mailbox kind and lane assertions.
- **New abstractions:** None; the existing helper is sufficient.
- **Complexity intentionally avoided:** No runtime checkpoints, sleeps, helpers, or production behavior were added.

## Complexity impact

- **Guard:** pass — `pnpm complexity:diff` passed; the guard found no authored production JavaScript or TypeScript source changes to analyze.
- **Hotspots:** None; the only TypeScript change is a test assertion.
- **Agent judgment:** No further behavior-preserving simplification is justified.

## Hot reply path impact

Not applicable. No production code or foreground reply critical-path operation changes.

## Murph initial provider input impact

- **Murph runtime:** Not applicable; no prompt, tool schema, generated guidance, or provider-visible request surface changes.
- **Codex runtime:** Not applicable; no prompt, tool schema, generated guidance, or provider-visible request surface changes.

## Design proof

Not applicable. No hosted Web UI changes.

## Change-shape breakdown

Classification: the E2E file is tests/fixtures; the Frog friction record is docs. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 16 | 6 |
| Docs | 35 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **51** | **6** |

## Deployment concerns

- Deployment: not applicable
- Reason: test-only and documentation-only changes do not alter deployable artifacts or runtime contracts.

## Changelog

- Changelog: not applicable
- Reason: this internal E2E synchronization fix is not member-visible.

