### PR TITLE
Route achievable outcome help through public Goals

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-04-goal-help-routing.md
+++ b/agent-docs/exec-plans/active/2026-09-04-goal-help-routing.md
@@ -1,0 +1,70 @@
+# Goal Help Routing
+
+## Outcome
+
+Route explicit requests for help pursuing an achievable health outcome through
+the existing `goal-setup` owner before broad domain guidance, so public Goal
+CTAs resolve their exact Health Commons Goal record when one exists.
+
+## Protected invariants
+
+- Informational health questions remain owned by their domain skill and do not
+  manufacture a Goal.
+- A bare Goal CTA authorizes read-only grounding and one useful question, not
+  saved state or outbound support.
+- Health Commons Goal resolution remains owned by `goal-setup`; no second
+  router, tool, or state owner is introduced.
+- Internal implementation names, keys, and revisions remain out of the reply.
+
+## Current owner and evidence
+
+- `buildAssistantSkillRouteHintText` owns the top-level skill-routing hint.
+- `goal-setup/SKILL.md` already owns exact public Goal list/show resolution.
+- The exact public sleep-continuity outcome exists in the generated Goal
+  catalog, while recent production behavior did not complete list plus show.
+
+## Product UX classification
+
+Product UX Patch: correct an existing conversational route without adding a
+new surface or interaction. Replay an exact public Goal CTA, a plain-language
+equivalent outcome request, and a knowledge-only sleep question.
+
+## Smallest correction
+
+Clarify one existing setup-router line so concrete requests to pursue an
+achievable health outcome—including natural “help me” phrasing—load
+`goal-setup` before domain or broad knowledge routing. Keep the detailed exact
+lookup policy in `goal-setup`.
+
+## Proof
+
+1. Add deterministic prompt-composition coverage for the route and its
+   knowledge-only boundary.
+2. Add a focused production-derived real-Codex journey for the public sleep
+   Goal CTA, asserting successful Goal list/show before the first question,
+   no mutation, and no internal terminology.
+3. Run the live journey against the pre-fix prompt to attempt direct
+   reproduction, then rerun after the prompt correction.
+4. Run the focused unit tests, assistant-engine typecheck, and final diff/privacy
+   inspection.
+
+## Observed evidence
+
+- The pre-change live sample happened to resolve the exact public Goal, so the
+  production miss is stochastic rather than a deterministic local failure.
+- The first post-change sample resolved the exact Goal but exposed an unrelated
+  over-broad assertion for a secondary readiness owner; the focused regression
+  now stays on the missing route and exact Goal resolution while the existing
+  full setup journey continues to cover registered-owner reads.
+- The final post-change live sample read `goal-setup`, listed and showed the
+  exact sleep-continuity Goal, checked private Goal state and compact memory,
+  made no writes, and asked one question only after grounding.
+- Focused prompt tests, the assistant-engine typecheck, and the complexity
+  ratchet pass. The stable route prompt is smaller than its prior bound.
+
+## Delivery
+
+Commit the scoped prompt, deterministic test, live journey, and completed plan;
+open a draft PR, start ReviewGPT only if the final scope triggers it, and use
+exact-head CI as the merge gate. Deployment remains a separate authorization
+boundary.

--- a/agent-docs/exec-plans/completed/2026-09-04-goal-help-routing.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-goal-help-routing.md
@@ -61,10 +61,20 @@ lookup policy in `goal-setup`.
   made no writes, and asked one question only after grounding.
 - Focused prompt tests, the assistant-engine typecheck, and the complexity
   ratchet pass. The stable route prompt is smaller than its prior bound.
+- A normalized local Responses capture of identical direct and group initial
+  requests measured base/head at 27,531/27,538 tokens and 127,558/127,554
+  bytes for direct, and 23,446/23,453 tokens and 109,019/109,015 bytes for
+  group. The +7-token, -4-byte delta is entirely assembled router instructions;
+  tool schemas and other provider-visible fields are unchanged.
+- The public changelog fragment for PR 2814 passes its focused nine-test suite,
+  and the Web typecheck passes.
 
 ## Delivery
 
-Commit the scoped prompt, deterministic test, live journey, and completed plan;
-open a draft PR, start ReviewGPT only if the final scope triggers it, and use
-exact-head CI as the merge gate. Deployment remains a separate authorization
-boundary.
+Commit the scoped prompt, deterministic test, live journey, changelog, and
+completed plan; update draft PR 2814, start ReviewGPT only if the final scope
+triggers it, and use exact-head CI as the merge gate. Deployment remains a
+separate authorization boundary.
+Status: completed
+Updated: 2026-09-04
+Completed: 2026-09-04

--- a/apps/web/changelog/entries/2026-09-04/goal-requests-find-matching-guidance.json
+++ b/apps/web/changelog/entries/2026-09-04/goal-requests-find-matching-guidance.json
@@ -1,0 +1,18 @@
+{
+  "publishedOn": "2026-09-04",
+  "order": 100,
+  "item": {
+    "id": "goal-requests-find-matching-guidance",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Goal requests find the matching guidance",
+    "summary": "When you ask Murph to help with a concrete health outcome, it now checks for matching public Goal guidance before beginning the setup conversation.",
+    "details": "Informational questions remain ordinary health Q&A, and Murph does not save a Goal or ongoing support until you accept the proposed plan.",
+    "relevanceTags": ["goals", "health-commons", "conversation"],
+    "sourcePullRequests": [2814],
+    "tryIt": {
+      "label": "Work on a sleep goal",
+      "prompt": "Hey Murph, help me sleep through the night."
+    }
+  }
+}

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -1568,8 +1568,8 @@ function buildAssistantSkillRouteHintText(
 ): string {
   const routeLines = [
     "Murph skill router:",
-    "- Specialized skills live at `$MURPH_ASSISTANT_SKILLS_ROOT/<slug>/SKILL.md`. Route by the user's visible outcome and read the primary owner. If routing is ambiguous, inspect at most two candidates; this cap is discovery-only. Then follow explicit handoffs and load every distinct safety or execution owner. Do not preload skills or call a discovery CLI just to route.",
-    "- Setup: murph-onboarding, goal-setup, hosted-low-usage, signup-link (explicit requests), experiment-onboarding, behavior-followthrough.",
+    "- Skills live at `$MURPH_ASSISTANT_SKILLS_ROOT/<slug>/SKILL.md`. Read the primary owner for the user's visible outcome. If ambiguous, inspect at most two for discovery; then follow handoffs and load each safety/execution owner. Do not preload or use a discovery CLI.",
+    "- Setup: explicit achievable-outcome help (`help me ...`/Goals CTA) -> goal-setup before domain/Commons knowledge; facts -> domain. Also: murph-onboarding, hosted-low-usage, signup-link, experiment-onboarding, behavior-followthrough.",
     "- Automatic meal capture: automatic-meal-capture for the iPhone app, Photos permission, background timing, Meals review, import verification, and photo-only meal enrichment.",
     "- Sleep/readiness: sleep-improvement, circadian-rhythm, sleep-recovery-readiness, hrv-resting-heart-rate, energy-fatigue.",
     "- Sleep safety outranks fatigue/clock routing: snoring/gasping, unrefreshing sleep with enough opportunity, unexplained awakenings, morning headache, sleep attacks, or dangerous daytime sleepiness -> sleep-improvement. If driving/work safety is affected, give immediate safety guidance before coaching.",

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -15138,6 +15138,8 @@ describeRealCodex('real Codex Habitat voice maintenance e2e', () => {
 })
 
 const PUBLIC_GOAL_SETUP_KEY = 'goal_template:improve-deep-sleep'
+const PUBLIC_GOAL_SLEEP_THROUGH_NIGHT_KEY =
+  'goal_template:sleep-through-the-night'
 
 interface PublicGoalSetupRecord {
   goalPhrase: string
@@ -15336,6 +15338,164 @@ type PublicGoalSetupAutomationSaveRequest = Extract<
 >
 
 describeRealCodex('real Codex public goal setup e2e', () => {
+  it(
+    'resolves an achievable sleep Goal before asking one setup question',
+    async () => {
+      const config = await resolveRealCodexE2eConfig()
+      const publicGoal = await readPublicGoalSetupRecord(
+        PUBLIC_GOAL_SLEEP_THROUGH_NIGHT_KEY,
+      )
+      const workingDirectory = await mkdtemp(
+        path.join(tmpdir(), 'murph-public-sleep-goal-routing-e2e-'),
+      )
+      const skillsRoot = path.join(workingDirectory, 'skills')
+      const binDirectory = path.join(workingDirectory, 'bin')
+      const vaultRoot = path.join(workingDirectory, 'vault')
+      const commandLogPath = path.join(workingDirectory, 'goal-commands.log')
+
+      try {
+        await initializeVault({
+          timezone: 'America/New_York',
+          vaultRoot,
+        })
+        await Promise.all([
+          materializeAssistantSkill({ skillsRoot, slug: 'goal-setup' }),
+          materializeAssistantSkill({ skillsRoot, slug: 'sleep-improvement' }),
+          materializeAssistantSkill({
+            skillsRoot,
+            slug: 'sleep-recovery-readiness',
+          }),
+          materializePublicGoalSetupVaultCli({
+            binDirectory,
+            commandLogPath,
+            vaultRoot,
+          }),
+        ])
+        const inheritedPath = normalizeEnvString(config.env.PATH)
+        const result = await executeRealCodexAppServerTurn({
+          approvalPolicy: 'never',
+          baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+          codexCommand:
+            normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+            ?? undefined,
+          codexHome: config.codexHome,
+          developerInstructions: buildPublicGoalSetupDeveloperInstructions(),
+          dynamicTools: [MURPH_AUTOMATION_TOOL],
+          env: {
+            ...config.env,
+            [MURPH_ASSISTANT_SKILLS_ROOT_ENV]: skillsRoot,
+            PATH: inheritedPath
+              ? `${binDirectory}${path.delimiter}${inheritedPath}`
+              : binDirectory,
+          },
+          excludeResumeTurns: true,
+          model: config.model,
+          modelProvider: config.modelProvider,
+          prompt: publicGoal.startPrompt,
+          reasoningEffort: 'medium',
+          sandbox: 'workspace-write',
+          workingDirectory,
+        })
+        const actions = readCapabilityRoutingActions(result.jsonEvents)
+        const commandAttempts = readGoalSetupVaultCommands(actions, {
+          successfulOnly: false,
+        })
+        const reply = result.finalMessage.trim()
+        process.stdout.write(
+          `[public-goal-setup-e2e] ${JSON.stringify({
+            reply,
+            scenario: 'sleep-through-the-night-routing',
+          })}\n`,
+        )
+
+        const publicGoalListRead = actions.find(
+          isSuccessfulPublicGoalListAction,
+        )
+        const publicGoalShowRead = actions.find((action) =>
+          isSuccessfulPublicGoalShowActionFor(
+            action,
+            'sleep-through-the-night',
+          )
+        )
+        const goalInventoryRead = actions.find(
+          isSuccessfulGoalInventoryReadAction,
+        )
+        const memoryRead = actions.find(isSuccessfulCompactMemoryReadAction)
+        const normalizeWhitespace = (value: string) =>
+          value.replace(/\s+/gu, ' ').trim()
+        const goalSetupSkillPathSuffix =
+          `${path.sep}goal-setup${path.sep}SKILL.md`
+        const goalSetupSkillReads = actions.filter(
+          (candidate): candidate is Extract<
+            CapabilityRoutingAction,
+            { kind: 'command' }
+          > => candidate.kind === 'command'
+            && candidate.ok
+            && candidate.command.includes(goalSetupSkillPathSuffix),
+        )
+        expect(
+          goalSetupSkillReads.length,
+          'goal-setup read actions before setup',
+        ).toBeGreaterThan(0)
+        const expectedGoalSetupSkill = await readFile(
+          path.join(skillsRoot, 'goal-setup', 'SKILL.md'),
+          'utf8',
+        )
+        expect(
+          normalizeWhitespace(
+            goalSetupSkillReads.map((action) => action.output).join('\n'),
+          ),
+          'goal-setup full-file read before setup',
+        ).toContain(normalizeWhitespace(expectedGoalSetupSkill))
+        expect(publicGoalListRead, 'exact public Goal search').toBeDefined()
+        expect(publicGoalListRead?.output).toContain(
+          PUBLIC_GOAL_SLEEP_THROUGH_NIGHT_KEY,
+        )
+        expect(publicGoalShowRead, 'exact public Goal read').toBeDefined()
+        expect(goalInventoryRead, 'all-status Goal inventory').toBeDefined()
+        expect(memoryRead, 'compact memory read').toBeDefined()
+        expect(commandAttempts.some(isGoalSetupMutationCommand)).toBe(false)
+        expect(actions.filter((action) => action.kind === 'dynamic')).toHaveLength(0)
+
+        const firstQuestion = readCompletedAgentMessages(result.jsonEvents)
+          .find((message) => message.text.includes('?'))
+        expect(firstQuestion, 'one grounded setup question').toBeDefined()
+        if (
+          !firstQuestion
+          || !publicGoalListRead
+          || !publicGoalShowRead
+          || !goalInventoryRead
+          || !memoryRead
+        ) {
+          throw new Error('Expected Goal grounding before the setup question.')
+        }
+        for (const groundingRead of [
+          publicGoalListRead,
+          publicGoalShowRead,
+          goalInventoryRead,
+          memoryRead,
+          ...goalSetupSkillReads,
+        ]) {
+          expect(groundingRead.eventIndex).toBeLessThan(firstQuestion.eventIndex)
+        }
+        expect(reply.match(/\?/gu) ?? []).toHaveLength(1)
+        expect(reply).toMatch(/sleep|night|waking|awakening/iu)
+        expect(reply).not.toMatch(
+          /Health Commons|commons goal|goal_template:|sha256:/iu,
+        )
+        expect(reply).not.toMatch(
+          /(?:no|did not|didn't|could not|couldn't).{0,40}(?:matching|match|entry|goal)/iu,
+        )
+      } finally {
+        await removeRealCodexTemporaryPaths([
+          workingDirectory,
+          ...config.temporaryPaths,
+        ])
+      }
+    },
+    360_000,
+  )
+
   it(
     'grounds from memory, persists finite support, and reuses one Goal package in a fresh session',
     async () => {
@@ -16337,7 +16497,9 @@ function buildPublicGoalSetupDeveloperInstructions(): string {
   })
 }
 
-async function readPublicGoalSetupRecord(): Promise<PublicGoalSetupRecord> {
+async function readPublicGoalSetupRecord(
+  key = PUBLIC_GOAL_SETUP_KEY,
+): Promise<PublicGoalSetupRecord> {
   const artifactPath = fileURLToPath(new URL(
     '../../health-commons/generated/web/browse/goals.json',
     import.meta.url,
@@ -16346,7 +16508,7 @@ async function readPublicGoalSetupRecord(): Promise<PublicGoalSetupRecord> {
   const goals = Array.isArray(artifact?.goals) ? artifact.goals : []
   const goal = goals
     .map((value) => readRecord(value))
-    .find((value) => value?.key === PUBLIC_GOAL_SETUP_KEY)
+    .find((value) => value?.key === key)
   const revision = readRecord(goal?.revision)
   const goalPhrase = readString(goal?.goalPhrase)
   const pageRevisionId = readString(revision?.pageRevisionId)
@@ -16362,13 +16524,13 @@ async function readPublicGoalSetupRecord(): Promise<PublicGoalSetupRecord> {
     || !workflowSpecRevisionId
   ) {
     throw new Error(
-      `Generated Goal index is missing ${PUBLIC_GOAL_SETUP_KEY}.`,
+      `Generated Goal index is missing ${key}.`,
     )
   }
 
   return {
     goalPhrase,
-    key: PUBLIC_GOAL_SETUP_KEY,
+    key,
     pageRevisionId,
     startPrompt,
     workflowSpecRevisionId,
@@ -16534,15 +16696,29 @@ function isSuccessfulGoalSetupEntityShowAction(
 function isSuccessfulPublicGoalShowAction(
   action: CapabilityRoutingAction,
 ): boolean {
+  return isSuccessfulPublicGoalShowActionFor(action, 'improve-deep-sleep')
+}
+
+function escapeGoalSetupRegularExpression(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&')
+}
+
+function isSuccessfulPublicGoalShowActionFor(
+  action: CapabilityRoutingAction,
+  slug: string,
+): boolean {
+  const escapedSlug = escapeGoalSetupRegularExpression(slug)
   return action.kind === 'command'
     && action.ok
     && (
       (
         action.command.includes('commons goal show')
-        && action.command.includes('improve-deep-sleep')
+        && action.command.includes(slug)
       )
-      || /"argv":\s*\[\s*"commons",\s*"goal",\s*"show",\s*"(?:goal_template:)?improve-deep-sleep"/u
-        .test(action.output)
+      || new RegExp(
+        `"argv":\\s*\\[\\s*"commons",\\s*"goal",\\s*"show",\\s*"(?:goal_template:)?${escapedSlug}"`,
+        'u',
+      ).test(action.output)
     )
 }
 

--- a/packages/assistant-engine/test/assistant-goal-setup-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-goal-setup-skill.test.ts
@@ -66,10 +66,13 @@ describe('assistant goal setup skill', () => {
     const prompt = buildPrompt()
 
     expect(prompt).toContain(
-      "Route by the user's visible outcome and read the primary owner.",
+      "Read the primary owner for the user's visible outcome.",
     )
     expect(prompt).toContain(
-      'Setup: murph-onboarding, goal-setup, hosted-low-usage',
+      'explicit achievable-outcome help (`help me ...`/Goals CTA) -> goal-setup before domain/Commons knowledge',
+    )
+    expect(prompt).toContain(
+      'facts -> domain.',
     )
   })
 

--- a/packages/assistant-engine/test/assistant-nutrition-strategy-skill.test.ts
+++ b/packages/assistant-engine/test/assistant-nutrition-strategy-skill.test.ts
@@ -85,15 +85,15 @@ describe('assistant nutrition strategy skill', () => {
     const prompt = buildPrompt()
 
     expect(prompt).toContain(
-      "Route by the user's visible outcome and read the primary owner.",
+      "Read the primary owner for the user's visible outcome.",
     )
     expect(prompt).toContain(
-      'inspect at most two candidates; this cap is discovery-only',
+      'inspect at most two for discovery',
     )
     expect(prompt).toContain(
-      'follow explicit handoffs and load every distinct safety or execution owner',
+      'follow handoffs and load each safety/execution owner',
     )
-    expect(prompt).toContain('Do not preload skills or call a discovery CLI just to route.')
+    expect(prompt).toContain('Do not preload or use a discovery CLI.')
   })
 
   it('stays policy-only and composes with existing owners', async () => {

--- a/packages/assistant-engine/test/model-behavior.test.ts
+++ b/packages/assistant-engine/test/model-behavior.test.ts
@@ -2537,7 +2537,10 @@ describe('assistant system prompt cache stability', () => {
     expect(openStablePrefix).toEqual(closedStablePrefix)
     expect(openStablePrefix).toContain('Murph skill router:')
     expect(openStablePrefix).toContain(
-      'Setup: murph-onboarding, goal-setup, hosted-low-usage, signup-link (explicit requests), experiment-onboarding, behavior-followthrough.',
+      'explicit achievable-outcome help (`help me ...`/Goals CTA) -> goal-setup before domain/Commons knowledge;',
+    )
+    expect(openStablePrefix).toContain(
+      'facts -> domain.',
     )
     expect(openStablePrefix).toContain(
       'When the private longitudinal default in turn priority applies, read self-management-experiments.',
@@ -2900,7 +2903,7 @@ describe('assistant experiment onboarding guidance', () => {
       'Stress-regulation owns the immediate downshift when acute stress or overload blocks action;',
     )
     expect(prompt).toContain(
-      'Specialized skills live at `$MURPH_ASSISTANT_SKILLS_ROOT/<slug>/SKILL.md`.',
+      'Skills live at `$MURPH_ASSISTANT_SKILLS_ROOT/<slug>/SKILL.md`.',
     )
   })
 
@@ -2911,21 +2914,22 @@ describe('assistant experiment onboarding guidance', () => {
 
     expect(prompt).toContain('Murph skill router:')
     expect(prompt).toContain(
-      'Specialized skills live at `$MURPH_ASSISTANT_SKILLS_ROOT/<slug>/SKILL.md`.',
+      'Skills live at `$MURPH_ASSISTANT_SKILLS_ROOT/<slug>/SKILL.md`.',
     )
     expect(prompt).toContain(
-      'Route by the user\'s visible outcome and read the primary owner.',
+      'Read the primary owner for the user\'s visible outcome.',
     )
     expect(prompt).toContain(
-      'If routing is ambiguous, inspect at most two candidates; this cap is discovery-only.',
+      'If ambiguous, inspect at most two for discovery;',
     )
     expect(prompt).toContain(
-      'Then follow explicit handoffs and load every distinct safety or execution owner.',
+      'then follow handoffs and load each safety/execution owner.',
     )
     expect(prompt).toContain(
-      'Do not preload skills or call a discovery CLI just to route.',
+      'Do not preload or use a discovery CLI.',
     )
-    expect(prompt).toContain('Setup: murph-onboarding, goal-setup, hosted-low-usage, signup-link (explicit requests), experiment-onboarding, behavior-followthrough.')
+    expect(prompt).toContain('explicit achievable-outcome help (`help me ...`/Goals CTA) -> goal-setup before domain/Commons knowledge;')
+    expect(prompt).toContain('facts -> domain.')
     expect(prompt).toContain('Sleep/readiness: sleep-improvement, circadian-rhythm, sleep-recovery-readiness, hrv-resting-heart-rate, energy-fatigue.')
     expect(prompt).toContain('Nutrition/metabolic: food-journal, nutrition-strategy, body-composition, gut-digestion, micronutrients-supplements, cardiometabolic-health, cycle-hormonal-health.')
     expect(prompt).toContain(
@@ -3086,7 +3090,10 @@ describe('assistant Murph onboarding guidance', () => {
     }))
 
     expect(prompt).toContain(
-      'Setup: murph-onboarding, goal-setup, hosted-low-usage, signup-link (explicit requests), experiment-onboarding, behavior-followthrough.',
+      'explicit achievable-outcome help (`help me ...`/Goals CTA) -> goal-setup before domain/Commons knowledge;',
+    )
+    expect(prompt).toContain(
+      'facts -> domain.',
     )
     expect(prompt).toContain('Murph skill router:')
     expect(prompt).not.toContain('Murph onboarding:')


### PR DESCRIPTION
## Why and outcome

Murph can receive an exact public Goal CTA yet take the broad domain-knowledge route and incorrectly say there is no direct match. The exact Sleep Through the Night Goal exists in Health Commons.

This change makes explicit achievable-outcome help, including natural `help me ...` wording and public Goals CTAs, route through the existing `goal-setup` owner before domain or broad Health Commons knowledge. Purely informational questions stay with the domain owner.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: An exact public sleep Goal CTA and equivalent concrete-outcome requests now enter grounded Goal setup. The first turn resolves the exact public Goal, checks existing private state, makes no writes, and asks one useful question. Knowledge-only sleep questions remain ordinary sleep guidance.

## Evidence

- Direct: A real Codex subscription-auth journey used the public `Hey Murph, help me sleep through the night.` CTA in a synthetic empty vault. The final post-change run read `goal-setup`, successfully listed the exact public Goal key, showed the exact Goal slug, read private Goal inventory and compact memory, made no mutation or hosted automation call, and asked exactly one question after those reads.
- Coverage: 96 focused assistant prompt tests passed; the assistant-engine typecheck passed; the focused changelog suite passed 9 tests; the Web typecheck passed; and the diff dispatcher completed the full workspace typecheck in 332 seconds. The pre-change live sample also resolved the Goal, so the production miss is stochastic rather than a deterministic local failure.
- ReviewGPT: Skipped under the repository's prompt-primary low-risk rule. The only production logic change is one existing router hint; the remaining diff is focused regression coverage, the required changelog item, and the completed execution plan.

## Non-obvious affected surfaces

- The shared router wording is resident in direct and group prompts. Existing model-behavior and nutrition-routing assertions cover the compacted generic router text and unchanged handoff semantics.
- The public changelog fragment is covered by the production archive loader and server-rendered changelog test.

## Architecture and reuse

- Existing systems reused: `buildAssistantSkillRouteHintText`, `goal-setup`, the generated Health Commons Goal catalog, and registered domain owners.
- New logic: One top-level precedence hint for explicit achievable-outcome help.
- New abstractions: None. A test helper now accepts a Goal key and exact show slug so the existing public-Goal harness can cover another catalog entry.
- Complexity intentionally avoided: No second router, intent classifier, lookup service, persistence owner, or per-Goal prompt was added.

## Complexity impact

- Guard: Pass - `pnpm complexity:diff`.
- Hotspots: Existing `buildStableRouteCapabilityPrompt` at 30 and `buildAssistantHostedGroupGuidanceText` at 25 remain unchanged in complexity.
- Agent judgment: No further behavior-preserving simplification is justified. The existing router text was compacted enough that the stable route prompt is four bytes smaller while retaining every setup owner.

## Hot reply path impact

- Path status: Touched - the model's route selection changes for explicit achievable-outcome help; host orchestration code is unchanged.
- Database calls: None added in code. Correctly routed turns use the existing bounded private Goal inventory and memory reads owned by `goal-setup`.
- Network/provider calls: No new external service call. The public Goal catalog is local; provider continuations remain the existing Codex tool loop.
- Other awaited latency: Correctly routed turns perform the existing public Goal list/show and required local grounding reads before the first setup question. No retry, timeout, or fallback mechanism changed.
- Before/after proof: The final focused live journey passed the exact list/show, order, no-write, and one-question assertions. The earlier production response and the passing pre-change sample together characterize the issue as stochastic routing.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | 27,531 | 27,538 | +7 | +0.0254% | 127,558 | 127,554 | -4 |
| Group Murph | 23,446 | 23,453 | +7 | +0.0299% | 109,019 | 109,015 | -4 |

- Assembled instructions: The two existing router lines are the only changed provider-visible content. Both direct and group requests gain 7 `o200k_harmony` tokens and lose 4 UTF-8 bytes.
- Tool/schema/generated guidance: Unchanged byte-for-byte.
- Other provider-visible input: Unchanged byte-for-byte.
- Measurement method: Captured complete first provider-visible requests from a pinned Codex App Server against a deterministic local Responses stub with identical synthetic direct/group fixtures and `gpt-5.6-terra`. Reconstructed base by substituting only the exact reviewed router lines from `origin/main`; tokenized with `gpt-tokenizer` 3.4.0 `o200k_harmony`. Temporary paths were normalized by using the same captured request for base/head reconstruction, and capture artifacts were removed.

## Design proof

- Design page: [Production changelog archive study](https://www.withmurph.ai/screenshots/ops#changelog-archive)
- Evidence: Content-only changelog fragment; no rendering, component, style, interaction, or visual primitive changed, so an image would add no proof.
- Coverage: The focused server-rendered changelog test loads every authored fragment and proves the copy and try-it affordance through the unchanged production archive component.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new assistant runtimes are mutually compatible; there is no schema, stored-state, CLI, or client contract change.
- Safe order: Deploy the normal assistant runtime artifact. No migration or coordinated service order is required.
- Rollback floor: The prior production assistant runtime artifact from `main`.
- Expected exposure: New direct and group turns after runtime rollout; only explicit achievable-outcome routing changes.
- Reversibility: Redeploy the prior artifact. No data rollback is needed.
- Convergence proof: The prompt is assembled per turn from the active runtime code, and no persistent backfill or cache migration exists.
- Post-deploy checks: Send a public Goal CTA from a test account and verify the runtime trace includes exact Goal list/show before the first setup question, with no write before acceptance.

## Change-shape breakdown

Classification rule: Runtime prompt code is Source; assistant assertions and the real-Codex journey are Tests / fixtures; the completed plan and public changelog fragment are Docs. No binary or generated file is committed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 2 | 2 |
| Tests / fixtures | 208 | 22 |
| Docs | 98 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **308** | **24** |

## Changelog

- Changelog: updated
- Items: 2026-09-04 · goal-requests-find-matching-guidance
