### PR TITLE
fix(cloudflare): correlate container startup timeout stages

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-container-startup-timeout-observability.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-container-startup-timeout-observability.md
@@ -1,0 +1,77 @@
+# Correlate container startup timeout stages
+
+Status: completed
+Created: 2026-09-04
+
+## Goal
+
+- Make an exact runtime-processing timeout attributable to the existing
+  container-local startup stage without adding a request, timer, retry, state
+  owner, or user-visible delay.
+- Keep the diagnostic metadata-only and preserve every readiness, cleanup, and
+  write-fence behavior.
+
+## Evidence
+
+- UserRunner already records the orchestration attempt, caller deadline, retry
+  reason, and elapsed time when its readiness RPC times out.
+- RunnerContainer already records the local failure stage and elapsed time, but
+  intentionally omits correlation metadata, so the two records cannot be joined
+  for one exact failed attempt.
+- The readiness RPC already receives a metadata-only request from UserRunner;
+  the existing orchestration attempt identifier is already logged at the
+  caller boundary.
+
+## Scope
+
+- Add the existing orchestration attempt identifier as optional metadata on the
+  internal readiness RPC and the existing failure-only container log.
+- Record the effective readiness timeout on both failure boundaries.
+- Add focused correlation, compatibility, and privacy regressions and align the
+  hosted runtime protocol documentation.
+
+## Protected invariants
+
+- No raw user, workspace, message, provider, prompt, payload, credential, URL,
+  path, environment value, or error text enters the new fields.
+- Old callers remain valid when the optional correlation field is absent, and
+  old callees continue ignoring the additive field during rollout skew.
+- The foreground reply path gains no awaited work, network call, retry, or
+  persistence.
+- Cloudflare remains the container-startup diagnostic owner; Temporal remains
+  pointer-only and owns durable retry/coalescing.
+
+## Tasks
+
+1. [x] Implement the additive internal correlation metadata in the existing
+   readiness request and failure logger.
+2. [x] Add focused tests for exact-attempt correlation, timeout values, absent-field
+   compatibility, and identifier exclusion.
+3. [x] Update the durable runtime protocol and run focused tests, typecheck,
+   complexity, diff, and privacy checks.
+4. [x] Prepare the scoped candidate and archive this implementation plan.
+
+PR creation, exact-head CI, and the final ReviewGPT gate follow the repository's
+external completion workflow after this plan is archived.
+
+## Verification
+
+- Passed twice: `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts apps/cloudflare/test/runner-container.test.ts apps/cloudflare/test/user-runner-alarm.test.ts --no-coverage` (395 tests).
+- Passed: `pnpm --dir apps/cloudflare typecheck`.
+- Passed: `pnpm complexity:diff`; both touched-source hotspot totals are
+  unchanged and the patch adds no branch to either listed hotspot.
+- Passed: `pnpm docs:drift`, `pnpm docs:gardening`, `git diff --check`, and the
+  task-diff direct-identifier scan.
+- The root typecheck dispatcher was not used as duplicate proof: it was waiting
+  behind an independently owned acceptance run, while the directly relevant
+  Cloudflare typecheck completed successfully.
+
+## Deployment concerns
+
+- This is additive diagnostic metadata inside one Worker deployment and is
+  independently reversible. No schema or state migration exists.
+- Deploy through the protected Cloudflare workflow only after exact-head review
+  and CI. Confirm one natural timeout or bounded synthetic smoke correlates the
+  caller deadline with a container-local stage before relying on the field.
+Updated: 2026-09-04
+Completed: 2026-09-04

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -96,6 +96,12 @@ timeout retry, the 30-second deadline, fixed-schema timeout diagnostics,
 joined-cancellation ownership, and direct proof expectations are specified by
 `agent-docs/references/hosted-runtime-protocol.md`.
 
+Hosted container-startup timeout diagnostics join the existing UserRunner
+caller warning to its exact container-local failure stage with one opaque
+orchestration attempt identifier and the effective readiness timeout. The
+metadata-only, failure-only, mixed-version-safe contract is specified by
+`agent-docs/references/hosted-runtime-protocol.md`.
+
 Hosted workspace-read failure classification, including the unchanged caller
 error, background bounded envelope inspection, closed error-code allowlist, and
 privacy-safe Worker fields, is specified by

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -4065,12 +4065,15 @@ add no request, polling loop, persisted state owner, or reply-path work.
 Failed authoritative startup confirmation has one failure-only local
 observation because Durable Object RPC does not preserve custom properties on a
 thrown error. `Hosted execution container startup confirmation failed.` carries
-only `runtimeStartupFailureStage`, `runtimeStartupFailureElapsedMs`, and
-`runtimeStartupCleanupUnsettled`; it carries no user, workspace, message,
-command, provider, path, URL, prompt, transcript, argument, payload, health
-value, credential, environment value, raw error, stack, hash, or correlation
-identifier. Elapsed time is a non-negative integer saturated at 60,000 ms. The
-four container-local stages are `lifecycle_lock_or_state_read`,
+`runtimeStartupFailureStage`, `runtimeStartupFailureElapsedMs`,
+`runtimeStartupConfirmTimeoutMs`, and `runtimeStartupCleanupUnsettled`. When the
+validated caller supplied one, it also carries the same opaque
+`orchestrationAttemptId` already present on the UserRunner warning so operators
+can join the caller deadline to its exact container-local stage. It carries no
+user, workspace, message, command, provider, path, URL, prompt, transcript,
+argument, payload, health value, credential, environment value, raw error,
+stack, or hash. Elapsed time is a non-negative integer saturated at 60,000 ms.
+The four container-local stages are `lifecycle_lock_or_state_read`,
 `warm_health_or_cleanup`, `cold_start_or_ports`, and
 `cold_health_or_finalization`. The cleanup boolean overlays the stage that
 triggered cleanup instead of replacing it.
@@ -4096,7 +4099,10 @@ without a safely transported local stage; it must never be guessed into a
 container-local bucket. `caller_deadline` means the command budget or the outer
 startup guard elapsed. The generic
 `Hosted runner runtime processing startup confirmation failed.` warning also
-records its already-selected closed retry reason. Retry selection, fence
+records its already-selected closed retry reason. After readiness dispatch, the
+UserRunner failure warnings also record the effective
+`runtimeStartupConfirmTimeoutMs`; pre-dispatch command-budget exhaustion omits
+it because no readiness timeout was assigned. Retry selection, fence
 clearing or preservation, cleanup, readiness, and exception/RPC behavior remain
 unchanged. Both observations reuse the existing structured logger and add no
 awaited I/O, timer, retry, state, queue, or telemetry backend. During skew, an

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -222,6 +222,7 @@ export interface HostedExecutionContainerInvokeRequest {
 type HostedExecutionContainerInvokeInput = HostedExecutionContainerInvokeRequest;
 
 export interface RunnerContainerEnsureReadyForProcessingInput {
+  orchestrationAttemptId?: string;
   timeoutMs: number;
   userId: string;
 }
@@ -984,16 +985,20 @@ export class RunnerContainer extends Container {
       if (result.kind === "cleanup_unsettled") {
         emitRunnerContainerStartupFailureObservation({
           cleanupUnsettled: true,
+          orchestrationAttemptId: input.orchestrationAttemptId,
           readinessRequestedAtEpochMs,
           stage: startupFailureObservation.stage,
+          timeoutMs: input.timeoutMs,
         });
       }
       return result;
     } catch (error) {
       emitRunnerContainerStartupFailureObservation({
         cleanupUnsettled: cleanupSettlementTimedOut,
+        orchestrationAttemptId: input.orchestrationAttemptId,
         readinessRequestedAtEpochMs,
         stage: startupFailureObservation.stage,
+        timeoutMs: input.timeoutMs,
       });
       if (cleanupSettlementTimedOut) {
         return { kind: "cleanup_unsettled" };
@@ -4554,8 +4559,10 @@ function hostedRunnerContainerFragmentsOverlap(left: string, right: string): boo
 
 function emitRunnerContainerStartupFailureObservation(input: {
   cleanupUnsettled: boolean;
+  orchestrationAttemptId?: string;
   readinessRequestedAtEpochMs: number;
   stage: RunnerContainerLocalStartupFailureStage;
+  timeoutMs: number;
 }): void {
   try {
     const rawElapsedMs = Date.now() - input.readinessRequestedAtEpochMs;
@@ -4568,6 +4575,10 @@ function emitRunnerContainerStartupFailureObservation(input: {
     emitHostedExecutionStructuredLog({
       component: "container",
       details: {
+        ...(input.orchestrationAttemptId === undefined
+          ? {}
+          : { orchestrationAttemptId: input.orchestrationAttemptId }),
+        runtimeStartupConfirmTimeoutMs: input.timeoutMs,
         runtimeStartupCleanupUnsettled: input.cleanupUnsettled,
         runtimeStartupFailureElapsedMs: elapsedMs,
         runtimeStartupFailureStage: input.stage,
@@ -4749,6 +4760,14 @@ function parseRunnerContainerEnsureReadyForProcessingInput(
   payload: RunnerContainerEnsureReadyForProcessingInput,
 ): RunnerContainerEnsureReadyForProcessingInput {
   return {
+    ...(payload.orchestrationAttemptId === undefined
+      ? {}
+      : {
+          orchestrationAttemptId: requireString(
+            payload.orchestrationAttemptId,
+            "payload.orchestrationAttemptId",
+          ),
+        }),
     timeoutMs: readTimeoutMs(payload.timeoutMs, DEFAULT_RUNNER_READY_TIMEOUT_MS),
     userId: requireString(payload.userId, "payload.userId"),
   };

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -1721,8 +1721,8 @@ export class RuntimeProcessingController {
     }
 
     let readinessRpcDispatched = false;
+    let timeoutMs = RUNTIME_PROCESSING_STARTUP_CONFIRM_TIMEOUT_MS;
     try {
-      let timeoutMs = RUNTIME_PROCESSING_STARTUP_CONFIRM_TIMEOUT_MS;
       const readinessResult = await runRuntimeProcessingCommandStep({
         budget: input.commandBudget,
         operation: async () => {
@@ -1742,6 +1742,7 @@ export class RuntimeProcessingController {
           );
           readinessRpcDispatched = true;
           return await container.ensureReadyForProcessing!({
+            orchestrationAttemptId: input.input.orchestrationAttemptId,
             timeoutMs,
             userId: input.input.userId,
           });
@@ -1754,6 +1755,7 @@ export class RuntimeProcessingController {
           details: {
             orchestrationAttemptId: input.input.orchestrationAttemptId,
             runtimeProcessingRetryReason: "container_rpc_timeout",
+            runtimeStartupConfirmTimeoutMs: timeoutMs,
             runtimeStartupCleanupUnsettled: true,
             runtimeStartupFailureElapsedMs:
               readBoundedRuntimeStartupFailureElapsedMs(
@@ -1811,6 +1813,7 @@ export class RuntimeProcessingController {
             ...buildHostedRunnerMetadataOnlyErrorDetails(error),
             orchestrationAttemptId: input.input.orchestrationAttemptId,
             runtimeProcessingRetryReason: "container_rpc_timeout",
+            runtimeStartupConfirmTimeoutMs: timeoutMs,
             runtimeStartupFailureElapsedMs:
               readBoundedRuntimeStartupFailureElapsedMs(
                 startupConfirmationStartedAtEpochMs,
@@ -1843,6 +1846,9 @@ export class RuntimeProcessingController {
           ? "command_budget_exhausted"
           : undefined,
         startupConfirmationStartedAtEpochMs,
+        startupConfirmationTimeoutMs: readinessRpcDispatched
+          ? timeoutMs
+          : undefined,
         token: input.token,
       });
     }
@@ -1854,6 +1860,7 @@ export class RuntimeProcessingController {
     input: RuntimeProcessingInput;
     retryReason?: RuntimeProcessingStartFailureRetryReason;
     startupConfirmationStartedAtEpochMs: number;
+    startupConfirmationTimeoutMs?: number;
     token: RunnerWriteFenceToken;
   }): Promise<{
     confirmed: false;
@@ -1869,6 +1876,7 @@ export class RuntimeProcessingController {
           input.startupConfirmationStartedAtEpochMs,
         ),
         stage: input.failureStage,
+        timeoutMs: input.startupConfirmationTimeoutMs,
       },
       token: input.token,
     });
@@ -1882,6 +1890,7 @@ export class RuntimeProcessingController {
     startupFailure?: {
       elapsedMs: number;
       stage: RuntimeStartupCallerFailureStage;
+      timeoutMs?: number;
     };
     token: RunnerWriteFenceToken;
   }): Promise<{
@@ -1902,6 +1911,9 @@ export class RuntimeProcessingController {
         orchestrationAttemptId: input.input.orchestrationAttemptId,
         ...(input.startupFailure === undefined ? {} : {
           runtimeProcessingRetryReason: retryReason,
+          ...(input.startupFailure.timeoutMs === undefined ? {} : {
+            runtimeStartupConfirmTimeoutMs: input.startupFailure.timeoutMs,
+          }),
           runtimeStartupFailureElapsedMs: input.startupFailure.elapsedMs,
           runtimeStartupFailureStage: input.startupFailure.stage,
         }),

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -83,6 +83,8 @@ type RunnerContainerLocalStartupFailureStage = Exclude<
 function expectRunnerContainerStartupFailureObservation(input: {
   cleanupUnsettled: boolean;
   expectedElapsedMs?: number;
+  expectedOrchestrationAttemptId?: string;
+  expectedTimeoutMs?: number;
   forbiddenValues?: readonly string[];
   stage: RunnerContainerLocalStartupFailureStage;
 }): void {
@@ -100,6 +102,10 @@ function expectRunnerContainerStartupFailureObservation(input: {
   expect(observation).toEqual({
     component: "container",
     details: {
+      ...(input.expectedOrchestrationAttemptId === undefined
+        ? {}
+        : { orchestrationAttemptId: input.expectedOrchestrationAttemptId }),
+      runtimeStartupConfirmTimeoutMs: input.expectedTimeoutMs ?? expect.any(Number),
       runtimeStartupCleanupUnsettled: input.cleanupUnsettled,
       runtimeStartupFailureElapsedMs: expect.any(Number),
       runtimeStartupFailureStage: input.stage,
@@ -121,6 +127,12 @@ function expectRunnerContainerStartupFailureObservation(input: {
   expect(elapsedMs).toBeLessThanOrEqual(
     RUNNER_CONTAINER_STARTUP_FAILURE_ELAPSED_MAX_MS,
   );
+  const timeoutMs = details.runtimeStartupConfirmTimeoutMs;
+  expect(typeof timeoutMs).toBe("number");
+  if (typeof timeoutMs !== "number") {
+    throw new Error("Expected numeric startup confirmation timeout milliseconds.");
+  }
+  expect(timeoutMs).toBeGreaterThan(0);
   if (input.expectedElapsedMs !== undefined) {
     expect(elapsedMs).toBe(input.expectedElapsedMs);
   }
@@ -2370,6 +2382,7 @@ describe("RunnerContainer", () => {
   });
 
   it("classifies cold start and port-readiness failures", async () => {
+    const orchestrationAttemptId = "test-cold-start-timeout-correlation";
     const privateErrorText = "port wait failed with token=private-start-token";
     const startFailure = new Error(privateErrorText);
     const { container } = createContainerDouble({
@@ -2379,12 +2392,15 @@ describe("RunnerContainer", () => {
     });
 
     await expect(container.ensureReadyForProcessing({
+      orchestrationAttemptId,
       timeoutMs: 15_000,
       userId: "member_private_cold_start",
     })).rejects.toBe(startFailure);
 
     expectRunnerContainerStartupFailureObservation({
       cleanupUnsettled: false,
+      expectedOrchestrationAttemptId: orchestrationAttemptId,
+      expectedTimeoutMs: 15_000,
       forbiddenValues: [privateErrorText, "member_private_cold_start"],
       stage: "cold_start_or_ports",
     });

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1552,6 +1552,7 @@ describe("HostedUserRunner execution coordination", () => {
 
     await vi.waitFor(() => expect(ensureReadyForProcessing).toHaveBeenCalledOnce());
     expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-orchestration-attempt",
       timeoutMs: 15_000,
       userId: TEST_USER_ID,
     });
@@ -2495,6 +2496,7 @@ describe("HostedUserRunner execution coordination", () => {
     );
     await vi.waitFor(() => expect(ensureReadyForProcessing).toHaveBeenCalledOnce());
     expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-orchestration-attempt",
       timeoutMs: 15_000,
       userId: TEST_USER_ID,
     });
@@ -2689,6 +2691,7 @@ describe("HostedUserRunner execution coordination", () => {
       ([input]) => input.path === HOSTED_RUNTIME_CRYPTO_CONTEXT_PATH,
     )).toHaveLength(1);
     expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-orchestration-attempt",
       timeoutMs: 3_000,
       userId: TEST_USER_ID,
     });
@@ -2722,6 +2725,7 @@ describe("HostedUserRunner execution coordination", () => {
 
     expect(workspaceReadTimeouts).toEqual([29_000]);
     expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-orchestration-attempt",
       timeoutMs: 15_000,
       userId: TEST_USER_ID,
     });
@@ -2748,6 +2752,7 @@ describe("HostedUserRunner execution coordination", () => {
       userId: TEST_USER_ID,
     });
     await vi.waitFor(() => expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-orchestration-attempt",
       timeoutMs: 15_000,
       userId: TEST_USER_ID,
     }));
@@ -2781,6 +2786,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
     await vi.waitFor(() => expect(ensureReadyForProcessing).toHaveBeenCalledOnce());
     expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "default-budget-tail-readiness",
       timeoutMs: 15_000,
       userId: TEST_USER_ID,
     });
@@ -2818,6 +2824,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-orchestration-attempt",
       timeoutMs: 8_000,
       userId: TEST_USER_ID,
     });
@@ -2914,6 +2921,7 @@ describe("HostedUserRunner execution coordination", () => {
       retryAt: "2026-04-27T00:00:19.000Z",
     });
     expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-orchestration-attempt",
       timeoutMs: 8_000,
       userId: TEST_USER_ID,
     });
@@ -2958,6 +2966,7 @@ describe("HostedUserRunner execution coordination", () => {
       kind: "runtime_processing_accepted",
     });
     expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-orchestration-attempt",
       timeoutMs: 8_000,
       userId: TEST_USER_ID,
     });
@@ -3136,6 +3145,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-orchestration-attempt",
       timeoutMs: 15_000,
       userId: TEST_USER_ID,
     });
@@ -3232,6 +3242,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
     expect(workspaceReadStarted).toBe(true);
     expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-orchestration-attempt",
       timeoutMs: 15_000,
       userId: TEST_USER_ID,
     });
@@ -3334,6 +3345,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-orchestration-attempt",
       timeoutMs: 15_000,
       userId: TEST_USER_ID,
     });
@@ -3360,6 +3372,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-orchestration-attempt",
       timeoutMs: 15_000,
       userId: TEST_USER_ID,
     });
@@ -3547,6 +3560,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-orchestration-attempt",
       timeoutMs: 15_000,
       userId: TEST_USER_ID,
     });
@@ -3561,7 +3575,9 @@ describe("HostedUserRunner execution coordination", () => {
     expect(readStructuredLogDetails(
       "Hosted runner runtime processing startup confirmation failed.",
     )).toMatchObject({
+      orchestrationAttemptId: "test-orchestration-attempt",
       runtimeProcessingRetryReason: "container_rpc_timeout",
+      runtimeStartupConfirmTimeoutMs: 15_000,
       runtimeStartupFailureElapsedMs: 0,
       runtimeStartupFailureStage: "rpc_unattributed",
       transportFailureFenceCleared: true,
@@ -3599,6 +3615,7 @@ describe("HostedUserRunner execution coordination", () => {
       responseSettled = true;
     });
     await vi.waitFor(() => expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-cleanup-settlement",
       timeoutMs: 15_000,
       userId: TEST_USER_ID,
     }));
@@ -3669,7 +3686,9 @@ describe("HostedUserRunner execution coordination", () => {
     expect(readStructuredLogDetails(
       "Hosted runner runtime processing startup cleanup did not settle.",
     )).toMatchObject({
+      orchestrationAttemptId: "test-unsettled-cleanup",
       runtimeProcessingRetryReason: "container_rpc_timeout",
+      runtimeStartupConfirmTimeoutMs: 15_000,
       runtimeStartupCleanupUnsettled: true,
       runtimeStartupFailureElapsedMs: 0,
       runtimeStartupFailureStage: "rpc_unattributed",
@@ -3733,7 +3752,9 @@ describe("HostedUserRunner execution coordination", () => {
     expect(readStructuredLogDetails(
       "Hosted runner runtime processing startup confirmation guard elapsed.",
     )).toMatchObject({
+      orchestrationAttemptId: "test-orchestration-attempt",
       runtimeProcessingRetryReason: "container_rpc_timeout",
+      runtimeStartupConfirmTimeoutMs: expect.any(Number),
       runtimeStartupFailureElapsedMs: 8_950,
       runtimeStartupFailureStage: "caller_deadline",
       runtimeStartupWriteFencePreserved: true,
@@ -3785,14 +3806,17 @@ describe("HostedUserRunner execution coordination", () => {
         }),
       }),
     );
-    expect(readStructuredLogDetails(
+    const failureDetails = readStructuredLogDetails(
       "Hosted runner runtime processing startup confirmation failed.",
-    )).toMatchObject({
+    );
+    expect(failureDetails).toMatchObject({
+      orchestrationAttemptId: "pre-dispatch-budget-expired",
       runtimeProcessingRetryReason: "command_budget_exhausted",
       runtimeStartupFailureElapsedMs: 60_000,
       runtimeStartupFailureStage: "caller_deadline",
       transportFailureFenceCleared: true,
     });
+    expect(failureDetails).not.toHaveProperty("runtimeStartupConfirmTimeoutMs");
   });
 
   it("invokes startup readiness directly on the container stub", async () => {
@@ -3807,6 +3831,7 @@ describe("HostedUserRunner execution coordination", () => {
     ) {
       readinessReceiver = this;
       expect(input).toEqual({
+        orchestrationAttemptId: "test-orchestration-attempt",
         timeoutMs: 15_000,
         userId: TEST_USER_ID,
       });
@@ -3861,6 +3886,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(ensureReadyForProcessing).toHaveBeenCalledWith({
+      orchestrationAttemptId: "test-orchestration-attempt",
       timeoutMs: 15_000,
       userId: TEST_USER_ID,
     });


### PR DESCRIPTION
## Why and outcome

Container-local startup logs already named the failing stage, while UserRunner timeout logs already named the orchestration attempt. Durable Object RPC errors do not preserve custom error properties, so those records could not be joined for one exact timeout.

This passes the existing opaque orchestration attempt identifier through the existing readiness request and records it plus the effective timeout on failure-only logs. It adds no request, timer, retry, state owner, or user-visible delay.

## Product UX

- Effort: Not applicable — internal failure diagnostics only.
- Result: Not applicable
- Walkthrough: Members see no behavior, copy, timing, or retry change.

## Evidence

- Direct: Focused RunnerContainer and UserRunner suites pass twice: 395/395 tests. They prove exact-attempt propagation, effective timeout reporting, old-caller compatibility, pre-dispatch omission, fence behavior, and exclusion of raw user/error values.
- Coverage: Cloudflare typecheck, complexity guard, docs drift/gardening, diff whitespace, and identifier scan pass.

## Non-obvious affected surfaces

- The internal UserRunner-to-RunnerContainer Durable Object RPC gains one optional metadata field; tests prove both present and absent forms.
- Existing structured runtime failure logs gain correlation and timeout metadata only.
- The hosted runtime protocol and index document mixed-version and privacy behavior.

## Architecture and reuse

- Existing systems reused: Existing orchestration attempt ID, readiness RPC, structured logger, local failure-stage classifier, and timeout budget.
- New logic: Only conditional propagation and emission of existing metadata.
- New abstractions: None; the existing request type and failure logger remain the owners.
- Complexity intentionally avoided: No telemetry backend, lookup table, persisted correlation state, second request, timer, retry, or error-transport wrapper.

## Complexity impact

- Guard: pass — pnpm complexity:diff; both touched-source debt and maxima are unchanged.
- Hotspots: Existing wakeRuntime (74), ensureContainerReady (36), destroyIfRunning (26), classifyHostedRunnerContainerErrorResponse (24), invokeHostedExecution (21), ensureExistingRuntimeProcessing (25), and startRuntimeProcessing (22) are unchanged in complexity.
- Agent judgment: No further abstraction is justified; direct optional-field propagation is the smallest composable shape.

## Hot reply path impact

- Path status: Touched — the existing readiness RPC payload gains one opaque string.
- Database calls: None.
- Network/provider calls: No new calls; the existing Durable Object RPC carries one additional field.
- Other awaited latency: None.
- Before/after proof: Focused tests preserve readiness timeouts, retries, cleanup, and write-fence behavior across 395 cases.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Risks

ReviewGPT context sensitivity: sensitive
Classification reason: The patch touches Cloudflare hosted-execution diagnostics and an internal Durable Object RPC boundary.
ReviewGPT first-reviewed head: 3c70cf210efaf0156452039ad8d79e256ad02322

## Deployment concerns

- Deployment: applicable
- Supported skew: New callers are accepted by old containers because they ignore the additive field; new containers accept old callers because the field is optional.
- Safe order: One protected Cloudflare Worker deployment; either mixed-version direction remains valid.
- Rollback floor: Any current production version; there is no schema, persisted state, or required protocol floor.
- Expected exposure: Failure-only runtime logs gain the opaque attempt identifier and effective readiness timeout.
- Reversibility: Redeploy the prior Worker version.
- Convergence proof: Focused present/absent-field tests plus exact-head CI; after deploy, correlate one bounded natural or synthetic timeout across caller and container records.
- Post-deploy checks: Verify the deployed Worker version, inspect bounded startup-timeout aggregates, and confirm paired attempt/stage fields without an increased timeout rate.

## Change-shape breakdown

Classification rule: Runtime TypeScript is Source; Vitest files are Tests / fixtures; protocol, index, and execution plan are Docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 32 | 1 |
| Tests / fixtures | 44 | 2 |
| Docs | 96 | 7 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **172** | **10** |

## Changelog

- Changelog: not applicable
- Reason: Internal failure-only observability with no member-visible change.
