### PR TITLE
fix(runtime): release handled frontier from device retries

### DIFF
--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox-state.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox-state.ts
@@ -176,7 +176,12 @@ export function resolveHostedSystemMailboxProgress(input: {
   let earliestPendingSeq: bigint | null = null;
   const now = input.now ?? new Date().toISOString();
   for (const item of input.state.pending) {
-    if (isHostedDeviceSyncDenseRawRetentionMailboxItem(item)) {
+    // Retained device retries are local continuations of an already handled
+    // mailbox item, so they must not hold back canonical mailbox progress.
+    if (
+      isHostedDeviceSyncDenseRawRetentionMailboxItem(item)
+      || isHostedRetainedDeviceJobRetry(item)
+    ) {
       continue;
     }
     if (isExpiredHostedGroupContextHandoffSystemMailboxItem(item, now)) {
@@ -658,13 +663,19 @@ function isHostedFutureRetainedDeviceJobRetry(
   item: HostedSystemMailboxPendingItem,
   now: string,
 ): boolean {
+  return isHostedRetainedDeviceJobRetry(item)
+    && !systemMailboxItemIsDue(item, now);
+}
+
+function isHostedRetainedDeviceJobRetry(
+  item: HostedSystemMailboxPendingItem,
+): boolean {
   if (
     item.status !== "pending"
     || item.postCheckpointRecord !== null
     || item.nextAttemptAt === null
     || item.wake.kind !== "device-sync.wake"
     || !item.wake.connectionId
-    || systemMailboxItemIsDue(item, now)
   ) {
     return false;
   }

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-state.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-state.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import {
   buildHostedExecutionAssistantNotificationRequestedWake,
+  buildHostedExecutionDeviceSyncWake,
 } from "@murphai/hosted-execution";
 import { describe, expect, it } from "vitest";
 
@@ -329,6 +330,59 @@ describe("hosted runtime system mailbox state", () => {
     })).toEqual({
       firstPendingSeq: "4",
       handledThroughSeq: "3",
+    });
+  });
+
+  it("does not let a handled device item retained as a local retry pin the canonical prefix", () => {
+    const retryAt = "2026-04-28T00:00:00.000Z";
+    const base = buildPendingDeviceSyncMailboxItem({
+      itemId: "retained_device_retry",
+      mailboxLaneSeq: "4",
+    });
+    const retainedDeviceRetry: HostedSystemMailboxPendingItem = {
+      ...base,
+      attemptCount: 1,
+      lastAttemptAt: "2026-04-27T00:00:00.000Z",
+      nextAttemptAt: retryAt,
+      wake: buildHostedExecutionDeviceSyncWake({
+        connectionId: "dsc_retained_retry",
+        eventId: "device-sync.wake:retained_device_retry",
+        expectedConnectedAt: "2026-04-01T00:00:00.000Z",
+        hint: {
+          jobs: [{
+            availableAt: retryAt,
+            dedupeKey: "retained-weight-retry",
+            kind: "resource",
+            maxAttempts: 1,
+            payload: {},
+          }],
+        },
+        occurredAt: "2026-04-27T00:00:00.000Z",
+        provider: "junction",
+        reason: "reconcile_due",
+        userId: "member_123",
+      }),
+    };
+    const pendingSuccessor = buildPendingSystemMailboxItem({
+      itemId: "pending_successor",
+      mailboxLaneSeq: "9",
+    });
+
+    expect(resolveHostedSystemMailboxProgress({
+      importedSeq: "9",
+      now: "2026-04-27T00:00:00.000Z",
+      state: { pending: [retainedDeviceRetry, pendingSuccessor] },
+    })).toEqual({
+      firstPendingSeq: "9",
+      handledThroughSeq: "8",
+    });
+    expect(resolveHostedSystemMailboxProgress({
+      importedSeq: "9",
+      now: retryAt,
+      state: { pending: [retainedDeviceRetry] },
+    })).toEqual({
+      firstPendingSeq: null,
+      handledThroughSeq: "9",
     });
   });
 


### PR DESCRIPTION
## Outcome

Canonical system-mailbox progress no longer stays pinned behind a device-sync item that has already been handled and is retained only as a local retry timer. Real pending mailbox successors still bound the contiguous handled frontier.

## Product UX

- Effort: Patch
- Affected people: operators verifying a runtime recovery; existing members with recurring device-sync retries.
- Result: recovery status reflects canonical mailbox handling without changing device-sync execution, retries, or member data.

## Evidence

- The production-shaped regression reported handled-through 3 instead of 8 before the change and passes afterward, including when the local retry is due.
- `pnpm --dir packages/assistant-runtime exec vitest run test/hosted-runtime-mailbox-state.test.ts test/system-mailbox-state-delegated-direction.test.ts test/hosted-runtime-system-mailbox-notification.test.ts` — 94 tests passed.
- `pnpm --dir packages/assistant-runtime typecheck` — passed.
- `pnpm complexity:diff --base origin/main` — passed; debt and maximum complexity unchanged.
- `MURPH_CLOUDFLARE_VERIFY_SKIP_TYPECHECK=1 MURPH_VERIFY_STEP_PARALLEL=1 pnpm --dir apps/cloudflare verify` — passed: 155 files / 2,867 tests plus 6 built-worker tests.

## Non-obvious affected surfaces

- `hostedMailboxSystemHandledThroughSeq` and `hostedMailboxSystemFirstPendingSeq` now exclude only the existing structural shape for a successfully retained device job retry.
- Failed device retries, ordinary pending system items, unsequenced legacy work, and actual retry scheduling remain unchanged.
- Adjacent draft #2778 changes device-sync completion timing but is neither required nor modified here; this correction also covers retained state written by older runners.

## Architecture and reuse

- Existing systems reused: the canonical mailbox progress resolver and the existing retained-device-retry shape.
- New logic: retained local device retries no longer count as pending canonical mailbox rows.
- New abstractions: none; one existing predicate was split into stable identity and time-sensitive scheduling.
- Complexity intentionally avoided: no state, schema, queue, service, dependency, or new owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base origin/main` reports unchanged debt and maximum complexity.
- Hotspots: no new hotspot; the existing parser remains unchanged.
- Agent judgment: the predicate split is the smallest behavior-preserving shape and no further abstraction is justified.

## Hot reply path impact

None. This is background checkpoint metadata only.

## Murph initial provider input impact

None. No prompts, tools, schemas, or provider-visible input changed.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 13 | 2 |
| Tests/fixtures | 54 | 0 |
| Docs | 0 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 67 | 2 |

## Review findings

- Final ReviewGPT round 1: PASS with no qualifying findings.
- Non-blocking note: retired duplicate diagnostic counting may change after progress advances, but the retained retry and its wake remain durable and ReviewGPT found no material behavior impact. Rejected for remediation as disproportionate; no complexity added.

## Changelog

- Changelog: not applicable
- Reason: internal runtime progress accounting; no member-facing feature or promise changed.

## Deployment concerns

- Deployment: applicable
- Supported skew: old and new runners share the same persisted state and API; old warm runners may report the stale frontier until replaced.
- Safe order: deploy the Cloudflare hosted runtime normally after merge; no Web or Temporal tandem deploy is required.
- Rollback floor: unchanged persisted state and API shapes permit a normal runner rollback.
- Expected exposure: status-only; device execution and member data are unchanged.
- Reversibility: revert the runtime change and redeploy; no repair or migration is needed.
- Convergence proof: after replacement, a checkpoint derives progress from the retained local retry and real pending successors.
- Post-deploy checks: run one runtime recheck and confirm handled-through reaches imported while the next device reconciliation remains scheduled.

ReviewGPT context sensitivity: routine — one existing derived status calculation and a focused regression.


ReviewGPT first-reviewed head: 772f7dc6f155079f689b04b3a4e8ca36f6124e7e
