### PR TITLE
fix(web): migrate Telegram auth to OAuth

### DIFF
--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -788,11 +788,10 @@ export function ComponentsContent() {
                   </HostedInlineAuthButton>
                 </div>
               </DialogPreviewFrame>
-              <DialogPreviewFrame label="Telegram ready handoff">
+              <DialogPreviewFrame label="Telegram authorization available">
                 <HostedTelegramAuthButtonPresentation
                   active
                   onClick={() => {}}
-                  readyToContinue
                 />
               </DialogPreviewFrame>
             </div>

--- a/apps/web/app/design/homepage-auth-warm-runtime-study.tsx
+++ b/apps/web/app/design/homepage-auth-warm-runtime-study.tsx
@@ -81,22 +81,21 @@ export function HomepageAuthWarmRuntimeStudy() {
       </div>
       <div className="rounded-2xl border border-border bg-card p-6" inert>
         <p className="mb-4 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-          Telegram selected before ready
+          Telegram authorization starting
         </p>
-        <HomepageAuthFormStudy telegramQueued />
+        <HomepageAuthFormStudy telegramStarting />
       </div>
       <div
         className="rounded-2xl border border-border bg-card p-6 lg:col-span-2"
         inert
       >
         <p className="mb-4 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
-          Telegram ready for its trusted click
+          Telegram authorization available
         </p>
         <div className="grid max-w-xl grid-cols-2 gap-3">
           <HostedTelegramAuthButtonPresentation
             active
             onClick={() => {}}
-            readyToContinue
           />
           <HostedInlineAuthButton
             icon={<EmailIcon className="h-5 w-5" />}
@@ -112,18 +111,18 @@ export function HomepageAuthWarmRuntimeStudy() {
 
 function HomepageAuthFormStudy({
   phoneQueued = false,
-  telegramQueued = false,
+  telegramStarting = false,
 }: {
   phoneQueued?: boolean;
-  telegramQueued?: boolean;
+  telegramStarting?: boolean;
 }) {
-  const authWaiting = phoneQueued || telegramQueued;
+  const authWaiting = phoneQueued || telegramStarting;
 
   return (
     <div className="space-y-4">
       <HostedPhoneEntryStep
         pendingAction={phoneQueued ? "send-code" : null}
-        phoneInputDisabled={telegramQueued}
+        phoneInputDisabled={telegramStarting}
         phoneCountryOptions={HOSTED_PHONE_COUNTRY_OPTIONS}
         phoneNumber="415 555 2671"
         sendCodeDisabled={authWaiting}
@@ -139,9 +138,9 @@ function HomepageAuthFormStudy({
       </div>
       <div className="grid grid-cols-2 gap-3">
         <HostedTelegramAuthButtonPresentation
-          active={telegramQueued}
+          active={telegramStarting}
           disabled={authWaiting}
-          loading={telegramQueued}
+          loading={telegramStarting}
           onClick={() => {}}
         />
         <HostedInlineAuthButton

--- a/apps/web/changelog/entries/2026-09-04/telegram-sign-in-works-again.json
+++ b/apps/web/changelog/entries/2026-09-04/telegram-sign-in-works-again.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-04",
+  "order": 100,
+  "item": {
+    "id": "telegram-sign-in-works-again",
+    "kind": "improvement",
+    "priority": 4,
+    "title": "Telegram sign-in works again",
+    "summary": "Telegram sign-in and account linking now use Telegram's current secure authorization flow.",
+    "details": "Returning from Telegram restores the sign-in or connection step so you can finish without restarting. Phone and email sign-in are unchanged.",
+    "relevanceTags": ["telegram", "onboarding", "reliability"],
+    "sourcePullRequests": [2816]
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -74,7 +74,7 @@
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "@privy-io/node": "^0.18.0",
-    "@privy-io/react-auth": "^3.24.0",
+    "@privy-io/react-auth": "^3.40.0",
     "@temporalio/client": "~1.16.3",
     "@vercel/analytics": "2.0.1",
     "@vercel/functions": "3.4.6",

--- a/apps/web/src/components/hosted-onboarding/auth-dialog.tsx
+++ b/apps/web/src/components/hosted-onboarding/auth-dialog.tsx
@@ -13,6 +13,7 @@ import type { HostedPrivyCompletionPayload } from "@/src/lib/hosted-onboarding/t
 import { cn } from "@/src/lib/utils";
 
 import type { HostedAuthPanelView } from "./hosted-auth-panel";
+import { consumeHostedTelegramOAuthDialogIntent } from "./hosted-telegram-oauth-intent";
 import type { HostedAuthRuntimeState } from "./hosted-auth-runtime";
 
 type HostedAuthPanelModule = typeof import(
@@ -199,6 +200,14 @@ export function AuthDialog({
   const loadedPanelRef = useRef<HTMLDivElement | null>(null);
   const restorePanelFocusRef = useRef(false);
   const readyAuthPanelModule = AuthPanelModule ?? hostedAuthPanelModule;
+
+  useEffect(() => {
+    if (open || !consumeHostedTelegramOAuthDialogIntent()) {
+      return;
+    }
+
+    onOpenChange(true);
+  }, [onOpenChange, open]);
 
   useEffect(() => {
     if (!open || privyRuntime !== undefined || readyAuthPanelModule) {

--- a/apps/web/src/components/hosted-onboarding/hosted-auth-panel.tsx
+++ b/apps/web/src/components/hosted-onboarding/hosted-auth-panel.tsx
@@ -410,10 +410,7 @@ export function HostedAuthPanel({
                 && selectedAuthMethod !== "telegram"
               }
               onAuthCancel={() => cancelAuthMethod("telegram")}
-              onAuthQueue={() => queueAuthMethod("telegram")}
-              onAuthQueueCancel={() => clearQueuedAuthMethod("telegram")}
               onAuthStart={() => beginAuthMethod("telegram")}
-              onAuthenticated={completion.completeAuth}
               onActivate={() => {
                 setPrimaryMethod("phone");
                 setTelegramActive(true);

--- a/apps/web/src/components/hosted-onboarding/hosted-telegram-auth-button.tsx
+++ b/apps/web/src/components/hosted-onboarding/hosted-telegram-auth-button.tsx
@@ -1,12 +1,7 @@
 "use client";
 
-import { useLoginWithTelegram, usePrivy } from "@privy-io/react-auth";
-import {
-  useEffect,
-  useEffectEvent,
-  useRef,
-  useState,
-} from "react";
+import { useLoginWithOAuth, usePrivy } from "@privy-io/react-auth";
+import { useRef, useState } from "react";
 
 import { TelegramIcon } from "@/src/components/homepage/telegram-icon";
 import { Spinner } from "@/src/components/ui/spinner";
@@ -16,10 +11,10 @@ import {
   type TelegramAuthNotice,
 } from "./hosted-auth-shared";
 import { HostedInlineAuthButton } from "./hosted-inline-auth-button";
-import type { HostedPrivyAuthenticatedInput } from "./use-hosted-auth-completion";
-
-const TELEGRAM_WIDGET_READY_POLL_MS = 100;
-const TELEGRAM_WIDGET_READY_TIMEOUT_MS = 20_000;
+import {
+  clearHostedTelegramOAuthDialogIntent,
+  markHostedTelegramOAuthDialogIntent,
+} from "./hosted-telegram-oauth-intent";
 
 export function HostedTelegramAuthButton({
   active = false,
@@ -27,11 +22,8 @@ export function HostedTelegramAuthButton({
   disableSignup = false,
   disabled = false,
   onAuthCancel,
-  onAuthQueue,
-  onAuthQueueCancel,
   onAuthStart,
   onActivate,
-  onAuthenticated,
   onNoticeChange,
 }: {
   active?: boolean;
@@ -39,211 +31,57 @@ export function HostedTelegramAuthButton({
   disableSignup?: boolean;
   disabled?: boolean;
   onAuthCancel?: () => void;
-  onAuthQueue?: () => boolean;
-  onAuthQueueCancel?: () => void;
   onAuthStart?: () => boolean;
   onActivate: () => void;
-  onAuthenticated: (input: HostedPrivyAuthenticatedInput) => Promise<void> | void;
   onNoticeChange?: (notice: TelegramAuthNotice | null) => void;
 }) {
-  const { login, state } = useLoginWithTelegram();
-  const { authenticated, ready } = usePrivy();
-  const [telegramLoginPhase, setTelegramLoginPhase] = useState<
-    "idle" | "waiting" | "login"
-  >("idle");
-  const [telegramWidgetReady, setTelegramWidgetReady] = useState(false);
+  const { initOAuth, loading: oauthLoading } = useLoginWithOAuth();
+  const { ready } = usePrivy();
+  const [telegramLoginPending, setTelegramLoginPending] = useState(false);
   const telegramLoginInFlightRef = useRef(false);
-  const previouslyActiveRef = useRef(active);
-  const pendingTelegramLoginRef = useRef<{
-    queueClaimed: boolean;
-    startAuthOnDrain: boolean;
-  } | null>(null);
-
-  const telegramReadyToContinue =
-    telegramLoginPhase === "waiting" && ready && telegramWidgetReady;
-  const loading =
-    (telegramLoginPhase === "waiting" && !telegramReadyToContinue)
-    || telegramLoginPhase === "login"
-    || state.status === "loading";
-
-  function cancelPendingTelegramLogin() {
-    const pendingLogin = pendingTelegramLoginRef.current;
-    if (!pendingLogin) return;
-
-    pendingTelegramLoginRef.current = null;
-    setTelegramLoginPhase("idle");
-    setTelegramWidgetReady(false);
-    if (pendingLogin.queueClaimed) {
-      onAuthQueueCancel?.();
-    }
-  }
-
-  const cancelPendingTelegramLoginEffect = useEffectEvent(() => {
-    cancelPendingTelegramLogin();
-  });
-  const markTelegramWidgetReadyEffect = useEffectEvent(() => {
-    const pendingLogin = pendingTelegramLoginRef.current;
-    if (!pendingLogin) return;
-
-    setTelegramWidgetReady(true);
-    if (pendingLogin.queueClaimed && onAuthQueueCancel) {
-      pendingLogin.queueClaimed = false;
-      onAuthQueueCancel();
-    }
-  });
-
-  useEffect(() => {
-    const pendingLogin = pendingTelegramLoginRef.current;
-    if (!pendingLogin) return;
-
-    if (authenticated && pendingLogin.startAuthOnDrain) {
-      cancelPendingTelegramLoginEffect();
-    }
-  }, [authenticated]);
-
-  useEffect(() => {
-    const wasActive = previouslyActiveRef.current;
-    previouslyActiveRef.current = active;
-    if (wasActive && !active) {
-      cancelPendingTelegramLoginEffect();
-    }
-  }, [active]);
-
-  useEffect(() => {
-    if (telegramLoginPhase !== "waiting" || !ready) return;
-
-    let stopped = false;
-    let pollId = 0;
-    const stopPolling = () => {
-      stopped = true;
-      window.clearInterval(pollId);
-    };
-    const checkWidget = () => {
-      if (stopped || !isTelegramLoginWidgetReady()) return;
-      stopPolling();
-      markTelegramWidgetReadyEffect();
-    };
-    const initialCheckId = window.setTimeout(checkWidget, 0);
-    pollId = window.setInterval(checkWidget, TELEGRAM_WIDGET_READY_POLL_MS);
-    const timeoutId = window.setTimeout(
-      stopPolling,
-      TELEGRAM_WIDGET_READY_TIMEOUT_MS,
-    );
-
-    return () => {
-      stopPolling();
-      window.clearTimeout(initialCheckId);
-      window.clearTimeout(timeoutId);
-    };
-  }, [ready, telegramLoginPhase]);
+  const loading = telegramLoginPending || oauthLoading;
 
   async function handleClick() {
-    const pendingLogin = pendingTelegramLoginRef.current;
-    if (pendingLogin && telegramReadyToContinue && ready) {
-      if (
-        pendingLogin.startAuthOnDrain
-        && onAuthStart
-        && !onAuthStart()
-      ) {
-        cancelPendingTelegramLogin();
-        return;
-      }
-
-      pendingTelegramLoginRef.current = null;
-      setTelegramLoginPhase("login");
-      await runTelegramLogin();
-      return;
-    }
-
-    if (
-      telegramLoginInFlightRef.current
-      || pendingLogin !== null
-    ) {
-      return;
-    }
-
-    if (!ready || !isTelegramLoginWidgetReady()) {
-      const startAuthOnDrain = onAuthQueue !== undefined;
-      const authClaimed = onAuthQueue
-        ? onAuthQueue()
-        : onAuthStart
-          ? onAuthStart()
-          : true;
-      if (!authClaimed) return;
-
-      onActivate();
-      onNoticeChange?.(null);
-      queueTelegramLogin(startAuthOnDrain);
-      return;
-    }
+    if (telegramLoginInFlightRef.current || !ready) return;
 
     if (onAuthStart && !onAuthStart()) return;
 
     onActivate();
     onNoticeChange?.(null);
-    setTelegramLoginPhase("login");
     await runTelegramLogin();
   }
 
-  function queueTelegramLogin(startAuthOnDrain: boolean) {
-    pendingTelegramLoginRef.current = {
-      queueClaimed: startAuthOnDrain,
-      startAuthOnDrain,
-    };
-    setTelegramWidgetReady(false);
-    setTelegramLoginPhase("waiting");
-  }
-
   async function runTelegramLogin() {
-    if (telegramLoginInFlightRef.current) {
-      return;
-    }
-    if (!ready || !isTelegramLoginWidgetReady()) {
-      onAuthCancel?.();
-      setTelegramLoginPhase("idle");
-      setTelegramWidgetReady(false);
-      return;
-    }
+    if (telegramLoginInFlightRef.current || !ready) return;
+
     telegramLoginInFlightRef.current = true;
+    setTelegramLoginPending(true);
+    markHostedTelegramOAuthDialogIntent();
 
     try {
-      await login(disableSignup ? { disableSignup: true } : undefined);
+      await initOAuth({
+        provider: "telegram",
+        ...(disableSignup ? { disableSignup: true } : {}),
+      });
     } catch (error) {
+      clearHostedTelegramOAuthDialogIntent();
       onAuthCancel?.();
       onNoticeChange?.(describeTelegramAuthError(error));
-      return;
     } finally {
       telegramLoginInFlightRef.current = false;
-      setTelegramLoginPhase("idle");
-      setTelegramWidgetReady(false);
+      setTelegramLoginPending(false);
     }
-
-    await onAuthenticated({
-      authMethod: "telegram",
-    });
   }
 
   return (
     <HostedTelegramAuthButtonPresentation
       active={active}
       completionPending={completionPending}
-      disabled={disabled || loading || completionPending}
+      disabled={disabled || !ready || loading || completionPending}
       loading={loading}
       onClick={handleClick}
-      readyToContinue={telegramReadyToContinue}
     />
   );
-}
-
-function isTelegramLoginWidgetReady(): boolean {
-  if (typeof window === "undefined") return false;
-
-  const telegram = Reflect.get(window, "Telegram");
-  if (typeof telegram !== "object" || telegram === null) return false;
-  const login = Reflect.get(telegram, "Login");
-  if (typeof login !== "object" || login === null) return false;
-
-  return typeof Reflect.get(login, "auth") === "function";
 }
 
 export function HostedTelegramAuthButtonPresentation({
@@ -252,14 +90,12 @@ export function HostedTelegramAuthButtonPresentation({
   disabled = false,
   loading = false,
   onClick,
-  readyToContinue = false,
 }: {
   active?: boolean;
   completionPending?: boolean;
   disabled?: boolean;
   loading?: boolean;
   onClick: () => void;
-  readyToContinue?: boolean;
 }) {
   return (
     <div className="space-y-2">
@@ -278,25 +114,8 @@ export function HostedTelegramAuthButtonPresentation({
           ? "Finishing..."
           : loading
             ? "Connecting..."
-            : readyToContinue
-              ? (
-                  <>
-                    Continue
-                    <span className="sr-only"> with Telegram</span>
-                  </>
-                )
-              : "Telegram"}
+            : "Telegram"}
       </HostedInlineAuthButton>
-      {readyToContinue ? (
-        <p
-          aria-atomic="true"
-          aria-live="polite"
-          role="status"
-          className="px-1 text-xs leading-relaxed text-muted-foreground"
-        >
-          Telegram is ready. Continue to open sign in.
-        </p>
-      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/hosted-onboarding/hosted-telegram-oauth-intent.ts
+++ b/apps/web/src/components/hosted-onboarding/hosted-telegram-oauth-intent.ts
@@ -1,0 +1,37 @@
+const HOSTED_TELEGRAM_OAUTH_DIALOG_INTENT_KEY =
+  "murph:telegram-oauth-dialog-intent:v1";
+
+export function markHostedTelegramOAuthDialogIntent(): void {
+  try {
+    window.sessionStorage.setItem(
+      HOSTED_TELEGRAM_OAUTH_DIALOG_INTENT_KEY,
+      "1",
+    );
+  } catch {
+    // OAuth can still proceed when browser storage is unavailable.
+  }
+}
+
+export function clearHostedTelegramOAuthDialogIntent(): void {
+  try {
+    window.sessionStorage.removeItem(HOSTED_TELEGRAM_OAUTH_DIALOG_INTENT_KEY);
+  } catch {
+    // Nothing else is required when browser storage is unavailable.
+  }
+}
+
+export function consumeHostedTelegramOAuthDialogIntent(): boolean {
+  try {
+    if (
+      window.sessionStorage.getItem(HOSTED_TELEGRAM_OAUTH_DIALOG_INTENT_KEY)
+      !== "1"
+    ) {
+      return false;
+    }
+
+    window.sessionStorage.removeItem(HOSTED_TELEGRAM_OAUTH_DIALOG_INTENT_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/components/settings/hosted-telegram-card-settings.tsx
+++ b/apps/web/src/components/settings/hosted-telegram-card-settings.tsx
@@ -59,7 +59,7 @@ export function HostedTelegramCardSettings(props: {
   const isBusy = isLinkingTelegram || (isSyncingTelegram && !isQuietSyncingTelegram);
   const canUsePrivyTelegramLink = authenticated && privyReady && privyAuthenticated;
 
-  const { linkTelegram } = useLinkAccount({
+  const { linkOAuth } = useLinkAccount({
     onError: (error, details) => {
       if (!details || details.linkMethod === "telegram") {
         setIsLinkingTelegram(false);
@@ -171,7 +171,7 @@ export function HostedTelegramCardSettings(props: {
       return;
     }
 
-    if (typeof linkTelegram !== "function") {
+    if (typeof linkOAuth !== "function") {
       setErrorMessage("Telegram linking is not available yet.");
       return;
     }
@@ -184,7 +184,7 @@ export function HostedTelegramCardSettings(props: {
     setIsLinkingTelegram(true);
 
     try {
-      linkTelegram();
+      linkOAuth({ provider: "telegram" });
     } catch (error) {
       setIsLinkingTelegram(false);
       setErrorMessage(toHostedTelegramLinkErrorMessage(error));
@@ -192,7 +192,7 @@ export function HostedTelegramCardSettings(props: {
   }, [
     authenticated,
     currentTelegramUserId,
-    linkTelegram,
+    linkOAuth,
     privyAuthenticated,
     privyReady,
     privyTelegramUserId,

--- a/apps/web/src/components/settings/hosted-telegram-settings.tsx
+++ b/apps/web/src/components/settings/hosted-telegram-settings.tsx
@@ -50,7 +50,7 @@ export function ConnectTelegram(props: {
   const clientAuthenticated = privyReady && privyAuthenticated;
   const isBusy = isLinkingTelegram || (isSyncingTelegram && !isQuietSyncingTelegram);
 
-  const { linkTelegram } = useLinkAccount({
+  const { linkOAuth } = useLinkAccount({
     onError: (error, details) => {
       if (!details || details.linkMethod === "telegram") {
         setIsLinkingTelegram(false);
@@ -168,7 +168,7 @@ export function ConnectTelegram(props: {
       return;
     }
 
-    if (typeof linkTelegram !== "function") {
+    if (typeof linkOAuth !== "function") {
       setErrorMessage("Telegram linking is not available yet.");
       return;
     }
@@ -176,7 +176,7 @@ export function ConnectTelegram(props: {
     setIsLinkingTelegram(true);
 
     try {
-      linkTelegram();
+      linkOAuth({ provider: "telegram" });
     } catch (error) {
       setIsLinkingTelegram(false);
       setErrorMessage(toHostedTelegramLinkErrorMessage(error));

--- a/apps/web/test/auth-dialog-loading-accessibility.test.tsx
+++ b/apps/web/test/auth-dialog-loading-accessibility.test.tsx
@@ -347,6 +347,44 @@ test("uses a panel preloaded after a closed dialog mounts without suppressing ph
   expect(rendered.container.querySelector('[aria-busy="true"]')).toBeNull();
 });
 
+test("reopens a closed dialog so Privy can finish Telegram OAuth after redirect", async () => {
+  const { AuthDialog } = await import(
+    "@/src/components/hosted-onboarding/auth-dialog"
+  );
+  const initialOpenChange = vi.fn();
+  const returnedOpenChange = vi.fn();
+  const rendered = await renderClientComponent(
+    createElement(AuthDialog, {
+      key: "before-redirect",
+      onOpenChange: initialOpenChange,
+      open: false,
+    }),
+    { requireButton: false },
+  );
+  cleanupRender = rendered.cleanup;
+
+  rendered.window.sessionStorage.setItem(
+    "murph:telegram-oauth-dialog-intent:v1",
+    "1",
+  );
+  await rendered.rerender(
+    createElement(AuthDialog, {
+      key: "after-redirect",
+      onOpenChange: returnedOpenChange,
+      open: false,
+    }),
+  );
+
+  await vi.waitFor(() => {
+    expect(returnedOpenChange).toHaveBeenCalledWith(true);
+  });
+  expect(
+    rendered.window.sessionStorage.getItem(
+      "murph:telegram-oauth-dialog-intent:v1",
+    ),
+  ).toBeNull();
+});
+
 async function renderPendingAuthDialog() {
   const { AuthDialog } = await import(
     "@/src/components/hosted-onboarding/auth-dialog"

--- a/apps/web/test/homepage-telegram-auth-button.test.tsx
+++ b/apps/web/test/homepage-telegram-auth-button.test.tsx
@@ -1,23 +1,20 @@
-import {
-  act,
-  createElement,
-  useState,
-} from "react";
+import { act, createElement, useState } from "react";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
 import { renderClientComponent } from "./render-client-component";
 
+const TELEGRAM_OAUTH_DIALOG_INTENT_KEY =
+  "murph:telegram-oauth-dialog-intent:v1";
+
 const mocks = vi.hoisted(() => ({
-  login: vi.fn(),
-  onAuthenticated: vi.fn(),
+  initOAuth: vi.fn(),
   onNoticeChange: vi.fn(),
-  telegramWidgetAvailable: true,
-  useLoginWithTelegram: vi.fn(),
+  useLoginWithOAuth: vi.fn(),
   usePrivy: vi.fn(),
 }));
 
 vi.mock("@privy-io/react-auth", () => ({
-  useLoginWithTelegram: mocks.useLoginWithTelegram,
+  useLoginWithOAuth: mocks.useLoginWithOAuth,
   usePrivy: mocks.usePrivy,
 }));
 
@@ -27,21 +24,13 @@ let cleanupRender: (() => Promise<void>) | null = null;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.usePrivy.mockReturnValue({
-    ready: true,
+  mocks.usePrivy.mockReturnValue({ ready: true });
+  mocks.useLoginWithOAuth.mockReturnValue({
+    initOAuth: mocks.initOAuth,
+    loading: false,
+    state: { status: "initial" },
   });
-  mocks.telegramWidgetAvailable = true;
-  mocks.useLoginWithTelegram.mockImplementation(() => {
-    if (mocks.telegramWidgetAvailable && typeof window !== "undefined") {
-      installTelegramLoginWidget(window);
-    }
-    return {
-      login: mocks.login,
-      state: { status: "initial" },
-    };
-  });
-  mocks.login.mockResolvedValue(undefined);
-  mocks.onAuthenticated.mockResolvedValue(undefined);
+  mocks.initOAuth.mockResolvedValue(undefined);
 });
 
 afterEach(async () => {
@@ -58,122 +47,15 @@ function HomepageTelegramAuthButtonHarness() {
     <HostedTelegramAuthButton
       active={active}
       onActivate={() => setActive(true)}
-      onAuthenticated={mocks.onAuthenticated}
       onNoticeChange={mocks.onNoticeChange}
     />
   );
 }
 
-test("HomepageTelegramAuthButton logs in with Telegram and reports the authenticated session", async () => {
-  const { button, cleanup } = await renderClientComponent(
+test("HomepageTelegramAuthButton starts Telegram OAuth and preserves the dialog intent across redirect", async () => {
+  const rendered = await renderClientComponent(
     createElement(HomepageTelegramAuthButtonHarness),
   );
-  cleanupRender = cleanup;
-
-  await act(async () => {
-    button.dispatchEvent(new Event("click", { bubbles: true }));
-  });
-
-  expect(mocks.login).toHaveBeenCalledTimes(1);
-  expect(mocks.onAuthenticated).toHaveBeenCalledWith({
-    authMethod: "telegram",
-  });
-});
-
-test("HomepageTelegramAuthButton queues one login with busy feedback until Privy is ready", async () => {
-  const queueAuth = vi.fn(() => true);
-  const startAuth = vi.fn(() => true);
-  let privyReady = false;
-  mocks.usePrivy.mockImplementation(() => ({
-    authenticated: false,
-    ready: privyReady,
-  }));
-
-  function ReadyTelegramHarness() {
-    return (
-      <HostedTelegramAuthButton
-        onActivate={() => {}}
-        onAuthQueue={queueAuth}
-        onAuthQueueCancel={() => {}}
-        onAuthStart={startAuth}
-        onAuthenticated={mocks.onAuthenticated}
-      />
-    );
-  }
-
-  const rendered = await renderClientComponent(
-    createElement(ReadyTelegramHarness),
-  );
-  cleanupRender = rendered.cleanup;
-  const { button } = rendered;
-
-  expect(button.disabled).toBe(false);
-
-  await act(async () => {
-    button.dispatchEvent(new Event("click", { bubbles: true }));
-    button.dispatchEvent(new Event("click", { bubbles: true }));
-  });
-
-  expect(queueAuth).toHaveBeenCalledTimes(1);
-  expect(startAuth).not.toHaveBeenCalled();
-  expect(mocks.login).not.toHaveBeenCalled();
-  expect(button.disabled).toBe(true);
-  expect(button.getAttribute("aria-busy")).toBe("true");
-  expect(button.textContent).toContain("Connecting...");
-  expect(button.querySelector('[data-slot="spinner"]')).toBeTruthy();
-
-  privyReady = true;
-  await rendered.rerender(createElement(ReadyTelegramHarness));
-  await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  });
-
-  expect(startAuth).not.toHaveBeenCalled();
-  expect(mocks.login).not.toHaveBeenCalled();
-  expect(button.disabled).toBe(false);
-  expect(button.getAttribute("aria-busy")).toBe("false");
-  expect(button.textContent).toContain("Continue with Telegram");
-  const readyStatus = rendered.container.querySelector('[role="status"]');
-  expect(readyStatus?.getAttribute("aria-live")).toBe("polite");
-  expect(readyStatus?.getAttribute("aria-atomic")).toBe("true");
-  expect(readyStatus?.textContent).toContain(
-    "Telegram is ready. Continue to open sign in.",
-  );
-
-  await act(async () => {
-    button.dispatchEvent(new Event("click", { bubbles: true }));
-  });
-
-  expect(startAuth).toHaveBeenCalledTimes(1);
-  expect(mocks.login).toHaveBeenCalledTimes(1);
-  expect(mocks.onAuthenticated).toHaveBeenCalledTimes(1);
-});
-
-test("HomepageTelegramAuthButton clears a queued continuation when shared ownership is denied", async () => {
-  const queueAuth = vi.fn(() => true);
-  const releaseQueue = vi.fn();
-  const startAuth = vi.fn(() => false);
-  let privyReady = false;
-  mocks.usePrivy.mockImplementation(() => ({
-    authenticated: false,
-    ready: privyReady,
-  }));
-
-  function DeniedTelegramHarness() {
-    return (
-      <HostedTelegramAuthButton
-        onActivate={() => {}}
-        onAuthQueue={queueAuth}
-        onAuthQueueCancel={releaseQueue}
-        onAuthStart={startAuth}
-        onAuthenticated={mocks.onAuthenticated}
-      />
-    );
-  }
-
-  const rendered = await renderClientComponent(
-    createElement(DeniedTelegramHarness),
-  );
   cleanupRender = rendered.cleanup;
 
   await act(async () => {
@@ -182,149 +64,62 @@ test("HomepageTelegramAuthButton clears a queued continuation when shared owners
     );
   });
 
-  privyReady = true;
-  await rendered.rerender(createElement(DeniedTelegramHarness));
-  await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  });
-
-  expect(releaseQueue).toHaveBeenCalledTimes(1);
-  expect(rendered.button.textContent).toContain("Continue with Telegram");
-
-  await act(async () => {
-    rendered.button.dispatchEvent(
-      new rendered.window.Event("click", { bubbles: true }),
-    );
-  });
-
-  expect(startAuth).toHaveBeenCalledTimes(1);
-  expect(mocks.login).not.toHaveBeenCalled();
-  expect(rendered.button.disabled).toBe(false);
-  expect(rendered.button.getAttribute("aria-busy")).toBe("false");
-  expect(rendered.button.textContent).toBe("Telegram");
+  expect(mocks.initOAuth).toHaveBeenCalledWith({ provider: "telegram" });
+  expect(
+    rendered.window.sessionStorage.getItem(TELEGRAM_OAUTH_DIALOG_INTENT_KEY),
+  ).toBe("1");
 });
 
-test("HomepageTelegramAuthButton drops a ready continuation when another method becomes active", async () => {
-  const releaseQueue = vi.fn();
-  let privyReady = false;
-  mocks.usePrivy.mockImplementation(() => ({
-    authenticated: false,
-    ready: privyReady,
-  }));
-
-  const renderButton = (active: boolean) =>
-    createElement(HostedTelegramAuthButton, {
-      active,
-      onActivate: () => {},
-      onAuthQueue: () => true,
-      onAuthQueueCancel: releaseQueue,
-      onAuthStart: () => true,
-      onAuthenticated: mocks.onAuthenticated,
-    });
-  const rendered = await renderClientComponent(renderButton(true));
-  cleanupRender = rendered.cleanup;
-
-  await act(async () => {
-    rendered.button.dispatchEvent(
-      new rendered.window.Event("click", { bubbles: true }),
-    );
-  });
-
-  privyReady = true;
-  await rendered.rerender(renderButton(true));
-  await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  });
-
-  expect(rendered.button.textContent).toContain("Continue with Telegram");
-  expect(releaseQueue).toHaveBeenCalledTimes(1);
-
-  await rendered.rerender(renderButton(false));
-  await act(async () => {
-    await Promise.resolve();
-  });
-
-  expect(rendered.button.disabled).toBe(false);
-  expect(rendered.button.textContent).toBe("Telegram");
-  expect(rendered.container.querySelector('[role="status"]')).toBeNull();
-  expect(mocks.login).not.toHaveBeenCalled();
-});
-
-test("HomepageTelegramAuthButton releases active ownership if widget readiness vanishes at login", async () => {
-  const cancelAuth = vi.fn();
-  const startAuth = vi.fn(() => true);
+test("HomepageTelegramAuthButton forwards the no-signup boundary to Telegram OAuth", async () => {
   const rendered = await renderClientComponent(
     createElement(HostedTelegramAuthButton, {
-      active: true,
+      disableSignup: true,
       onActivate: () => {},
-      onAuthCancel: cancelAuth,
-      onAuthStart: startAuth,
-      onAuthenticated: mocks.onAuthenticated,
     }),
   );
   cleanupRender = rendered.cleanup;
 
-  let authReads = 0;
-  Reflect.set(rendered.window, "Telegram", {
-    Login: {
-      get auth() {
-        authReads += 1;
-        return authReads === 1 ? vi.fn() : undefined;
-      },
-    },
-  });
-
   await act(async () => {
     rendered.button.dispatchEvent(
       new rendered.window.Event("click", { bubbles: true }),
     );
   });
 
-  expect(startAuth).toHaveBeenCalledTimes(1);
-  expect(cancelAuth).toHaveBeenCalledTimes(1);
-  expect(mocks.login).not.toHaveBeenCalled();
-  expect(rendered.button.disabled).toBe(false);
-  expect(rendered.button.getAttribute("aria-busy")).toBe("false");
-  expect(rendered.button.textContent).toBe("Telegram");
+  expect(mocks.initOAuth).toHaveBeenCalledWith({
+    disableSignup: true,
+    provider: "telegram",
+  });
 });
 
-test("HomepageTelegramAuthButton waits for Privy's Telegram widget before asking for the follow-up click", async () => {
-  mocks.telegramWidgetAvailable = false;
-  const queueAuth = vi.fn(() => true);
-  const releaseQueue = vi.fn();
+test("HomepageTelegramAuthButton waits until Privy can start OAuth", async () => {
+  mocks.usePrivy.mockReturnValue({ ready: false });
   const startAuth = vi.fn(() => true);
   const rendered = await renderClientComponent(
     createElement(HostedTelegramAuthButton, {
       onActivate: () => {},
-      onAuthQueue: queueAuth,
-      onAuthQueueCancel: releaseQueue,
       onAuthStart: startAuth,
-      onAuthenticated: mocks.onAuthenticated,
     }),
   );
   cleanupRender = rendered.cleanup;
-  Reflect.deleteProperty(rendered.window, "Telegram");
 
-  await act(async () => {
-    rendered.button.dispatchEvent(
-      new rendered.window.Event("click", { bubbles: true }),
-    );
-  });
-
-  expect(queueAuth).toHaveBeenCalledTimes(1);
   expect(rendered.button.disabled).toBe(true);
-  expect(rendered.button.textContent).toContain("Connecting...");
-  expect(mocks.login).not.toHaveBeenCalled();
+  rendered.button.dispatchEvent(
+    new rendered.window.Event("click", { bubbles: true }),
+  );
 
-  installTelegramLoginWidget(rendered.window);
-  await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 110));
-  });
+  expect(startAuth).not.toHaveBeenCalled();
+  expect(mocks.initOAuth).not.toHaveBeenCalled();
+});
 
-  expect(releaseQueue).toHaveBeenCalledTimes(1);
-  expect(rendered.button.disabled).toBe(false);
-  expect(rendered.button.textContent).toContain("Continue with Telegram");
-  expect(mocks.login).not.toHaveBeenCalled();
+test("HomepageTelegramAuthButton respects shared auth ownership", async () => {
+  const startAuth = vi.fn(() => false);
+  const rendered = await renderClientComponent(
+    createElement(HostedTelegramAuthButton, {
+      onActivate: () => {},
+      onAuthStart: startAuth,
+    }),
+  );
+  cleanupRender = rendered.cleanup;
 
   await act(async () => {
     rendered.button.dispatchEvent(
@@ -333,101 +128,106 @@ test("HomepageTelegramAuthButton waits for Privy's Telegram widget before asking
   });
 
   expect(startAuth).toHaveBeenCalledTimes(1);
-  expect(mocks.login).toHaveBeenCalledTimes(1);
+  expect(mocks.initOAuth).not.toHaveBeenCalled();
 });
 
 test("HomepageTelegramAuthButton keeps account completion on the active CTA", async () => {
-  const { button, cleanup } = await renderClientComponent(
+  const rendered = await renderClientComponent(
     createElement(HostedTelegramAuthButton, {
       active: true,
       completionPending: true,
       onActivate: () => {},
-      onAuthenticated: mocks.onAuthenticated,
     }),
   );
-  cleanupRender = cleanup;
+  cleanupRender = rendered.cleanup;
 
-  expect(button.disabled).toBe(true);
-  expect(button.getAttribute("aria-busy")).toBe("true");
-  expect(button.textContent).toContain("Finishing...");
-  expect(button.querySelector('[data-slot="spinner"]')).toBeTruthy();
-  expect(mocks.login).not.toHaveBeenCalled();
+  expect(rendered.button.disabled).toBe(true);
+  expect(rendered.button.getAttribute("aria-busy")).toBe("true");
+  expect(rendered.button.textContent).toContain("Finishing...");
+  expect(rendered.button.querySelector('[data-slot="spinner"]')).toBeTruthy();
+  expect(mocks.initOAuth).not.toHaveBeenCalled();
 });
 
-test("HomepageTelegramAuthButton exposes Privy's own loading phase as button progress", async () => {
-  mocks.useLoginWithTelegram.mockReturnValue({
-    login: mocks.login,
+test("HomepageTelegramAuthButton exposes Privy's OAuth loading phase as button progress", async () => {
+  mocks.useLoginWithOAuth.mockReturnValue({
+    initOAuth: mocks.initOAuth,
+    loading: true,
     state: { status: "loading" },
   });
 
-  const { button, cleanup } = await renderClientComponent(
+  const rendered = await renderClientComponent(
     createElement(HomepageTelegramAuthButtonHarness),
   );
-  cleanupRender = cleanup;
+  cleanupRender = rendered.cleanup;
 
-  expect(button.disabled).toBe(true);
-  expect(button.getAttribute("aria-busy")).toBe("true");
-  expect(button.textContent).toContain("Connecting...");
-  expect(button.querySelector('[data-slot="spinner"]')).toBeTruthy();
+  expect(rendered.button.disabled).toBe(true);
+  expect(rendered.button.getAttribute("aria-busy")).toBe("true");
+  expect(rendered.button.textContent).toContain("Connecting...");
+  expect(rendered.button.querySelector('[data-slot="spinner"]')).toBeTruthy();
 });
 
-test("HomepageTelegramAuthButton softens cancellation messages without alarming the user", async () => {
-  mocks.login.mockRejectedValueOnce(new Error("Telegram auth failed or was canceled by the client"));
-
-  const { button, cleanup } = await renderClientComponent(
-    createElement(HomepageTelegramAuthButtonHarness),
+test("HomepageTelegramAuthButton softens cancellation and clears the redirect intent", async () => {
+  mocks.initOAuth.mockRejectedValueOnce(
+    new Error("Telegram auth failed or was canceled by the client"),
   );
-  cleanupRender = cleanup;
+  const cancelAuth = vi.fn();
+  const rendered = await renderClientComponent(
+    createElement(HostedTelegramAuthButton, {
+      onActivate: () => {},
+      onAuthCancel: cancelAuth,
+      onNoticeChange: mocks.onNoticeChange,
+    }),
+  );
+  cleanupRender = rendered.cleanup;
 
   await act(async () => {
-    button.dispatchEvent(new Event("click", { bubbles: true }));
+    rendered.button.dispatchEvent(
+      new rendered.window.Event("click", { bubbles: true }),
+    );
   });
 
+  expect(cancelAuth).toHaveBeenCalledTimes(1);
   expect(mocks.onNoticeChange).toHaveBeenLastCalledWith({
     message: "Telegram sign-in was canceled. Try again or use another option.",
     tone: "cancel",
   });
-  expect(button.disabled).toBe(false);
-  expect(mocks.onAuthenticated).not.toHaveBeenCalled();
+  expect(
+    rendered.window.sessionStorage.getItem(TELEGRAM_OAUTH_DIALOG_INTENT_KEY),
+  ).toBeNull();
+  expect(rendered.button.disabled).toBe(false);
 });
 
-test("HomepageTelegramAuthButton surfaces unexpected Telegram failures as a destructive notice", async () => {
-  mocks.login.mockRejectedValueOnce(new Error("Telegram is unreachable"));
-
-  const { button, cleanup } = await renderClientComponent(
+test("HomepageTelegramAuthButton surfaces unexpected Telegram failures", async () => {
+  mocks.initOAuth.mockRejectedValueOnce(new Error("Telegram is unreachable"));
+  const rendered = await renderClientComponent(
     createElement(HomepageTelegramAuthButtonHarness),
   );
-  cleanupRender = cleanup;
+  cleanupRender = rendered.cleanup;
 
   await act(async () => {
-    button.dispatchEvent(new Event("click", { bubbles: true }));
+    rendered.button.dispatchEvent(
+      new rendered.window.Event("click", { bubbles: true }),
+    );
   });
 
   expect(mocks.onNoticeChange).toHaveBeenLastCalledWith({
     message: "Telegram is unreachable",
     tone: "error",
   });
-  expect(button.disabled).toBe(false);
-  expect(mocks.onAuthenticated).not.toHaveBeenCalled();
+  expect(rendered.button.disabled).toBe(false);
 });
 
-test("HomepageTelegramAuthButton clears the notice before retrying", async () => {
-  const { button, cleanup } = await renderClientComponent(
+test("HomepageTelegramAuthButton clears the notice before redirecting", async () => {
+  const rendered = await renderClientComponent(
     createElement(HomepageTelegramAuthButtonHarness),
   );
-  cleanupRender = cleanup;
+  cleanupRender = rendered.cleanup;
 
   await act(async () => {
-    button.dispatchEvent(new Event("click", { bubbles: true }));
+    rendered.button.dispatchEvent(
+      new rendered.window.Event("click", { bubbles: true }),
+    );
   });
 
   expect(mocks.onNoticeChange).toHaveBeenCalledWith(null);
 });
-
-function installTelegramLoginWidget(targetWindow: Window & typeof globalThis) {
-  Reflect.set(targetWindow, "Telegram", {
-    Login: {
-      auth: vi.fn(),
-    },
-  });
-}

--- a/apps/web/test/hosted-auth-panel-controls.test.tsx
+++ b/apps/web/test/hosted-auth-panel-controls.test.tsx
@@ -8,7 +8,7 @@ const mocks = vi.hoisted(() => ({
   completeHostedPrivyAuth: vi.fn(),
   isMobile: false,
   loginWithCode: vi.fn(),
-  loginWithTelegram: vi.fn(),
+  initOAuth: vi.fn(),
   privyReady: false,
   sendCode: vi.fn(),
   user: null as { linkedAccounts?: unknown } | null,
@@ -31,9 +31,10 @@ vi.mock("@privy-io/react-auth", () => ({
       sendCode: mocks.sendCode,
     };
   },
-  useLoginWithTelegram() {
+  useLoginWithOAuth() {
     return {
-      login: mocks.loginWithTelegram,
+      initOAuth: mocks.initOAuth,
+      loading: false,
       state: { status: "initial" },
     };
   },
@@ -77,7 +78,7 @@ beforeEach(() => {
     redirectUrl: "/home",
   });
   mocks.loginWithCode.mockResolvedValue(undefined);
-  mocks.loginWithTelegram.mockResolvedValue(undefined);
+  mocks.initOAuth.mockResolvedValue(undefined);
   mocks.sendCode.mockResolvedValue(undefined);
 });
 
@@ -86,7 +87,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-test("HostedAuthPanel releases the real phone controls at Telegram's trusted-click handoff", async () => {
+test("HostedAuthPanel enables Telegram when Privy becomes ready", async () => {
   const renderPanel = () => createElement(HostedAuthPanelHarness);
   const rendered = await renderClientComponent(renderPanel(), {
     matchMedia: createDesktopMatchMedia(),
@@ -100,35 +101,22 @@ test("HostedAuthPanel releases the real phone controls at Telegram's trusted-cli
 
     expect(phoneInput.disabled).toBe(false);
     expect(countryTrigger.disabled).toBe(false);
-    expect(telegramButton.disabled).toBe(false);
-
-    await act(async () => {
-      telegramButton.dispatchEvent(
-        new rendered.window.Event("click", { bubbles: true }),
-      );
-    });
-
-    expect(readButton(rendered.container, "Connecting...").disabled).toBe(true);
-    expect(phoneInput.disabled).toBe(true);
-    expect(countryTrigger.disabled).toBe(true);
-    expect(mocks.loginWithTelegram).not.toHaveBeenCalled();
+    expect(telegramButton.disabled).toBe(true);
+    expect(phoneInput.disabled).toBe(false);
+    expect(countryTrigger.disabled).toBe(false);
+    expect(mocks.initOAuth).not.toHaveBeenCalled();
 
     mocks.privyReady = true;
-    installTelegramLoginWidget(rendered.window);
     await rendered.rerender(renderPanel());
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    const continueButton = readButton(rendered.container, "Continue");
-    expect(continueButton.disabled).toBe(false);
-    expect(continueButton.textContent).toContain("Continue with Telegram");
-    expect(rendered.container.textContent).toContain(
-      "Telegram is ready. Continue to open sign in.",
-    );
+    const telegramReadyButton = readButton(rendered.container, "Telegram");
+    expect(telegramReadyButton.disabled).toBe(false);
     expect(phoneInput.disabled).toBe(false);
     expect(countryTrigger.disabled).toBe(false);
-    expect(mocks.loginWithTelegram).not.toHaveBeenCalled();
+    expect(mocks.initOAuth).not.toHaveBeenCalled();
   } finally {
     await rendered.cleanup();
   }
@@ -166,7 +154,7 @@ test("HostedAuthPanel keeps real phone controls enabled for their own queued sen
   }
 });
 
-test("HostedAuthPanel disables the real mobile country trigger while Telegram waits", async () => {
+test("HostedAuthPanel keeps the mobile country trigger available while Telegram initializes", async () => {
   mocks.isMobile = true;
   const rendered = await renderClientComponent(
     createElement(HostedAuthPanelHarness),
@@ -177,15 +165,8 @@ test("HostedAuthPanel disables the real mobile country trigger while Telegram wa
     const countryTrigger = readCountryTrigger(rendered.container);
     const telegramButton = readButton(rendered.container, "Telegram");
     expect(countryTrigger.disabled).toBe(false);
-
-    await act(async () => {
-      telegramButton.dispatchEvent(
-        new rendered.window.Event("click", { bubbles: true }),
-      );
-    });
-
-    expect(readButton(rendered.container, "Connecting...").disabled).toBe(true);
-    expect(countryTrigger.disabled).toBe(true);
+    expect(telegramButton.disabled).toBe(true);
+    expect(countryTrigger.disabled).toBe(false);
   } finally {
     await rendered.cleanup();
   }
@@ -238,7 +219,7 @@ test("HostedAuthPanel gates method actions until an authenticated session snapsh
     ).toBe(false);
     expect(mocks.sendCode).not.toHaveBeenCalled();
     expect(mocks.loginWithCode).not.toHaveBeenCalled();
-    expect(mocks.loginWithTelegram).not.toHaveBeenCalled();
+    expect(mocks.initOAuth).not.toHaveBeenCalled();
     expect(mocks.completeHostedPrivyAuth).not.toHaveBeenCalled();
 
     mocks.user = {};
@@ -429,13 +410,6 @@ function readButton(container: HTMLElement, label: string): HTMLButtonElement {
   return button;
 }
 
-function installTelegramLoginWidget(targetWindow: Window & typeof globalThis) {
-  Reflect.set(targetWindow, "Telegram", {
-    Login: {
-      auth: vi.fn(),
-    },
-  });
-}
 
 function createDesktopMatchMedia(): typeof window.matchMedia {
   return vi.fn((query: string) => ({

--- a/apps/web/test/hosted-auth-panel.test.ts
+++ b/apps/web/test/hosted-auth-panel.test.ts
@@ -19,7 +19,7 @@ const mocks = vi.hoisted(() => ({
     onCompleted?: (payload: unknown) => Promise<void> | void;
   } | null,
   loginWithCode: vi.fn(),
-  loginWithTelegram: vi.fn(),
+  initOAuth: vi.fn(),
   legalConsentCardProps: null as {
     declinePending?: boolean;
     initialStatus?: unknown;
@@ -58,16 +58,10 @@ vi.mock("@privy-io/react-auth", () => ({
       state: { status: "initial" },
     };
   },
-  useLoginWithTelegram() {
-    if (typeof window !== "undefined") {
-      Reflect.set(window, "Telegram", {
-        Login: {
-          auth: () => {},
-        },
-      });
-    }
+  useLoginWithOAuth() {
     return {
-      login: mocks.loginWithTelegram,
+      initOAuth: mocks.initOAuth,
+      loading: false,
       state: { status: "initial" },
     };
   },
@@ -178,6 +172,10 @@ let cleanupRender: (() => Promise<void>) | null = null;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.completeHostedPrivyAuth.mockReset();
+  mocks.declineHostedLaunchConsent.mockReset();
+  mocks.initOAuth.mockReset();
+  mocks.logoutHostedAppSession.mockReset();
   mocks.declineHostedLaunchConsent.mockImplementation(
     async ({ logoutPrivy }: { logoutPrivy?: () => Promise<void> | void }) => {
       await logoutPrivy?.();
@@ -198,7 +196,7 @@ beforeEach(() => {
   mocks.useUser.mockReturnValue({
     user: null,
   });
-  mocks.loginWithTelegram.mockResolvedValue(undefined);
+  mocks.initOAuth.mockResolvedValue(undefined);
   mocks.sendCode.mockResolvedValue(undefined);
   mocks.loginWithCode.mockResolvedValue(undefined);
   mocks.completeHostedPrivyAuth.mockResolvedValue({
@@ -243,7 +241,7 @@ test("HostedAuthPanel keeps a pre-ready method queued and dismissible until its 
       (candidate) => candidate.textContent?.trim() === label,
     ) as HTMLButtonElement | undefined;
 
-  expect(readAlternateButton("Telegram")?.disabled).toBe(false);
+  expect(readAlternateButton("Telegram")?.disabled).toBe(true);
   expect(readAlternateButton("Email")?.disabled).toBe(false);
   expect(mocks.hostedPhoneAuthProps?.interactionGated).toBe(false);
   expect(onViewChange).toHaveBeenLastCalledWith("auth");
@@ -274,7 +272,7 @@ test("HostedAuthPanel keeps a pre-ready method queued and dismissible until its 
   });
 
   expect(onViewChange).toHaveBeenLastCalledWith("auth");
-  expect(readAlternateButton("Telegram")?.disabled).toBe(false);
+  expect(readAlternateButton("Telegram")?.disabled).toBe(true);
   expect(readAlternateButton("Email")?.disabled).toBe(false);
 });
 
@@ -302,7 +300,7 @@ test("HostedAuthPanel gates a warm authenticated session until its user snapshot
   expect(mocks.completeHostedPrivyAuth).not.toHaveBeenCalled();
 });
 
-test("HostedAuthPanel retires Telegram continuation when phone takes over", async () => {
+test("HostedAuthPanel keeps Telegram unavailable until Privy is ready", async () => {
   let privyReady = false;
   mocks.usePrivy.mockImplementation(() => ({
     authenticated: false,
@@ -323,15 +321,8 @@ test("HostedAuthPanel retires Telegram continuation when phone takes over", asyn
     ) as HTMLButtonElement | undefined;
   const telegramButton = readTelegramButton();
   expect(telegramButton).toBeTruthy();
-
-  await act(async () => {
-    telegramButton?.dispatchEvent(
-      new rendered.window.Event("click", { bubbles: true }),
-    );
-  });
-
-  expect(telegramButton?.textContent).toContain("Connecting...");
-  expect(mocks.loginWithTelegram).not.toHaveBeenCalled();
+  expect(telegramButton?.disabled).toBe(true);
+  expect(mocks.initOAuth).not.toHaveBeenCalled();
 
   privyReady = true;
   await rendered.rerender(renderPanel());
@@ -339,12 +330,8 @@ test("HostedAuthPanel retires Telegram continuation when phone takes over", asyn
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
 
-  expect(telegramButton?.textContent).toContain(
-    "Continue with Telegram",
-  );
-  expect(rendered.container.textContent).toContain(
-    "Telegram is ready. Continue to open sign in.",
-  );
+  expect(readTelegramButton()?.textContent).toBe("Telegram");
+  expect(readTelegramButton()?.disabled).toBe(false);
 
   let phoneStarted = false;
   await act(async () => {
@@ -362,7 +349,7 @@ test("HostedAuthPanel retires Telegram continuation when phone takes over", asyn
   expect(rendered.container.textContent).not.toContain(
     "Telegram is ready. Continue to open sign in.",
   );
-  expect(mocks.loginWithTelegram).not.toHaveBeenCalled();
+  expect(mocks.initOAuth).not.toHaveBeenCalled();
 });
 
 test("HostedAuthPanel discards queued email when Privy hydrates an existing session", async () => {
@@ -602,7 +589,7 @@ test("HostedAuthPanel restores phone recovery once, then permits a deliberate em
   ).toBeTruthy();
 });
 
-test("HostedAuthPanel discards queued Telegram when Privy hydrates an existing session", async () => {
+test("HostedAuthPanel offers Telegram resume when Privy hydrates an existing session", async () => {
   let authenticated = false;
   let ready = false;
   let user: { linkedAccounts?: unknown } | null = null;
@@ -629,8 +616,8 @@ test("HostedAuthPanel discards queued Telegram when Privy hydrates an existing s
     );
   });
 
-  expect(mocks.loginWithTelegram).not.toHaveBeenCalled();
-  expect(rendered.container.textContent).toContain("Connecting...");
+  expect(mocks.initOAuth).not.toHaveBeenCalled();
+  expect(telegramButton).toBeTruthy();
 
   authenticated = true;
   ready = true;
@@ -645,7 +632,7 @@ test("HostedAuthPanel discards queued Telegram when Privy hydrates an existing s
   };
   await rendered.rerender(renderPanel());
 
-  expect(mocks.loginWithTelegram).not.toHaveBeenCalled();
+  expect(mocks.initOAuth).not.toHaveBeenCalled();
   expect(rendered.container.textContent).toContain("Continue with Telegram");
   expect(rendered.container.textContent).toContain(
     "You're signed in as @telegram_user.",
@@ -653,7 +640,7 @@ test("HostedAuthPanel discards queued Telegram when Privy hydrates an existing s
   expect(rendered.container.textContent).not.toContain("Telegram is ready.");
 });
 
-test("HostedAuthPanel restores phone session recovery after a queued alternate hydrates", async () => {
+test("HostedAuthPanel restores phone session recovery after Privy hydrates", async () => {
   let authenticated = false;
   let ready = false;
   let user: { linkedAccounts?: unknown } | null = null;
@@ -684,7 +671,7 @@ test("HostedAuthPanel restores phone session recovery after a queued alternate h
     rendered.container
       .querySelector('[data-hosted-phone-auth="mounted"]')
       ?.getAttribute("data-hosted-phone-auth-suppressed"),
-  ).toBe("yes");
+  ).toBe("no");
 
   authenticated = true;
   ready = true;
@@ -699,7 +686,7 @@ test("HostedAuthPanel restores phone session recovery after a queued alternate h
   };
   await rendered.rerender(renderPanel());
 
-  expect(mocks.loginWithTelegram).not.toHaveBeenCalled();
+  expect(mocks.initOAuth).not.toHaveBeenCalled();
   expect(
     rendered.container
       .querySelector('[data-hosted-phone-auth="mounted"]')
@@ -838,7 +825,7 @@ test("HostedAuthPanel keeps a phone-less Telegram resume busy while completion i
 });
 
 test("HostedAuthPanel keeps only one alternate auth method active at a time", async () => {
-  mocks.loginWithTelegram.mockRejectedValue(new Error("Telegram popup closed"));
+  mocks.initOAuth.mockRejectedValue(new Error("Telegram popup closed"));
 
   const { cleanup, container } = await renderClientComponent(
     createElement(HostedAuthPanel, {
@@ -931,7 +918,7 @@ test("HostedAuthPanel keeps the email journey authoritative after requesting a c
     telegramButton?.dispatchEvent(new window.Event("click", { bubbles: true }));
   });
 
-  expect(mocks.loginWithTelegram).not.toHaveBeenCalled();
+  expect(mocks.initOAuth).not.toHaveBeenCalled();
 
   await act(async () => {
     resolveEmailCodeRequest?.();
@@ -941,8 +928,8 @@ test("HostedAuthPanel keeps the email journey authoritative after requesting a c
   expect(container.contains(telegramButton ?? null)).toBe(false);
 });
 
-test("HostedAuthPanel keeps auth mounted and puts completion progress on the active button", async () => {
-  mocks.completeHostedPrivyAuth.mockReturnValueOnce(new Promise(() => {}));
+test("HostedAuthPanel keeps auth mounted and puts OAuth redirect progress on the active button", async () => {
+  mocks.initOAuth.mockReturnValueOnce(new Promise(() => {}));
 
   const { cleanup, container, window } = await renderClientComponent(
     createElement(HostedAuthPanel, {
@@ -960,7 +947,7 @@ test("HostedAuthPanel keeps auth mounted and puts completion progress on the act
   });
 
   const pendingTelegramButton = Array.from(container.querySelectorAll("button")).find(
-    (candidate) => candidate.textContent?.includes("Finishing..."),
+    (candidate) => candidate.textContent?.includes("Connecting..."),
   ) as HTMLButtonElement | undefined;
   const pendingEmailButton = Array.from(container.querySelectorAll("button")).find(
     (candidate) => candidate.textContent?.trim() === "Email",
@@ -975,11 +962,12 @@ test("HostedAuthPanel keeps auth mounted and puts completion progress on the act
   expect(container.textContent).not.toContain("Keep this tab open");
   expect(container.querySelector('[data-hosted-phone-auth="mounted"]')).toBeTruthy();
   expect(mocks.hostedPhoneAuthProps?.interactionGated).toBe(true);
+  expect(mocks.completeHostedPrivyAuth).not.toHaveBeenCalled();
 });
 
-test("HostedAuthPanel makes a started Telegram journey reject a late phone provider result", async () => {
+test("HostedAuthPanel keeps shared auth ownership while Telegram redirects", async () => {
   let resolveTelegramLogin: (() => void) | null = null;
-  mocks.loginWithTelegram.mockReturnValueOnce(
+  mocks.initOAuth.mockReturnValueOnce(
     new Promise<void>((resolve) => {
       resolveTelegramLogin = resolve;
     }),
@@ -1002,7 +990,7 @@ test("HostedAuthPanel makes a started Telegram journey reject a late phone provi
     await Promise.resolve();
   });
 
-  expect(mocks.loginWithTelegram).toHaveBeenCalledTimes(1);
+  expect(mocks.initOAuth).toHaveBeenCalledTimes(1);
   expect(mocks.hostedPhoneAuthProps?.interactionGated).toBe(true);
 
   await act(async () => {
@@ -1013,19 +1001,8 @@ test("HostedAuthPanel makes a started Telegram journey reject a late phone provi
 
   expect(mocks.completeHostedPrivyAuth).not.toHaveBeenCalled();
 
-  await act(async () => {
-    resolveTelegramLogin?.();
-    await Promise.resolve();
-    await Promise.resolve();
-  });
-
-  await vi.waitFor(() => {
-    expect(mocks.completeHostedPrivyAuth).toHaveBeenCalledTimes(1);
-  });
-  expect(mocks.completeHostedPrivyAuth).toHaveBeenCalledWith({
-    authMethod: "telegram",
-  });
-  expect(container.textContent).toContain("Hosted legal consent card");
+  expect(resolveTelegramLogin).toBeTypeOf("function");
+  expect(mocks.completeHostedPrivyAuth).not.toHaveBeenCalled();
 });
 
 test("HostedAuthPanel makes a started phone request reject Telegram provider initiation", async () => {
@@ -1052,7 +1029,7 @@ test("HostedAuthPanel makes a started phone request reject Telegram provider ini
     telegramButton?.dispatchEvent(new window.Event("click", { bubbles: true }));
   });
 
-  expect(mocks.loginWithTelegram).not.toHaveBeenCalled();
+  expect(mocks.initOAuth).not.toHaveBeenCalled();
 
   await act(async () => {
     mocks.hostedPhoneAuthProps?.onCodeSent?.();
@@ -1124,44 +1101,6 @@ test("HostedAuthPanel locks every competing method while phone completion is pen
   });
 });
 
-test("HostedAuthPanel surfaces shared completion failures and restores the auth methods", async () => {
-  mocks.completeHostedPrivyAuth.mockRejectedValueOnce(
-    new Error("Checkout did not return a redirect URL."),
-  );
-
-  const { assign, cleanup, container, window } = await renderClientComponent(
-    createElement(HostedAuthPanel, {
-      methods: ["phone", "telegram", "email"],
-    }),
-  );
-  cleanupRender = cleanup;
-
-  const telegramButton = Array.from(container.querySelectorAll("button")).find(
-    (candidate) => candidate.textContent?.includes("Telegram"),
-  ) as HTMLButtonElement | undefined;
-
-  await act(async () => {
-    telegramButton?.dispatchEvent(new window.Event("click", { bubbles: true }));
-  });
-
-  const recoveredTelegramButton = Array.from(
-    container.querySelectorAll("button"),
-  ).find(
-    (candidate) => candidate.textContent?.trim() === "Telegram",
-  ) as HTMLButtonElement | undefined;
-  const recoveredEmailButton = Array.from(container.querySelectorAll("button")).find(
-    (candidate) => candidate.textContent?.trim() === "Email",
-  ) as HTMLButtonElement | undefined;
-
-  expect(assign).not.toHaveBeenCalled();
-  expect(container.textContent).toContain("Checkout did not return a redirect URL.");
-  expect(container.textContent).not.toContain("Finishing...");
-  expect(container.querySelector('[data-hosted-phone-auth="mounted"]')).toBeTruthy();
-  expect(mocks.hostedPhoneAuthProps?.interactionGated).toBe(false);
-  expect(recoveredTelegramButton?.disabled).toBe(false);
-  expect(recoveredEmailButton?.disabled).toBe(false);
-});
-
 test("HostedAuthPanel restores phone recovery and competing methods after phone completion fails", async () => {
   mocks.completeHostedPrivyAuth.mockRejectedValueOnce(
     new Error("Phone completion did not finish."),
@@ -1211,8 +1150,8 @@ test("HostedAuthPanel restores phone recovery and competing methods after phone 
   expect(mocks.completeHostedPrivyAuth).toHaveBeenCalledTimes(2);
 });
 
-test("HostedAuthPanel can require launch consent after homepage login completion", async () => {
-  const { assign, cleanup, container, window } = await renderClientComponent(
+test("HostedAuthPanel defers launch consent until Telegram returns authenticated", async () => {
+  const { cleanup, container, window } = await renderClientComponent(
     createElement(HostedAuthPanel, {
       methods: ["phone", "telegram", "email"],
       requireLaunchConsentOnCompletion: true,
@@ -1228,15 +1167,11 @@ test("HostedAuthPanel can require launch consent after homepage login completion
     telegramButton?.dispatchEvent(new window.Event("click", { bubbles: true }));
   });
 
-  expect(mocks.loginWithTelegram).toHaveBeenCalledWith(undefined);
-  expect(assign).not.toHaveBeenCalled();
-  expect(container.textContent).toContain("Hosted legal consent card");
-  expect(mocks.legalConsentCardProps).toMatchObject({
-    initialStatus: launchConsentStatus,
-    mode: "compact",
-    preferredScope: "launch.legal",
-    source: "homepage-auth-dialog",
+  expect(mocks.initOAuth).toHaveBeenCalledWith({
+    provider: "telegram",
   });
+  expect(mocks.completeHostedPrivyAuth).not.toHaveBeenCalled();
+  expect(container.textContent).not.toContain("Hosted legal consent card");
 });
 
 test("HostedAuthPanel records the launch decline and returns to auth", async () => {
@@ -1257,11 +1192,10 @@ test("HostedAuthPanel records the launch decline and returns to auth", async () 
   );
   cleanupRender = cleanup;
 
-  const telegramButton = Array.from(container.querySelectorAll("button")).find(
-    (candidate) => candidate.textContent?.includes("Telegram"),
-  );
   await act(async () => {
-    telegramButton?.dispatchEvent(new window.Event("click", { bubbles: true }));
+    await mocks.hostedPhoneAuthProps?.onAuthenticated?.({
+      authMethod: "phone",
+    });
   });
 
   const declineButton = Array.from(container.querySelectorAll("button")).find(
@@ -1305,11 +1239,10 @@ test("HostedAuthPanel leaves the gate mounted and Decline usable when sign-out f
   );
   cleanupRender = cleanup;
 
-  const telegramButton = Array.from(container.querySelectorAll("button")).find(
-    (candidate) => candidate.textContent?.includes("Telegram"),
-  );
   await act(async () => {
-    telegramButton?.dispatchEvent(new window.Event("click", { bubbles: true }));
+    await mocks.hostedPhoneAuthProps?.onAuthenticated?.({
+      authMethod: "phone",
+    });
   });
 
   const firstDeclineButton = Array.from(container.querySelectorAll("button")).find(
@@ -1369,58 +1302,16 @@ test("HostedAuthPanel skips launch consent handoff when completion says launch c
   );
   cleanupRender = cleanup;
 
-  const telegramButton = Array.from(container.querySelectorAll("button")).find(
-    (candidate) => candidate.textContent?.includes("Telegram"),
-  ) as HTMLButtonElement | undefined;
-
   await act(async () => {
-    telegramButton?.dispatchEvent(new window.Event("click", { bubbles: true }));
+    await mocks.hostedPhoneAuthProps?.onAuthenticated?.({
+      authMethod: "phone",
+    });
   });
 
   expect(reload).toHaveBeenCalledTimes(1);
   expect(assign).not.toHaveBeenCalled();
   expect(container.textContent).not.toContain("Hosted legal consent card");
   expect(mocks.legalConsentCardProps).toBeNull();
-});
-
-test("HostedAuthPanel shows launch consent after homepage signup auth before redirecting", async () => {
-  const { assign, cleanup, container, window } = await renderClientComponent(
-    createElement(HostedAuthPanel, {
-      methods: ["phone", "telegram", "email"],
-      requireLaunchConsentOnCompletion: true,
-    }),
-  );
-  cleanupRender = cleanup;
-
-  const telegramButton = Array.from(container.querySelectorAll("button")).find(
-    (candidate) => candidate.textContent?.includes("Telegram"),
-  ) as HTMLButtonElement | undefined;
-  expect(telegramButton).toBeTruthy();
-
-  await act(async () => {
-    telegramButton?.dispatchEvent(new window.Event("click", { bubbles: true }));
-  });
-
-  expect(assign).not.toHaveBeenCalled();
-  expect(container.textContent).toContain("Hosted legal consent card");
-  expect(mocks.legalConsentCardProps).toMatchObject({
-    initialStatus: launchConsentStatus,
-    mode: "compact",
-    preferredScope: "launch.legal",
-    source: "homepage-auth-dialog",
-  });
-
-  const continueButton = Array.from(container.querySelectorAll("button")).find(
-    (candidate) => candidate.textContent?.includes("Continue"),
-  );
-  await act(async () => {
-    continueButton?.dispatchEvent(new window.Event("click", { bubbles: true }));
-  });
-
-  expect(assign).toHaveBeenCalledWith("/home");
-  expect(container.querySelector('[data-hosted-phone-auth="mounted"]')).toBeNull();
-  expect(container.textContent).not.toContain("Hosted phone auth");
-  expect(container.textContent).toContain("Hosted legal consent card");
 });
 
 test("HostedAuthPanel phone signup completion pauses on launch consent before redirecting", async () => {

--- a/apps/web/test/settings-telegram-settings.test.ts
+++ b/apps/web/test/settings-telegram-settings.test.ts
@@ -15,7 +15,7 @@ type LinkAccountCallbacks = {
 const mocks = vi.hoisted(() => ({
   openAuthDialog: vi.fn(),
   linkAccountCallbacks: null as LinkAccountCallbacks | null,
-  linkTelegram: vi.fn(),
+  linkOAuth: vi.fn(),
   refreshUser: vi.fn(),
   requestHostedOnboardingJson: vi.fn(),
   useLinkAccount: vi.fn(),
@@ -73,7 +73,7 @@ describe("ConnectTelegram", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.linkAccountCallbacks = null;
-    mocks.linkTelegram.mockReturnValue(undefined);
+    mocks.linkOAuth.mockReturnValue(undefined);
     mocks.refreshUser.mockResolvedValue({
       linkedAccounts: [],
     });
@@ -91,7 +91,7 @@ describe("ConnectTelegram", () => {
       mocks.linkAccountCallbacks = callbacks;
 
       return {
-        linkTelegram: mocks.linkTelegram,
+        linkOAuth: mocks.linkOAuth,
       };
     });
     mocks.useUser.mockReturnValue({
@@ -262,7 +262,7 @@ describe("ConnectTelegram", () => {
     });
 
     expect(mocks.openAuthDialog).toHaveBeenCalledTimes(1);
-    expect(mocks.linkTelegram).not.toHaveBeenCalled();
+    expect(mocks.linkOAuth).not.toHaveBeenCalled();
   });
 
   it("uses a sanitized initial Telegram account when Privy user state has not loaded", async () => {
@@ -383,7 +383,7 @@ describe("ConnectTelegram", () => {
       changeButton?.dispatchEvent(new Event("click", { bubbles: true }));
     });
 
-    expect(mocks.linkTelegram).toHaveBeenCalledTimes(1);
+    expect(mocks.linkOAuth).toHaveBeenCalledWith({ provider: "telegram" });
     expect(mocks.requestHostedOnboardingJson).toHaveBeenCalledTimes(1);
 
     await act(async () => {
@@ -506,7 +506,7 @@ describe("HostedTelegramCardSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.linkAccountCallbacks = null;
-    mocks.linkTelegram.mockReturnValue(undefined);
+    mocks.linkOAuth.mockReturnValue(undefined);
     mocks.refreshUser.mockResolvedValue({
       linkedAccounts: [
         {
@@ -530,7 +530,7 @@ describe("HostedTelegramCardSettings", () => {
       mocks.linkAccountCallbacks = callbacks;
 
       return {
-        linkTelegram: mocks.linkTelegram,
+        linkOAuth: mocks.linkOAuth,
       };
     });
     mocks.useUser.mockReturnValue({
@@ -686,7 +686,7 @@ describe("HostedTelegramCardSettings", () => {
       linkButton?.dispatchEvent(new Event("click", { bubbles: true }));
     });
 
-    expect(mocks.linkTelegram).toHaveBeenCalledTimes(1);
+    expect(mocks.linkOAuth).toHaveBeenCalledWith({ provider: "telegram" });
     expect(mocks.requestHostedOnboardingJson).not.toHaveBeenCalled();
 
     await act(async () => {
@@ -748,7 +748,7 @@ describe("HostedTelegramCardSettings", () => {
     );
     expect(linkButton).toBeTruthy();
 
-    expect(mocks.linkTelegram).not.toHaveBeenCalled();
+    expect(mocks.linkOAuth).not.toHaveBeenCalled();
     expect(linkButton?.disabled).toBe(true);
     expect(container.textContent).toContain("Preparing Telegram linking");
   });
@@ -779,7 +779,7 @@ describe("HostedTelegramCardSettings", () => {
       linkButton?.dispatchEvent(new Event("click", { bubbles: true }));
     });
 
-    expect(mocks.linkTelegram).not.toHaveBeenCalled();
+    expect(mocks.linkOAuth).not.toHaveBeenCalled();
   });
 
   it("opens app auth from the card instead of launching Telegram link when the Privy client user is absent", async () => {
@@ -810,7 +810,7 @@ describe("HostedTelegramCardSettings", () => {
     });
 
     expect(mocks.openAuthDialog).toHaveBeenCalledTimes(1);
-    expect(mocks.linkTelegram).not.toHaveBeenCalled();
+    expect(mocks.linkOAuth).not.toHaveBeenCalled();
   });
 
   it("auto-links Telegram once Privy becomes ready and authenticated", async () => {
@@ -843,7 +843,7 @@ describe("HostedTelegramCardSettings", () => {
     const { cleanup, container } = await renderClientComponent(createElement(PrivyReadyHarness));
     cleanupRender = cleanup;
 
-    expect(mocks.linkTelegram).not.toHaveBeenCalled();
+    expect(mocks.linkOAuth).not.toHaveBeenCalled();
 
     await act(async () => {
       privyState.authenticated = true;
@@ -852,7 +852,7 @@ describe("HostedTelegramCardSettings", () => {
     });
 
     await vi.waitFor(() => {
-      expect(mocks.linkTelegram).toHaveBeenCalledTimes(1);
+      expect(mocks.linkOAuth).toHaveBeenCalledTimes(1);
     });
     expect(mocks.requestHostedOnboardingJson).not.toHaveBeenCalled();
     expect(container.textContent).toContain("Opening Telegram");
@@ -900,7 +900,7 @@ describe("HostedTelegramCardSettings", () => {
       });
     });
 
-    expect(mocks.linkTelegram).not.toHaveBeenCalled();
+    expect(mocks.linkOAuth).not.toHaveBeenCalled();
 
     await act(async () => {
       autoLinkSync.resolveSync({
@@ -966,7 +966,7 @@ describe("HostedTelegramCardSettings", () => {
         url: "/api/settings/telegram/sync",
       });
     });
-    expect(mocks.linkTelegram).not.toHaveBeenCalled();
+    expect(mocks.linkOAuth).not.toHaveBeenCalled();
 
     await act(async () => {
       manualSync.resolveSync({
@@ -1026,7 +1026,7 @@ describe("HostedTelegramCardSettings", () => {
       const { cleanup } = await renderClientComponent(createElement(PrivyUserArrivalHarness));
       cleanupRender = cleanup;
 
-      expect(mocks.linkTelegram).not.toHaveBeenCalled();
+      expect(mocks.linkOAuth).not.toHaveBeenCalled();
 
       await act(async () => {
         privyUserState.linkedAccounts = [
@@ -1051,7 +1051,7 @@ describe("HostedTelegramCardSettings", () => {
           url: "/api/settings/telegram/sync",
         });
       });
-      expect(mocks.linkTelegram).not.toHaveBeenCalled();
+      expect(mocks.linkOAuth).not.toHaveBeenCalled();
 
       await act(async () => {
         autoLinkSync.resolveSync({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,8 +281,8 @@ importers:
         specifier: ^0.18.0
         version: 0.18.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       '@privy-io/react-auth':
-        specifier: ^3.24.0
-        version: 3.24.0(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(css-to-react-native@3.2.0)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@4.3.6)
+        specifier: ^3.40.0
+        version: 3.40.0(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(typescript@5.9.3))(@stripe/stripe-js@1.54.2)(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(css-to-react-native@3.2.0)(date-fns@4.1.0)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@4.3.6)
       '@temporalio/client':
         specifier: ~1.16.3
         version: 1.16.3
@@ -1394,8 +1394,35 @@ packages:
       date-fns:
         optional: true
 
+  '@base-ui/react@1.7.0':
+    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
   '@base-ui/utils@0.2.8':
     resolution: {integrity: sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@base-ui/utils@0.3.2':
+    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -1803,11 +1830,23 @@ packages:
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
   '@floating-ui/dom@1.7.6':
     resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
 
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
   '@floating-ui/react-dom@2.1.8':
     resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -1820,6 +1859,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@gemini-wallet/core@0.3.2':
     resolution: {integrity: sha512-Z4aHi3ECFf5oWYWM3F1rW83GJfB9OvhBYPTmb5q+VyK3uvzvS48lwo+jwh2eOoCRWEuT/crpb9Vwp2QaS5JqgQ==}
@@ -3087,31 +3129,31 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@privy-io/api-base@1.9.0':
-    resolution: {integrity: sha512-8OJ2chadFcgUwr+Kqim0z5paIdadEdMH8pW94WJz0O3s2X4aX7vhN1eqiNZqcdgSIk9FHm8c3A+/epJUwiTYuQ==}
+  '@privy-io/api-base@1.10.0':
+    resolution: {integrity: sha512-3HxU0umyY8IBAqyZP/m/qfIkrdjlbcECdGKqfGR7LSkmWiAhq+9BC0Rtv1um6wkO/67b3d8nbRzSNVQvahdnrw==}
 
-  '@privy-io/api-types@0.12.0':
-    resolution: {integrity: sha512-gIZ6pX4wFpaN+8znTsQw47g/auKNjDTHFlLubITVkZezI2WTqja+zOBYHzeMkcBLAH4wn69jEyrET3I18Vptiw==}
+  '@privy-io/api-types@0.20.0':
+    resolution: {integrity: sha512-CqzPGb4xj2jJC07UiBhbdBf7a02UhI047IVu2rr6EP5xImhR0iD2aSxCbjVo9fx07TNM6Sv/O14Dcrqc96c8uw==}
 
-  '@privy-io/are-addresses-equal@0.0.4':
-    resolution: {integrity: sha512-l/Vq2uZrwsR/dxVdzyRUDtqB41smFjqrcLYUeEqkbfJbu0pn3h9N7SknEGSFTIZ34L6sBi6MQCZ98feexSvpAQ==}
+  '@privy-io/are-addresses-equal@0.0.12':
+    resolution: {integrity: sha512-tuevtCjOlja9LyB7mZYUxxdWnUp7i9tSA/PWI+AtUekLk+ypgQFbkXpMaOZVQuoniY1NFlNempLmMz4s1V6iCA==}
 
-  '@privy-io/chains@0.3.0':
-    resolution: {integrity: sha512-27dTj94S4PbyiJuknRuqXzYZSqbk62y2Ht/8ppSNlsaIswxrso9uE8w5PKX82zNyz7crHRULfxDPv2xM2ZXHTg==}
+  '@privy-io/chains@0.5.2':
+    resolution: {integrity: sha512-h6Zr9hOFNdZamiv/XuFPPJwaMeoWJBOPCqSczr12Nh731tYHhCdCXr5RG+1WvCowbvj3xCXWokkAlByxnU2xsw==}
 
-  '@privy-io/encoding@0.1.3':
-    resolution: {integrity: sha512-tvSuC0umDmkfmdKe339P/IZzqh04y7WQ7fOB5iU0aQoxdEivjO0hAD4GHxNOTdn9be9hS2WfIp7u/q6h7ZvvTg==}
+  '@privy-io/encoding@0.2.2':
+    resolution: {integrity: sha512-bQHM5AB+F3/MIEaJ0WcFbCqAyuls7nUbQ34AlyctibPK1tmYL0tc9D2voeHo9q2S31nlgIKLEDJ65VZc+pcv6Q==}
 
-  '@privy-io/ethereum@0.1.0':
-    resolution: {integrity: sha512-yoNXDK2d7P/VgwxJ+pybPL9OMANx9A2eHsw4ZuHiZ+vokDmybeW/RaUPLY8RVvcsN2rZD/Ql5hSr+f4GDW+zwQ==}
+  '@privy-io/ethereum@0.2.3':
+    resolution: {integrity: sha512-ofYileoIrrR+QDfZH/YF5fkeJZGJEwH4FJDQ3ipm16p8feHqImPXWrqIKOOT0n7IM6OUMvKpAP6QeEgXMc18jA==}
     peerDependencies:
-      viem: 2.47.12
+      viem: 2.56.0
 
-  '@privy-io/js-sdk-core@0.62.0':
-    resolution: {integrity: sha512-jFnTfoPmQcUfvV5xHUyvGVmZtVd7K3E/Y1J8A88WlYTPFViaRMzJ1elY8gfXu+2xUShUW0oOMeAFAcj8J7eKLw==}
+  '@privy-io/js-sdk-core@0.73.0':
+    resolution: {integrity: sha512-mrwJB6pi+B/LyLDaSAYQMAOWq0UPL1H2xXRYKw+bhzS0Xv7RbuIdDrZkWJNPn7dmOoDX5R5TKmS/EaJPu5FzsQ==}
     peerDependencies:
       permissionless: ^0.2.47
-      viem: 2.47.12
+      viem: 2.56.0
     peerDependenciesMeta:
       permissionless:
         optional: true
@@ -3138,11 +3180,11 @@ packages:
       viem:
         optional: true
 
-  '@privy-io/popup@0.0.4':
-    resolution: {integrity: sha512-Lk5BqB//F9naVOR9tkHbrcGs55fM4ILS50tdsgIQ76Kr9i7Og4Ob5IRGIKb75P11f5hXTwAjMezRmWM/7uAsrw==}
+  '@privy-io/popup@0.0.5':
+    resolution: {integrity: sha512-lIwErJA86rHmLkSyapv86Z6hVzoLl544iZsVgk4tcVCHxbLBlLI4UmgLDmviNTZdp+uY0VEZe8fjUQIPpa6tZg==}
 
-  '@privy-io/react-auth@3.24.0':
-    resolution: {integrity: sha512-HY1Wp1ZKbKsINXJHCdE1sabswItNJQRq5UBUIe12Sa7JNhqqbB6QbDZ6BG0cZ3YTE1b1Kzd9r42rfL41jgUTbw==}
+  '@privy-io/react-auth@3.40.0':
+    resolution: {integrity: sha512-nj80Yms88E7cPDH9KjqI1VA5yAi3/Elwntef32lv5faVimHOZr97jNKGFxQqWtx+YwdKDbdMh1hHmttEtY6rDQ==}
     peerDependencies:
       '@abstract-foundation/agw-client': ^1.0.0
       '@farcaster/mini-app-solana': ^1.0.0
@@ -3169,11 +3211,11 @@ packages:
       permissionless:
         optional: true
 
-  '@privy-io/routes@0.1.0':
-    resolution: {integrity: sha512-I60LrGRLGGFxkWz8IiABa6VA8LU3MTZ995b7uGWapK/7wMWJikXjkeisqjduiDPjlEhtQMu4ONrEg8CMxP68MA==}
+  '@privy-io/routes@0.2.12':
+    resolution: {integrity: sha512-jLidE/l+OGjzMvDeV+tIGASQGblIYaqBNYHLlpNKEBspmUdfU5EM/BBT9WyphtNhVelsGyX3jIxW5PukqC6b7Q==}
 
-  '@privy-io/urls@0.0.4':
-    resolution: {integrity: sha512-YYLt3zD4GlMgVm+VkdMF8BnRYlUrfkcchF7fVTPwdP8ljPytCP295yxi26iOsbJfT/xy3+sLsvvrDthjpk6ERA==}
+  '@privy-io/urls@0.0.5':
+    resolution: {integrity: sha512-cy4SQY60I9aGm+Er/gL4P+Rrsw2B7RoD6GKw5ZlwEN3jCm3tfclWeZI+xlJSKIwIu71YV9fWpO0bjLTs0tMLgQ==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -4232,6 +4274,14 @@ packages:
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@stripe/crypto@1.1.3':
+    resolution: {integrity: sha512-1Qz1B9uuF1wwuu3IXtHP2Rllm/pCOZ80is6jWweoPPQLwTnCjTT1Keia4IHHSSRN88Miq8s8UQ5wT5M0A/b6ZQ==}
+    peerDependencies:
+      '@stripe/stripe-js': ^1.46.0
+
+  '@stripe/stripe-js@1.54.2':
+    resolution: {integrity: sha512-R1PwtDvUfs99cAjfuQ/WpwJ3c92+DAMy9xGApjqlWQMj0FKQabUAys2swfTRNzuYAYJh7NqK2dzcYVNkKLEKUg==}
 
   '@swc/cli@0.8.1':
     resolution: {integrity: sha512-L+ACCGHCiS0VqHVep/INLVnvRvJ2XooQFLZq4L8snhxw1jsqz+XRcY313UsyPVturPPE1shW3jic7rt3qEQTSQ==}
@@ -8348,6 +8398,14 @@ packages:
       typescript:
         optional: true
 
+  ox@0.14.34:
+    resolution: {integrity: sha512-12seOIk7dv8eAoGQhcWaeKZxNz304IVcDvb9U5Y7JZAEVe21Nm1YMxLjhWah+su5BD4Omx4Zz0z5x3ij9M4GYQ==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ox@0.6.7:
     resolution: {integrity: sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==}
     peerDependencies:
@@ -8712,9 +8770,6 @@ packages:
   preact@10.24.2:
     resolution: {integrity: sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==}
 
-  preact@10.29.1:
-    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
-
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
@@ -9017,6 +9072,9 @@ packages:
 
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
+  reselect@5.3.0:
+    resolution: {integrity: sha512-XGoLeRAVzUTcJ1qkxPQhDJyIZ5d6zzZD9nT7AEZOaaU9UbWclhycElmhO+VD5bFeLuzhPBaOV2oXC8uG35ZSpg==}
 
   resend@6.18.0:
     resolution: {integrity: sha512-EjxZ9AVzywJgOlUoIJe9ytBWVrfbUtJbjeoLnRSvpU1sv97Hh9DSwhw+k8kiujrG4Rg4bzTBsjlmwWWuoOxSug==}
@@ -10117,6 +10175,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.56.0:
+    resolution: {integrity: sha512-JmkgIk4jN+im4oguLxwPv19pwSaGH9kcGSq25Ilm55106ULBBMNR3eWKKA0wZoeyLPSHIiOwZ4sGceEYEIq7LA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite@8.0.12:
     resolution: {integrity: sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -11016,6 +11082,19 @@ snapshots:
       '@types/react': 19.2.14
       date-fns: 4.1.0
 
+  '@base-ui/react@1.7.0(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.3.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      use-sync-external-store: 1.6.0(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      date-fns: 4.1.0
+
   '@base-ui/utils@0.2.8(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -11023,6 +11102,17 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@base-ui/utils@0.3.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      reselect: 5.3.0
       use-sync-external-store: 1.6.0(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
@@ -11171,7 +11261,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       clsx: 1.2.1
       eventemitter3: 5.0.4
-      preact: 10.29.1
+      preact: 10.29.2
 
   '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
@@ -11411,14 +11501,29 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
   '@floating-ui/dom@1.7.6':
     dependencies:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
   '@floating-ui/react-dom@2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@floating-ui/dom': 1.7.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -11431,6 +11536,8 @@ snapshots:
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@floating-ui/utils@0.2.12': {}
 
   '@gemini-wallet/core@0.3.2(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
@@ -12764,39 +12871,39 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
 
-  '@privy-io/api-base@1.9.0':
+  '@privy-io/api-base@1.10.0':
     dependencies:
       zod: 3.25.76
 
-  '@privy-io/api-types@0.12.0': {}
+  '@privy-io/api-types@0.20.0': {}
 
-  '@privy-io/are-addresses-equal@0.0.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@privy-io/are-addresses-equal@0.0.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
       - zod
 
-  '@privy-io/chains@0.3.0': {}
+  '@privy-io/chains@0.5.2': {}
 
-  '@privy-io/encoding@0.1.3':
+  '@privy-io/encoding@0.2.2':
     dependencies:
       '@scure/base': 1.2.6
 
-  '@privy-io/ethereum@0.1.0(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@privy-io/ethereum@0.2.3(viem@2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
 
-  '@privy-io/js-sdk-core@0.62.0(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@privy-io/js-sdk-core@0.73.0(viem@2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
-      '@privy-io/api-base': 1.9.0
-      '@privy-io/api-types': 0.12.0
-      '@privy-io/chains': 0.3.0
-      '@privy-io/encoding': 0.1.3
-      '@privy-io/ethereum': 0.1.0(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      '@privy-io/routes': 0.1.0
+      '@privy-io/api-base': 1.10.0
+      '@privy-io/api-types': 0.20.0
+      '@privy-io/chains': 0.5.2
+      '@privy-io/encoding': 0.2.2
+      '@privy-io/ethereum': 0.2.3(viem@2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@privy-io/routes': 0.2.12
       canonicalize: 2.1.0
       eventemitter3: 5.0.4
       fetch-retry: 6.0.0
@@ -12805,7 +12912,7 @@ snapshots:
       libphonenumber-js: 1.13.1
       set-cookie-parser: 2.7.2
     optionalDependencies:
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
 
   '@privy-io/node@0.18.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
@@ -12822,29 +12929,31 @@ snapshots:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
 
-  '@privy-io/popup@0.0.4': {}
+  '@privy-io/popup@0.0.5': {}
 
-  '@privy-io/react-auth@3.24.0(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(css-to-react-native@3.2.0)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@privy-io/react-auth@3.40.0(@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(typescript@5.9.3))(@stripe/stripe-js@1.54.2)(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(css-to-react-native@3.2.0)(date-fns@4.1.0)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@base-org/account': 1.1.1(@types/react@19.2.14)(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@base-ui/react': 1.7.0(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@coinbase/wallet-sdk': 4.3.2
       '@floating-ui/react': 0.26.28(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@hcaptcha/react-hcaptcha': 1.17.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@headlessui/react': 2.2.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@heroicons/react': 2.2.0(react@19.2.6)
       '@marsidev/react-turnstile': 1.5.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@privy-io/api-base': 1.9.0
-      '@privy-io/api-types': 0.12.0
-      '@privy-io/are-addresses-equal': 0.0.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@privy-io/chains': 0.3.0
-      '@privy-io/encoding': 0.1.3
-      '@privy-io/ethereum': 0.1.0(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      '@privy-io/js-sdk-core': 0.62.0(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      '@privy-io/popup': 0.0.4
-      '@privy-io/routes': 0.1.0
-      '@privy-io/urls': 0.0.4
+      '@privy-io/api-base': 1.10.0
+      '@privy-io/api-types': 0.20.0
+      '@privy-io/are-addresses-equal': 0.0.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@privy-io/chains': 0.5.2
+      '@privy-io/encoding': 0.2.2
+      '@privy-io/ethereum': 0.2.3(viem@2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@privy-io/js-sdk-core': 0.73.0(viem@2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@privy-io/popup': 0.0.5
+      '@privy-io/routes': 0.2.12
+      '@privy-io/urls': 0.0.5
       '@scure/base': 1.2.6
       '@simplewebauthn/browser': 13.3.0
+      '@stripe/crypto': 1.1.3(@stripe/stripe-js@1.54.2)
       '@tanstack/react-virtual': 3.13.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@wallet-standard/app': 1.1.0
       '@walletconnect/ethereum-provider': 2.22.4(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
@@ -12865,7 +12974,7 @@ snapshots:
       styled-components: 6.4.1(css-to-react-native@3.2.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       stylis: 4.4.0
       tinycolor2: 1.6.0
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       x402: 0.7.3(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)
       zustand: 5.0.13(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
     optionalDependencies:
@@ -12880,11 +12989,13 @@ snapshots:
       - '@azure/keyvault-secrets'
       - '@azure/storage-blob'
       - '@capacitor/preferences'
+      - '@date-fns/tz'
       - '@deno/kv'
       - '@netlify/blobs'
       - '@planetscale/database'
       - '@react-native-async-storage/async-storage'
       - '@solana/sysvars'
+      - '@stripe/stripe-js'
       - '@tanstack/query-core'
       - '@tanstack/react-query'
       - '@types/react'
@@ -12895,6 +13006,7 @@ snapshots:
       - aws4fetch
       - bufferutil
       - css-to-react-native
+      - date-fns
       - db0
       - debug
       - encoding
@@ -12912,11 +13024,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@privy-io/routes@0.1.0':
+  '@privy-io/routes@0.2.12':
     dependencies:
-      '@privy-io/api-types': 0.12.0
+      '@privy-io/api-types': 0.20.0
 
-  '@privy-io/urls@0.0.4': {}
+  '@privy-io/urls@0.0.5': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -14550,6 +14662,12 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
+  '@stripe/crypto@1.1.3(@stripe/stripe-js@1.54.2)':
+    dependencies:
+      '@stripe/stripe-js': 1.54.2
+
+  '@stripe/stripe-js@1.54.2': {}
+
   '@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.21))(chokidar@5.0.0)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.21)
@@ -15160,7 +15278,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(@wagmi/core@2.22.1(@tanstack/query-core@5.95.2)(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@3.25.76))(zod@3.25.76)':
+  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(@wagmi/core@2.22.1(@tanstack/query-core@5.95.2)(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -15171,8 +15289,8 @@ snapshots:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.95.2)(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.95.2)(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@3.25.76))
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      porto: 0.2.35(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.95.2)(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -17775,8 +17893,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.3.0(eslint@9.39.4(jiti@2.7.0))
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -17798,7 +17916,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -17809,22 +17927,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -17835,7 +17953,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -19922,6 +20040,21 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  ox@0.14.34(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@5.9.3)(zod@4.3.6)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
   ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -19929,7 +20062,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.4(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -19958,7 +20091,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.6)
+      abitype: 1.2.4(typescript@5.9.3)(zod@4.3.6)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -20234,14 +20367,14 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.95.2)(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@3.25.76)):
+  porto@0.2.35(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.95.2)(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
     dependencies:
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.95.2)(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       hono: 4.12.25
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.17(typescript@5.9.3)(zod@4.4.3)
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 4.4.3
       zustand: 5.0.13(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
     optionalDependencies:
@@ -20297,8 +20430,6 @@ snapshots:
   powershell-utils@0.1.0: {}
 
   preact@10.24.2: {}
-
-  preact@10.29.1: {}
 
   preact@10.29.2: {}
 
@@ -20692,6 +20823,8 @@ snapshots:
   require-main-filename@2.0.0: {}
 
   reselect@5.1.1: {}
+
+  reselect@5.3.0: {}
 
   resend@6.18.0:
     dependencies:
@@ -22001,6 +22134,23 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.56.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.34(typescript@5.9.3)(zod@4.3.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite@8.0.12(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -22094,7 +22244,7 @@ snapshots:
   wagmi@2.19.5(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6):
     dependencies:
       '@tanstack/react-query': 5.95.2(react@19.2.6)
-      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(@wagmi/core@2.22.1(@tanstack/query-core@5.95.2)(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@3.25.76))(zod@3.25.76)
+      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(@wagmi/core@2.22.1(@tanstack/query-core@5.95.2)(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.95.2)(@tanstack/react-query@5.95.2(react@19.2.6))(@types/react@19.2.14)(@vercel/functions@3.4.6(@aws-sdk/credential-provider-web-identity@3.972.13))(bufferutil@4.1.0)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.95.2)(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       react: 19.2.6
       use-sync-external-store: 1.4.0(react@19.2.6)


### PR DESCRIPTION
## Why and outcome

Production Telegram sign-in invokes Telegram’s retired Login Widget and receives an obsolete-login response. This restores sign-in and account linking by migrating hosted Web to Telegram OAuth/OIDC through Privy’s current API.

## Product UX

- Effort: Patch - restores an existing sign-in and account-linking path without changing the surrounding auth experience.
- Result: Ready
- Walkthrough: New and returning members can choose Telegram once, authorize on Telegram, and return to Murph for automatic Telegram completion. Existing members can link Telegram from either settings presentation. Accounts that also have a phone stay on the Telegram completion path instead of seeing unrelated phone recovery. Phone and email auth are unchanged. Telegram dashboard credential rotation remains an operator action outside this code patch.

## Evidence

- Direct: The focused hosted Web auth suite passed 69 tests, the changelog page suite passed 9 tests, hosted Web typecheck passed, `pnpm complexity:diff` passed, dependency policy passed, and the base/head dependency-audit severity totals match.
- Coverage: Tests prove the exact `telegram` OAuth provider call, no-signup forwarding, provider readiness, shared auth ownership, loading and error recovery, tab-scoped redirect intent persistence, auth-dialog remount recovery, direct Telegram completion for an identity that also has a phone, and both settings link entry points.

ReviewGPT first-reviewed head: 31aecc472cc8322538feeea3e38e518291dca6f7

## Non-obvious affected surfaces

Privy React and its transitive lockfile graph move from 3.24 to 3.40. The existing server identity shape, session completion endpoint, Telegram synchronization, phone auth, and email auth are unchanged. Existing design studies were updated to remove the retired widget-ready second-click state.

## Architecture and reuse

- Existing systems reused: Privy OAuth, the hosted auth dialog, existing Murph session completion, and existing Telegram identity synchronization.
- New logic: A tab-scoped intent reopens the auth dialog after Telegram redirects back and remains authoritative until the mounted Privy callback completes specifically as Telegram.
- New abstractions: One three-function browser-storage helper owns that redirect intent; no service, database state, or server state was added.
- Complexity intentionally avoided: The retired widget poller, readiness timers, queued-click state, a second callback owner, and any new backend callback service were deleted or avoided.

## Complexity impact

- Guard: pass - `pnpm complexity:diff`; no debt was added and the Telegram button maximum fell from 18 to 10.
- Hotspots: Existing `AuthDialog` at 22, `HostedAuthPanel` at 55, and `HostedTelegramCardSettings` at 30 remain unchanged; this patch does not increase them.
- Agent judgment: The redirect intent is the smallest behavior-preserving owner because Privy must remount after the full-page OAuth return; no further state or abstraction is justified.

## Hot reply path impact

- Path status: Not applicable - this patch changes hosted Web authentication only.
- Database calls: None.
- Network/provider calls: None on the assistant hot reply path.
- Other awaited latency: None on the assistant hot reply path.
- Before/after proof: Changed-file inspection shows no assistant runtime, durable message, reply handoff, or provider-start path changes.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run - no assistant prompt, tool schema, wrapper, history, fixture, or provider-input surface changed.

## Design proof

- Design page: [Telegram auth transitions](https://www.withmurph.ai/design?tab=components#homepage-auth-transitions), [Telegram warm-runtime states](https://www.withmurph.ai/design?tab=components#homepage-auth-warm-runtime)
- Evidence: The repository-owned studies render the real production Telegram button with synthetic props; an image adds no proof for the external full-page redirect mechanism.
- Coverage: The studies cover provider initialization, authorization starting, authorization available, and responsive grid composition; focused component tests cover disabled, busy, completion, and recovery states.

## Risks

ReviewGPT context sensitivity: sensitive
Classification reason: This patch changes an authentication SDK, OAuth initiation, account linking, and redirect completion behavior.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new Web bundles use the same hosted session-completion endpoint and Telegram identity shape; no shared Web/Cloudflare protocol changes.
- Safe order: Merge and deploy hosted Web through Vercel; no Cloudflare or database deployment is required.
- Rollback floor: No schema or persisted-data migration is introduced, so the prior build remains technically compatible, but it contains the known broken Telegram path and any rollback requires explicit operator authorization.
- Expected exposure: Existing browser tabs may retain the old bundle until navigation or refresh; new production loads converge through the ordinary Vercel rollout.
- Reversibility: Code-only and data-preserving; a forward correction is preferred because the previous Telegram flow is retired.
- Convergence proof: Confirm the Vercel production deployment maps the merged commit and the live client initiates Telegram OAuth without legacy `bot_id` parameters.
- Post-deploy checks: Start Telegram sign-in from the homepage, confirm OAuth parameter shape and successful return, start Telegram linking from settings, and smoke phone and email auth entry points.

## Change-shape breakdown

Classification rule: Auth and design component files are source; Vitest files are tests; the changelog fragment is docs; the package manifest is config; the lockfile is generated/other. No binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 107 | 222 |
| Tests / fixtures | 290 | 493 |
| Docs | 14 | 0 |
| Config / tooling | 1 | 1 |
| Generated / other | 230 | 80 |
| **Total** | **642** | **796** |

## Changelog

- Changelog: updated
- Items: 2026-09-04 · telegram-sign-in-works-again