### PR TITLE
Retire biweekly product notes automation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -312,6 +312,14 @@ existing explicit `authenticated-group` owner scope; any feature-specific
 activity, evidence, identity, or participant policy must be designed with that
 feature rather than embedded in the generic ownership boundary.
 
+The removed biweekly product-notes automation follows the same permanent
+retirement contract. Its historical immutable ID is not a seed:
+reconciliation archives active or paused persisted copies, and a claimed
+occurrence fails closed before lifecycle or model work. Direct product-update
+questions remain supported through the ordinary conversation prompt and its
+canonical public changelog and feature-catalog feeds; retirement removes only
+the unsolicited recurring note.
+
 Web then captures the current roster and exact active grants, decrypts the
 bounded encrypted snapshots owned by those share rows, and returns every member
 with every requested scope as `not_granted`, `granted` plus `missing`, or

--- a/agent-docs/exec-plans/completed/2026-09-03-retire-biweekly-product-updates.md
+++ b/agent-docs/exec-plans/completed/2026-09-03-retire-biweekly-product-updates.md
@@ -1,0 +1,134 @@
+# Retire biweekly product updates automation
+
+Status: completed
+Created: 2026-09-03
+Updated: 2026-09-03
+
+## Goal
+
+- Stop Murph from creating or sending the built-in biweekly product-notes
+  automation while preserving the existing on-demand product-update answer.
+
+## Success criteria
+
+- The biweekly product-notes seed is absent from the managed automation
+  registry.
+- Reconciliation archives any persisted copy with the immutable historical id,
+  including paused copies, and a claimed occurrence fails closed before model
+  or delivery work.
+- Deterministic managed-automation coverage and one focused production-derived
+  real-Codex journey prove the retirement boundary.
+- The architecture contract and public changelog describe the shipped outcome.
+- Focused tests, assistant-engine typecheck, Web changelog proof, and Web
+  typecheck pass.
+
+## Scope
+
+- In scope: the built-in biweekly product-notes seed, its immutable retirement
+  tombstone, affected managed-automation tests, assistant live proof, owning
+  architecture text, and one public changelog item.
+- Out of scope: on-demand product-update guidance, feature-catalog and
+  changelog lookup tools, member-created automations, and other built-in
+  schedules.
+
+## Constraints
+
+- Technical constraints: keep the historical automation id stable; reuse the
+  existing retired-id reconciliation and claim fences; add no new state owner,
+  migration queue, or schedule mechanism.
+- Product/process constraints: use synthetic private-free evidence, preserve
+  direct-route authority for all remaining member automations, and follow the
+  assistant verification and changelog workflows.
+
+## Risks and mitigations
+
+1. Risk: removing only the seed leaves an existing member's persisted schedule
+   active.
+   Mitigation: move the immutable id to the permanent retirement set and prove
+   reconciliation archives both active and paused records.
+2. Risk: a previously claimed occurrence reaches the model or delivery after
+   retirement.
+   Mitigation: keep the id in the host-owned retired-id fence and assert the
+   occurrence fails closed before provider work.
+3. Risk: retiring product notes accidentally removes Murph's ability to answer
+   a direct question about recent changes.
+   Mitigation: leave the product-update guidance and lookup owners unchanged;
+   restrict source edits to the managed seed and retirement registry.
+
+## Tasks
+
+1. Inventory all production and test references to the product-notes managed
+   identity.
+2. Replace the current seed with a permanent retirement tombstone and update
+   the owning architecture contract.
+3. Replace active-schedule expectations with deterministic retirement
+   coverage, then add one focused production-derived real-Codex journey.
+4. Add a concise public changelog item and run its content-only proof.
+5. Run focused tests and typechecks, perform the Product UX walkthrough and
+   privacy/diff review, then complete the PR workflow.
+
+## Decisions
+
+- Product UX level: Product change. This removes an existing scheduled message
+  rather than creating a new audience or authority relationship.
+- Changelog: updated. Members can experience the absence of a recurring
+  product message, and the safe public outcome is useful to state.
+
+## Product UX plan
+
+- Outcome: members no longer receive unsolicited biweekly product notes from
+  Murph, while they can still ask what changed whenever they choose.
+- Entry and promise: reconciliation is the entry for existing and new member
+  vaults. Existing persisted copies are archived; new vaults receive no such
+  seed. There is no replacement message or delayed continuation.
+- Affected people: an existing member with an active or paused historical copy,
+  and a new member with no persisted copy. Both retain ordinary direct
+  conversation and all unrelated authorized automations.
+- Challenge: a seed-only deletion would fail existing members because their
+  stored automation could keep running. The permanent tombstone is therefore
+  required even though no new schedule is created.
+- Proof path: reconcile a synthetic vault containing active and paused copies,
+  verify both become archived, verify a retired claimed occurrence never enters
+  the provider path, and verify a fresh managed seed inventory omits the id.
+- UX finish: silence is the observable result; no new UI, fallback message, or
+  substitute nudge is introduced.
+- Done when: new and established members cannot receive this built-in recurring
+  note, existing copies close without manual repair, and direct product-update
+  questions remain outside the changed path.
+
+## Verification
+
+- Passed: `managed-automations-core.test.ts` (44 tests),
+  `managed-automations.test.ts` (57 tests), `assistant-cron-runtime.test.ts`
+  (216 tests), `assistant-product-feedback.test.ts` (14 tests),
+  `managed-automations-recovery-readiness.test.ts` (3 tests), and
+  `assistant-codex-scripted-runtime.test.ts` (111 tests).
+- Passed: the non-live `assistant-codex-real-e2e.test.ts` suite (25 tests, 187
+  gated journeys skipped) and assistant-engine typecheck.
+- Passed: `pnpm test:assistant:live -- --test "retired product notes leave
+  on-demand updates available"` with an authenticated alternate Codex home
+  after the default profile was quota-blocked before provider action. The one
+  provider request made one canonical changelog call and returned both requested
+  on-demand updates without recurring-note language.
+- Passed: `pnpm --dir apps/web test -- changelog-page.test.tsx` (9 tests) and
+  Web typecheck.
+- Post-plan PR gates: exact-head CI and the required final ReviewGPT review run
+  on the pushed candidate.
+
+## Product UX walkthrough
+
+- Existing active copy: normal reconciliation archives the exact historical
+  built-in ID without rewriting its route, cadence, instructions, or user-owned
+  records.
+- Existing paused copy: normal reconciliation archives it as well, so pausing
+  cannot preserve a future recurring send.
+- Claimed occurrence: the runtime returns `managed_automation_retired` before
+  lifecycle, provider, or delivery work.
+- New member: the active seed inventory omits the historical ID, so no new copy
+  is created.
+- Direct question: the real-Codex journey read the canonical changelog once and
+  answered the requested product-update question normally.
+- Differences from plan: none. No replacement message, new UI, or new state
+  owner was introduced.
+- Result: Ready.
+Completed: 2026-09-03

--- a/apps/web/changelog/entries/2026-09-03/product-updates-are-now-on-demand.json
+++ b/apps/web/changelog/entries/2026-09-03/product-updates-are-now-on-demand.json
@@ -1,0 +1,18 @@
+{
+  "publishedOn": "2026-09-03",
+  "order": 100,
+  "item": {
+    "id": "product-updates-are-now-on-demand",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Product updates are now on demand",
+    "summary": "Murph no longer sends recurring biweekly product notes. You can still ask what is new whenever you choose.",
+    "details": "Direct questions continue to use Murph's current changelog and feature catalog. Other reminders and health check-ins are unchanged.",
+    "relevanceTags": ["assistant", "automations", "product-updates"],
+    "sourcePullRequests": [2795],
+    "tryIt": {
+      "label": "Ask what is new",
+      "prompt": "What is new in Murph?"
+    }
+  }
+}

--- a/packages/assistant-engine/src/assistant/managed-automations.ts
+++ b/packages/assistant-engine/src/assistant/managed-automations.ts
@@ -163,9 +163,6 @@ export const MURPH_MONTHLY_IMPROVEMENT_COACH_AUTOMATION_ID =
   'automation_01K2WKKY3F8Q4R5S6T7V8W9XAB'
 export const MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID =
   'automation_01K0EXA5C0VT9F7X3KG6JMPZ5A'
-export const MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID =
-  'automation_01K0Z7X9Y8W6V5T4S3R2Q1P0NM'
-const MURPH_PRODUCT_NOTES_INTERVAL_MS = 14 * 24 * 60 * 60 * 1000
 export const MURPH_OVERNIGHT_MEMORY_CONSOLIDATION_AUTOMATION_ID =
   'automation_01K4Y0Q5C8M9N2P3R4S5T6V7WX'
 export const MURPH_OVERNIGHT_MEMORY_CONSOLIDATION_PRIVATE_SUMMARY =
@@ -176,11 +173,14 @@ export const MURPH_GROUP_ROOM_MODEL_CONSOLIDATION_PRIVATE_SUMMARY =
   'Group room model consolidation maintenance wake completed.'
 const MURPH_RETIRED_GROUP_SUNDAY_SUPERLATIVES_AUTOMATION_ID =
   'automation_01K55N7S9X4Q2M6P8R3T0V1WYZ'
+export const MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID =
+  'automation_01K0Z7X9Y8W6V5T4S3R2Q1P0NM'
 export const MURPH_AUTOMATIC_MEAL_CLOSEOUT_AUTOMATION_ID =
   'automation_01KZZM3A9C7P4R6T8V2W5X0YQZ'
 
 const MURPH_RETIRED_MANAGED_AUTOMATION_IDS = new Set<string>([
   MURPH_RETIRED_GROUP_SUNDAY_SUPERLATIVES_AUTOMATION_ID,
+  MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
 ])
 
 export function isRetiredMurphManagedAutomationId(
@@ -816,70 +816,6 @@ export const MURPH_MANAGED_AUTOMATIONS = [
       '- Put at most one practical next move in the prose. Prefer keep one variable stable, measure one thing, ignore a metric their own data shows is noisy for them, ask a clinician a better question, or avoid changing the plan based on weak/noisy evidence. Suggest adding behavior only when it passes the burden check.',
       '- Keep the message practical, calm, and non-alarmist.',
       '- Append one dated section to `weekly-health-research-scout` with source details, synthesis notes, candidate ranking notes, why the final insight was chosen, and why close alternatives were suppressed.',
-    ].join('\n'),
-  },
-  {
-    automationId: MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
-    slug: 'weekly-product-updates',
-    title: 'Murph product notes',
-    summary: 'A biweekly personalized note alternating what is new in Murph with things Murph can do for you.',
-    schedule: {
-      kind: 'every',
-      everyMs: MURPH_PRODUCT_NOTES_INTERVAL_MS,
-    },
-    continuityPolicy: 'fresh',
-    ownerScope: 'member',
-    assistantTargetOverride: {
-      reasoningEffort: 'high',
-    },
-    tags: [
-      'murph-managed:weekly-product-updates',
-    ],
-    instructions: [
-      'Goal: every two weeks, send one concise personalized in-chat product note. Each run is one of two kinds, alternating run to run: a changelog note with the 2-3 recently shipped Murph updates this user is most likely to find genuinely interesting, or a feature discovery note with the 2-3 things Murph can already do that this user has not tried and is most likely to value. Fallback is allowed at most once: attempt the initially chosen kind once; you may attempt the other kind once as the fallback; never fall back from a fallback. If both kinds are unavailable, invalid, empty, or below bar, return `{"kind":"skip","privateSummary":"No product note cleared the send bar."}`. A note with no substance is worse than no note.',
-      '',
-      "Decide this run's kind first:",
-      '- Read `vault-cli knowledge show murph-product-notes`. If the page is missing, treat that as no prior product notes and choose the feature discovery kind.',
-      '- Otherwise find the most recent dated section and choose the other kind: last recorded changelog means feature discovery now; last recorded feature discovery means changelog now.',
-      '- Use `murph-product-notes` as the only ledger for this automation. Do not create per-week pages and do not scan unrelated wiki pages.',
-      '',
-      'Changelog kind:',
-      `- Fetch the canonical JSON feed once from ${MURPH_PRODUCT_ORIGIN}/api/changelog?days=14&featureLimit=70&improvementLimit=10.`,
-      '- Treat that feed as the only source of shipped-product truth. Do not infer launches from repository history or invent availability, benefits, or try-it instructions.',
-      '- If the feed is unavailable, invalid, or empty, do not fabricate updates; fall back to the feature discovery kind.',
-      '- Treat this as a member-facing product update, not a dump of release notes. Keep an item when it introduces or materially changes a member-facing action, decision, or visible experience the member can use. Judge that by substance, not by feed kind or wording, so relevant improvements and capabilities described with phrases such as `can now` or `resume` stay eligible.',
-      '- Never pitch reliability work. Drop an item when it only restores or hardens otherwise unchanged behavior or reports internal durability, even if the feed lists it as a feature and even if this member hit that issue. Reliability is answered in conversation when a member raises it, not offered as product news.',
-      '- Treat settings, privacy, consent, connection-management, export, and other administrative controls as user-visible but lower priority than exciting capabilities unless they directly answer a known concern or unlock a current intention.',
-      '- Do not send a changelog note merely because the feed contains valid items. Prefer one genuinely interesting item over filler; if no changelog item clears, fall back to feature discovery, and if neither kind clears, skip.',
-      '- Choose 2-3 items using only context Murph already has for normal assistance: connected providers and channels, active experiments and automations, recurring request categories, and features the user already uses.',
-      '- Skip items already covered in a prior ledger section.',
-      '- Do not inspect raw health values solely to personalize product news, and do not open raw health records, uploaded documents, inbox attachments, provider payloads, transcripts, or raw notes solely to judge relevance.',
-      '- Prefer user-fit, practical benefit, editorial priority, and novelty. Do not pad with weak matches; one strong item beats stretching to fill 2-3 slots.',
-      '- Use the canonical title, summary, and tryIt fields from the feed, and verify each selected item has a concrete reason it may interest this user. Treat URL only as source metadata; never include it in the outbound note.',
-      '',
-      'Feature discovery kind:',
-      `- Fetch the canonical JSON catalog once from ${MURPH_PRODUCT_ORIGIN}/api/feature-catalog.`,
-      '- Treat that catalog as the only source of truth for what Murph can do. Do not invent capabilities, availability, or try-it instructions beyond it.',
-      '- If the catalog is unavailable or invalid, do not fabricate capabilities; fall back to the changelog kind.',
-      "- Drop items the user is already using. Each item's alreadyUsing field says what to check; judge it using only context Murph already has for normal assistance, and do not inspect raw health values solely to personalize suggestions. Judge alreadyUsing only from context already surfaced for ordinary assistance: connected providers and channels, active experiments and automations, group memberships, and recurring request categories. Do not open raw health records, uploaded documents, inbox attachments, provider payloads, transcripts, or raw notes solely to decide whether a feature was used.",
-      '- Require positive eligibility evidence: if the ordinary context does not establish that an alreadyUsing condition is false, drop the item instead of guessing. For `connect-wearables`, any active or reconnect-required wearable means the feature is already in use; if wearable connection status context is absent or unclear, drop it.',
-      '- Drop items already pitched in any prior ledger section; never repeat a feature pitch.',
-      '- Drop items this conversation cannot actually do right now: if the capability behind an item, such as phone calls, voice memos, songs, or a connected-app action, is not available as a tool in this runtime or supported on this channel, do not pitch it. When unsure, prefer items you are certain work here.',
-      "- If an item lists a requires prerequisite, check it from the same ordinary context. When the user clearly lacks the prerequisite, either skip the item or make the prerequisite an explicit, honest part of the pitch, such as connecting a wearable first.",
-      '- From the remainder pick the 2-3 items this user is most likely to genuinely value right now, judged by user-fit, practical benefit, and editorial priority. Each needs a concrete reason grounded in this user\'s context. One strong item beats padding.',
-      "- Frame each as something the user can try right now in this chat, weaving the item's tryIt prompt in naturally rather than quoting it mechanically.",
-      '',
-      'Both kinds:',
-      '- Before sending, append one dated section to the ledger with the locked append surface, for example: `vault-cli knowledge append-section murph-product-notes YYYY-MM-DD --title "Murph product notes" --body <markdown>`. The appended section body must record only this run\'s kind and the chosen item ids; do not include reasons, user context, health details, raw user wording, provider data, or copied catalog/changelog text.',
-      '- If `append-section` reports that the section already exists, another run already recorded today\'s note: read that section and, if its recorded kind and item ids still clear the current bar, compose and send a note for those exact items; otherwise return `{"kind":"skip","privateSummary":"No product note cleared the send bar."}`. Do not append again and do not switch kinds.',
-      '- Keep this scheduled note text-only. Do not create, attach, or send images or response media.',
-      '- The outbound note must be link-free. Never include URLs, Markdown links, bare domains, or link labels such as "read more".',
-      '- Use exactly one bullet per selected item. Each bullet must be one sentence and no more than 28 words after the bullet marker, including the title. State the benefit directly; omit optional color and repeated personalization, but preserve required prerequisites, availability limits, and approval or confirmation boundaries.',
-      '- Open every outbound note with one sentence of no more than 20 words before the first bullet. In Murph\'s first-person voice, explain that these occasional updates cover what is new or useful so the user can make use of it.',
-      '- Close with one invitation sentence of no more than 12 words.',
-      '- If sending nothing, return `{"kind":"skip","privateSummary":"No product note cleared the send bar."}` and do not append to the ledger.',
-      '',
-      'On a later user turn, call `murph.submit_product_feedback` for explicit product frustration, feature requests, interest in shipped changelog or catalog items, clear inferred workflow friction, or repeated Murph-observed product/tool friction. Start inferred summaries with `Speculative:` and assistant-observed summaries with `Murph-observed:`. Do not log vague low-confidence guesses. Use only structured kind, a concise product-only summary, and optional changelog item ids; do not include tags, topics, raw user wording, raw conversation text, health details, identifiers, contact details, secrets, or provider payloads.',
     ].join('\n'),
   },
   {

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -166,9 +166,9 @@ import {
   MURPH_MANAGED_AUTOMATIONS,
   MURPH_OVERNIGHT_MEMORY_CONSOLIDATION_AUTOMATION_ID,
   MURPH_OVERNIGHT_MEMORY_CONSOLIDATION_PRIVATE_SUMMARY,
+  MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID,
-  MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
 } from '../src/assistant/managed-automations.ts'
 import {
   MURPH_ONBOARDING_FOLLOWUP_AUTOMATION,
@@ -12716,35 +12716,27 @@ describeRealCodex('real Codex private group Journal capture e2e', () => {
   }, 720_000)
 })
 
-describeRealCodex('real Codex product notes eligibility e2e', () => {
+describeRealCodex('real Codex on-demand updates after product-note retirement e2e', () => {
   it(
-    'filters repair-only product notes without dropping member-facing changes',
+    'retired product notes leave on-demand updates available',
     async () => {
       const config = await resolveRealCodexE2eConfig()
-      const productNotes = MURPH_MANAGED_AUTOMATIONS.find(
+      expect(MURPH_MANAGED_AUTOMATIONS.some(
         (automation) =>
           automation.automationId
-          === MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
-      )
-      if (!productNotes) {
-        throw new Error('Expected the managed product-notes automation.')
-      }
+          === MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+      )).toBe(false)
       const workingDirectory = await mkdtemp(
-        path.join(tmpdir(), 'murph-product-notes-eligibility-e2e-'),
+        path.join(tmpdir(), 'murph-on-demand-product-updates-e2e-'),
       )
 
       try {
-        const appendCapturePath = path.join(
-          workingDirectory,
-          'product-notes-append.txt',
-        )
         const binDirectory = path.join(workingDirectory, 'bin')
         const curlCapturePath = path.join(
           workingDirectory,
-          'product-notes-curl.txt',
+          'product-updates-curl.txt',
         )
-        await materializeProductNotesFixtures({
-          appendCapturePath,
+        await materializeProductUpdatesFixture({
           binDirectory,
           curlCapturePath,
         })
@@ -12756,7 +12748,7 @@ describeRealCodex('real Codex product notes eligibility e2e', () => {
             normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
             ?? undefined,
           codexHome: config.codexHome,
-          developerInstructions: buildProductNotesDeveloperInstructions(),
+          developerInstructions: buildDirectConversationDeveloperInstructions(),
           dynamicTools: [],
           env: {
             ...config.env,
@@ -12766,15 +12758,11 @@ describeRealCodex('real Codex product notes eligibility e2e', () => {
           model: config.model,
           modelProvider: config.modelProvider,
           prompt: [
-            productNotes.instructions,
-            'Scheduled occurrence context:',
-            '- Current local date: 2026-08-19.',
-            '- The member regularly reviews scheduled reminders and has an active workout they use from Messages.',
-            '- A past connected-health sync delayed one reminder.',
-            '- The controlled canonical ledger and changelog feed are available through the normal vault-cli and curl commands.',
-            '- Complete the normal selection, ledger append, and terminal scheduled decision.',
-          ].join('\n\n'),
-          reasoningEffort: 'high',
+            'What is new in Murph?',
+            'Check the canonical product feed and briefly name the recent automation-recipient and workout-resume updates.',
+            'The controlled canonical feed is available through the normal curl command.',
+          ].join('\n'),
+          reasoningEffort: 'low',
           sandbox: 'workspace-write',
           workingDirectory,
         })
@@ -12784,27 +12772,17 @@ describeRealCodex('real Codex product notes eligibility e2e', () => {
           .split('\n')
         expect(curlCalls).toHaveLength(1)
         expect(curlCalls[0]).toContain(
-          '/api/changelog?days=14&featureLimit=70&improvementLimit=10',
+          '/api/changelog?days=14',
         )
-
-        const appendArguments = await readFile(appendCapturePath, 'utf8')
-        expect(appendArguments).toContain('clearer-automation-recipients')
-        expect(appendArguments).toContain('resume-workouts-in-messages')
-        expect(appendArguments).not.toContain(
-          'scheduled-support-resumes-after-syncs',
+        process.stdout.write(
+          `[real-codex] retired product notes keep on-demand updates: ${JSON.stringify({
+            curlCalls,
+            finalMessage: result.finalMessage,
+          })}\n`,
         )
-
-        const decision = parseAssistantNotificationDecision(
-          result.finalMessage,
-        )
-        expect(decision.kind).toBe('send_message')
-        if (decision.kind === 'send_message') {
-          expect(decision.text).toMatch(/automation/iu)
-          expect(decision.text).toMatch(/resume|workout/iu)
-          expect(decision.text).not.toMatch(
-            /health-data maintenance|reliability|scheduled support resumes/iu,
-          )
-        }
+        expect(result.finalMessage).toMatch(/automation/iu)
+        expect(result.finalMessage).toMatch(/resume|workout/iu)
+        expect(result.finalMessage).not.toMatch(/biweekly|scheduled product note/iu)
       } finally {
         await removeRealCodexTemporaryPaths([
           workingDirectory,
@@ -18216,80 +18194,6 @@ describeRealCodex('real Codex product-feedback summary e2e', () => {
           }
         }
 
-        const managedAutomation = MURPH_MANAGED_AUTOMATIONS.find(
-          (automation) =>
-            automation.automationId
-            === MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
-        )
-        if (!managedAutomation) {
-          throw new Error('Expected the managed product-notes automation.')
-        }
-        const managedWorkingDirectory = await mkdtemp(
-          path.join(tmpdir(), 'murph-product-feedback-managed-e2e-'),
-        )
-        try {
-          const first = await executeRealCodexAppServerTurn({
-            ...commonInput,
-            productFeedbackRecorder: createRealCodexFeedbackRecorder(),
-            prompt: [
-              'This is a deterministic context-loading probe.',
-              'Do not execute the scheduled instructions or call tools; reply exactly PRODUCT_NOTES_CONTEXT_READY.',
-              'The managed product-notes instructions that precede a later member turn are:',
-              managedAutomation.instructions,
-            ].join('\n\n'),
-            workingDirectory: managedWorkingDirectory,
-          })
-          expect(first.finalMessage).toContain('PRODUCT_NOTES_CONTEXT_READY')
-          expect(
-            readCapabilityRoutingActions(first.jsonEvents).filter(
-              (action) =>
-                action.kind === 'dynamic'
-                && action.tool === MURPH_SUBMIT_PRODUCT_FEEDBACK_TOOL.name,
-            ),
-          ).toHaveLength(0)
-
-          const second = await executeRealCodexAppServerTurn({
-            ...commonInput,
-            productFeedbackRecorder: createRealCodexFeedbackRecorder(),
-            prompt: [
-              'Treat this synthetic later-turn report as explicit Murph product frustration and use the product-feedback tool.',
-              'A member expected Murph product notes to show two recent changelog updates, but the note was skipped after the feature catalog failed.',
-              'The source establishes that the changelog fetch succeeded.',
-            ].join(' '),
-            resumeSessionId: first.sessionId,
-            workingDirectory: managedWorkingDirectory,
-          })
-          const managedFeedbackCalls = readCapabilityRoutingActions(
-            second.jsonEvents,
-          ).filter(
-            (action) =>
-              action.kind === 'dynamic'
-              && action.tool === MURPH_SUBMIT_PRODUCT_FEEDBACK_TOOL.name,
-          )
-          expect(managedFeedbackCalls).toHaveLength(1)
-          const managedFeedbackCall = managedFeedbackCalls[0]
-          if (managedFeedbackCall?.kind !== 'dynamic') {
-            throw new Error(
-              'Expected one managed product-feedback dynamic tool call.',
-            )
-          }
-          const managedSummary = readString(
-            managedFeedbackCall.argumentsValue.summary,
-          )
-          expect(managedSummary).not.toBeNull()
-          expect(managedSummary?.length).toBeLessThanOrEqual(
-            PRODUCT_FEEDBACK_SUMMARY_MAX_LENGTH,
-          )
-          expect(managedSummary).toMatch(/\b(?:member|user)\b/iu)
-          expect(managedSummary).toMatch(/\bproduct[- ]notes?\b/iu)
-          expect(managedSummary).toMatch(/\b(?:expect|wanted|should)\w*\b/iu)
-          expect(managedSummary).toMatch(/\bskip/iu)
-          expect(managedSummary).toMatch(
-            /\b(?:changelog.*succeed|success\w*.*changelog)\w*\b/iu,
-          )
-        } finally {
-          await removeRealCodexTemporaryPaths([managedWorkingDirectory])
-        }
       } finally {
         await removeRealCodexTemporaryPaths(config.temporaryPaths)
       }
@@ -29367,8 +29271,7 @@ async function materializeWeeklyHealthInsightVaultCli(input: {
   await chmod(executablePath, 0o700)
 }
 
-async function materializeProductNotesFixtures(input: {
-  appendCapturePath: string
+async function materializeProductUpdatesFixture(input: {
   binDirectory: string
   curlCapturePath: string
 }): Promise<void> {
@@ -29452,12 +29355,12 @@ async function materializeProductNotesFixtures(input: {
     [
       '#!/bin/sh',
       'case "$*" in',
-      '  *"/api/changelog?days=14&featureLimit=70&improvementLimit=10"*)',
+      '  *"/api/changelog?days=14"*)',
       `    printf '%s\\n' "$*" >> '${input.curlCapturePath}'`,
       `    printf '%s\\n' '${feed}'`,
       '    ;;',
       '  *)',
-      '    printf \'%s\\n\' \'unexpected product-notes URL\' >&2',
+      '    printf \'%s\\n\' \'unexpected product-updates URL\' >&2',
       '    exit 69',
       '    ;;',
       'esac',
@@ -29466,30 +29369,6 @@ async function materializeProductNotesFixtures(input: {
     { encoding: 'utf8', mode: 0o700 },
   )
   await chmod(curlPath, 0o700)
-
-  const vaultCliPath = path.join(input.binDirectory, 'vault-cli')
-  await writeFile(
-    vaultCliPath,
-    [
-      '#!/bin/sh',
-      'case "$*" in',
-      '  *"knowledge show murph-product-notes"*)',
-      '    printf \'%s\\n\' \'# Murph product notes\' \'\' \'## 2026-08-05 — Murph product notes\' \'Kind: feature discovery\' \'Item ids: earlier-feature\'',
-      '    ;;',
-      '  *"knowledge append-section murph-product-notes"*)',
-      `    printf '%s\\n' "$*" > '${input.appendCapturePath}'`,
-      '    printf \'%s\\n\' \'{"ok":true,"status":"appended"}\'',
-      '    ;;',
-      '  *)',
-      '    printf \'%s\\n\' \'unexpected product-notes vault command\' >&2',
-      '    exit 69',
-      '    ;;',
-      'esac',
-      '',
-    ].join('\n'),
-    { encoding: 'utf8', mode: 0o700 },
-  )
-  await chmod(vaultCliPath, 0o700)
 }
 
 async function buildWearableArrivalPrompt(input: {
@@ -31199,29 +31078,6 @@ function buildAutomaticMealCloseoutDeveloperInstructions(input: {
     onboardingGuidance: false,
     scheduledOccurrenceAt:
       input.scheduledOccurrenceAt ?? '2026-08-25T01:00:00.000Z',
-    turnTrigger: 'automation-cron',
-  })
-}
-
-function buildProductNotesDeveloperInstructions(): string {
-  return buildAssistantSystemPrompt({
-    assistantCliContract: null,
-    assistantContextSnapshotPrompt: null,
-    assistantHostedDeviceConnectAvailable: false,
-    assistantHostedDeviceConnectProviders: [],
-    assistantKnowledgeToolsAvailable: false,
-    channel: 'linq',
-    cliAccess: {
-      rawCommand: 'vault-cli',
-      setupCommand: 'murph',
-    },
-    conversationScope: 'direct',
-    currentLocalDate: '2026-08-19',
-    currentTimeZone: 'America/New_York',
-    hostedRuntime: true,
-    modelBehaviorProfile: 'gpt5-agentic',
-    onboardingGuidance: false,
-    scheduledOccurrenceAt: '2026-08-19T14:00:00.000Z',
     turnTrigger: 'automation-cron',
   })
 }

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -250,7 +250,7 @@ import {
   MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID,
-  MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+  MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
 } from '../src/assistant/managed-automations.ts'
 import type { AssistantRunEvent } from '../src/assistant/automation/shared.ts'
 import { resolveAssistantStatePaths } from '../src/assistant/store/paths.ts'
@@ -9727,7 +9727,7 @@ describe('assistant cron runtime orchestration', () => {
   })
 
   it.each([
-    ['static', MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID],
+    ['static', MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID],
     ['dynamic onboarding', MURPH_ONBOARDING_GOAL_CHECKIN_AUTOMATION_ID],
   ] as const)(
     'skips a %s member managed automation on a group route before lifecycle or model work',
@@ -9832,9 +9832,9 @@ describe('assistant cron runtime orchestration', () => {
   })
 
   it.each([
-    ['static group from an unspecified route', MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID, undefined, 'mismatch'],
-    ['static group from a direct route', MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID, true, 'mismatch'],
-    ['static direct chat from an unspecified route', MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID, undefined, 'direct'],
+    ['static group from an unspecified route', MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID, undefined, 'mismatch'],
+    ['static group from a direct route', MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID, true, 'mismatch'],
+    ['static direct chat from an unspecified route', MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID, undefined, 'direct'],
     ['dynamic onboarding direct chat from an old route', MURPH_ONBOARDING_GOAL_CHECKIN_AUTOMATION_ID, true, 'direct'],
   ] as const)(
     'enforces a member managed automation when live Linq authority resolves a %s',
@@ -9858,7 +9858,7 @@ describe('assistant cron runtime orchestration', () => {
             ? 'preserve'
             : 'fresh',
         createdAt: '2026-04-12T16:00:00.000Z',
-        instructions: 'Send product notes.',
+        instructions: 'Send the weekly health digest.',
         route: {
           channel: 'linq',
           deliverySource: null,
@@ -9871,11 +9871,11 @@ describe('assistant cron runtime orchestration', () => {
             : { threadIsDirect: savedThreadIsDirect }),
         },
         schedule: { at: '2026-04-12T18:00:00.000Z', kind: 'at' },
-        slug: 'weekly-product-updates',
+        slug: 'weekly-health-digest',
         status: 'active',
         summary: null,
         tags: ['assistant', 'scheduled', 'murph-managed'],
-        title: 'Murph product notes',
+        title: 'Weekly health digest',
         updatedAt: '2026-04-12T16:00:00.000Z',
       })
       const resolveScheduledLinqRoute = liveAuthority === 'mismatch'
@@ -9955,10 +9955,10 @@ describe('assistant cron runtime orchestration', () => {
       'assistant-cron-runtime-member-owner-live-route-change-',
     )
     getVaultAutomationStore(vaultRoot).push({
-      automationId: MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+      automationId: MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
       continuityPolicy: 'fresh',
       createdAt: '2026-04-12T16:00:00.000Z',
-      instructions: 'Send product notes.',
+      instructions: 'Send the weekly health digest.',
       route: {
         channel: 'linq',
         deliverySource: null,
@@ -9969,11 +9969,11 @@ describe('assistant cron runtime orchestration', () => {
         threadIsDirect: true,
       },
       schedule: { at: '2026-04-12T18:00:00.000Z', kind: 'at' },
-      slug: 'weekly-product-updates',
+      slug: 'weekly-health-digest',
       status: 'active',
       summary: null,
       tags: ['assistant', 'scheduled', 'murph-managed'],
-      title: 'Murph product notes',
+      title: 'Weekly health digest',
       updatedAt: '2026-04-12T16:00:00.000Z',
     })
     const resolveScheduledLinqRoute = vi.fn()
@@ -10037,7 +10037,7 @@ describe('assistant cron runtime orchestration', () => {
     const runtimeStore = await readAssistantCronCanonicalRuntimeStore(paths)
     const runtimeRecord = runtimeStore.jobs.find(
       (record) =>
-        record.jobId === MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+        record.jobId === MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
     )
     expect(runtimeRecord?.state.pendingOccurrenceAt ?? null).toBeNull()
     expect(runtimeRecord?.state.retryAfterAt ?? null).toBeNull()
@@ -10120,6 +10120,55 @@ describe('assistant cron runtime orchestration', () => {
     const result = await executeClaimedAssistantCronJob({
       executionContext: {
         hosted: { memberId: 'retired-group-runtime', userEnvKeys: [] },
+      },
+      job: claimed,
+      paths,
+      trigger: 'scheduled',
+      vault: vaultRoot,
+    })
+
+    expect(result.run).toMatchObject({
+      outcome: 'skipped_gate',
+      reason: 'managed_automation_retired',
+      status: 'skipped',
+    })
+    expect(cronMocks.runExperimentLifecycleOutcomePrecondition).not.toHaveBeenCalled()
+    expect(cronMocks.sendAssistantMessageLocal).not.toHaveBeenCalled()
+  })
+
+  it('skips a persisted product-notes occurrence after the seed is retired', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-03T18:10:00.000Z'))
+    const { vaultRoot } = await createRuntimeContext(
+      'assistant-cron-runtime-retired-product-notes-',
+    )
+    getVaultAutomationStore(vaultRoot).push({
+      automationId: MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+      continuityPolicy: 'fresh',
+      createdAt: '2026-09-03T16:00:00.000Z',
+      instructions: 'Legacy biweekly product-note instructions.',
+      route: {
+        channel: 'linq',
+        deliverySource: null,
+        deliveryTarget: 'legacy-member-chat',
+        identityId: null,
+        participantId: null,
+        threadId: 'legacy-member-chat',
+        threadIsDirect: true,
+      },
+      schedule: { at: '2026-09-03T18:00:00.000Z', kind: 'at' },
+      slug: 'weekly-product-updates',
+      status: 'active',
+      summary: null,
+      tags: ['assistant', 'scheduled', 'murph-managed'],
+      title: 'Murph product notes',
+      updatedAt: '2026-09-03T16:00:00.000Z',
+    })
+    const { claimed, paths } = await claimFirstCanonicalCronJob(vaultRoot)
+
+    const result = await executeClaimedAssistantCronJob({
+      executionContext: {
+        hosted: { memberId: 'retired-product-notes-runtime', userEnvKeys: [] },
       },
       job: claimed,
       paths,

--- a/packages/assistant-engine/test/assistant-product-feedback.test.ts
+++ b/packages/assistant-engine/test/assistant-product-feedback.test.ts
@@ -15,10 +15,6 @@ import {
   resolveAssistantProductFeedbackAcceptedInputIds,
 } from "../src/assistant/turn-progress.js";
 import {
-  MURPH_MANAGED_AUTOMATIONS,
-  MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
-} from "../src/assistant/managed-automations.js";
-import {
   buildAssistantSystemPrompt,
 } from "../src/assistant/system-prompt.js";
 
@@ -212,11 +208,6 @@ describe("assistant product feedback", () => {
       onboardingGuidance: false,
       turnTrigger: null,
     });
-    const productNotes = MURPH_MANAGED_AUTOMATIONS.find(
-      (automation) =>
-        automation.automationId === MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
-    );
-    expect(productNotes).toBeDefined();
     expect(systemPrompt).toContain(
       "append a privacy-safe `Reproduction:` section in that same summary field",
     );
@@ -225,11 +216,8 @@ describe("assistant product feedback", () => {
       MURPH_SUBMIT_PRODUCT_FEEDBACK_TOOL.inputSchema,
     );
     const ordinaryStack = `${systemPrompt}\n${toolSchema}`;
-    const managedStack =
-      `${systemPrompt}\n${productNotes?.instructions ?? ""}\n${toolSchema}`;
 
     expect(ordinaryStack.split(rubricMarker)).toHaveLength(2);
-    expect(managedStack.split(rubricMarker)).toHaveLength(2);
   });
 
   it("parses and collects one explicit feedback candidate without a pre-reply write", async () => {

--- a/packages/assistant-engine/test/managed-automations-core.test.ts
+++ b/packages/assistant-engine/test/managed-automations-core.test.ts
@@ -24,8 +24,8 @@ import {
   MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID,
   MURPH_MONTHLY_IMPROVEMENT_COACH_AUTOMATION_ID,
+  MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID,
-  MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
   applyMurphManagedAutomations,
   ensureAutomaticMealCloseoutAutomation,
   type MurphManagedAutomationDiagnosticStage,
@@ -134,15 +134,6 @@ function expectCronSchedule(
   schedule: NonNullable<Awaited<ReturnType<typeof showAutomation>>>['schedule'] | undefined,
 ): void {
   expect(schedule?.kind).toBe('cron')
-}
-
-function expectEveryTwoWeeksSchedule(
-  schedule: NonNullable<Awaited<ReturnType<typeof showAutomation>>>['schedule'] | undefined,
-): void {
-  expect(schedule).toEqual({
-    kind: 'every',
-    everyMs: 14 * 24 * 60 * 60 * 1000,
-  })
 }
 
 const legacyOnboardingFollowupInstructions = [
@@ -455,7 +446,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       vaultRoot,
     })
 
-    expect(result.created).toBe(6)
+    expect(result.created).toBe(5)
     expect(result.experimentLifecycleFailure).toMatchObject({
       code: 'EXPERIMENT_STORAGE_INVALID',
     })
@@ -505,7 +496,7 @@ describe('applyMurphManagedAutomations core integration', () => {
     expect(result.experimentLifecycleFailure).toMatchObject({
       code: 'EXPERIMENT_STORAGE_INVALID',
     })
-    expect(result.created).toBe(6)
+    expect(result.created).toBe(5)
     expect(
       await showAutomation({ automationId: experimentAutomationId, vaultRoot }),
     ).toMatchObject({ status: 'active' })
@@ -524,7 +515,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       vaultRoot,
     })
     expect(result).toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -532,8 +523,8 @@ describe('applyMurphManagedAutomations core integration', () => {
       { stage: 'experiment_lifecycle' },
       { stage: 'onboarding_goal_checkin' },
       { stage: 'seed_composition' },
-      ...Array.from({ length: 6 }, (_value, seedIndex) => ({
-        seedCount: 6,
+      ...Array.from({ length: 5 }, (_value, seedIndex) => ({
+        seedCount: 5,
         seedPosition: seedIndex + 1,
         stage: 'managed_seed' as const,
       })),
@@ -848,114 +839,10 @@ describe('applyMurphManagedAutomations core integration', () => {
     expect(researchScoutRecord?.instructions).toContain('Skipping is the expected outcome')
     expect(researchScoutRecord?.instructions).toContain('Do not reuse the provider candidate\'s `actionOrQuestion` as advice')
 
-    const productUpdatesRecord = await showAutomation({
-      automationId: MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+    await expect(showAutomation({
+      automationId: MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
       vaultRoot,
-    })
-
-    expect(productUpdatesRecord).toMatchObject({
-      automationId: MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
-      route: defaultRoute,
-      slug: 'weekly-product-updates',
-      status: 'active',
-      summary: 'A biweekly personalized note alternating what is new in Murph with things Murph can do for you.',
-      title: 'Murph product notes',
-    })
-    expectEveryTwoWeeksSchedule(productUpdatesRecord?.schedule)
-    expect(productUpdatesRecord?.instructions).toContain('Goal: every two weeks')
-    expect(productUpdatesRecord?.assistantTargetOverride).toEqual({
-      reasoningEffort: 'high',
-    })
-    expect(productUpdatesRecord?.tags).toContain('murph-managed:weekly-product-updates')
-    expect(productUpdatesRecord?.tags).not.toContain(ASSISTANT_REQUIRE_SEND_AUTOMATION_TAG)
-    expect(productUpdatesRecord?.instructions).toContain('/api/changelog?days=14&featureLimit=70&improvementLimit=10')
-    expect(productUpdatesRecord?.instructions).toContain('/api/feature-catalog')
-    expect(productUpdatesRecord?.instructions).toContain('Read `vault-cli knowledge show murph-product-notes`')
-    expect(productUpdatesRecord?.instructions).toContain('choose the feature discovery kind')
-    expect(productUpdatesRecord?.instructions).toContain('last recorded changelog means feature discovery now')
-    expect(productUpdatesRecord?.instructions).toContain('last recorded feature discovery means changelog now')
-    expect(productUpdatesRecord?.instructions).toContain('Use `murph-product-notes` as the only ledger')
-    expect(productUpdatesRecord?.instructions).toContain('Do not create per-week pages')
-    expect(productUpdatesRecord?.instructions).toContain('vault-cli knowledge append-section murph-product-notes YYYY-MM-DD')
-    expect(productUpdatesRecord?.instructions).toContain('Fallback is allowed at most once')
-    expect(productUpdatesRecord?.instructions).toContain('never fall back from a fallback')
-    expect(productUpdatesRecord?.instructions).toContain('If both kinds are unavailable, invalid, empty, or below bar')
-    expect(productUpdatesRecord?.instructions).toContain('record only this run\'s kind and the chosen item ids')
-    expect(productUpdatesRecord?.instructions).toContain('do not include reasons, user context, health details, raw user wording, provider data, or copied catalog/changelog text')
-    expect(productUpdatesRecord?.instructions).toContain('another run already recorded today\'s note')
-    expect(productUpdatesRecord?.instructions).toContain('Do not append again and do not switch kinds')
-    expect(productUpdatesRecord?.instructions).toContain('2-3 recently shipped Murph updates')
-    expect(productUpdatesRecord?.instructions).toContain('2-3 things Murph can already do')
-    expect(productUpdatesRecord?.instructions).toContain('Do not pad with weak matches')
-    expect(productUpdatesRecord?.instructions).toContain(
-      'member-facing product update, not a dump of release notes',
-    )
-    expect(productUpdatesRecord?.instructions).toContain(
-      'introduces or materially changes a member-facing action, decision, or visible experience',
-    )
-    expect(productUpdatesRecord?.instructions).toContain(
-      'Never pitch reliability work.',
-    )
-    expect(productUpdatesRecord?.instructions).toContain(
-      'only restores or hardens otherwise unchanged behavior or reports internal durability',
-    )
-    expect(productUpdatesRecord?.instructions).not.toContain(
-      'member encountered the corresponding issue',
-    )
-    expect(productUpdatesRecord?.instructions).toContain(
-      'lower priority than exciting capabilities',
-    )
-    expect(productUpdatesRecord?.instructions).toContain(
-      'if neither kind clears, skip',
-    )
-    expect(productUpdatesRecord?.instructions).toContain('Drop items the user is already using')
-    expect(productUpdatesRecord?.instructions).toContain('context already surfaced for ordinary assistance')
-    expect(productUpdatesRecord?.instructions).toContain('Do not open raw health records, uploaded documents, inbox attachments, provider payloads, transcripts, or raw notes solely to decide whether a feature was used')
-    expect(productUpdatesRecord?.instructions).toContain('Drop items already pitched in any prior ledger section; never repeat a feature pitch')
-    expect(productUpdatesRecord?.instructions).toContain('If an item lists a requires prerequisite')
-    expect(productUpdatesRecord?.instructions).toContain('Drop items this conversation cannot actually do right now')
-    expect(productUpdatesRecord?.instructions).toContain('Keep this scheduled note text-only')
-    expect(productUpdatesRecord?.instructions).toContain(
-      'The outbound note must be link-free',
-    )
-    expect(productUpdatesRecord?.instructions).toContain(
-      'no more than 28 words after the bullet marker',
-    )
-    expect(productUpdatesRecord?.instructions).toContain(
-      'preserve required prerequisites, availability limits, and approval or confirmation boundaries',
-    )
-    expect(productUpdatesRecord?.instructions).toContain(
-      'Open every outbound note with one sentence of no more than 20 words before the first bullet',
-    )
-    expect(productUpdatesRecord?.instructions).toContain(
-      "In Murph's first-person voice",
-    )
-    expect(productUpdatesRecord?.instructions).not.toContain(
-      'If the ledger page was missing before this run',
-    )
-    expect(productUpdatesRecord?.instructions).toContain(
-      'Close with one invitation sentence of no more than 12 words',
-    )
-    expect(productUpdatesRecord?.instructions).not.toContain(
-      'canonical title, summary, URL, and tryIt fields',
-    )
-    expect(productUpdatesRecord?.instructions).not.toContain('Choose 3-7 items')
-    expect(productUpdatesRecord?.instructions).not.toContain('murph.attach_response_media')
-    expect(productUpdatesRecord?.instructions).not.toContain('visual digest')
-    expect(productUpdatesRecord?.instructions).not.toContain('links.digestCardTemplate')
-    expect(productUpdatesRecord?.instructions).toContain('murph.submit_product_feedback')
-    expect(productUpdatesRecord?.instructions).toContain('clear inferred workflow friction')
-    expect(productUpdatesRecord?.instructions).toContain('interest in shipped changelog or catalog items')
-    expect(productUpdatesRecord?.instructions).toContain('Speculative:')
-    expect(productUpdatesRecord?.instructions).toContain('Murph-observed:')
-    expect(productUpdatesRecord?.instructions).toContain('Do not log vague low-confidence guesses')
-    expect(productUpdatesRecord?.instructions).toContain('concise product-only summary')
-    expect(productUpdatesRecord?.instructions).toContain('tags, topics, raw user wording')
-    expect(productUpdatesRecord?.instructions).not.toContain('kind/topic')
-    expect(productUpdatesRecord?.instructions).toContain(
-      '{"kind":"skip","privateSummary":"No product note cleared the send bar."}',
-    )
-    expect(productUpdatesRecord?.instructions).not.toContain('finish_without_reply')
+    })).resolves.toBeNull()
     await expect(showAutomation({
       automationId: MURPH_OVERNIGHT_MEMORY_CONSOLIDATION_AUTOMATION_ID,
       vaultRoot,
@@ -1340,7 +1227,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       },
       vaultRoot,
     })).resolves.toEqual({
-      created: 9,
+      created: 8,
       skipped: 0,
       updated: 0,
     })
@@ -1409,7 +1296,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       routeValidationProfile: 'hosted',
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -1449,7 +1336,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-09T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -1486,7 +1373,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       vaultRoot,
     })).resolves.toEqual({
       created: 0,
-      skipped: 6,
+      skipped: 5,
       updated: 0,
     })
 
@@ -1518,7 +1405,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       vaultRoot,
     })).resolves.toEqual({
       created: 0,
-      skipped: 6,
+      skipped: 5,
       updated: 0,
     })
   })
@@ -1531,7 +1418,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -1577,7 +1464,7 @@ describe('applyMurphManagedAutomations core integration', () => {
         now: new Date('2026-06-23T13:00:00.000Z'),
         vaultRoot,
       })).resolves.toEqual({
-        created: 6,
+      created: 5,
         skipped: 0,
         updated: 1,
       })
@@ -1639,7 +1526,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       },
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 1,
     })
@@ -1707,7 +1594,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-23T13:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -1860,7 +1747,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       },
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 1,
     })
@@ -1927,7 +1814,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-23T13:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 1,
     })
@@ -1977,7 +1864,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-23T13:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -2031,7 +1918,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-23T13:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -2076,7 +1963,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-23T13:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 7,
+      created: 6,
       skipped: 0,
       updated: 1,
     })
@@ -2152,7 +2039,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-23T13:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 1,
     })
@@ -2274,7 +2161,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-09T13:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 5,
+      created: 4,
       skipped: 0,
       updated: 1,
     })
@@ -2301,11 +2188,11 @@ describe('applyMurphManagedAutomations core integration', () => {
     expect(insightRecord?.instructions).not.toContain('6:00 PM local time')
   })
 
-  it('migrates an existing weekly product note to the two-week cadence', async () => {
+  it('archives an existing product-note automation after retirement', async () => {
     const vaultRoot = await createVaultRoot()
 
     await upsertAutomation({
-      automationId: MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+      automationId: MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
       continuityPolicy: 'preserve',
       instructions: 'Send the old weekly product update.',
       now: new Date('2026-06-09T12:00:00.000Z'),
@@ -2332,84 +2219,19 @@ describe('applyMurphManagedAutomations core integration', () => {
       updated: 1,
     })
 
-    const productNotesRecord = await showAutomation({
-      automationId: MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+    const retiredProductNotes = await showAutomation({
+      automationId: MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
       vaultRoot,
     })
 
-    expect(productNotesRecord).toMatchObject({
-      automationId: MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+    expect(retiredProductNotes).toMatchObject({
+      automationId: MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
       route: defaultRoute,
       slug: 'weekly-product-updates',
-      status: 'active',
-      summary: 'A biweekly personalized note alternating what is new in Murph with things Murph can do for you.',
-      title: 'Murph product notes',
+      status: 'archived',
+      summary: 'Old weekly product updates.',
+      title: 'Weekly product updates',
     })
-    expectEveryTwoWeeksSchedule(productNotesRecord?.schedule)
-    expect(productNotesRecord?.instructions).toContain('Goal: every two weeks')
-    expect(productNotesRecord?.instructions).toContain(
-      '/api/changelog?days=14&featureLimit=70&improvementLimit=10',
-    )
-    expect(productNotesRecord?.instructions).toContain(
-      'last recorded changelog means feature discovery now',
-    )
-    expect(productNotesRecord?.instructions).toContain(
-      'last recorded feature discovery means changelog now',
-    )
-  })
-
-  it('reconciles the product-note introduction for an otherwise-current installed record', async () => {
-    const vaultRoot = await createVaultRoot()
-    const productNotesSeed = MURPH_MANAGED_AUTOMATIONS.find(
-      (seed) => seed.automationId === MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
-    )
-    if (!productNotesSeed) {
-      throw new Error('Expected the managed product-notes seed.')
-    }
-
-    const currentIntroduction =
-      '- Open every outbound note with one sentence of no more than 20 words before the first bullet. In Murph\'s first-person voice, explain that these occasional updates cover what is new or useful so the user can make use of it.'
-    const previousIntroduction =
-      '- If the ledger page was missing before this run, open with one sentence of no more than 10 words saying Murph occasionally shares what is new or useful.'
-    const previousInstructions = productNotesSeed.instructions.replace(
-      currentIntroduction,
-      previousIntroduction,
-    )
-    expect(previousInstructions).not.toBe(productNotesSeed.instructions)
-
-    await upsertAutomation({
-      assistantTargetOverride: productNotesSeed.assistantTargetOverride,
-      automationId: productNotesSeed.automationId,
-      continuityPolicy: productNotesSeed.continuityPolicy,
-      instructions: previousInstructions,
-      now: new Date('2026-08-06T12:00:00.000Z'),
-      route: defaultRoute,
-      schedule: productNotesSeed.schedule,
-      slug: productNotesSeed.slug,
-      status: 'active',
-      summary: productNotesSeed.summary,
-      tags: [...productNotesSeed.tags],
-      title: productNotesSeed.title,
-      vaultRoot,
-    })
-
-    await expect(applyMurphManagedAutomations({
-      defaultRoute,
-      now: new Date('2026-08-06T13:00:00.000Z'),
-      seeds: [productNotesSeed],
-      vaultRoot,
-    })).resolves.toEqual({
-      created: 0,
-      skipped: 0,
-      updated: 1,
-    })
-
-    const productNotesRecord = await showAutomation({
-      automationId: MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
-      vaultRoot,
-    })
-    expect(productNotesRecord?.instructions).toContain(currentIntroduction)
-    expect(productNotesRecord?.instructions).not.toContain(previousIntroduction)
   })
 
   it('migrates the deployed weekly improvement coach in place to monthly', async () => {
@@ -2445,7 +2267,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-09T13:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 5,
+      created: 4,
       skipped: 0,
       updated: 1,
     })
@@ -2523,7 +2345,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       now: new Date('2026-06-09T13:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 5,
+      created: 4,
       skipped: 0,
       updated: 1,
     })
@@ -2631,7 +2453,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       vaultRoot,
     })).resolves.toEqual({
       created: 1,
-      skipped: 5,
+      skipped: 4,
       updated: 0,
     })
 
@@ -2652,7 +2474,7 @@ describe('applyMurphManagedAutomations core integration', () => {
       vaultRoot,
     })).resolves.toBeNull()
     await expect(showAutomation({
-      automationId: MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+      automationId: MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
       vaultRoot,
     })).resolves.toBeNull()
     await expect(showAutomation({

--- a/packages/assistant-engine/test/managed-automations.test.ts
+++ b/packages/assistant-engine/test/managed-automations.test.ts
@@ -140,8 +140,8 @@ import {
   MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID,
   MURPH_MONTHLY_IMPROVEMENT_COACH_AUTOMATION_ID,
+  MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
   MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID,
-  MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
   applyMurphManagedAutomations,
   ensureAutomaticMealCloseoutAutomation,
   resolveMurphManagedAutomationSeed,
@@ -149,10 +149,7 @@ import {
   type MurphManagedAutomationSeed,
 } from '../src/assistant/managed-automations.ts'
 import { ASSISTANT_REQUIRE_SEND_AUTOMATION_TAG } from '../src/assistant/automation-tags.ts'
-import {
-  computeAssistantCronNextRunAt,
-  findNextAssistantCronOccurrence,
-} from '../src/assistant/cron/schedule.ts'
+import { findNextAssistantCronOccurrence } from '../src/assistant/cron/schedule.ts'
 
 const vaultRoot = '/tmp/murph-managed-automations/vault'
 
@@ -178,11 +175,6 @@ const EXPECTED_MANAGED_SPREAD_CRONS = {
   digest: { kind: 'cron', expression: '30 10 * * 2' },
   insight: { kind: 'cron', expression: '0 13 * * 0' },
   researchScout: { kind: 'cron', expression: '0 14 * * 3' },
-} as const
-
-const EXPECTED_PRODUCT_NOTES_SCHEDULE = {
-  kind: 'every',
-  everyMs: 14 * 24 * 60 * 60 * 1000,
 } as const
 
 const legacyOnboardingFollowupInstructions = [
@@ -500,9 +492,13 @@ describe('applyMurphManagedAutomations', () => {
       updated: 0,
       yielded: true,
     })
-    expect(managedAutomationMocks.showAutomation).toHaveBeenCalledOnce()
-    expect(managedAutomationMocks.showAutomation).toHaveBeenCalledWith({
+    expect(managedAutomationMocks.showAutomation).toHaveBeenCalledTimes(2)
+    expect(managedAutomationMocks.showAutomation).toHaveBeenNthCalledWith(1, {
       automationId: 'automation_01K55N7S9X4Q2M6P8R3T0V1WYZ',
+      vaultRoot,
+    })
+    expect(managedAutomationMocks.showAutomation).toHaveBeenNthCalledWith(2, {
+      automationId: MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
       vaultRoot,
     })
     expect(managedAutomationMocks.upsertAutomation).not.toHaveBeenCalled()
@@ -1049,81 +1045,12 @@ describe('applyMurphManagedAutomations', () => {
     )).toBe('2026-07-01T23:30:00.000Z')
   })
 
-  it('runs alternating product notes every two weeks', () => {
-    const seed = MURPH_MANAGED_AUTOMATIONS.find(
-      (entry) => entry.automationId === MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
-    )
-    if (!seed) {
-      throw new Error('Expected managed product notes to exist.')
-    }
-
-    expect(seed.schedule).toEqual(EXPECTED_PRODUCT_NOTES_SCHEDULE)
-    expect(seed.title).toBe('Murph product notes')
-    expect(seed.summary).toBe('A biweekly personalized note alternating what is new in Murph with things Murph can do for you.')
-    expect(seed.instructions).toContain('Goal: every two weeks')
-    expect(seed.instructions).toContain('/api/changelog?days=14&featureLimit=70&improvementLimit=10')
-    expect(seed.instructions).toContain('/api/feature-catalog')
-    expect(seed.instructions).toContain('Read `vault-cli knowledge show murph-product-notes`')
-    expect(seed.instructions).toContain('choose the feature discovery kind')
-    expect(seed.instructions).toContain('last recorded changelog means feature discovery now')
-    expect(seed.instructions).toContain('last recorded feature discovery means changelog now')
-    expect(seed.instructions).toContain('Use `murph-product-notes` as the only ledger')
-    expect(seed.instructions).toContain('vault-cli knowledge append-section murph-product-notes YYYY-MM-DD')
-    expect(seed.instructions).toContain('Fallback is allowed at most once')
-    expect(seed.instructions).toContain('never fall back from a fallback')
-    expect(seed.instructions).toContain('If both kinds are unavailable, invalid, empty, or below bar')
-    expect(seed.instructions).toContain('record only this run\'s kind and the chosen item ids')
-    expect(seed.instructions).toContain('do not include reasons, user context, health details, raw user wording, provider data, or copied catalog/changelog text')
-    expect(seed.instructions).toContain('another run already recorded today\'s note')
-    expect(seed.instructions).toContain('Do not append again and do not switch kinds')
-    expect(seed.instructions).toContain('2-3 recently shipped Murph updates')
-    expect(seed.instructions).toContain('2-3 things Murph can already do')
-    expect(seed.instructions).toContain('Do not pad with weak matches')
-    expect(seed.instructions).toContain('member-facing product update, not a dump of release notes')
-    expect(seed.instructions).toContain('introduces or materially changes a member-facing action, decision, or visible experience')
-    expect(seed.instructions).toContain('Never pitch reliability work.')
-    expect(seed.instructions).toContain('only restores or hardens otherwise unchanged behavior or reports internal durability')
-    expect(seed.instructions).not.toContain('member encountered the corresponding issue')
-    expect(seed.instructions).toContain('lower priority than exciting capabilities')
-    expect(seed.instructions).toContain('if neither kind clears, skip')
-    expect(seed.instructions).toContain('Drop items the user is already using')
-    expect(seed.instructions).toContain('context already surfaced for ordinary assistance')
-    expect(seed.instructions).toContain('Require positive eligibility evidence')
-    expect(seed.instructions).toContain('any active or reconnect-required wearable means the feature is already in use')
-    expect(seed.instructions).toContain('if wearable connection status context is absent or unclear, drop it')
-    expect(seed.instructions).toContain('Do not open raw health records, uploaded documents, inbox attachments, provider payloads, transcripts, or raw notes solely to decide whether a feature was used')
-    expect(seed.instructions).toContain('Drop items already pitched in any prior ledger section; never repeat a feature pitch')
-    expect(seed.instructions).toContain('If an item lists a requires prerequisite')
-    expect(seed.instructions).toContain('Drop items this conversation cannot actually do right now')
-    expect(seed.instructions).toContain('Keep this scheduled note text-only')
-    expect(seed.instructions).toContain('The outbound note must be link-free')
-    expect(seed.instructions).toContain('no more than 28 words after the bullet marker')
-    expect(seed.instructions).toContain('preserve required prerequisites, availability limits, and approval or confirmation boundaries')
-    expect(seed.instructions).toContain('Open every outbound note with one sentence of no more than 20 words before the first bullet')
-    expect(seed.instructions).toContain("In Murph's first-person voice")
-    expect(seed.instructions).not.toContain('If the ledger page was missing before this run')
-    expect(seed.instructions).toContain('Close with one invitation sentence of no more than 12 words')
-    expect(seed.instructions).not.toContain('canonical title, summary, URL, and tryIt fields')
-    expect(seed.instructions).not.toContain('Choose 3-7 items')
-    expect(seed.instructions).not.toContain('murph.attach_response_media')
-    expect(seed.instructions).not.toContain('visual digest')
-    expect(seed.instructions).not.toContain('links.digestCardTemplate')
-    expect(seed.instructions).toContain('murph.submit_product_feedback')
-    expect(seed.instructions).toContain('clear inferred workflow friction')
-    expect(seed.instructions).toContain('interest in shipped changelog or catalog items')
-    expect(seed.instructions).toContain('Speculative:')
-    expect(seed.instructions).toContain('Murph-observed:')
-    expect(seed.instructions).toContain('Do not log vague low-confidence guesses')
-    expect(seed.instructions).toContain('concise product-only summary')
-    expect(seed.instructions).toContain('tags, topics, raw user wording')
-    expect(seed.instructions).not.toContain('kind/topic')
-    expect(seed.instructions).toContain(
-      '{"kind":"skip","privateSummary":"No product note cleared the send bar."}',
-    )
-    expect(computeAssistantCronNextRunAt(
-      seed.schedule,
-      new Date('2026-06-22T12:00:00.000Z'),
-    )).toBe('2026-07-06T12:00:00.000Z')
+  it('does not expose the retired product-notes automation as a managed seed', () => {
+    expect(MURPH_MANAGED_AUTOMATIONS.some(
+      (entry) =>
+        entry.automationId
+        === MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+    )).toBe(false)
   })
 
   it('keeps the group room model as a lightweight twice-weekly group-only maintenance seed', () => {
@@ -1369,11 +1296,11 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
-    expect(managedAutomationMocks.upsertAutomation).toHaveBeenCalledTimes(6)
+    expect(managedAutomationMocks.upsertAutomation).toHaveBeenCalledTimes(5)
     const patternsUpdateRecord = managedAutomationMocks.records.get(
       MURPH_PERSONAL_PATTERNS_UPDATE_AUTOMATION_ID,
     )
@@ -1717,49 +1644,9 @@ describe('applyMurphManagedAutomations', () => {
     expect(researchScoutRecord?.instructions).toContain('why close alternatives were suppressed')
     expect(researchScoutRecord?.instructions).toContain('clinician discussion prompt')
 
-    const productUpdatesRecord = managedAutomationMocks.records.get(
-      MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
-    )
-    expect(productUpdatesRecord).toMatchObject({
-      automationId: MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
-      continuityPolicy: 'fresh',
-      route: defaultRoute,
-      slug: 'weekly-product-updates',
-      status: 'active',
-      summary: 'A biweekly personalized note alternating what is new in Murph with things Murph can do for you.',
-      title: 'Murph product notes',
-    })
-    expect(productUpdatesRecord?.schedule).toEqual(EXPECTED_PRODUCT_NOTES_SCHEDULE)
-    expect(productUpdatesRecord?.tags).toContain(
-      'murph-managed:weekly-product-updates',
-    )
-    expect(productUpdatesRecord?.tags).not.toContain(
-      ASSISTANT_REQUIRE_SEND_AUTOMATION_TAG,
-    )
-    expect(productUpdatesRecord?.instructions).toContain('/api/changelog?days=14&featureLimit=70&improvementLimit=10')
-    expect(productUpdatesRecord?.instructions).toContain('/api/feature-catalog')
-    expect(productUpdatesRecord?.instructions).toContain('Read `vault-cli knowledge show murph-product-notes`')
-    expect(productUpdatesRecord?.instructions).toContain('choose the feature discovery kind')
-    expect(productUpdatesRecord?.instructions).toContain('Use `murph-product-notes` as the only ledger')
-    expect(productUpdatesRecord?.instructions).toContain('vault-cli knowledge append-section murph-product-notes YYYY-MM-DD')
-    expect(productUpdatesRecord?.instructions).toContain('Fallback is allowed at most once')
-    expect(productUpdatesRecord?.instructions).toContain('never fall back from a fallback')
-    expect(productUpdatesRecord?.instructions).toContain('If both kinds are unavailable, invalid, empty, or below bar')
-    expect(productUpdatesRecord?.instructions).toContain('record only this run\'s kind and the chosen item ids')
-    expect(productUpdatesRecord?.instructions).toContain('do not include reasons, user context, health details, raw user wording, provider data, or copied catalog/changelog text')
-    expect(productUpdatesRecord?.instructions).toContain('another run already recorded today\'s note')
-    expect(productUpdatesRecord?.instructions).toContain('Do not append again and do not switch kinds')
-    expect(productUpdatesRecord?.instructions).toContain('2-3 recently shipped Murph updates')
-    expect(productUpdatesRecord?.instructions).toContain('2-3 things Murph can already do')
-    expect(productUpdatesRecord?.instructions).toContain('Do not pad with weak matches')
-    expect(productUpdatesRecord?.instructions).toContain('Drop items the user is already using')
-    expect(productUpdatesRecord?.instructions).toContain('context already surfaced for ordinary assistance')
-    expect(productUpdatesRecord?.instructions).toContain('Do not open raw health records, uploaded documents, inbox attachments, provider payloads, transcripts, or raw notes solely to decide whether a feature was used')
-    expect(productUpdatesRecord?.instructions).not.toContain('Choose 3-7 items')
-    expect(productUpdatesRecord?.instructions).toContain(
-      '{"kind":"skip","privateSummary":"No product note cleared the send bar."}',
-    )
-    expect(productUpdatesRecord?.instructions).not.toContain('finish_without_reply')
+    expect(managedAutomationMocks.records.has(
+      MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+    )).toBe(false)
     expect(
       managedAutomationMocks.records.has(MURPH_OVERNIGHT_MEMORY_CONSOLIDATION_AUTOMATION_ID),
     ).toBe(false)
@@ -1801,7 +1688,7 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 9,
+      created: 8,
       skipped: 0,
       updated: 0,
     })
@@ -1974,17 +1861,17 @@ describe('applyMurphManagedAutomations', () => {
   })
 
   it('archives existing personal managed automations that are bound to Linq group chat routes', async () => {
-    managedAutomationMocks.records.set(MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID, {
-      automationId: MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+    managedAutomationMocks.records.set(MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID, {
+      automationId: MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
       continuityPolicy: 'fresh',
-      instructions: 'OLD weekly product updates instructions.',
+      instructions: 'OLD weekly health digest instructions.',
       route: groupChatRoute,
-      schedule: { kind: 'cron', expression: '30 12 * * 5' },
-      slug: 'weekly-product-updates',
+      schedule: { kind: 'cron', expression: '0 9 * * 1' },
+      slug: 'weekly-health-digest',
       status: 'active',
-      summary: 'Old weekly product updates.',
-      tags: ['assistant', 'scheduled', 'murph-managed', 'murph-managed:weekly-product-updates'],
-      title: 'Murph product notes',
+      summary: 'Old weekly health digest.',
+      tags: ['assistant', 'scheduled', 'murph-managed', 'murph-managed:weekly-health-digest'],
+      title: 'Weekly health digest',
     })
 
     const result = await applyMurphManagedAutomations({
@@ -1994,26 +1881,26 @@ describe('applyMurphManagedAutomations', () => {
 
     expect(result).toEqual({
       created: 0,
-      skipped: 5,
+      skipped: 4,
       updated: 1,
     })
     expect(managedAutomationMocks.patchAutomation).toHaveBeenCalledWith({
-      lookup: MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+      lookup: MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID,
       now: new Date('2026-07-09T14:00:00.000Z'),
       status: 'archived',
       vaultRoot,
     })
     expect(
-      managedAutomationMocks.records.get(MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID)?.status,
+      managedAutomationMocks.records.get(MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID)?.status,
     ).toBe('archived')
   })
 
   it('archives paused personal built-ins that are persisted on a group route', async () => {
     const seed = MURPH_MANAGED_AUTOMATIONS.find(
-      (entry) => entry.automationId === MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+      (entry) => entry.automationId === MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID,
     )
     if (!seed) {
-      throw new Error('Expected the managed product updates seed.')
+      throw new Error('Expected the managed weekly health insight seed.')
     }
     managedAutomationMocks.records.set(seed.automationId, {
       automationId: seed.automationId,
@@ -2109,6 +1996,34 @@ describe('applyMurphManagedAutomations', () => {
       .toBe('archived')
   })
 
+  it('archives a paused persisted product-notes record after its seed is retired', async () => {
+    managedAutomationMocks.records.set(
+      MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+      {
+        automationId: MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+        continuityPolicy: 'fresh',
+        instructions: 'Legacy biweekly product-note instructions.',
+        route: defaultRoute,
+        schedule: { kind: 'every', everyMs: 14 * 24 * 60 * 60 * 1000 },
+        slug: 'weekly-product-updates',
+        status: 'paused',
+        summary: 'Legacy biweekly product notes.',
+        tags: ['assistant', 'scheduled', 'murph-managed'],
+        title: 'Murph product notes',
+      },
+    )
+
+    await applyMurphManagedAutomations({
+      defaultRoute,
+      now: new Date('2026-09-03T14:00:00.000Z'),
+      vaultRoot,
+    })
+
+    expect(managedAutomationMocks.records.get(
+      MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+    )?.status).toBe('archived')
+  })
+
   it('updates existing research-oriented automations without rewriting their cadence', async () => {
     managedAutomationMocks.records.set(MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID, {
       automationId: MURPH_WEEKLY_HEALTH_INSIGHT_AUTOMATION_ID,
@@ -2148,7 +2063,7 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 4,
+      created: 3,
       skipped: 0,
       updated: 2,
     })
@@ -2190,10 +2105,10 @@ describe('applyMurphManagedAutomations', () => {
     ).not.toContain('Wednesday at 7:30 PM local time')
   })
 
-  it('migrates existing weekly product notes to the two-week cadence', async () => {
+  it('archives existing product notes instead of reconciling their cadence', async () => {
     const existingSchedule = { kind: 'cron', expression: '30 12 * * 5' } as const
-    managedAutomationMocks.records.set(MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID, {
-      automationId: MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+    managedAutomationMocks.records.set(MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID, {
+      automationId: MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
       continuityPolicy: 'preserve',
       instructions: 'OLD weekly product updates instructions with changelog-only behavior.',
       route: defaultRoute,
@@ -2216,19 +2131,13 @@ describe('applyMurphManagedAutomations', () => {
       skipped: 0,
       updated: 1,
     })
-    const productUpdatesRecord = managedAutomationMocks.records.get(
-      MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
-    )
-    expect(productUpdatesRecord?.schedule).toEqual(EXPECTED_PRODUCT_NOTES_SCHEDULE)
-    expect(productUpdatesRecord?.summary).toBe(
-      'A biweekly personalized note alternating what is new in Murph with things Murph can do for you.',
-    )
-    expect(productUpdatesRecord?.instructions).toContain('Goal: every two weeks')
-    expect(productUpdatesRecord?.instructions).toContain('/api/feature-catalog')
-    expect(productUpdatesRecord?.instructions).toContain('record only this run\'s kind and the chosen item ids')
-    expect(productUpdatesRecord?.instructions).toContain('do not include reasons, user context, health details, raw user wording, provider data, or copied catalog/changelog text')
-    expect(productUpdatesRecord?.instructions).toContain('Do not append again and do not switch kinds')
-    expect(productUpdatesRecord?.instructions).not.toContain('OLD weekly product updates instructions')
+    expect(managedAutomationMocks.records.get(
+      MURPH_RETIRED_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID,
+    )).toEqual(expect.objectContaining({
+      instructions: 'OLD weekly product updates instructions with changelog-only behavior.',
+      schedule: existingSchedule,
+      status: 'archived',
+    }))
   })
 
   it('removes the legacy require-send tag from an existing active weekly digest', async () => {
@@ -2312,7 +2221,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-20T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 5,
+      created: 4,
       skipped: 0,
       updated: 1,
     })
@@ -2361,7 +2270,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-20T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 5,
+      created: 4,
       skipped: 1,
       updated: 0,
     })
@@ -2399,8 +2308,6 @@ describe('applyMurphManagedAutomations', () => {
       .toEqual(firstSchedules.get(MURPH_MONTHLY_IMPROVEMENT_COACH_AUTOMATION_ID))
     expect(managedAutomationMocks.records.get(MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID)?.schedule)
       .toEqual(firstSchedules.get(MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID))
-    expect(managedAutomationMocks.records.get(MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID)?.schedule)
-      .toEqual(EXPECTED_PRODUCT_NOTES_SCHEDULE)
   })
 
   it('defers spread-managed creation when vault metadata cannot be read', async () => {
@@ -2412,21 +2319,18 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-09T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 3,
+      created: 2,
       skipped: 3,
       stableKeyFailure: metadataError,
       stableKeyRetryNeeded: true,
       updated: 0,
     })
-    expect(managedAutomationMocks.upsertAutomation).toHaveBeenCalledTimes(3)
+    expect(managedAutomationMocks.upsertAutomation).toHaveBeenCalledTimes(2)
     expect(managedAutomationMocks.records.get(MURPH_MONTHLY_IMPROVEMENT_COACH_AUTOMATION_ID)?.schedule)
       .toEqual({
         kind: 'cron',
         expression: '0 17 1 * *',
       })
-    expect(managedAutomationMocks.records.get(MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID)?.schedule)
-      .toEqual(EXPECTED_PRODUCT_NOTES_SCHEDULE)
-
     managedAutomationMocks.loadVault.mockResolvedValue({
       metadata: { vaultId: 'vault_managed_automations_test' },
     })
@@ -2436,7 +2340,7 @@ describe('applyMurphManagedAutomations', () => {
       vaultRoot,
     })).resolves.toEqual({
       created: 3,
-      skipped: 3,
+      skipped: 2,
       updated: 0,
     })
 
@@ -2451,8 +2355,6 @@ describe('applyMurphManagedAutomations', () => {
       })
     expect(managedAutomationMocks.records.get(MURPH_WEEKLY_HEALTH_RESEARCH_SCOUT_AUTOMATION_ID)?.schedule)
       .toEqual(EXPECTED_MANAGED_SPREAD_CRONS.researchScout)
-    expect(managedAutomationMocks.records.get(MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID)?.schedule)
-      .toEqual(EXPECTED_PRODUCT_NOTES_SCHEDULE)
   })
 
   it('continues non-spread seeds and existing updates when stable-key metadata is unavailable', async () => {
@@ -2475,10 +2377,10 @@ describe('applyMurphManagedAutomations', () => {
     const digestSeed = MURPH_MANAGED_AUTOMATIONS.find((seed) =>
       seed.automationId === MURPH_WEEKLY_HEALTH_DIGEST_AUTOMATION_ID
     )
-    const productUpdatesSeed = MURPH_MANAGED_AUTOMATIONS.find((seed) =>
-      seed.automationId === MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID
+    const improvementCoachSeed = MURPH_MANAGED_AUTOMATIONS.find((seed) =>
+      seed.automationId === MURPH_MONTHLY_IMPROVEMENT_COACH_AUTOMATION_ID
     )
-    if (!digestSeed || !productUpdatesSeed) {
+    if (!digestSeed || !improvementCoachSeed) {
       throw new Error('Expected managed seeds to exist.')
     }
     const experimentSeed: MurphManagedAutomationSeed = {
@@ -2493,7 +2395,7 @@ describe('applyMurphManagedAutomations', () => {
     await expect(applyMurphManagedAutomations({
       defaultRoute,
       now: new Date('2026-06-09T12:00:00.000Z'),
-      seeds: [digestSeed, productUpdatesSeed, experimentSeed],
+      seeds: [digestSeed, improvementCoachSeed, experimentSeed],
       vaultRoot,
     })).resolves.toEqual({
       created: 2,
@@ -2511,8 +2413,9 @@ describe('applyMurphManagedAutomations', () => {
         instructions: experimentSeed.instructions,
         schedule: experimentSeed.schedule,
       }))
-    expect(managedAutomationMocks.records.get(MURPH_WEEKLY_PRODUCT_UPDATES_AUTOMATION_ID)?.schedule)
-      .toEqual(EXPECTED_PRODUCT_NOTES_SCHEDULE)
+    expect(managedAutomationMocks.records.get(
+      MURPH_MONTHLY_IMPROVEMENT_COACH_AUTOMATION_ID,
+    )?.schedule).toEqual({ kind: 'cron', expression: '0 17 1 * *' })
   })
 
   it('skips the research scout seed when hosted runtime env lacks Exa', async () => {
@@ -2524,7 +2427,7 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 5,
+      created: 4,
       skipped: 1,
       updated: 0,
     })
@@ -2554,7 +2457,7 @@ describe('applyMurphManagedAutomations', () => {
 
     expect(result).toEqual({
       created: 0,
-      skipped: 6,
+      skipped: 5,
       updated: 0,
     })
     expect(managedAutomationMocks.upsertAutomation).not.toHaveBeenCalled()
@@ -2584,7 +2487,7 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 5,
+      created: 4,
       skipped: 1,
       updated: 0,
     })
@@ -2628,7 +2531,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 1,
     })
@@ -2684,7 +2587,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 1,
     })
@@ -2730,7 +2633,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -2768,7 +2671,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 1,
     })
@@ -2812,7 +2715,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -2841,7 +2744,7 @@ describe('applyMurphManagedAutomations', () => {
       now: new Date('2026-06-23T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -2879,7 +2782,7 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 5,
+      created: 4,
       skipped: 0,
       updated: 1,
     })
@@ -2907,7 +2810,7 @@ describe('applyMurphManagedAutomations', () => {
     })
 
     expect(result).toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 0,
     })
@@ -2938,7 +2841,7 @@ describe('applyMurphManagedAutomations', () => {
 
     expect(result).toEqual({
       created: 0,
-      skipped: 6,
+      skipped: 5,
       updated: 0,
     })
     expect(
@@ -2966,7 +2869,7 @@ describe('applyMurphManagedAutomations', () => {
 
     expect(result).toEqual({
       created: 0,
-      skipped: 6,
+      skipped: 5,
       updated: 0,
     })
     expect(managedAutomationMocks.upsertAutomation).not.toHaveBeenCalled()
@@ -3072,7 +2975,7 @@ describe('applyMurphManagedAutomations', () => {
 
     expect(result).toEqual({
       created: 0,
-      skipped: 6,
+      skipped: 5,
       updated: 0,
     })
     expect(managedAutomationMocks.upsertAutomation).not.toHaveBeenCalled()
@@ -3093,7 +2996,7 @@ describe('applyMurphManagedAutomations', () => {
 
     expect(result).toEqual({
       created: 0,
-      skipped: 6,
+      skipped: 5,
       updated: 0,
     })
     expect(managedAutomationMocks.upsertAutomation).not.toHaveBeenCalled()

--- a/packages/assistant-engine/test/onboarding-goal-checkin-automation.test.ts
+++ b/packages/assistant-engine/test/onboarding-goal-checkin-automation.test.ts
@@ -291,7 +291,7 @@ describe('post-onboarding support-gap automation', () => {
       now: new Date('2026-03-02T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 7,
+      created: 6,
       skipped: 0,
       updated: 0,
     })
@@ -318,7 +318,7 @@ describe('post-onboarding support-gap automation', () => {
       vaultRoot,
     })).resolves.toEqual({
       created: 0,
-      skipped: 7,
+      skipped: 6,
       updated: 0,
     })
   })
@@ -366,7 +366,7 @@ describe('post-onboarding support-gap automation', () => {
       vaultRoot,
     })).resolves.toEqual({
       created: 0,
-      skipped: 6,
+      skipped: 5,
       updated: 1,
     })
     const reconciled = await showAutomation({
@@ -405,7 +405,7 @@ describe('post-onboarding support-gap automation', () => {
       now: new Date('2026-06-04T15:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 7,
+      created: 6,
       skipped: 0,
       updated: 0,
     })
@@ -427,7 +427,7 @@ describe('post-onboarding support-gap automation', () => {
       vaultRoot,
     })).resolves.toEqual({
       created: 0,
-      skipped: 7,
+      skipped: 6,
       updated: 0,
     })
     await expect(showAutomation({
@@ -485,7 +485,7 @@ describe('post-onboarding support-gap automation', () => {
       now: new Date('2026-06-10T12:00:00.000Z'),
       vaultRoot,
     })).resolves.toEqual({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 1,
     })
@@ -527,7 +527,7 @@ describe('post-onboarding support-gap automation', () => {
       vaultRoot,
     })).resolves.toEqual({
       created: 0,
-      skipped: 7,
+      skipped: 6,
       updated: 0,
     })
     await expect(showAutomation({
@@ -635,7 +635,7 @@ describe('post-onboarding support-gap automation', () => {
     })
 
     expect(result).toMatchObject({
-      created: 6,
+      created: 5,
       skipped: 0,
       updated: 0,
     })


### PR DESCRIPTION
## Why and outcome

Murph still seeded a built-in biweekly product-notes automation, so existing and new members could continue receiving unsolicited product updates. This retires that exact managed identity: fresh vaults no longer create it, persisted active or paused copies are archived, and already-claimed occurrences fail before model or delivery work.

Members can still ask what is new in Murph. The ordinary direct-conversation guidance continues to read the canonical changelog and feature catalog on demand.

## Product UX

- Effort: Product change
- Result: Ready
- Walkthrough: A fresh member receives no product-notes seed; an established member's active or paused historical copy archives during normal reconciliation; a claimed legacy occurrence stops before provider work; a direct member request still returns current product updates. Other reminders, health check-ins, and user-owned automations sharing the historical slug are unchanged.

## Evidence

- Direct: `pnpm test:assistant:live -- --test "retired product notes leave on-demand updates available" --codex-home <authenticated-alternate>` passed. One provider request made one canonical `/api/changelog?days=14` call and returned the two requested updates without recurring-note language.
- Coverage: Deterministic registry and runtime tests prove seed omission, active and paused archival, immutable-ID selection, custom-slug preservation, and the pre-provider retirement gate. The live journey proves the retained on-demand path through the production prompt builder.

## Non-obvious affected surfaces

- Managed reconciliation: the historical immutable ID now lives in the existing permanent retirement set. `managed-automations-core.test.ts` and `managed-automations.test.ts` cover persisted archival and omission from fresh seeds.
- Cron execution: a claimed historical occurrence returns `managed_automation_retired` before lifecycle, model, tools, or delivery. `assistant-cron-runtime.test.ts` covers that boundary.
- Product feedback: the removed scheduled prompt no longer duplicates later-turn feedback guidance; the ordinary system prompt remains the sole owner. `assistant-product-feedback.test.ts` passes.
- On-demand product answers: the ordinary system prompt and canonical feeds are unchanged; the focused real-Codex journey covers the member-visible result.

## Architecture and reuse

- Existing systems reused: the permanent managed-automation tombstone set, normal reconciliation archive path, and claimed-occurrence retirement fence.
- New logic: one existing immutable automation ID is classified as retired; its active seed, cadence, and scheduled instructions are deleted.
- New abstractions: None. The existing retirement contract already owns this lifecycle.
- Complexity intentionally avoided: no migration queue, feature flag, replacement schedule, ledger cleanup, or slug-wide archival. User-owned records are not selected by mutable slug.

## Complexity impact

- Guard: pass, `pnpm complexity:diff`.
- Hotspots: `applyMurphManagedAutomations` remains 109 and `reconcileExistingOnboardingFollowupAutomation` remains 29; both are unchanged legacy hotspots, and this PR deletes one seed without adding branches.
- Agent judgment: further refactoring is not justified for this retirement. Reusing the existing immutable-ID tombstone is the smallest behavior-preserving shape.

## Hot reply path impact

- Path status: Not applicable. This changes managed background reconciliation and scheduled execution, not durable acceptance of a current conversation message through reply handoff.
- Database calls: None.
- Network/provider calls: None added or moved onto the foreground path.
- Other awaited latency: None added or moved onto the foreground path.
- Before/after proof: The direct on-demand prompt path is unchanged and passed the focused live journey.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Ordinary individual and group provider inputs are unchanged. The deleted instructions belonged only to the retired scheduled identity, whose occurrences now stop before provider entry.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged for every surviving invocation.
- Measurement method: Not run because no surviving provider-input composition changed; deterministic runtime proof confirms the retired path admits no provider request.

## Design proof

- Design page: [Production changelog archive](https://www.withmurph.ai/screenshots/ops#changelog-archive)
- Evidence: Content-only changelog fragment reviewed directly; `pnpm --dir apps/web test -- changelog-page.test.tsx` passed against the production archive component.
- Coverage: The entry's title, summary, details, and try-it affordance render through the unchanged responsive archive. No component, style, layout, or interaction changed.

## Risks

- The historical ID must remain immutable and permanent; changing or removing the tombstone could leave an old persisted copy executable.
ReviewGPT context sensitivity: sensitive
- Classification reason: The change alters persisted managed-automation lifecycle and hosted fail-closed execution behavior.
ReviewGPT first-reviewed head: 595ffa0561abae2a120afe6b75f20e67586b3dc3

## Deployment concerns

- Deployment: applicable
- Supported skew: Old instances may still recognize the seed during rollout, while new instances archive it. Once archived, old reconciliation code preserves the archived status and does not reactivate it.
- Safe order: Deploy the assistant-engine change normally; no separate producer or schema rollout is required.
- Rollback floor: Archival is intentionally sticky. Reverting code does not reactivate archived copies, which preserves the no-send outcome.
- Expected exposure: Until old instances drain and a new reconciliation or claimed-occurrence fence runs, a due legacy occurrence could still execute on an old instance.
- Reversibility: Restoring recurring product notes would require an explicit new product decision and managed reactivation or identity, not a code-only rollback.
- Convergence proof: Fresh-seed tests omit the ID, reconciliation tests archive active and paused copies, and runtime tests reject a claimed copy before provider work.
- Post-deploy checks: Confirm the new assistant-engine version is live and inspect bounded managed-automation diagnostics for archival without product-note deliveries.

## Change-shape breakdown

Classification rule: Production TypeScript is source; test files are tests/fixtures; architecture, completed plan, and changelog content are docs. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 3 | 67 |
| Tests / fixtures | 234 | 616 |
| Docs | 160 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **397** | **683** |

## Changelog

- Changelog: updated
- Items: 2026-09-03 · product-updates-are-now-on-demand


