### PR TITLE
fix(ci): ignore skipped private proof jobs

### DIFF
--- a/.agents/friction-log/20260904015740-skipped-github-job/friction.md
+++ b/.agents/friction-log/20260904015740-skipped-github-job/friction.md
@@ -1,0 +1,28 @@
+---
+title: 'Skipped GitHub job names can invalidate cross-repository Temporal proof parsing'
+severity: 'major'
+---
+
+## Expected Behavior
+
+The public release controller should distinguish successful requested proof jobs from completed/skipped jobs belonging to an inactive workflow lane, while still failing closed when any requested proof is missing or skipped.
+
+## Current Behavior
+
+GitHub leaves needs-output expressions uninterpolated in names of skipped jobs. The public verifier treated those inactive names as malformed before it could evaluate the successful proof jobs, and the private release mode also omitted the ordinary compatibility attestation required by the documented two-proof contract. A successful protected private release run was therefore rejected by public production admission.
+
+## Possible Solution
+
+Keep a secret-free contract fixture that models the exact GitHub Jobs API shape for every dispatch mode, including completed/skipped jobs with literal output expressions. Require release mode to emit both the compatibility attestation and the hosted-release attestation.
+
+## Minimal Reproducible Example
+
+1. Dispatch the protected private workflow in release-admission mode.
+2. Let the reader matrix and hosted release attestation succeed.
+3. List the run jobs through the GitHub Jobs API.
+4. Observe an inactive attestation job with conclusion skipped and an uninterpolated needs-output expression in its name.
+5. Pass the jobs to the public verifier and observe a malformed-proof rejection before the successful hosted-release proof is accepted.
+
+## Context
+
+This surfaced only in the first exact-main production admission run after the cross-repository release controller merged. Focused unit fixtures had modeled only successful proof jobs.

--- a/scripts/hosted-orchestration-compatibility.mjs
+++ b/scripts/hosted-orchestration-compatibility.mjs
@@ -396,13 +396,10 @@ function inspectPrivateProofJob(raw, { ids, privateSha, runId }) {
   }
 
   const name = requiredString(raw.name, "private compatibility job name");
-  if (
-    name.startsWith("Hosted release attestation")
-    && raw.status === "completed"
-    && raw.conclusion === "skipped"
-  ) {
-    return null;
-  }
+  // GitHub leaves output-based job names uninterpolated when their lane is
+  // skipped. Required proof jobs still fail closed below because their proof
+  // count or digest is then missing.
+  if (raw.status === "completed" && raw.conclusion === "skipped") return null;
   const patterns = [
     ["reader", /^Temporal compatibility reader \[sha=([0-9a-f]{40})\]$/u],
     ["attestation", /^Temporal compatibility attestation \[proof=([0-9a-f]{64})\]$/u],

--- a/scripts/hosted-orchestration-compatibility.test.mjs
+++ b/scripts/hosted-orchestration-compatibility.test.mjs
@@ -586,6 +586,35 @@ test("hosted release attestation binds scope, exact revisions, and the expected 
   ), /does not bind the requested proof/u);
 });
 
+test("attestation ignores completed skipped jobs from inactive proof lanes", () => {
+  const skippedJobs = [
+    {
+      conclusion: "skipped",
+      head_sha: PRIVATE_SHA,
+      id: 5,
+      name: "Hosted release attestation [proof=${{ needs.hosted-integration-plan.outputs.proof_digest }}]",
+      run_id: RUN_ID,
+      status: "completed",
+    },
+    {
+      conclusion: "skipped",
+      head_sha: PRIVATE_SHA,
+      id: 6,
+      name: "Temporal compatibility attestation [proof=${{ needs.temporal-compatibility-setup.outputs.proof_digest }}]",
+      run_id: RUN_ID,
+      status: "completed",
+    },
+  ];
+  const expected = inspectAttestationJobs(proofJobs(), {
+    ...proofInspectionArgs(),
+  });
+  for (const skippedJob of skippedJobs) {
+    assert.deepEqual(inspectAttestationJobs([...proofJobs(), skippedJob], {
+      ...proofInspectionArgs(),
+    }), expected);
+  }
+});
+
 test("attestation rejects omission of the dispatched private candidate", () => {
   assert.throws(() => inspectAttestationJobs(
     proofJobs().filter((job) => job.name !== buildReaderJobName(PRIVATE_SHA)),
@@ -609,10 +638,10 @@ test("attestation rejects duplicate readers and duplicate job ids", () => {
   }), /duplicate id/u);
 });
 
-test("attestation rejects malformed, skipped, failed, and mismatched proof jobs", () => {
+test("attestation rejects malformed, required-skipped, failed, and mismatched proof jobs", () => {
   const scenarios = [
     [{ ...proofJobs()[0], name: "Temporal compatibility reader main" }, /malformed proof job/u],
-    [{ ...proofJobs()[0], conclusion: "skipped" }, /did not complete successfully/u],
+    [{ ...proofJobs()[0], conclusion: "skipped" }, /does not bind the requested proof/u],
     [{ ...proofJobs()[0], conclusion: "failure" }, /did not complete successfully/u],
     [{ ...proofJobs()[0], head_sha: PUBLIC_SHA }, /not bound to the accepted run/u],
   ];


### PR DESCRIPTION
## Why and outcome

GitHub leaves needs-output expressions uninterpolated in names of completed/skipped jobs. The exact-main controller treated an inactive sibling attestation as malformed before evaluating the requested proofs. It now ignores only completed/skipped jobs after validating their run and head identity; every requested proof still fails closed when absent, skipped, malformed, or digest-mismatched.

## Product UX

- Effort: Patch; production deployment admission recovery.
- Result: Ready.
- Walkthrough: A public main merge dispatches the exact private run, inactive proof lanes are excluded, both requested release proofs are verified, and the deployment remains blocked on any missing or invalid required proof.

## Evidence

- Direct: The first exact-main production run reached a successful private release run but rejected the uninterpolated name of its skipped sibling attestation.
- Coverage: A provider-shaped Jobs API fixture covers both inactive proof namespaces, while a skipped required reader still fails the proof digest.

## Non-obvious affected surfaces

- Exact-main Web production admission and pull-request Temporal compatibility both share the proof-job parser.
- The private workflow must emit the ordinary compatibility attestation during release mode; the companion private PR lands first.

## Architecture and reuse

- Existing systems reused: Exact dispatch receipt, accepted run/head identity, proof counts, reader digest, and hosted-release digest.
- New logic: Completed/skipped jobs are excluded only after exact run and head validation.
- New abstractions: None; one guard in the existing parser.
- Complexity intentionally avoided: No polling fallback, inferred run selection, proof-format version, state, or service.

## Complexity impact

- Guard: pass — pnpm complexity:diff.
- Hotspots: None above 20; changed-file maximum remains 19.
- Agent judgment: No further behavior-preserving simplification is justified.

## Hot reply path impact

- Path status: Not applicable; CI deployment admission only.
- Database calls: None.
- Network/provider calls: None added or moved.
- Other awaited latency: None.
- Before/after proof: Provider-shaped unit regression plus exact-main admission after merge.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Risks

Required skipped proofs must remain rejected. The verifier preserves this through exact proof counts, private-candidate reader inclusion, and digest equality after inactive jobs are excluded.

## Deployment concerns

- Deployment: applicable
- Supported skew: Land the private attestation-condition fix first. The public parser remains fail-closed until this PR lands.
- Safe order: Merge the companion private PR, then this public PR, then require one green exact-main production admission.
- Rollback floor: Do not roll back a deployment; use a fresh forward-fix or revert commit on main so admission runs again.
- Expected exposure: GitHub Actions and the Vercel production Deployment Check only.
- Reversibility: The parser guard and test can be reverted with an ordinary commit.
- Convergence proof: Exact public/private main rereads plus both protected proof jobs on one accepted run.
- Post-deploy checks: Confirm the exact-main public job and its accepted private release run both succeed.

## Change-shape breakdown

Classification rule: Runtime verifier is source, node assertions are tests, and the Frog record is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 0 |
| Tests / fixtures | 31 | 2 |
| Docs | 28 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **63** | **2** |

## Changelog

- Changelog: not applicable
- Reason: Internal deployment-admission correction with no member-visible product behavior.

## Verification

- pnpm typecheck
- node --test scripts/hosted-orchestration-compatibility.test.mjs — 42 of 42 passed
- pnpm complexity:diff — pass, no current hotspot above 20
- git diff --check
- Current-base merge-tree proof is clean.
- ReviewGPT was not run per explicit user instruction.
