### PR TITLE
fix(cloudflare): allow Goal deploy smoke to finish

### DIFF
--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -2307,6 +2307,9 @@ Gradual deploys run managed-container smoke with a longer retry window so Cloudf
 - `GET /health`, including the canonical effective standby mode when the deploy
   workflow supplies an expected mode
 - if `HOSTED_EXECUTION_SMOKE_RUNNER_CONTAINER=true`, one signed `POST /internal/deploy/container-smoke` that waits until the Cloudflare-managed runner container reports the expected runner-bundle fingerprint and assistant CLI surface hot-path schema proof
+- the managed-container Codex shell phase has its own 60-second Worker budget
+  for the container's bounded 45-second app-server and CLI proof; ordinary
+  runner readiness and health checks retain their 20-second default
 - the managed-container runner smoke also proves the native
   `murph-group-read` profile enforcement used by Assistant Ask:
   intended root reads succeed while writes, `.runtime/**`, `.codex/**`, environment

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -71,6 +71,8 @@ const RUNNER_LIVE_MODEL_TURN_SMOKE_URL =
   "http://container/internal/deploy-live-model-turn-smoke";
 const RUNNER_DIRECT_R2_PRESIGNED_PUT_SMOKE_URL =
   "http://container/internal/direct-r2-presigned-put-smoke";
+// Covers the container-side 45s app-server and CLI budget plus dispatch margin.
+const RUNNER_CODEX_SHELL_SMOKE_MIN_TIMEOUT_MS = 60_000;
 // Covers the container-side 60s codex exec budget plus boot/dispatch margin.
 const RUNNER_LIVE_MODEL_TURN_SMOKE_MIN_TIMEOUT_MS = 90_000;
 const RUNNER_RUNTIME_WAKE_URL = "http://container/internal/runtime-wake";
@@ -1648,7 +1650,10 @@ export class RunnerContainer extends Container {
   private async smokeCodexShell(
     readyTimeoutMs: number,
   ): Promise<NonNullable<HostedExecutionContainerSmokeHealthResult["codexShell"]>> {
-    const smokeSignal = AbortSignal.timeout(readyTimeoutMs);
+    const smokeSignal = AbortSignal.timeout(Math.max(
+      readyTimeoutMs,
+      RUNNER_CODEX_SHELL_SMOKE_MIN_TIMEOUT_MS,
+    ));
     const response = await this.containerFetch(
       RUNNER_CODEX_SHELL_SMOKE_URL,
       {

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -4663,6 +4663,36 @@ describe("RunnerContainer", () => {
     expect(destroy).toHaveBeenCalledTimes(1);
   });
 
+  it("bounds Codex shell smoke separately from ordinary runner readiness", async () => {
+    const originalAbortSignalTimeout = AbortSignal.timeout;
+    const timeoutBySignal = new Map<AbortSignal, number>();
+    const timeout = vi.spyOn(AbortSignal, "timeout")
+      .mockImplementation((timeoutMs: number) => {
+        const signal = originalAbortSignalTimeout(timeoutMs);
+        timeoutBySignal.set(signal, timeoutMs);
+        return signal;
+      });
+    const { container, containerFetch, startAndWaitForPorts } = createContainerDouble();
+
+    try {
+      await container.smokeHealth();
+
+      const healthCall = containerFetch.mock.calls.find(([url]) =>
+        String(url).endsWith("/health")
+      );
+      const codexShellCall = containerFetch.mock.calls.find(([url]) =>
+        String(url).endsWith("/internal/deploy-codex-shell-smoke")
+      );
+      expect(timeoutBySignal.get(
+        startAndWaitForPorts.mock.calls[0]?.[0]?.cancellationOptions.abort,
+      )).toBe(20_000);
+      expect(timeoutBySignal.get(healthCall?.[1]?.signal)).toBe(20_000);
+      expect(timeoutBySignal.get(codexShellCall?.[1]?.signal)).toBe(60_000);
+    } finally {
+      timeout.mockRestore();
+    }
+  });
+
   it("can extend deploy smoke to run a direct R2 presigned PUT probe", async () => {
     const presignedPutUrl =
       "https://example-account.r2.cloudflarestorage.com/test-bucket/snapshot.enc?X-Amz-Signature=test";


### PR DESCRIPTION
## Why and outcome

The protected production deploy reached the new public Goal CLI proof, but the Worker aborted its container request after the ordinary 20-second readiness budget. The bounded container proof itself permits 45 seconds.

Give only the Codex shell smoke phase a 60-second Worker budget. Keep normal runner readiness and health at 20 seconds.

## Product UX

- Effort: Not applicable — deploy-only reliability fix
- Result: Not applicable
- Walkthrough: No member-facing UI or behavior changes; this allows the existing protected Goal deployment proof to complete.

## Evidence

- Direct: Production deploy run 33853288959 repeatedly reached managed-container smoke and aborted the Codex shell request at the old deadline; the protected pre-deploy container gate completed the Goal proof with `healthCommonsCliGoalProofCount=6`.
- Coverage: `pnpm --dir apps/cloudflare test` — 156 files / 2,893 tests passed (2 skipped), plus 6 container-helper tests; the package gate also passed typecheck. The focused regression maps each request signal to its timeout and proves readiness/health remain 20 seconds while the Codex shell phase receives 60 seconds.

## Non-obvious affected surfaces

- The signed managed-container deployment smoke only. Full Cloudflare tests cover container lifecycle cleanup, health, direct R2, live-model fencing, error forwarding, and the new timeout boundary.

## Architecture and reuse

- Existing systems reused: Existing per-phase `AbortSignal.timeout` pattern already used by direct-R2 and live-model smoke.
- New logic: One phase-specific minimum timeout for the bounded Codex shell proof.
- New abstractions: None; a local constant is sufficient.
- Complexity intentionally avoided: No retry, lifecycle, endpoint, configuration, or state changes.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; debt and maximum complexity unchanged.
- Hotspots: Existing `wakeRuntime`, `ensureContainerReady`, `destroyIfRunning`, `classifyHostedRunnerContainerErrorResponse`, and `invokeHostedExecution` hotspots are unchanged; the edited `smokeCodexShell` function is below threshold.
- Agent judgment: No further simplification is justified; the existing phase-specific timeout shape is direct and consistent.

## Hot reply path impact

- Path status: Not applicable — only the signed deployment smoke calls this path.
- Database calls: None
- Network/provider calls: None added or moved
- Other awaited latency: The deploy-only Codex shell request may now wait up to 60 seconds instead of 20 seconds.
- Before/after proof: Focused signal-mapping regression test plus the existing smoke lifecycle suite.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged
- Tool/schema/generated guidance: Unchanged
- Other provider-visible input: Unchanged
- Measurement method: Not run — no provider-input surface changed.

## Risks

ReviewGPT context sensitivity: sensitive
Classification reason: This changes the timeout on a protected production deployment gate, though not the member execution path.

## Deployment concerns

- Deployment: applicable
- Supported skew: The new Worker is compatible with old and new runner images; the endpoint and response contract are unchanged.
- Safe order: Deploy Worker and runner together with `container_rollout=immediate` because the public Goal lineage rollout still requires exact bundle convergence.
- Rollback floor: Preserve the existing public Goal lineage-compatible runner floor after any lineage write; forward-fix rather than rolling below it.
- Expected exposure: Signed deploy-smoke requests only; ordinary user readiness retains its existing timeout.
- Reversibility: The timeout change is independently reversible, subject to the existing Goal lineage rollback floor.
- Convergence proof: Protected managed-container smoke must report the exact runner-bundle fingerprint and `healthCommonsCliGoalProofCount=6`.
- Post-deploy checks: Require public health at the new Worker version, direct-R2 smoke, managed-container Goal proof, and the fenced live-model turn.

## Change-shape breakdown

Classification rule: Runtime TypeScript is Source, the focused Vitest case is Tests / fixtures, and the deploy runbook change is Docs. No binaries or generated output.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 6 | 1 |
| Tests / fixtures | 30 | 0 |
| Docs | 3 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **39** | **1** |

## Changelog

- Changelog: not applicable
- Reason: Internal deployment verification reliability; no member-visible product change.

ReviewGPT first-reviewed head: 6bfe947800bfdd8bec16bde7bbf1bc296a432009



