### PR TITLE
fix(ci): accept dynamic Temporal integration run names

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-03-temporal-dynamic-run-name.md
+++ b/agent-docs/exec-plans/active/2026-09-03-temporal-dynamic-run-name.md
@@ -1,0 +1,72 @@
+# Accept Dynamic Private Temporal Run Names
+
+Status: active
+Created: 2026-09-03
+Updated: 2026-09-03
+
+## Goal
+
+- Restore public Temporal compatibility admission after the private integration
+  workflow adopted a dynamic GitHub Actions run name, without weakening the
+  existing exact run id, workflow id/path, repository, branch, SHA, event, and
+  first-attempt identity checks.
+
+## Success criteria
+
+- `inspectPrivateRun` accepts the legacy workflow name and the dynamic
+  `Public Murph Integration / ...` run-name family.
+- An unrelated or merely similar workflow name remains rejected.
+- Focused controller tests and the scoped repository verification lane pass.
+- The exact pushed PR head receives required CI and final ReviewGPT review.
+
+## Scope
+
+- In scope: the public compatibility controller, its focused regression test,
+  and PR evidence for the independently observed Vercel deployment-check gap.
+- Out of scope: modifying the private workflow, changing Vercel project
+  configuration, manually promoting or rolling back a deployment, or changing
+  Temporal reader admission semantics.
+
+## Risks and mitigations
+
+1. Risk: accepting arbitrary runs after relaxing the display-name check.
+   Mitigation: retain the exact dispatch-returned run id, workflow id and path,
+   private repository, main SHA, event, branch, and first-attempt checks; accept
+   only the canonical legacy name or its slash-delimited dynamic prefix.
+2. Risk: a focused unit test misses cancellation-path behavior.
+   Mitigation: keep both polling and cancellation on the same
+   `inspectPrivateRun` owner and run the complete focused controller test file.
+3. Risk: presenting the public script fix as repairing Vercel promotion.
+   Mitigation: report the observed non-blocking production promotion as a
+   separate configuration gap and do not claim it is fixed by this PR.
+
+## Tasks
+
+1. Add the narrow dynamic-name compatibility condition and regression cases.
+2. Run focused controller proof, scoped verification, complexity, and final
+   privacy/diff review.
+3. Commit and push the candidate, open a draft PR with complete deployment
+   evidence, mark it ready, and start ReviewGPT concurrently with CI.
+4. Resolve required review/CI gates and prove current-base mergeability.
+
+## Decisions
+
+- Treat GitHub's run `name` as a presentation field beneath the stronger exact
+  workflow/run/path/repository/SHA identity checks.
+- Preserve legacy exact-name acceptance for runs created before the private
+  workflow's dynamic `run-name` change.
+- Keep the production-domain promotion gap outside this code diff because it is
+  owned by Vercel project configuration and requires separate live correction
+  and proof.
+
+## Verification
+
+- Passed: `node --check scripts/hosted-orchestration-compatibility.mjs` and
+  `node --test scripts/hosted-orchestration-compatibility.test.mjs` (40 tests).
+- Passed: live read-only `inspectPrivateRun` validation against an actual
+  post-change private workflow run with the dynamic title.
+- Passed: `pnpm test:diff scripts/hosted-orchestration-compatibility.mjs scripts/hosted-orchestration-compatibility.test.mjs`
+  (53 files and 726 repo-tool tests plus the scoped guards).
+- Passed: `pnpm complexity:diff` with no current hotspot above 20 and no
+  complexity-debt increase.
+- Pending: exact-head CI, final ReviewGPT, and current-base merge-tree proof.

--- a/agent-docs/exec-plans/completed/2026-09-03-temporal-dynamic-run-name.md
+++ b/agent-docs/exec-plans/completed/2026-09-03-temporal-dynamic-run-name.md
@@ -1,6 +1,6 @@
 # Accept Dynamic Private Temporal Run Names
 
-Status: active
+Status: completed
 Created: 2026-09-03
 Updated: 2026-09-03
 
@@ -69,4 +69,10 @@ Updated: 2026-09-03
   (53 files and 726 repo-tool tests plus the scoped guards).
 - Passed: `pnpm complexity:diff` with no current hotspot above 20 and no
   complexity-debt increase.
-- Pending: exact-head CI, final ReviewGPT, and current-base merge-tree proof.
+- Passed: PR #2796 Pull Request Evidence after the required literal complexity
+  disposition was corrected in PR metadata.
+- Passed: final ReviewGPT round 1 on the exact pushed source head with no
+  qualifying findings. Apollo failed before send; the same round completed on
+  Eragon with a full snapshot and a validated `ROUND_OUTCOME: PASS`.
+- Pending after plan closure: exact-head CI and current-base merge-tree proof.
+Completed: 2026-09-03

--- a/scripts/hosted-orchestration-compatibility.mjs
+++ b/scripts/hosted-orchestration-compatibility.mjs
@@ -280,12 +280,16 @@ export function inspectDispatchReceipt(raw) {
 
 export function inspectPrivateRun(raw, { privateSha, runId, workflowId }) {
   assertRecord(raw, "private compatibility run");
+  const runName = typeof raw.name === "string" ? raw.name : "";
   const repository = isRecord(raw.repository) ? raw.repository.full_name : null;
   const headRepository = isRecord(raw.head_repository) ? raw.head_repository.full_name : null;
   if (
     raw.id !== runId
     || raw.workflow_id !== workflowId
-    || raw.name !== TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW_NAME
+    || (
+      runName !== TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW_NAME
+      && !runName.startsWith(`${TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW_NAME} / `)
+    )
     || !isPrivateWorkflowRunPath(raw.path)
     || raw.event !== "workflow_dispatch"
     || raw.head_branch !== TEMPORAL_COMPATIBILITY_PRIVATE_BRANCH

--- a/scripts/hosted-orchestration-compatibility.test.mjs
+++ b/scripts/hosted-orchestration-compatibility.test.mjs
@@ -418,6 +418,13 @@ test("private run proof binds repository, workflow, main SHA, event, and first a
     workflowId: WORKFLOW_ID,
   }), { complete: true, conclusion: "success" });
   assert.deepEqual(inspectPrivateRun(privateRun({
+    name: `${TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW_NAME} / temporal_compatibility / ${PUBLIC_SHA} / none`,
+  }), {
+    privateSha: PRIVATE_SHA,
+    runId: RUN_ID,
+    workflowId: WORKFLOW_ID,
+  }), { complete: true, conclusion: "success" });
+  assert.deepEqual(inspectPrivateRun(privateRun({
     path: TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW_PATH,
   }), {
     privateSha: PRIVATE_SHA,
@@ -425,6 +432,7 @@ test("private run proof binds repository, workflow, main SHA, event, and first a
     workflowId: WORKFLOW_ID,
   }), { complete: true, conclusion: "success" });
   for (const overrides of [
+    { name: `${TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW_NAME}-spoofed` },
     { event: "push" },
     { head_branch: "release" },
     { head_sha: PUBLIC_SHA },


### PR DESCRIPTION
## Why and outcome

Private Murph Integration PR 96 added a dynamic GitHub Actions `run-name`. The public Temporal compatibility controller still required the dispatched run's display name to equal the static workflow name, so it rejected and cancelled otherwise exact private runs.

Accept the legacy static name and the slash-delimited dynamic name family while retaining the exact dispatch-returned run id, workflow id/path, repository, private `main` SHA, branch, event, and first-attempt checks.

## Product UX

Not applicable. This is internal deployment-admission infrastructure and changes no member-visible behavior.

## Evidence

- `node --check scripts/hosted-orchestration-compatibility.mjs`
- `node --test scripts/hosted-orchestration-compatibility.test.mjs` — 40 passed
- Live read-only validation of `inspectPrivateRun` against an actual post-PR-96 dynamic-name private run — accepted with its true terminal conclusion; raw response was not persisted
- `pnpm test:diff scripts/hosted-orchestration-compatibility.mjs scripts/hosted-orchestration-compatibility.test.mjs` — 53 files and 726 repo-tool tests passed with all scoped guards
- `pnpm complexity:diff` — passed; no hotspot above 20 and no complexity-debt increase

## Non-obvious affected surfaces

- Accepted-run cancellation and terminal polling reuse `inspectPrivateRun`; accepting the dynamic title lets both the success path and failure cleanup inspect the exact dispatched run.
- Vercel production promotion is presently not blocked by the documented Deployment Check. This PR repairs the controller only; Vercel project configuration still requires separate live correction and proof.

## Architecture and reuse

- Existing systems reused: the existing dispatch receipt, workflow id/path, repository, branch, SHA, event, and run-attempt identity checks remain the authority.
- New logic: one compatibility condition accepts either the static workflow name or its slash-delimited dynamic run-name prefix.
- New abstractions: none; the existing `inspectPrivateRun` owner remains sufficient.
- Complexity intentionally avoided: no duplicated workflow-name parser, cross-repository configuration reader, or alternate run lookup was added.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: no changed-file function is above 20; `inspectPrivateRun` remains at 19.
- Agent judgment: no further behavior-preserving simplification is justified without obscuring the fail-closed identity predicate.

## Hot reply path impact

Not applicable. The change runs only in GitHub Actions deployment admission and does not touch message acceptance, provider start, or reply handoff.

## Murph initial provider input impact

Not applicable for both individual and group runtimes. No prompt, tool schema, generated guidance, or provider-visible request surface changed.

## Change-shape breakdown

Classification rule: controller implementation is source, its Node test is tests/fixtures, and the execution plan is docs. No binaries or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 5 | 1 |
| Tests/fixtures | 8 | 0 |
| Docs | 72 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| **Total** | **85** | **1** |

ReviewGPT context sensitivity: sensitive — this changes fail-closed cross-repository deployment admission.
ReviewGPT first-reviewed head: 4929d948a9457f59b48ceba5d2c779d01920affb

## Deployment concerns

- Deployment: applicable
- Supported skew: New public code accepts both the legacy private static run name and the already-deployed dynamic private run-name family; old public code rejects the dynamic name.
- Safe order: Land the backward-compatible public consumer while the private workflow keeps its current dynamic name; do not roll the public consumer back unless the private workflow first restores the legacy static run name.
- Rollback floor: The private dynamic `run-name` is the floor; reverting this public compatibility change above that floor reopens the admission failure.
- Expected exposure: Until the public fix lands, every selected PR proof and exact-main production admission dispatch is rejected and cancelled before reader attestation.
- Reversibility: Restore the private static run name before reverting this public change, or keep the dual-name public reader.
- Convergence proof: Focused tests cover legacy acceptance, dynamic acceptance, and lookalike rejection; a live post-change private run object passes the patched validator.
- Post-deploy checks: Confirm a fresh exact-main admission succeeds against current private `main`, then separately verify Vercel lists `Temporal Web production admission` as a blocking production Deployment Check and that the production domain cannot move while a controlled check is pending or failed.

## Changelog

- Changelog: not applicable
- Reason: Internal CI and deployment-admission compatibility only; no member-visible product outcome changes.

