### PR TITLE
Upgrade hosted video analysis to Gemini 3.8 Flash

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3904,7 +3904,7 @@ the digest and MP4/QuickTime/WebM signature, and only then permits external
 egress.
 
 The tool makes one inline legacy `generateContent` request to the fixed
-`gemini-3.7-flash` model. Murph chooses one semantic sampling mode before
+`gemini-3.8-flash` model. Murph chooses one semantic sampling mode before
 egress: omitted or `standard` maps to `videoMetadata.fps = 1`, while
 `detailed_motion` maps to 5 FPS for rapid movement, exercise phases, quick
 scene changes, or brief events. Both modes use medium thinking and new requests
@@ -3946,11 +3946,13 @@ Hosted execution carries only the Gemini sentinel in the runner. The exact
 Google host, model path, method, JSON shape, MIME set, sampling profile,
 thinking level, request/response limits, and manual redirect posture are
 revalidated by the Cloudflare egress interceptor before the Worker substitutes
-its credential. During the rollout compatibility window, that reader also
-admits only the exact previously deployed 1 FPS, low-thinking,
-1,800-output-token profile from a warm old runner. New runners never emit that
-legacy shape; remove the reader branch only after warm runners and the rollback
-floor have advanced.
+its credential. During the model rollout compatibility window, that reader also
+admits the exact previous `gemini-3.7-flash` path with either current request
+profile or the previously deployed 1 FPS, low-thinking, 1,800-output-token
+profile from an older warm runner. The capped profile remains invalid on the
+3.8 path. Usage records retain the model derived from the admitted path. New
+runners emit only the 3.8 path and current profiles; remove the 3.7 reader only
+after warm runners and the rollback floor have advanced.
 The narrow raw HTTP owner is intentional: the Google SDK does not expose the
 request-scoped fetch injection required by Murph's identity-bound provider
 boundary, while the current Interactions API cannot explicitly set video FPS.

--- a/agent-docs/SECURITY.md
+++ b/agent-docs/SECURITY.md
@@ -379,20 +379,22 @@ Last verified: 2026-08-31
   replies only because snapshot exclusion is the independent persistence
   boundary. An explicit canonical event raw reference is the sole durable-save
   exception and keeps its separately authorized lifecycle. The tool
-  pins Gemini 3.7 Flash and maps only `standard` to 1 FPS or
+  pins Gemini 3.8 Flash and maps only `standard` to 1 FPS or
   `detailed_motion` to 5 FPS. Murph chooses that semantic mode before egress;
   raw FPS remains unavailable to the model and member. Both current profiles
   use medium thinking, omit an explicit output-token cap, allow one call, do
   not retry, keep the 14 MiB raw cap and 90-second timeout, and bound both the
   delivered response and tool result. The Worker must revalidate the exact
   request and use manual redirects before replacing the runner sentinel with
-  `GEMINI_API_KEY`. During rollout it may also accept only the exact deployed
-  legacy profile of 1 FPS, low thinking, and a 1,800-token output cap from a
-  warm old runner; mixed profiles remain denied, new runners never emit the
-  legacy shape, and the compatibility reader is removed after the rollback
-  floor advances. A protocol-valid successful response must be
-  withheld until Web durably accepts its exact usage record; callback rejection
-  fails the tool closed. An upstream response above the 1 MiB delivery cap is a
+  `GEMINI_API_KEY`. During the model rollout it may also accept the exact
+  previous `gemini-3.7-flash` path with either current profile or the exact
+  deployed legacy profile of 1 FPS, low thinking, and a 1,800-token output cap
+  from an older warm runner. The capped profile remains invalid on the 3.8
+  path, mixed profiles remain denied, usage records retain the model derived
+  from the admitted path, new runners emit only 3.8 current profiles, and the
+  3.7 reader is removed after the rollback floor advances. Usage recording is
+  best-effort and cannot withhold an otherwise valid provider response. An
+  upstream response above the 1 MiB delivery cap is a
   protocol violation: reject it without widening the buffer, let Murph absorb
   that unaccountable provider cost, and log only bounded status metadata. Do not
   persist or log video bytes, prompts,

--- a/agent-docs/exec-plans/active/2026-09-03-gemini-3-8-flash.md
+++ b/agent-docs/exec-plans/active/2026-09-03-gemini-3-8-flash.md
@@ -1,0 +1,94 @@
+# Upgrade hosted video analysis to Gemini 3.8 Flash
+
+Status: active
+Created: 2026-09-03
+Updated: 2026-09-03
+
+## Goal
+
+- Move Murph's on-demand hosted video analysis from Gemini 3.7 Flash to the
+  stable `gemini-3.8-flash` model without interrupting requests or usage
+  accounting during the Web/Worker/warm-runner rollout window.
+
+## Success criteria
+
+- New assistant video-analysis requests target `gemini-3.8-flash` with the
+  existing 1/5 FPS, medium-thinking request profiles.
+- The Worker accepts and records both the new 3.8 path and the prior 3.7 path
+  during rollout, while binding the deprecated capped request profile only to
+  the prior model.
+- Web prices exact 3.8 usage and rollout-era 3.7 usage under model-specific
+  pricing versions using Google's published rates.
+- Focused provider-boundary, assistant-engine, hosted-execution, Web, and
+  Cloudflare tests plus relevant typechecks pass.
+- Live owner docs describe the consumer-first rollout and rollback floor.
+
+## Scope
+
+- In scope: hosted video-analysis model pin, Worker egress-path compatibility,
+  model-aware usage accounting, regression tests, and current architecture,
+  security, and deployment documentation.
+- Out of scope: changing sampling modes, prompts, video limits, retry behavior,
+  credentials, or other Gemini-backed features.
+
+## Constraints
+
+- Technical constraints: preserve the fixed legacy `generateContent` request,
+  request-scoped fetch boundary, one-call ceiling, exact-body validation, and
+  current usage-record schema.
+- Product/process constraints: deploy the compatible Web consumer before the
+  Worker/new runner writer; keep production secrets unavailable locally; use
+  only privacy-safe synthetic verification evidence.
+
+## Risks and mitigations
+
+1. Risk: New Web or Worker code rejects a request or usage row from a warm 3.7
+   runner.
+   Mitigation: Retain one explicit 3.7 rollout reader in both boundaries and
+   prove both model paths.
+2. Risk: The old capped/low-thinking profile is accidentally admitted for 3.8.
+   Mitigation: Bind that temporary body-shape compatibility to the 3.7 model
+   path and reject the cross-product.
+3. Risk: Usage is priced or labeled as the wrong model.
+   Mitigation: Derive the trusted model from the exact admitted path and carry
+   it through the usage record and model-specific pricing snapshot.
+
+## Tasks
+
+1. Update the shared current model and add the narrow previous-model rollout
+   contract.
+2. Make Worker path/body validation and usage recording model-aware.
+3. Make Web allowance pricing accept and label both exact rollout models.
+4. Update focused tests and live owner docs.
+5. Run focused verification, inspect the final diff, complete review/CI, and
+   close the plan with the scoped task commit.
+
+## Decisions
+
+- Keep raw REST rather than adding the SDK: Murph's documented request-scoped
+  fetch injection and explicit video-FPS boundary still require the existing
+  owner.
+- Keep request semantics unchanged because the current body already satisfies
+  Google's 3.8 migration requirements: medium `thinkingLevel`, no deprecated
+  sampling parameters, no prefilled model turn, and a non-empty final user
+  turn.
+- Treat 3.7 only as a temporary deployed-reader compatibility model, not a
+  configurable fallback or second writer.
+
+## Verification
+
+- Passed focused Vitest coverage for Gemini request construction, hosted usage
+  records, Worker egress/interception, runner platform boundaries, Web
+  allowance pricing, and provider-request ownership: 680 assertions across the
+  selected files.
+- Passed typechecks for `packages/assistant-engine`,
+  `packages/hosted-execution`, `apps/cloudflare`, and `apps/web`; the assembled
+  hosted-local build also completed before its deploy smoke prerequisite.
+- Passed `pnpm complexity:diff`, `git diff --check`, and identifier/privacy
+  scans of the authored diff.
+- The local hosted roundtrip could not execute because the Docker daemon was
+  unavailable. The harness completed its build and setup work, then skipped the
+  scenario after the runner-container deploy smoke exhausted its retries.
+- No ambient non-production `GEMINI_API_KEY` was available, so no live vendor
+  call was attempted. Exact-head CI, ReviewGPT, and the documented consented
+  post-deploy smoke remain the external verification boundaries.

--- a/agent-docs/exec-plans/completed/2026-09-03-gemini-3-8-flash.md
+++ b/agent-docs/exec-plans/completed/2026-09-03-gemini-3-8-flash.md
@@ -1,6 +1,6 @@
 # Upgrade hosted video analysis to Gemini 3.8 Flash
 
-Status: active
+Status: completed
 Created: 2026-09-03
 Updated: 2026-09-03
 
@@ -79,8 +79,8 @@ Updated: 2026-09-03
 
 - Passed focused Vitest coverage for Gemini request construction, hosted usage
   records, Worker egress/interception, runner platform boundaries, Web
-  allowance pricing, and provider-request ownership: 680 assertions across the
-  selected files.
+  allowance pricing, provider-request ownership, and the public changelog:
+  689 assertions across the selected files.
 - Passed typechecks for `packages/assistant-engine`,
   `packages/hosted-execution`, `apps/cloudflare`, and `apps/web`; the assembled
   hosted-local build also completed before its deploy smoke prerequisite.
@@ -92,3 +92,10 @@ Updated: 2026-09-03
 - No ambient non-production `GEMINI_API_KEY` was available, so no live vendor
   call was attempted. Exact-head CI, ReviewGPT, and the documented consented
   post-deploy smoke remain the external verification boundaries.
+- ReviewGPT round 1 audited the full exact-head snapshot for about 16 minutes,
+  returned `ROUND_OUTCOME: PASS` with no qualifying findings, and bound the
+  captured response to the requested Sol lane and compatible
+  `gpt-5-6-pro` backend slug. Its rendered-evidence note is non-actionable under
+  the repository's content-only changelog proof exception; the production
+  archive server-render test passed.
+Completed: 2026-09-03

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -300,7 +300,7 @@ specified by `agent-docs/SECURITY.md`,
 `agent-docs/references/testing-ci-map.md`, and
 `agent-docs/exec-plans/active/2026-08-12-provider-request-guard.md`.
 
-On-demand hosted video analysis is one turn-scoped Gemini 3.7 Flash call over
+On-demand hosted video analysis is one turn-scoped Gemini 3.8 Flash call over
 an exact accepted-message attachment authority. The tool is offered on
 private-direct turns and authenticated Linq/Telegram group turns with accepted
 user-action input and a configured Worker credential. Any participant in an

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -105,29 +105,31 @@ do not publish trace, attempt, mailbox, or member identifiers.
 
 ## Gemini Video Analysis Rollout
 
-Deploy Web's Gemini usage-record acceptance and date-bound Gemini 3.7 Flash
-pricing first. Next, map the platform-owned `GEMINI_API_KEY` in the private
-Murph Cloud workflow and GitHub Environment without exposing its value to the
-public repository, only after vendor approval confirms that the exact hosted
-Gemini project has the applicable paid/no-training controls required by
-Murph's health-data policy. Key presence alone does not prove those controls.
-Finally, deploy the Worker and runner bundle with the compatible egress reader
-active before a new runner request shape can reach it. The runner receives only
-the normal injected-credential sentinel; the Worker owns the real key and
+Deploy Web's dual Gemini 3.8/3.7 usage-record acceptance and date-bound pricing
+first. Next, map the platform-owned `GEMINI_API_KEY` in the private Murph Cloud
+workflow and GitHub Environment without exposing its value to the public
+repository, only after vendor approval confirms that the exact hosted Gemini
+project has the applicable paid/no-training controls required by Murph's
+health-data policy. Key presence alone does not prove those controls. Finally,
+deploy the Worker and runner bundle with the compatible egress reader active
+before a new runner request path can reach it. The runner receives only the
+normal injected-credential sentinel; the Worker owns the real key and
 substitutes it only after the exact Gemini request passes authorization and
-shape validation. During this rollout the Worker accepts the two current
-profiles, standard 1 FPS or detailed-motion 5 FPS with medium thinking and no
-explicit output-token cap, plus only the exact previous 1 FPS, low-thinking,
-1,800-token shape from a warm old runner.
+shape validation. During this rollout the Worker accepts the 3.8 path with the
+two current profiles—standard 1 FPS or detailed-motion 5 FPS with medium
+thinking and no explicit output-token cap—and the previous 3.7 path with those
+same profiles or only the exact older 1 FPS, low-thinking, 1,800-token shape.
+The capped profile is never valid on the 3.8 path.
 
-Do not deploy the Cloudflare producer ahead of Web pricing: the Worker now
-withholds a successful Gemini response until Web accepts its usage row, so an
-older Web would turn every otherwise successful analysis into a 502. Missing
-key configuration is fail-closed and
-omits `murph.analyze_video`. During this update, an old runner continues to emit
-the exact legacy profile while a new runner may emit either current profile;
-the compatible Worker accepts both without permitting arbitrary FPS, thinking,
-or output settings. Both generations expose the tool for private-direct turns
+Do not deploy the Cloudflare producer ahead of Web pricing: warm 3.7 runners
+can continue to publish usage while new 3.8 runners start. Usage-record failure
+does not withhold a successful analysis, but it would undercount allowance
+usage. Missing key configuration is fail-closed and omits
+`murph.analyze_video`. During this update, an old runner continues to emit the
+3.7 path while a new runner emits the 3.8 path with either current profile; the
+compatible Worker derives the usage model from the exact path and accepts all
+three deployed path/profile combinations without permitting arbitrary models,
+FPS, thinking, or output settings. Both generations expose the tool for private-direct turns
 and authenticated Linq/Telegram group turns with accepted user-action input.
 Any authenticated group participant may request analysis of another
 participant's video in the same accepted group turn; unverified external groups
@@ -138,13 +140,14 @@ turn start; this lets the first live-steered video be frozen and authorized
 before tool execution in that same turn. There is no schema, backfill,
 dual-write, or stored compatibility state.
 
-Do not revert the compatible Worker while a new runner can still emit the new
-request shape. Disable the tool or roll back the runner writer first, drain warm
-new runners, and only then revert the reader; the Web usage reader and pricing
-branch are safe to leave in place. Post-deploy, use consented short supported
+Do not revert the compatible Worker while a new runner can still emit the 3.8
+path. Disable the tool or roll back the runner writer to 3.7 first, drain warm
+3.8 runners, and only then revert the reader; the Web dual-model usage reader
+and pricing branch are safe to leave in place. Post-deploy, use consented short supported
 videos in a private direct conversation to verify one ordinary request selects
 standard 1 FPS and one rapid-movement or exercise-form request selects detailed
-motion 5 FPS. Confirm both finish with one Gemini call and one usage record.
+motion 5 FPS. Confirm both finish with one Gemini 3.8 call and one usage record
+whose requested model and pricing version name 3.8.
 Then use one consented group video and verify the same single-request result
 when its uploader requests analysis. Have a different authenticated participant
 request analysis of a second consented group video and verify the same result.

--- a/apps/cloudflare/src/runner-egress-gemini.ts
+++ b/apps/cloudflare/src/runner-egress-gemini.ts
@@ -5,15 +5,20 @@ import {
   HOSTED_GEMINI_VIDEO_ANALYSIS_MAX_RESPONSE_BODY_BYTES as SHARED_GEMINI_VIDEO_ANALYSIS_MAX_RESPONSE_BODY_BYTES,
   HOSTED_GEMINI_VIDEO_ANALYSIS_MAX_VIDEO_BYTES,
   HOSTED_GEMINI_VIDEO_ANALYSIS_MODEL,
+  HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL,
+  HOSTED_GEMINI_VIDEO_ANALYSIS_ROLLOUT_MODELS,
   HOSTED_GEMINI_VIDEO_ANALYSIS_SUPPORTED_MIME_TYPES,
   HOSTED_GEMINI_VIDEO_ANALYSIS_SYSTEM_INSTRUCTION,
   HOSTED_GEMINI_VIDEO_ANALYSIS_THINKING_LEVEL,
+  type HostedGeminiVideoAnalysisRolloutModel,
 } from "@murphai/hosted-execution/assistant-capabilities";
 
 export const DEFAULT_GEMINI_API_BASE_URL =
   HOSTED_GEMINI_VIDEO_ANALYSIS_API_BASE_URL;
 export const HOSTED_GEMINI_VIDEO_ANALYSIS_PATH =
   `/v1beta/models/${HOSTED_GEMINI_VIDEO_ANALYSIS_MODEL}:generateContent`;
+export const HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL_PATH =
+  `/v1beta/models/${HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL}:generateContent`;
 export const HOSTED_GEMINI_VIDEO_ANALYSIS_MAX_BODY_BYTES =
   HOSTED_GEMINI_VIDEO_ANALYSIS_MAX_REQUEST_BODY_BYTES;
 export const HOSTED_GEMINI_VIDEO_ANALYSIS_MAX_RESPONSE_BODY_BYTES =
@@ -33,6 +38,12 @@ const supportedMimeTypes = new Set<string>(
 );
 const supportedFps = new Set<number>(
   Object.values(HOSTED_GEMINI_VIDEO_ANALYSIS_FPS_BY_SAMPLING_MODE),
+);
+const modelByPath = new Map<string, HostedGeminiVideoAnalysisRolloutModel>(
+  HOSTED_GEMINI_VIDEO_ANALYSIS_ROLLOUT_MODELS.map((model) => [
+    `/v1beta/models/${model}:generateContent`,
+    model,
+  ]),
 );
 
 type HostedGeminiVideoAnalysisGenerationConfig =
@@ -69,11 +80,20 @@ export function isAllowedHostedGeminiVideoAnalysisRequest(
   method: string,
   pathname: string,
 ): boolean {
-  return method === "POST" && pathname === HOSTED_GEMINI_VIDEO_ANALYSIS_PATH;
+  return readHostedGeminiVideoAnalysisRequestModel(method, pathname) !== null;
+}
+
+export function readHostedGeminiVideoAnalysisRequestModel(
+  method: string,
+  pathname: string,
+): HostedGeminiVideoAnalysisRolloutModel | null {
+  return method === "POST" ? modelByPath.get(pathname) ?? null : null;
 }
 
 export function parseHostedGeminiVideoAnalysisRequestBody(
   value: unknown,
+  model: HostedGeminiVideoAnalysisRolloutModel =
+    HOSTED_GEMINI_VIDEO_ANALYSIS_MODEL,
 ): HostedGeminiVideoAnalysisRequestBody {
   const body = exactRecord(value, "Gemini video-analysis request", [
     "contents",
@@ -174,7 +194,8 @@ export function parseHostedGeminiVideoAnalysisRequestBody(
   );
   if (legacyProfile) {
     if (
-      fps !== LEGACY_GEMINI_VIDEO_ANALYSIS_FPS
+      model !== HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL
+      || fps !== LEGACY_GEMINI_VIDEO_ANALYSIS_FPS
       || generationConfig.maxOutputTokens
         !== LEGACY_GEMINI_VIDEO_ANALYSIS_MAX_OUTPUT_TOKENS
       || thinkingConfig.thinkingLevel

--- a/apps/cloudflare/src/runner-egress-intercept.ts
+++ b/apps/cloudflare/src/runner-egress-intercept.ts
@@ -22,9 +22,6 @@ import {
   HOSTED_ASSISTANT_VENICE_PROVIDER_MODELS,
 } from "@murphai/hosted-execution/assistant-model";
 import {
-  HOSTED_GEMINI_VIDEO_ANALYSIS_MODEL,
-} from "@murphai/hosted-execution/assistant-capabilities";
-import {
   buildHostedCodexMemoryUsageRecord,
   buildHostedElevenLabsMusicUsageRecord,
   buildHostedElevenLabsTtsUsageRecord,
@@ -139,8 +136,8 @@ import {
   DEFAULT_GEMINI_API_BASE_URL,
   HOSTED_GEMINI_VIDEO_ANALYSIS_MAX_BODY_BYTES,
   HOSTED_GEMINI_VIDEO_ANALYSIS_MAX_RESPONSE_BODY_BYTES,
-  isAllowedHostedGeminiVideoAnalysisRequest,
   parseHostedGeminiVideoAnalysisRequestBody,
+  readHostedGeminiVideoAnalysisRequestModel,
   readHostedGeminiVideoAnalysisUsageMetadata,
 } from "./runner-egress-gemini.ts";
 import {
@@ -2255,11 +2252,12 @@ async function maybeHandleGeminiRequest(input: {
   if (input.url.origin !== DEFAULT_GEMINI_API_BASE_URL) {
     return null;
   }
+  const model = readHostedGeminiVideoAnalysisRequestModel(
+    input.request.method,
+    input.url.pathname,
+  );
   if (
-    !isAllowedHostedGeminiVideoAnalysisRequest(
-      input.request.method,
-      input.url.pathname,
-    )
+    model === null
     || input.url.search.length > 0
     || input.request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase()
       !== "application/json"
@@ -2295,6 +2293,7 @@ async function maybeHandleGeminiRequest(input: {
   try {
     parsedBody = parseHostedGeminiVideoAnalysisRequestBody(
       JSON.parse(new TextDecoder().decode(requestBody)),
+      model,
     );
   } catch {
     return disallowedProviderEgress();
@@ -2347,7 +2346,7 @@ async function maybeHandleGeminiRequest(input: {
   const usageRecording = recordHostedGeminiVideoAnalysisUsage({
     authorization,
     env: input.env,
-    model: HOSTED_GEMINI_VIDEO_ANALYSIS_MODEL,
+    model,
     occurredAt: new Date(providerRequestStartedAt).toISOString(),
     providerRequestId:
       response.headers.get("x-goog-request-id")

--- a/apps/cloudflare/test/hosted-local-analyze-video-roundtrip-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-analyze-video-roundtrip-e2e.test.ts
@@ -318,7 +318,7 @@ async function expectGeminiUsageRows(expectedCount: number): Promise<void> {
         inputTokens: 320,
         outputTokens: 18,
         reasoningTokens: 7,
-        requestedModel: "gemini-3.7-flash",
+        requestedModel: "gemini-3.8-flash",
         totalTokens: 345,
         triggerKind: "analyze-video",
       });

--- a/apps/cloudflare/test/runner-egress-gemini.test.ts
+++ b/apps/cloudflare/test/runner-egress-gemini.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
+  HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL,
   HOSTED_GEMINI_VIDEO_ANALYSIS_SYSTEM_INSTRUCTION,
 } from "@murphai/hosted-execution/assistant-capabilities";
 
 import {
   HOSTED_GEMINI_VIDEO_ANALYSIS_MAX_BODY_BYTES,
   HOSTED_GEMINI_VIDEO_ANALYSIS_PATH,
+  HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL_PATH,
   isAllowedHostedGeminiVideoAnalysisRequest,
   parseHostedGeminiVideoAnalysisRequestBody,
+  readHostedGeminiVideoAnalysisRequestModel,
   readHostedGeminiVideoAnalysisUsageMetadata,
 } from "../src/runner-egress-gemini.ts";
 
@@ -48,11 +51,23 @@ function createLegacyRequestBody() {
 }
 
 describe("hosted Gemini video egress contract", () => {
-  it("pins the only admitted method and model path", () => {
+  it("pins the current and rollout model paths to POST", () => {
     expect(isAllowedHostedGeminiVideoAnalysisRequest(
       "POST",
       HOSTED_GEMINI_VIDEO_ANALYSIS_PATH,
     )).toBe(true);
+    expect(readHostedGeminiVideoAnalysisRequestModel(
+      "POST",
+      HOSTED_GEMINI_VIDEO_ANALYSIS_PATH,
+    )).toBe("gemini-3.8-flash");
+    expect(isAllowedHostedGeminiVideoAnalysisRequest(
+      "POST",
+      HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL_PATH,
+    )).toBe(true);
+    expect(readHostedGeminiVideoAnalysisRequestModel(
+      "POST",
+      HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL_PATH,
+    )).toBe(HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL);
     expect(isAllowedHostedGeminiVideoAnalysisRequest(
       "GET",
       HOSTED_GEMINI_VIDEO_ANALYSIS_PATH,
@@ -77,8 +92,14 @@ describe("hosted Gemini video egress contract", () => {
   });
 
   it("accepts only the exact deployed legacy profile during rollout", () => {
-    expect(parseHostedGeminiVideoAnalysisRequestBody(createLegacyRequestBody()))
+    expect(parseHostedGeminiVideoAnalysisRequestBody(
+      createLegacyRequestBody(),
+      HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL,
+    ))
       .toEqual(createLegacyRequestBody());
+    expect(() => parseHostedGeminiVideoAnalysisRequestBody(
+      createLegacyRequestBody(),
+    )).toThrow();
 
     const legacyAtDetailedFps = createLegacyRequestBody();
     legacyAtDetailedFps.contents[0]!.parts[0]!.videoMetadata!.fps = 5;
@@ -92,7 +113,10 @@ describe("hosted Gemini video egress contract", () => {
       mediumWithLegacyCap,
       lowWithoutLegacyCap,
     ]) {
-      expect(() => parseHostedGeminiVideoAnalysisRequestBody(candidate)).toThrow();
+      expect(() => parseHostedGeminiVideoAnalysisRequestBody(
+        candidate,
+        HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL,
+      )).toThrow();
     }
   });
 

--- a/apps/cloudflare/test/runner-egress-intercept.test.ts
+++ b/apps/cloudflare/test/runner-egress-intercept.test.ts
@@ -90,6 +90,7 @@ import {
 import { parseHostedXaiRequestBody } from "../src/runner-egress-xai.ts";
 import {
   HOSTED_GEMINI_VIDEO_ANALYSIS_PATH,
+  HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL_PATH,
 } from "../src/runner-egress-gemini.ts";
 import {
   sealHostedInferenceRuntimeTarget,
@@ -2201,7 +2202,16 @@ describe("hostedRunnerIntercept", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("injects Gemini credentials, preserves the fixed request, and records token usage", async () => {
+  it.each([
+    {
+      model: "gemini-3.8-flash",
+      path: HOSTED_GEMINI_VIDEO_ANALYSIS_PATH,
+    },
+    {
+      model: "gemini-3.7-flash",
+      path: HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL_PATH,
+    },
+  ])("injects Gemini credentials and records $model usage", async ({ model, path }) => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(PROVIDER_REQUEST_STARTED_AT));
     const upstreamPayload = {
@@ -2239,7 +2249,7 @@ describe("hostedRunnerIntercept", () => {
 
     const response = await hostedRunnerIntercept(
       new Request(
-        `https://generativelanguage.googleapis.com${HOSTED_GEMINI_VIDEO_ANALYSIS_PATH}`,
+        `https://generativelanguage.googleapis.com${path}`,
         {
           body: JSON.stringify(requestBody),
           headers: {
@@ -2294,7 +2304,7 @@ describe("hostedRunnerIntercept", () => {
       providerName: "Google Gemini",
       providerRequestId: "gemini-req-1",
       reasoningTokens: 7,
-      requestedModel: "gemini-3.7-flash",
+      requestedModel: model,
       totalTokens: 345,
       triggerKind: "analyze-video",
       usageExtractionSourcePath: "gemini.generateContent.usageMetadata",

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -6108,7 +6108,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     );
 
     const response = await hostedFetch(
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.7-flash:generateContent",
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.8-flash:generateContent",
       { body: "{}", method: "POST" },
     );
 

--- a/apps/web/changelog/entries/2026-09-03/video-analysis-gemini-3-8.json
+++ b/apps/web/changelog/entries/2026-09-03/video-analysis-gemini-3-8.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-03",
+  "order": 100,
+  "item": {
+    "id": "video-analysis-gemini-3-8",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Video analysis uses Gemini 3.8 Flash",
+    "summary": "When you ask Murph about a video, the analysis now uses Google's latest Flash model while keeping standard and detailed-motion sampling.",
+    "details": "Each request remains one bounded analysis call. Older in-flight requests stay compatible during the rollout.",
+    "relevanceTags": ["assistant", "video", "reliability"],
+    "sourcePullRequests": [2789]
+  }
+}

--- a/apps/web/src/lib/hosted-execution/usage-allowance.ts
+++ b/apps/web/src/lib/hosted-execution/usage-allowance.ts
@@ -17,7 +17,8 @@ import {
 import {
   HOSTED_GEMINI_VIDEO_ANALYSIS_API_BASE_URL,
   HOSTED_GEMINI_VIDEO_ANALYSIS_API_KEY_ENV,
-  HOSTED_GEMINI_VIDEO_ANALYSIS_MODEL,
+  HOSTED_GEMINI_VIDEO_ANALYSIS_ROLLOUT_MODELS,
+  type HostedGeminiVideoAnalysisRolloutModel,
 } from "@murphai/hosted-execution/assistant-capabilities";
 import {
   isHostedAiUsageOpenAiTokenPricingProviderName,
@@ -545,16 +546,13 @@ const HOSTED_AI_USAGE_ALLOWANCE_XAI_SEARCH_RAW_USAGE_KEYS: ReadonlySet<string> =
   ]);
 const HOSTED_AI_USAGE_ALLOWANCE_XAI_USD_TICKS_PER_USD_MICRO = 10_000n;
 
-// Gemini 3.7 Flash video analysis is token-priced independently from Murph's
-// primary assistant-model catalog. Google publishes one introductory rate
-// through 2026-12-31 and a higher rate beginning 2027-01-01. Output pricing
-// includes thinking tokens, so candidates and thoughts share one output bucket.
+// Gemini 3.8 Flash video analysis and its deployed 3.7 rollout reader are
+// token-priced independently from Murph's primary assistant-model catalog.
+// Google publishes the same introductory and standard rates for both models.
+// Output pricing includes thinking tokens, so candidates and thoughts share
+// one output bucket.
 const HOSTED_AI_USAGE_ALLOWANCE_GEMINI_VIDEO_PRICING_SOURCE =
   "https://ai.google.dev/gemini-api/docs/pricing";
-const HOSTED_AI_USAGE_ALLOWANCE_GEMINI_VIDEO_2026_PRICING_VERSION =
-  "gemini-3.7-flash-video-pricing-through-2026-12-31";
-const HOSTED_AI_USAGE_ALLOWANCE_GEMINI_VIDEO_2027_PRICING_VERSION =
-  "gemini-3.7-flash-video-pricing-from-2027-01-01";
 const HOSTED_AI_USAGE_ALLOWANCE_GEMINI_VIDEO_2027_START_MS =
   Date.parse("2027-01-01T00:00:00.000Z");
 const HOSTED_AI_USAGE_ALLOWANCE_GEMINI_VIDEO_2026_INPUT_USD_MICROS_PER_MILLION_TOKENS =
@@ -577,6 +575,9 @@ const HOSTED_AI_USAGE_ALLOWANCE_GEMINI_VIDEO_RAW_USAGE_KEYS: ReadonlySet<string>
     "thoughtsTokenCount",
     "totalTokenCount",
   ]);
+const hostedGeminiVideoAnalysisRolloutModels = new Set<string>(
+  HOSTED_GEMINI_VIDEO_ANALYSIS_ROLLOUT_MODELS,
+);
 
 const HOSTED_AI_USAGE_ALLOWANCE_GPT_56_SOL_MODEL_PRICE = {
   cachedInputUsdMicrosPerMillionTokens: 400_000n,
@@ -3029,6 +3030,7 @@ function divideXaiUsdTicksToMicrosCeil(costInUsdTicks: bigint): bigint {
 interface HostedAiUsageAllowanceGeminiVideoMatch {
   cachedInputTokens: bigint;
   inputTokens: bigint;
+  model: HostedGeminiVideoAnalysisRolloutModel;
   outputTokens: bigint;
   reasoningTokens: bigint;
   totalTokens: bigint;
@@ -3054,7 +3056,7 @@ function matchHostedAiUsageGeminiVideoAnalysisRecord(
       !== HOSTED_GEMINI_VIDEO_ANALYSIS_USAGE_EXTRACTION_SOURCE_PATH
     || record.usageExtractionVersion
       !== HOSTED_GEMINI_VIDEO_ANALYSIS_USAGE_EXTRACTION_VERSION
-    || record.requestedModel !== HOSTED_GEMINI_VIDEO_ANALYSIS_MODEL
+    || !isHostedGeminiVideoAnalysisRolloutModel(record.requestedModel)
     || record.servedModel !== null
     || record.cacheWriteTokens !== null
     || rawUsageJson === null
@@ -3105,10 +3107,17 @@ function matchHostedAiUsageGeminiVideoAnalysisRecord(
   return {
     cachedInputTokens: cachedInput.value,
     inputTokens,
+    model: record.requestedModel,
     outputTokens: output.value,
     reasoningTokens: reasoning.value,
     totalTokens,
   };
+}
+
+function isHostedGeminiVideoAnalysisRolloutModel(
+  value: string | null,
+): value is HostedGeminiVideoAnalysisRolloutModel {
+  return value !== null && hostedGeminiVideoAnalysisRolloutModels.has(value);
 }
 
 function readHostedAiUsageOptionalNonNegativeInteger(
@@ -3138,7 +3147,10 @@ function priceHostedAiUsageGeminiVideoForAllowance(input: {
   match: HostedAiUsageAllowanceGeminiVideoMatch;
   record: AssistantUsageRecord;
 }): HostedAiUsageAllowancePricingResult {
-  const pricing = resolveHostedAiUsageGeminiVideoPricing(input.record.occurredAt);
+  const pricing = resolveHostedAiUsageGeminiVideoPricing(
+    input.record.occurredAt,
+    input.match.model,
+  );
   const billableNonCachedInputTokens =
     input.match.inputTokens - input.match.cachedInputTokens;
   const billableOutputTokens =
@@ -3162,7 +3174,7 @@ function priceHostedAiUsageGeminiVideoForAllowance(input: {
     counted: input.counted,
     pricingSnapshot: {
       credentialSource: input.credentialSource,
-      model: HOSTED_GEMINI_VIDEO_ANALYSIS_MODEL,
+      model: input.match.model,
       modelSource: "requested",
       pricingSource: HOSTED_AI_USAGE_ALLOWANCE_GEMINI_VIDEO_PRICING_SOURCE,
       pricingWindow: {
@@ -3196,6 +3208,7 @@ function priceHostedAiUsageGeminiVideoForAllowance(input: {
 
 function resolveHostedAiUsageGeminiVideoPricing(
   occurredAt: Date | string,
+  model: HostedGeminiVideoAnalysisRolloutModel,
 ): {
   cachedInputUsdMicrosPerMillionTokens: bigint;
   effectiveFrom: string | null;
@@ -3215,8 +3228,7 @@ function resolveHostedAiUsageGeminiVideoPricing(
         HOSTED_AI_USAGE_ALLOWANCE_GEMINI_VIDEO_2027_INPUT_USD_MICROS_PER_MILLION_TOKENS,
       outputUsdMicrosPerMillionTokens:
         HOSTED_AI_USAGE_ALLOWANCE_GEMINI_VIDEO_2027_OUTPUT_USD_MICROS_PER_MILLION_TOKENS,
-      pricingVersion:
-        HOSTED_AI_USAGE_ALLOWANCE_GEMINI_VIDEO_2027_PRICING_VERSION,
+      pricingVersion: `${model}-video-pricing-from-2027-01-01`,
     };
   }
 
@@ -3229,8 +3241,7 @@ function resolveHostedAiUsageGeminiVideoPricing(
       HOSTED_AI_USAGE_ALLOWANCE_GEMINI_VIDEO_2026_INPUT_USD_MICROS_PER_MILLION_TOKENS,
     outputUsdMicrosPerMillionTokens:
       HOSTED_AI_USAGE_ALLOWANCE_GEMINI_VIDEO_2026_OUTPUT_USD_MICROS_PER_MILLION_TOKENS,
-    pricingVersion:
-      HOSTED_AI_USAGE_ALLOWANCE_GEMINI_VIDEO_2026_PRICING_VERSION,
+    pricingVersion: `${model}-video-pricing-through-2026-12-31`,
   };
 }
 

--- a/apps/web/test/hosted-execution-usage-allowance.test.ts
+++ b/apps/web/test/hosted-execution-usage-allowance.test.ts
@@ -1016,10 +1016,10 @@ describe("hosted AI usage allowance pricing", () => {
     });
   });
 
-  it("prices Gemini 3.7 Flash video analysis with thinking in the output bucket", () => {
+  it("prices Gemini 3.8 Flash video analysis with thinking in the output bucket", () => {
     const usage = buildHostedGeminiVideoAnalysisUsageRecord({
       memberId: "member_123",
-      model: "gemini-3.7-flash",
+      model: "gemini-3.8-flash",
       occurredAt: "2026-08-20T12:00:00.000Z",
       providerRequestId: "gemini_request_123",
       usage: {
@@ -1036,7 +1036,7 @@ describe("hosted AI usage allowance pricing", () => {
       counted: true,
       pricingSnapshot: {
         credentialSource: "platform",
-        model: "gemini-3.7-flash",
+        model: "gemini-3.8-flash",
         modelSource: "requested",
         pricingSource: "https://ai.google.dev/gemini-api/docs/pricing",
         pricingWindow: {
@@ -1048,7 +1048,7 @@ describe("hosted AI usage allowance pricing", () => {
           input: "750000",
           outputIncludingThinking: "3750000",
         },
-        requestedModel: "gemini-3.7-flash",
+        requestedModel: "gemini-3.8-flash",
         schema: "murph.hosted-ai-usage-allowance-pricing.v1",
         servedModel: null,
         standardCostUsdMicros: "620",
@@ -1068,7 +1068,7 @@ describe("hosted AI usage allowance pricing", () => {
         },
       },
       pricingVersion:
-        "gemini-3.7-flash-video-pricing-through-2026-12-31",
+        "gemini-3.8-flash-video-pricing-through-2026-12-31",
     });
 
     expect(priceHostedAiUsageForAllowance({
@@ -1087,14 +1087,38 @@ describe("hosted AI usage allowance pricing", () => {
           outputIncludingThinking: "7500000",
         },
       },
-      pricingVersion: "gemini-3.7-flash-video-pricing-from-2027-01-01",
+      pricingVersion: "gemini-3.8-flash-video-pricing-from-2027-01-01",
+    });
+
+    const previousModelUsage = buildHostedGeminiVideoAnalysisUsageRecord({
+      memberId: "member_123",
+      model: "gemini-3.7-flash",
+      occurredAt: "2026-08-20T12:00:00.000Z",
+      providerRequestId: "gemini_request_123",
+      usage: {
+        cachedContentTokenCount: 16,
+        candidatesTokenCount: 80,
+        promptTokenCount: 320,
+        thoughtsTokenCount: 24,
+        totalTokenCount: 424,
+      },
+    });
+
+    expect(priceHostedAiUsageForAllowance(previousModelUsage)).toMatchObject({
+      counted: true,
+      pricingSnapshot: {
+        model: "gemini-3.7-flash",
+        requestedModel: "gemini-3.7-flash",
+      },
+      pricingVersion:
+        "gemini-3.7-flash-video-pricing-through-2026-12-31",
     });
   });
 
   it("fails closed when Gemini video usage drifts from its Worker-authored shape", () => {
     const usage = buildHostedGeminiVideoAnalysisUsageRecord({
       memberId: "member_123",
-      model: "gemini-3.7-flash",
+      model: "gemini-3.8-flash",
       occurredAt: "2026-08-20T12:00:00.000Z",
       usage: {
         candidatesTokenCount: 80,
@@ -1153,7 +1177,7 @@ describe("hosted AI usage allowance pricing", () => {
   it("prices Gemini input-only usage when a blocked response omits candidates", () => {
     const usage = buildHostedGeminiVideoAnalysisUsageRecord({
       memberId: "member_123",
-      model: "gemini-3.7-flash",
+      model: "gemini-3.8-flash",
       occurredAt: "2026-08-20T12:00:00.000Z",
       usage: {
         promptTokenCount: 320,

--- a/packages/hosted-execution/src/assistant-capabilities.ts
+++ b/packages/hosted-execution/src/assistant-capabilities.ts
@@ -11,7 +11,16 @@ const HOSTED_ELEVENLABS_ENV = {
 export const HOSTED_GEMINI_VIDEO_ANALYSIS_API_KEY_ENV = "GEMINI_API_KEY";
 export const HOSTED_GEMINI_VIDEO_ANALYSIS_API_BASE_URL =
   "https://generativelanguage.googleapis.com";
-export const HOSTED_GEMINI_VIDEO_ANALYSIS_MODEL = "gemini-3.7-flash";
+export const HOSTED_GEMINI_VIDEO_ANALYSIS_MODEL = "gemini-3.8-flash";
+// Rollout-only reader for warm runners built before the 3.8 model upgrade.
+// Remove after the runner rollback floor and every warm container have advanced.
+export const HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL = "gemini-3.7-flash";
+export const HOSTED_GEMINI_VIDEO_ANALYSIS_ROLLOUT_MODELS = [
+  HOSTED_GEMINI_VIDEO_ANALYSIS_MODEL,
+  HOSTED_GEMINI_VIDEO_ANALYSIS_PREVIOUS_MODEL,
+] as const;
+export type HostedGeminiVideoAnalysisRolloutModel =
+  typeof HOSTED_GEMINI_VIDEO_ANALYSIS_ROLLOUT_MODELS[number];
 export const HOSTED_GEMINI_VIDEO_ANALYSIS_SAMPLING_MODES = [
   "standard",
   "detailed_motion",

--- a/packages/hosted-execution/test/assistant-usage.test.ts
+++ b/packages/hosted-execution/test/assistant-usage.test.ts
@@ -471,7 +471,7 @@ test("hosted ElevenLabs music usage retains the provider request start", () => {
 test("hosted Gemini video usage records preserve bounded token evidence", () => {
   const record = buildHostedGeminiVideoAnalysisUsageRecord({
     memberId: "member_123",
-    model: "gemini-3.7-flash",
+    model: "gemini-3.8-flash",
     occurredAt: PROVIDER_REQUEST_STARTED_AT,
     providerRequestId: "gemini_request_123",
     usage: {

--- a/scripts/check-provider-request-boundaries.test.ts
+++ b/scripts/check-provider-request-boundaries.test.ts
@@ -319,7 +319,7 @@ describe("check-provider-request-boundaries", () => {
     expect(violations(`
       async function executeAnalyzeVideoTool(fetchImpl: typeof fetch) {
         return fetchImpl(
-          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.7-flash:generateContent",
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.8-flash:generateContent",
           { method: "POST" },
         );
       }
@@ -328,7 +328,7 @@ describe("check-provider-request-boundaries", () => {
     expect(violations(`
       async function analyzeVideo(fetchImpl: typeof fetch) {
         return fetchImpl(
-          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.7-flash:generateContent",
+          "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.8-flash:generateContent",
           { method: "POST" },
         );
       }


### PR DESCRIPTION
## Why and outcome

Murph hosted video analysis was pinned to Gemini 3.7 Flash. This upgrades new requests to the stable Gemini 3.8 Flash model while preserving warm-runner compatibility and exact usage accounting during rollout.

## Product UX

- Effort: Patch
- Outcome: Existing video questions use the newer Flash model without changing who can analyze a video or how they ask.
- Reaches: Private-direct and authenticated Linq or Telegram group turns that invoke `murph.analyze_video`.
- Proof: Fixed request construction, dual-path Worker interception, usage pricing, and existing direct/group authority tests pass.
- Walkthrough: Ready. The supported member journeys and failure behavior are unchanged; only the bounded analysis model advances.
- Exclusions: No prompt, sampling mode, audience, permission, retry, timeout, or video-limit changes.

## Evidence

- 680 focused assertions pass across assistant request construction, hosted usage records, Worker egress/interception, runner-platform boundaries, Web pricing, and provider-boundary ownership.
- Typechecks pass for `packages/assistant-engine`, `packages/hosted-execution`, `apps/cloudflare`, and `apps/web`.
- The hosted-local workspace and runner bundle build passed. The full roundtrip scenario could not start because the local Docker daemon was unavailable; deploy smoke exhausted its retries and the scenario was skipped.
- No ambient non-production Gemini key was available, so a live vendor call was not attempted. The request contract matches the documented 3.8 migration requirements.
- `pnpm complexity:diff` and `git diff --check` pass.
- ReviewGPT audited the full substantive candidate for about 16 minutes and returned `ROUND_OUTCOME: PASS` with no qualifying findings; the final follow-up commit only archives the execution plan and records verification.

## Non-obvious affected surfaces

- Cloudflare provider egress now admits exactly the 3.8 path plus the deployed 3.7 rollout path, derives the usage model from that path, and keeps the deprecated capped body valid only for 3.7. Regression proof covers both paths and rejects mixed profiles.
- Web allowance pricing accepts exact 3.8 and rollout-era 3.7 usage so gradual deployment does not drop cost accounting. Regression proof covers both model-specific pricing versions.
- Live architecture, security, and deployment docs now describe consumer-first rollout and the actual best-effort usage callback behavior.

## Architecture and reuse

- Existing systems reused: The shared hosted capability contract, Worker egress interceptor, assistant usage-record builder, and Web allowance pricer remain the sole owners.
- New logic: One current/previous model tuple, exact path-to-model derivation, model-bound legacy body validation, and model-specific pricing labels.
- New abstractions: No new service, SDK, state owner, schema, or deployment mechanism; the tuple is a narrow rollout contract shared by existing owners.
- Complexity intentionally avoided: No configurable fallback, retry path, dual write, migration, or provider SDK was added; new runners write only 3.8.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` passes with no debt increase; Gemini egress maximum rises from 14 to 16 and stays below 20.
- Hotspots: Existing changed-file hotspots remain `maybeHandleOpenAiRequest` (34), `appendOpenAiInputShapeDiagnostics` (31), `emitHostedProviderEgressDiagnostic` (25), `maybeHandleVeniceRequest` (24), `matchHostedAiUsageGeminiVideoAnalysisRecord` (31), `resolveHostedAiUsageAllowancePricingDecision` (26), `ensureHostedAiUsageAllowancePeriodTx` (22), `matchHostedAiUsageRetellPhoneCallRecord` (22), and `matchHostedAiUsageXaiSearchRecord` (22). This patch adds no debt to them; the changed Gemini matcher retains explicit fail-closed shape checks.
- Agent judgment: Further simplification would either duplicate the trusted model or weaken exact rollout validation, so no additional behavior-preserving reduction is justified.

## Hot reply path impact

Applicable only when the existing `murph.analyze_video` tool runs during a foreground turn. The model ID changes on the existing Google request; no database, network, provider, or other awaited operation is added or moved. The branch remains at most one serial Gemini call, a 90-second timeout, no retry or fallback, and the same bounded tool-failure result. Focused request and Worker interception tests prove the before/after call shape.

## Murph initial provider input impact

- Individual runtime: Not applicable because no first provider-visible Murph or Codex input surface changed. The later tool-owned Gemini URL changes, while its system instruction, content body, tool schema, and generated guidance stay byte-identical.
- Group runtime: Not applicable for the same reason; group authority and the first assembled provider request are unchanged.
- Measurement: Path ownership and fixed-body regression tests; no measured-zero token claim is made because the initial-input surface is outside this diff.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: The only hosted Web presentation change in this PR is an independent changelog content item rendered by the unchanged production archive component.
- Coverage: Direct copy review and the focused changelog server-render test; no component, interaction, or responsive layout changes.

## Change-shape breakdown

Classification uses runtime TypeScript as source, `*.test.ts` plus the provider-boundary test as tests/fixtures, Markdown and the execution plan as docs, and no generated code. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 68 | 28 |
| Tests/fixtures | 77 | 19 |
| Docs | 164 | 42 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 309 | 89 |

## Deployment concerns

- Deployment: applicable
- Supported skew: New Web accepts 3.7 and 3.8 usage; the new Worker accepts old warm 3.7 runners and new 3.8 runners. The 3.8 writer requires the compatible Worker reader.
- Safe order: Deploy Web first, then deploy the Worker and runner bundle with the dual-path reader active before 3.8 requests can run.
- Rollback floor: Keep the 3.7 Web and Worker readers until all warm 3.7 runners have drained; do not remove the 3.8 reader while any 3.8 runner can remain active.
- Expected exposure: One gradual rollout window can contain both 3.7 and 3.8 warm runners; unsupported paths and body cross-products remain fail-closed.
- Reversibility: Roll the writer back to 3.7 and drain warm 3.8 runners before reverting the compatible Worker reader. The dual-model Web reader is safe to retain.
- Convergence proof: Focused interception and pricing tests cover old-runner/new-Worker and new-runner/new-Worker combinations; exact-head CI must pass before merge.
- Post-deploy checks: Run consented private and group video analyses for standard and detailed-motion sampling, then confirm one 3.8 request and one correctly labeled usage row per invocation.

## Changelog

- Changelog: updated
- Items: 2026-09-03 · video-analysis-gemini-3-8

## Risks

- Security and privacy: The existing exact host, method, path, JSON shape, MIME, size, timeout, redirect, and sentinel credential boundaries remain in force. No video, prompt, or secret logging is added.
- Billing: The model is derived from an exact admitted path and retained in the usage record and pricing version. Usage callback failure remains best-effort and can undercount allowance usage without changing response delivery.

ReviewGPT first-reviewed head: c873f513502be93c9387a01131f4eb2f0b503477

ReviewGPT context sensitivity: sensitive — this changes hosted external egress, usage pricing, and independently deployed Web/Worker/warm-runner compatibility.



