### PR TITLE
fix(web): expose food overview to WebMCP

### DIFF
--- a/apps/web/src/components/food-label-lab/food-label-lab.tsx
+++ b/apps/web/src/components/food-label-lab/food-label-lab.tsx
@@ -475,7 +475,7 @@ export function FoodLabelLab(input: {
   );
 
   const showEvidence = useCallback(
-    (productRef: string, view: "tests" | "gaps") => {
+    (productRef: string, view: FoodEvidencePanel) => {
       const product = products.find(
         (candidate) => candidate.productRef === productRef,
       );

--- a/apps/web/src/components/food-label-lab/food-label-webmcp.tsx
+++ b/apps/web/src/components/food-label-lab/food-label-webmcp.tsx
@@ -44,8 +44,12 @@ export interface FoodLabelWebMcpActions {
   getCurrentComparison: () => FoodWebMcpComparisonResult;
   showEvidence: (
     productRef: string,
-    view: "tests" | "gaps",
-  ) => { opened: boolean; productRef: string; view: "tests" | "gaps" };
+    view: "product" | "tests" | "gaps",
+  ) => {
+    opened: boolean;
+    productRef: string;
+    view: "product" | "tests" | "gaps";
+  };
 }
 
 interface WebMcpTool {
@@ -213,7 +217,7 @@ function createFoodWebMcpTools(
     {
       name: "search_food_products",
       description:
-        "Search branded foods on the open Murph Food page. Returns short exact product choices for a later comparison.",
+        "Use this tool instead of general web search whenever the user asks to find foods, brands, categories, or products to compare in Murph. Returns exact productRef values for compare_food_products.",
       inputSchema: {
         type: "object",
         properties: {
@@ -261,7 +265,7 @@ function createFoodWebMcpTools(
     {
       name: "compare_food_products",
       description:
-        "Compare two to ten exact branded foods and show the result on the open page. Use productRef values returned by search_food_products.",
+        "Use this tool after search_food_products whenever the user asks to compare, rank, choose, or find a healthier food. It compares two to ten returned productRef values and shows the result on the open page.",
       inputSchema: {
         type: "object",
         properties: {
@@ -291,7 +295,7 @@ function createFoodWebMcpTools(
     {
       name: "get_food_comparison",
       description:
-        "Read the compact result currently visible on the open Murph Food page.",
+        "Use this tool to answer questions about the food comparison already visible on the open Murph page, including nutrition values and the top match.",
       inputSchema: {
         type: "object",
         properties: {},
@@ -308,7 +312,7 @@ function createFoodWebMcpTools(
     {
       name: "show_food_evidence",
       description:
-        "Open the combined evidence drawer for a product already in the visible comparison. view focuses linked test results (tests) or known evidence gaps (gaps).",
+        "Use this tool whenever the user asks to open, show, inspect, or explain a product already in the visible comparison. Use product for its grade, health summary, and ingredients; tests for linked lab results; or gaps for known evidence gaps.",
       inputSchema: {
         type: "object",
         properties: {
@@ -316,7 +320,7 @@ function createFoodWebMcpTools(
             type: "string",
             pattern: "^food_[A-Za-z0-9_-]{1,1024}$",
           },
-          view: { type: "string", enum: ["tests", "gaps"] },
+          view: { type: "string", enum: ["product", "tests", "gaps"] },
         },
         required: ["productRef", "view"],
         additionalProperties: false,
@@ -326,7 +330,7 @@ function createFoodWebMcpTools(
         properties: {
           opened: { type: "boolean" },
           productRef: { type: "string" },
-          view: { type: "string", enum: ["tests", "gaps"] },
+          view: { type: "string", enum: ["product", "tests", "gaps"] },
         },
         required: ["opened", "productRef", "view"],
         additionalProperties: false,
@@ -337,8 +341,8 @@ function createFoodWebMcpTools(
         assertOnlyKeys(value, ["productRef", "view"]);
         const productRef = readFoodProductRef(value.productRef);
         const view = value.view;
-        if (view !== "tests" && view !== "gaps") {
-          throw new Error("view must be tests or gaps.");
+        if (view !== "product" && view !== "tests" && view !== "gaps") {
+          throw new Error("view must be product, tests, or gaps.");
         }
         return actionsRef.current.showEvidence(productRef, view);
       },

--- a/apps/web/test/food-label-webmcp.test.tsx
+++ b/apps/web/test/food-label-webmcp.test.tsx
@@ -137,16 +137,21 @@ describe("FoodLabelWebMcp", () => {
     cleanup = rendered.cleanup;
 
     const showEvidence = findTool(captured, "show_food_evidence");
-    const result = await Promise.resolve(showEvidence.execute({
-      productRef: "food_one",
-      view: "gaps",
-    }));
+    expect(showEvidence.inputSchema).toMatchObject({
+      properties: { view: { enum: ["product", "tests", "gaps"] } },
+    });
+    const result = await Promise.resolve(
+      showEvidence.execute({
+        productRef: "food_one",
+        view: "product",
+      }),
+    );
     expect(result).toEqual({
       opened: true,
       productRef: "food_one",
-      view: "gaps",
+      view: "product",
     });
-    expect(actions.showEvidence).toHaveBeenCalledWith("food_one", "gaps");
+    expect(actions.showEvidence).toHaveBeenCalledWith("food_one", "product");
   });
 
   test("returns the same bounded metric comparison that the page shows", async () => {


### PR DESCRIPTION
## Why and outcome\n\nChatGPT could discover the Food Lab site tools, but the product-details tool could not open the existing Overview view. General food prompts could also lead the model to web search.\n\nThis PR exposes the existing product overview through WebMCP and gives every tool a clearer usage description.\n\n## Product UX\n\n- Effort: Polish\n- People: visitors using Food Lab through ChatGPT site tools.\n- Result: ChatGPT can search, compare, read the visible result, and open the grade, health summary, and ingredients.\n- Manual page behavior and visuals do not change.\n\n## Evidence\n\n- Focused Food Label WebMCP test: 4 passed.\n- Web TypeScript check: passed.\n- Diff check: passed.\n- The test proves the product view is present in the input schema and reaches the existing drawer owner.\n\n## Non-obvious affected surfaces\n\nThe public page-scoped WebMCP contract adds one allowed view value. Existing tests and gaps values remain compatible.\n\n## Architecture and reuse\n\nThe change reuses the existing FoodEvidencePanel product state and existing drawer. It adds no endpoint, persistence, dependency, or state owner.\n\n## Complexity impact\n\nNo new branch owner or abstraction. One existing union and schema now include product.\n\n## Hot reply path impact\n\nNot applicable. This changes only the public Food Lab page.\n\n## Murph initial provider input impact\n\nNot applicable. No Murph assistant prompt or provider request changes.\n\n## Design proof\n\n- Page: https://www.withmurph.ai/food\n- Existing study: https://www.withmurph.ai/screenshots/health#food-label-lab\n- No visual component changed. WebMCP opens the existing Overview state.\n\n## Change-shape breakdown\n\n| Category | Added | Deleted |\n| --- | ---: | ---: |\n| Source | 15 | 11 |\n| Tests/fixtures | 11 | 6 |\n| Docs | 0 | 0 |\n| Config/tooling | 0 | 0 |\n| Generated/other | 0 | 0 |\n| Total | 26 | 17 |\n\n## Deployment concerns\n\n- Deployment: not applicable\n- Reason: one backward-compatible Web deployment with no cross-service ordering.\n\n## Changelog\n\nNot updated. This is a narrow compatibility correction for the new page-scoped agent surface.\n\n## Review\n\nReviewGPT was skipped by explicit user direction because of the hackathon deadline. Focused deterministic proof passed.