### PR TITLE
Remove extra Pattern help icons

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -767,8 +767,8 @@ factor coverage as a compact five-segment bar. Its tooltip uses `Data coverage` 
 title and gives the exact recorded-case count below it. Label total sleep time
 as `Sleep duration`. Group sleep score and sleep efficiency under `Sleep quality`. Keep
 their calculations separate and identify the metric in each result popover.
-Outcome headings reveal a short explanation of why each result matters on hover,
-focus, or press. Keep `No clear pattern` descriptions to one short sentence.
+Keep outcome headings clear without separate help controls. Keep `No clear pattern`
+descriptions to one short sentence.
 
 Keep the copy observational and conversational. Prefer `You slept less after cycling` over a statistical sentence. Never use `caused` or `proved`. Show the activity result and other comparable days as two labeled bars in the cell detail. Keep matched-day counts in accessible copy instead of repeating them visually. On narrow screens, keep the row labels readable and scroll the matrix horizontally.
 

--- a/apps/web/changelog/entries/2026-09-03/journal-patterns-cleaner-names.json
+++ b/apps/web/changelog/entries/2026-09-03/journal-patterns-cleaner-names.json
@@ -7,8 +7,8 @@
     "priority": 3,
     "title": "Journal and Patterns use cleaner names",
     "summary": "Repeated wearable names now group into short, consistent labels across Journal and Personal Patterns.",
-    "details": "Journal hides missing activity values and repeated details. Patterns keeps labels compact and its sortable headers clean. Weekly insights can also use verified timing and combination evidence from Journal records.",
+    "details": "Journal hides missing activity values and repeated details, and keeps its private-chat helper aligned. Patterns keeps labels compact and its sortable headers free of extra help controls. Weekly insights can also use verified timing and combination evidence from Journal records.",
     "relevanceTags": ["journal", "patterns", "wearables", "usability"],
-    "sourcePullRequests": [2745, 2776]
+    "sourcePullRequests": [2745, 2776, 2777]
   }
 }

--- a/apps/web/src/components/journal/journal-view.tsx
+++ b/apps/web/src/components/journal/journal-view.tsx
@@ -1437,7 +1437,7 @@ function JournalEntryActions({
   contactOptions: readonly MurphContactOption[];
 }) {
   const helper = (
-    <span className="flex items-start gap-[11px] px-1 text-left">
+    <span className="flex items-center gap-[11px] px-1 text-left">
       <span className="flex size-6 shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground">
         <NotebookPen className="size-3" aria-hidden="true" />
       </span>

--- a/apps/web/src/components/overview/personal-patterns-section.tsx
+++ b/apps/web/src/components/overview/personal-patterns-section.tsx
@@ -5,7 +5,6 @@ import {
   ArrowDown,
   ArrowRight,
   ArrowUp,
-  CircleHelp,
   Ellipsis,
   Minus,
   Moon,
@@ -656,11 +655,8 @@ function PatternOutcomeHeader({
   outcome: PatternOutcomeColumn;
   sortDirection: PatternSort["direction"] | null;
 }) {
-  const pointerAnchor = usePointerPopoverAnchor();
-  const popover = useExclusivePatternPopover();
-
   return (
-    <div className="flex items-center justify-center gap-1">
+    <div className="flex items-center justify-center">
       <button
         aria-label={`Sort by ${outcome.label}${
           sortDirection ? `, ${sortDirection}` : ""
@@ -674,41 +670,6 @@ function PatternOutcomeHeader({
       >
         <span>{outcome.label}</span>
       </button>
-      <Popover open={popover.open} onOpenChange={popover.onOpenChange}>
-        <PopoverTrigger
-          closeDelay={200}
-          delay={150}
-          openOnHover
-          render={
-            <button
-              aria-label={`About ${outcome.label}`}
-              className="rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-              onKeyDown={pointerAnchor.onKeyDown}
-              onPointerMove={pointerAnchor.onPointerMove}
-              type="button"
-            >
-              <CircleHelp aria-hidden="true" className="size-3" />
-            </button>
-          }
-        />
-        <PopoverContent
-          align="center"
-          anchor={pointerAnchor.anchor}
-          className="w-[min(19rem,calc(100vw-2rem))]"
-          positionMethod="fixed"
-          side="right"
-          sideOffset={10}
-        >
-          <PopoverHeader className="gap-1">
-            <PopoverTitle className="font-serif text-base font-semibold">
-              {outcome.label}
-            </PopoverTitle>
-            <PopoverDescription className="text-xs leading-5 text-muted-foreground">
-              {outcome.description}
-            </PopoverDescription>
-          </PopoverHeader>
-        </PopoverContent>
-      </Popover>
     </div>
   );
 }

--- a/apps/web/test/browser-vault-dashboard-pages.test.tsx
+++ b/apps/web/test/browser-vault-dashboard-pages.test.tsx
@@ -284,6 +284,7 @@ test("JournalPage renders the derived private health timeline", () => {
     assert.match(markup, /Morning walk/u);
     assert.match(markup, /Last 7 days/u);
     assert.match(markup, /Update your journal in private chat with Murph/u);
+    assert.match(markup, /flex items-center gap-\[11px\] px-1 text-left/u);
     assert.match(markup, /journal-day-2026-08-12/u);
     assert.doesNotMatch(markup, /journal-day-2026-08-13/u);
     assert.doesNotMatch(markup, /No data/u);
@@ -592,7 +593,8 @@ test("Personal Patterns comparison controls use plain result language", () => {
   assert.match(markup, />Sleep quality</u);
   assert.match(markup, /aria-label="Sort by Sleep quality/u);
   assert.doesNotMatch(markup, /lucide-arrow-up-down/u);
-  assert.match(markup, /aria-label="About Sleep quality"/u);
+  assert.doesNotMatch(markup, /aria-label="About Sleep quality"/u);
+  assert.doesNotMatch(markup, /lucide-circle-help/u);
   assert.match(markup, />SpO₂</u);
   assert.equal(
     getOutcomeDescription("spo2"),


### PR DESCRIPTION
## Outcome

Personal Patterns keeps sortable text headers without separate help icons. The Journal update helper aligns its icon and text on one horizontal center line.

## Product UX

The Patterns header is quieter and the Journal helper no longer looks vertically offset.

## Evidence

- Focused Web component tests: 36 passed.
- Changelog fragment tests: 7 passed.
- Hosted Web typecheck: passed.
- Focused ESLint: passed.
- Impeccable detector: no finding caused by this diff.
- ReviewGPT: skipped for this tiny follow-up.

## Design proof

- Design page: [Personal Patterns matrix](https://www.withmurph.ai/design?tab=components#personal-patterns-component)
- Evidence: The production component renders the changed header.
- Coverage: The same header component serves desktop and mobile layouts.

## Affected surfaces

Personal Patterns column headings and the Journal update helper.

## Architecture and reuse

- Existing systems reused: current Pattern header and Journal helper.
- New logic: None; the diff deletes the header help popover and changes one flex alignment class, so no behavior is added.
- New abstractions: None; the existing Pattern header and Journal helper components stay the only owners of this markup.
- Complexity intentionally avoided: deleted the help popover instead of adding another presentation rule.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` reports 2 changed source files, debt 0 -> 0, 0 hotspots above 20.
- Hotspots: none remain; journal-view.tsx max stays 16 and personal-patterns-section.tsx max stays 20.
- Agent judgment: This is the smallest complete UI correction.

## Runtime impact

No backend, provider, database, automation, or deployment pipeline change.

## Deployment concerns

- Deployment: applicable
- Supported skew: The Web-only markup remains compatible with every current backend and Cloudflare version.
- Safe order: Merge and let the normal Vercel Web deployment publish it; no Cloudflare action is required.
- Rollback floor: Revert only this Web commit if the presentation regresses.
- Expected exposure: All members see the cleanup after the production Web deployment completes.
- Reversibility: A Web revert restores the prior icons and alignment without changing member data.
- Convergence proof: The production Web deployment serves the merged commit and the same components at desktop and mobile widths.
- Post-deploy checks: Open Journal and Personal Patterns, confirm the helper alignment, confirm help icons are absent, and confirm header sorting still works.

## Changelog

- Changelog: updated
- Items: 2026-09-03 · journal-patterns-cleaner-names

## LOC

- Source: +2 / -41
- Tests and fixtures: +3 / -1
- Docs: +4 / -4
- Config and tooling: +0 / -0
- Generated and other: +0 / -0


https://claude.ai/code/session_01EMawMqbAT26VPQEvVU5cbv