### PR TITLE
Preserve device-sync progress in bounded metadata

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1388,6 +1388,13 @@ Last verified: 2026-09-04
   `device-sync.maintenance_failed`, and activity scheduling uses
   `assistant.device_activity_automation_failed`; none increments the
   failed-attempt metric.
+  Junction sync-result metadata preserves the existing historical progress and
+  coverage keys before optional diagnostics when the 16-entry envelope fills.
+  The provider owner supplies that priority to the shared sanitized merge for
+  success, failure, and coverage composition. Patch values and explicit null
+  clearing remain authoritative; secret filtering and size limits still apply.
+  This prevents local metadata eviction from manufacturing a canonical apply
+  conflict, without weakening Web's version or historical-progress fences.
   Every hosted device-sync lane also enqueues a best-effort
   `device-sync.pass_started` marker before snapshot/provider work and a paired
   `device-sync.pass_finished` marker before returning or rethrowing. Both use

--- a/agent-docs/exec-plans/completed/2026-09-04-device-sync-metadata-progress.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-device-sync-metadata-progress.md
@@ -1,0 +1,57 @@
+# Preserve device-sync progress in bounded metadata
+
+## Outcome and architecture
+
+Keep provider progress intact when a sync result adds metadata to a full
+16-entry envelope. The existing metadata merge remains the storage boundary;
+the Junction owner supplies its existing historical-progress keys. Keep
+sanitization, the entry limit, canonical version fences, and bounded retry.
+No new persistence, scheduler, dependency, or recovery service.
+
+## Product UX: Patch
+
+- Outcome: scheduled connected-health refreshes retain progress and finish.
+- Reaches: ordinary completion, provider failure, and cold retry with full metadata.
+- Proof: real-store progress preservation, canonical apply acceptance, and existing
+  stale-write rejection tests with entirely synthetic fixtures.
+
+## Tasks
+
+- [x] Reproduce bounded metadata eviction through the existing store.
+- [x] Preserve provider-owned history keys before optional patch fields.
+- [x] Prove successful and failed sync results, history coverage composition,
+  canonical apply acceptance, and unchanged privacy limits.
+- [x] Run focused tests, typechecks, package build, and parent review.
+- [x] Add changelog and durable contract for the scoped implementation commit.
+
+## Local evidence and walkthrough
+
+The two real-store regressions fail on the original metadata implementation:
+both success and failure evict historical window fields. The corrected store
+keeps those fields through a second full diagnostic patch. The Web test uses
+the actual store and apply owner: a stale timestamp still fails, and the fresh
+version accepts the full metadata plus cadence exactly once. Coverage merging
+also preserves summary progress at capacity. Product UX verdict: Ready for
+the existing scheduled refresh and failure/retry journeys; no UI changes.
+
+- Device-sync metadata, store, and hosted-runtime tests: 172 passing cases.
+- Web runtime-authority tests: 89 passing cases.
+- Device-sync typecheck and build: passed.
+- Web typecheck: passed.
+- Complexity and docs drift: passed; no source hotspot exceeds 20.
+
+External completion remains the exact pushed-head ReviewGPT gate and required
+CI. The draft PR's assigned number will be added to the isolated changelog
+entry before candidate admission. Preserve the worktree while those gates run.
+
+## Ownership and deployment
+
+Independent task branch: `fix/device-sync-metadata-progress`.
+Existing retained-wake and runtime-diagnostic PRs remain separate.
+The shared package is bundled by Web and Cloudflare; the wire and persisted
+shape remain unchanged. Updated runners must converge before claiming runtime
+recovery. No production mutation is part of local verification.
+
+Status: completed
+Updated: 2026-09-04
+Completed: 2026-09-04

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -4,6 +4,9 @@ Last verified: 2026-09-04
 
 ## Purpose
 
+Device-sync metadata priority within the existing bounded envelope is specified
+by `agent-docs/RELIABILITY.md`; Junction's progress keys remain provider-owned.
+
 This index is the table of contents for the current canonical docs in this repository.
 It intentionally lists only live architecture, product, verification, and package-boundary docs.
 

--- a/apps/web/changelog/entries/2026-09-04/connected-health-sync-keeps-progress.json
+++ b/apps/web/changelog/entries/2026-09-04/connected-health-sync-keeps-progress.json
@@ -9,6 +9,6 @@
     "summary": "Connected-health refreshes keep their saved progress as new sync details arrive.",
     "details": "This fixes a case where a refresh could repeatedly retry instead of finishing.",
     "relevanceTags": ["wearables", "reliability"],
-    "sourcePullRequests": []
+    "sourcePullRequests": [2824]
   }
 }

--- a/apps/web/changelog/entries/2026-09-04/connected-health-sync-keeps-progress.json
+++ b/apps/web/changelog/entries/2026-09-04/connected-health-sync-keeps-progress.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-04",
+  "order": 100,
+  "item": {
+    "id": "connected-health-sync-keeps-progress",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Connected health sync keeps its progress",
+    "summary": "Connected-health refreshes keep their saved progress as new sync details arrive.",
+    "details": "This fixes a case where a refresh could repeatedly retry instead of finishing.",
+    "relevanceTags": ["wearables", "reliability"],
+    "sourcePullRequests": []
+  }
+}

--- a/apps/web/test/device-sync-hosted-runtime-authority.test.ts
+++ b/apps/web/test/device-sync-hosted-runtime-authority.test.ts
@@ -1,4 +1,5 @@
 import { buildJunctionProviderSourceInstanceKey } from "@murphai/device-syncd/connect-config";
+import { SqliteDeviceSyncStore } from "@murphai/device-syncd/service";
 import {
   addJunctionExtendedTimeseriesHistoryBackfillCoverage,
   resolveJunctionExtendedTimeseriesHistoryBackfillVersion,
@@ -1022,6 +1023,76 @@ describe("ackHostedDeviceSyncDirtyStateProcessed", () => {
 });
 
 describe("applyHostedDeviceSyncRuntimeResult", () => {
+  it("accepts full-envelope sync progress after a canonical version retry", async () => {
+    const progress = {
+      junctionHistoricalBackfillStatus: "coverage_v3_complete",
+      junctionHistoricalBackfillEmptyAttempts: 0,
+      junctionHistoricalBackfillLastEmptyAt: null,
+      junctionHistoricalBackfillWindowStart: "2025-01-01",
+      junctionHistoricalBackfillWindowEnd: "2025-04-01",
+    };
+    const metadata = {
+      ...Object.fromEntries(Array.from({ length: 11 }, (_, index) => [`diagnostic${index}`, index])),
+      ...progress,
+    };
+    const harness = createAuthorityHarness({
+      record: buildHostedRecord({ provider: "junction", metadata }),
+    });
+    const store = new SqliteDeviceSyncStore(":memory:");
+    try {
+      const account = store.upsertAccount({
+        provider: "junction",
+        externalAccountId: "synthetic-progress-account",
+        credential: { kind: "provider_config", providerConfigKey: "junction", credentialMetadata: {} },
+        scopes: [],
+        metadata,
+        connectedAt: "2026-04-06T09:00:00.000Z",
+      });
+      store.markSyncSucceeded(account.id, "2026-04-06T10:05:00.000Z", account.disconnectGeneration, {
+        metadataPatch: {
+          junctionProfileSummaryCheckedAt: "2026-04-06T10:05:00.000Z",
+          junctionProfileSummaryNormalizationRevision: 2,
+        },
+      });
+      const updated = store.getAccountById(account.id);
+      expect(updated).not.toBeNull();
+      const { applyHostedDeviceSyncRuntimeResult } = await import(
+        "@/src/lib/device-sync/hosted-runtime-authority"
+      );
+      const apply = (observedUpdatedAt: string) => applyHostedDeviceSyncRuntimeResult({
+        request: new Request("https://example.test/device-sync/runtime/apply", {
+          method: "POST",
+          body: JSON.stringify({
+            userId: "user_123",
+            updates: [{
+              connectionId: "conn_123",
+              observedConnectedAt: "2026-04-06T09:00:00.000Z",
+              observedUpdatedAt,
+              connection: { metadata: updated?.metadata },
+              localState: { nextReconcileAt: "2026-04-06T11:00:00.000Z" },
+            }],
+          }),
+        }),
+        trustedUserId: "user_123",
+      });
+      const stale = await apply("2026-04-06T09:59:00.000Z");
+      expect(stale.updates[0]?.writeUpdate).toBe("skipped_version_mismatch");
+      expect(harness.syncDurableConnectionState).not.toHaveBeenCalled();
+
+      const accepted = await apply("2026-04-06T10:00:00.000Z");
+      expect(accepted.updates[0]?.writeUpdate).toBe("applied");
+      expect(harness.syncDurableConnectionState).toHaveBeenCalledTimes(1);
+      expect(harness.record.metadata).toMatchObject({
+        ...progress,
+        junctionProfileSummaryNormalizationRevision: 2,
+      });
+      expect(Object.keys(harness.record.metadata)).toHaveLength(16);
+      expect(harness.record.nextReconcileAt).toBe("2026-04-06T11:00:00.000Z");
+    } finally {
+      store.close();
+    }
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.resolveDeviceProviderApplication.mockReset();

--- a/packages/device-syncd/src/junction-historical-backfill-progress.ts
+++ b/packages/device-syncd/src/junction-historical-backfill-progress.ts
@@ -176,7 +176,7 @@ const JUNCTION_LEGACY_EXTENDED_TIMESERIES_HISTORY_BACKFILL_COVERAGE_METADATA_KEY
   JUNCTION_NOTE_HISTORY_BACKFILL_COVERAGE_METADATA_KEY,
 ] as const);
 
-const JUNCTION_RECONCILED_HISTORICAL_METADATA_KEYS = Object.freeze([
+export const JUNCTION_RECONCILED_HISTORICAL_METADATA_KEYS = Object.freeze([
   ...Object.values(JUNCTION_HISTORICAL_BACKFILL_METADATA_KEYS),
   ...JUNCTION_LEGACY_EXTENDED_TIMESERIES_HISTORY_BACKFILL_COVERAGE_METADATA_KEYS,
 ]);
@@ -587,9 +587,11 @@ function canRetainJunctionExtendedTimeseriesHistoryCoverageUpdate(
   update: JunctionExtendedTimeseriesHistoryCoverageUpdate,
 ): boolean {
   const existing = sanitizeStoredDeviceSyncMetadata(metadata);
-  const merged = mergeStoredDeviceSyncMetadataPatch(existing, {
-    [update.metadataKey]: update.value,
-  });
+  const merged = mergeStoredDeviceSyncMetadataPatch(
+    existing,
+    { [update.metadataKey]: update.value },
+    JUNCTION_RECONCILED_HISTORICAL_METADATA_KEYS,
+  );
   return merged[update.metadataKey] === update.value
     && Object.keys(existing).every((key) => Object.hasOwn(merged, key));
 }
@@ -946,9 +948,11 @@ function mergeJunctionExtendedTimeseriesHistoryCoverageMetadata(input: {
         delete metadata[legacyMetadataKey];
       }
     }
-    metadata = mergeStoredDeviceSyncMetadataPatch(metadata, {
-      [metadataKey]: encoded,
-    });
+    metadata = mergeStoredDeviceSyncMetadataPatch(
+      metadata,
+      { [metadataKey]: encoded },
+      JUNCTION_RECONCILED_HISTORICAL_METADATA_KEYS,
+    );
   }
 
   const localCoverageAdvanced = input.localConnectionStateUnpublished

--- a/packages/device-syncd/src/metadata.ts
+++ b/packages/device-syncd/src/metadata.ts
@@ -124,6 +124,7 @@ function sanitizeStoredDeviceSyncMetadataValue(value: unknown): DeviceSyncMetada
 
 export function sanitizeStoredDeviceSyncMetadata(
   value: Record<string, unknown> | null | undefined,
+  priorityKeys: readonly string[] = [],
 ): Record<string, DeviceSyncMetadataScalar> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return {};
@@ -131,7 +132,12 @@ export function sanitizeStoredDeviceSyncMetadata(
 
   const sanitized: Record<string, DeviceSyncMetadataScalar> = {};
 
-  for (const [rawKey, rawValue] of Object.entries(value)) {
+  const entries = Object.entries(value);
+  if (priorityKeys.length > 0) {
+    const priority = new Set(priorityKeys);
+    entries.sort(([left], [right]) => Number(priority.has(right)) - Number(priority.has(left)));
+  }
+  for (const [rawKey, rawValue] of entries) {
     if (Object.keys(sanitized).length >= DEVICE_SYNC_METADATA_MAX_ENTRIES) {
       break;
     }
@@ -157,27 +163,23 @@ export function sanitizeStoredDeviceSyncMetadata(
 export function mergeStoredDeviceSyncMetadataPatch(
   existing: Record<string, unknown> | null | undefined,
   patch: Record<string, unknown> | null | undefined,
+  priorityKeys: readonly string[] = [],
 ): Record<string, DeviceSyncMetadataScalar> {
   if (!patch) {
-    return sanitizeStoredDeviceSyncMetadata(existing);
+    return sanitizeStoredDeviceSyncMetadata(existing, priorityKeys);
   }
 
-  const sanitizedPatch = sanitizeStoredDeviceSyncMetadata(patch);
-  const sanitizedExisting = sanitizeStoredDeviceSyncMetadata(existing);
-  const merged: Record<string, DeviceSyncMetadataScalar> = {};
+  const sanitizedPatch = sanitizeStoredDeviceSyncMetadata(patch, priorityKeys);
+  const sanitizedExisting = sanitizeStoredDeviceSyncMetadata(existing, priorityKeys);
+  const merged = { ...sanitizedPatch };
 
-  for (const [key, value] of Object.entries(sanitizedPatch)) {
-    merged[key] = value;
-  }
-
+  // The caller owns which progress fields must survive the bounded envelope.
+  // Patch values still win, including an explicit null clearing tombstone.
   for (const [key, value] of Object.entries(sanitizedExisting)) {
-    if (Object.keys(merged).length >= DEVICE_SYNC_METADATA_MAX_ENTRIES) {
-      break;
-    }
-    if (!Object.prototype.hasOwnProperty.call(merged, key)) {
+    if (!Object.hasOwn(merged, key)) {
       merged[key] = value;
     }
   }
 
-  return merged;
+  return sanitizeStoredDeviceSyncMetadata(merged, priorityKeys);
 }

--- a/packages/device-syncd/src/store/sync-state.ts
+++ b/packages/device-syncd/src/store/sync-state.ts
@@ -3,6 +3,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { withImmediateTransaction } from "@murphai/runtime-state/node";
 
 import { deviceSyncError } from "../errors.ts";
+import { JUNCTION_RECONCILED_HISTORICAL_METADATA_KEYS } from "../junction-historical-backfill-progress.ts";
 import { mergeStoredDeviceSyncMetadataPatch, stringifyJson } from "../shared.ts";
 import type { DeviceSyncAccountStatus, OAuthStateConsumeClaim } from "../types.ts";
 import {
@@ -53,7 +54,11 @@ export function markSyncSucceededInTransaction(
     return false;
   }
 
-  const metadata = mergeStoredDeviceSyncMetadataPatch(existing.metadata, options.metadataPatch);
+  const metadata = mergeStoredDeviceSyncMetadataPatch(
+    existing.metadata,
+    options.metadataPatch,
+    existing.provider === "junction" ? JUNCTION_RECONCILED_HISTORICAL_METADATA_KEYS : [],
+  );
   const nextReconcileAt = Object.prototype.hasOwnProperty.call(options, "nextReconcileAt")
     ? options.nextReconcileAt ?? null
     : existing.nextReconcileAt;
@@ -162,7 +167,11 @@ export function markSyncFailed(
     const metadataPatch = options.metadataPatch;
 
     if (metadataPatch && Object.keys(metadataPatch).length > 0) {
-      const metadata = mergeStoredDeviceSyncMetadataPatch(existing.metadata, metadataPatch);
+      const metadata = mergeStoredDeviceSyncMetadataPatch(
+        existing.metadata,
+        metadataPatch,
+        existing.provider === "junction" ? JUNCTION_RECONCILED_HISTORICAL_METADATA_KEYS : [],
+      );
       database.prepare(`
         update device_connection
         set status = ?,

--- a/packages/device-syncd/test/hosted-runtime.test.ts
+++ b/packages/device-syncd/test/hosted-runtime.test.ts
@@ -514,6 +514,39 @@ describe("mergeHostedDeviceSyncConnectionMetadata", () => {
     }
   });
 
+  it("retains summary progress while composing coverage into a full envelope", () => {
+    const progress = {
+      junctionHistoricalBackfillStatus: "coverage_v3_complete",
+      junctionHistoricalBackfillEmptyAttempts: 0,
+      junctionHistoricalBackfillLastEmptyAt: null,
+      junctionHistoricalBackfillWindowStart: "2025-01-01",
+      junctionHistoricalBackfillWindowEnd: "2025-04-01",
+    };
+    const coverage = addJunctionExtendedTimeseriesHistoryBackfillCoverage({
+      metadata: progress,
+      providerSlug: "omron",
+      resource: "caffeine",
+      version: historyCoverageVersion("caffeine"),
+    });
+    if (!coverage) {
+      throw new TypeError("Expected representable Junction coverage.");
+    }
+    const result = mergeHostedDeviceSyncConnectionMetadata({
+      hostedMetadata: {
+        ...Object.fromEntries(Array.from({ length: 11 }, (_, index) => [`diagnostic${index}`, index])),
+        ...progress,
+      },
+      localConnectionStateUnpublished: true,
+      localMetadata: { ...progress, [coverage.metadataKey]: coverage.value },
+    });
+    expect(result.metadata).toMatchObject({
+      ...progress,
+      [coverage.metadataKey]: coverage.value,
+    });
+    expect(Object.keys(result.metadata)).toHaveLength(16);
+    expect(result.preservedLocalProgress).toBe(true);
+  });
+
   it("compacts split coverage slots before merging a full hosted envelope", () => {
     const sharedMetadata = Object.fromEntries(
       Array.from({ length: 15 }, (_, index) => [`sharedFact${index}`, `value-${index}`]),

--- a/packages/device-syncd/test/shared-metadata-security.test.ts
+++ b/packages/device-syncd/test/shared-metadata-security.test.ts
@@ -78,6 +78,43 @@ describe("sanitizeStoredDeviceSyncMetadata", () => {
 });
 
 describe("mergeStoredDeviceSyncMetadataPatch", () => {
+  it("retains caller-owned progress before optional patch fields at capacity", () => {
+    const existing = {
+      ...Object.fromEntries(Array.from({ length: 15 }, (_, index) => [`diagnostic${index}`, index])),
+      progress: "complete",
+    };
+    const merged = mergeStoredDeviceSyncMetadataPatch(
+      existing,
+      { checked: true, diagnostic0: 99 },
+      ["progress", "missing", "progress"],
+    );
+    expect(merged).toMatchObject({ progress: "complete", checked: true, diagnostic0: 99 });
+    expect(Object.keys(merged)).toHaveLength(16);
+    expect(merged.diagnostic14).toBeUndefined();
+    expect(merged.missing).toBeUndefined();
+  });
+
+  it("sanitizes prioritized fields and keeps patch tombstones authoritative", () => {
+    expect(mergeStoredDeviceSyncMetadataPatch(
+      { progress: "retrying", accessToken: "synthetic", source: "initial" },
+      { progress: null, userId: "synthetic" },
+      ["accessToken", "userId", "constructor", "toString", "__proto__", "progress"],
+    )).toEqual({ progress: null, source: "initial" });
+  });
+
+  it("prioritizes progress before truncating either oversized input", () => {
+    const diagnostics = Object.fromEntries(Array.from({ length: 16 }, (_, index) => [`diagnostic${index}`, index]));
+    for (const [existing, patch] of [
+      [{ ...diagnostics, progress: "complete" }, null],
+      [{ ...diagnostics, progress: "complete" }, { checked: true }],
+      [{ progress: "retrying" }, { ...diagnostics, progress: "complete" }],
+    ] as const) {
+      const merged = mergeStoredDeviceSyncMetadataPatch(existing, patch, ["progress"]);
+      expect(merged.progress).toBe("complete");
+      expect(Object.keys(merged)).toHaveLength(16);
+    }
+  });
+
   it("keeps patch keys when existing metadata is already capped", () => {
     const existing = Object.fromEntries(
       Array.from({ length: 16 }, (_, index) => [`existing${index}`, `value-${index}`]),

--- a/packages/device-syncd/test/store-metadata-progress.test.ts
+++ b/packages/device-syncd/test/store-metadata-progress.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { SqliteDeviceSyncStore } from "../src/store.ts";
+
+describe("bounded sync-result metadata", () => {
+  it.each(["success", "failure"] as const)(
+    "preserves historical progress across %s and a subsequent diagnostic patch",
+    (outcome) => {
+      const store = new SqliteDeviceSyncStore(":memory:");
+      const progress = {
+        junctionHistoricalBackfillStatus: "coverage_v3_complete",
+        junctionHistoricalBackfillEmptyAttempts: 0,
+        junctionHistoricalBackfillLastEmptyAt: null,
+        junctionHistoricalBackfillWindowStart: "2025-01-01",
+        junctionHistoricalBackfillWindowEnd: "2025-04-01",
+      };
+      const metadata = {
+        ...Object.fromEntries(Array.from({ length: 11 }, (_, index) => [`diagnostic${index}`, index])),
+        ...progress,
+      };
+      try {
+        const account = store.upsertAccount({
+          provider: "junction",
+          externalAccountId: "synthetic-progress-account",
+          credential: { kind: "provider_config", providerConfigKey: "junction", credentialMetadata: {} },
+          scopes: [],
+          metadata,
+          connectedAt: "2025-04-01T00:00:00.000Z",
+        });
+        const metadataPatch = {
+          junctionProfileSummaryCheckedAt: "2025-04-02T00:00:00.000Z",
+          junctionProfileSummaryNormalizationRevision: 2,
+        };
+        const applied = outcome === "success"
+          ? store.markSyncSucceeded(account.id, "2025-04-02T00:00:00.000Z", account.disconnectGeneration, {
+              metadataPatch,
+            })
+          : store.markSyncFailed(account.id, "2025-04-02T00:00:00.000Z", "RETRY", "Retry later.", "active", {
+              metadataPatch,
+            });
+        expect(applied).toBe(true);
+        const after = store.getAccountById(account.id);
+        expect(after?.metadata).toMatchObject({ ...progress, ...metadataPatch });
+        expect(Object.keys(after?.metadata ?? {})).toHaveLength(16);
+
+        store.markSyncSucceeded(account.id, "2025-04-03T00:00:00.000Z", account.disconnectGeneration, {
+          metadataPatch: Object.fromEntries(
+            Array.from({ length: 16 }, (_, index) => [`newDiagnostic${index}`, index]),
+          ),
+        });
+        expect(store.getAccountById(account.id)?.metadata).toMatchObject(progress);
+        expect(Object.keys(store.getAccountById(account.id)?.metadata ?? {})).toHaveLength(16);
+      } finally {
+        store.close();
+      }
+    },
+  );
+});


### PR DESCRIPTION
A full device-sync metadata envelope could evict historical progress when a job added diagnostic fields, causing canonical reconciliation to reject the result repeatedly. Junction now retains its existing historical-progress keys within the same 16-entry limit. Web's version checks and bounded retry remain intact.

## Product UX

- Effort: Patch
- Outcome: scheduled connected-health refreshes retain progress and finish.
- Reaches: successful sync, provider failure/retry, and coverage reconciliation.
- Walkthrough: Ready. Real-store and Web tests prove progress retention, stale-write rejection, and fresh-version acceptance without adding member steps.

## Evidence

- Exact-head CI: all 33 checks passed at `e54727bdbdd9c60d2765be7be1d228e29670116c`.
- Final ReviewGPT: [round 1 full-patch PASS](https://chatgpt.com/c/6a9b2edb-b178-83ea-9361-a7fd65a5248a), zero findings; requested and observed `gpt-6-pro` match, exact head/ZIP/turn and completion marker verified, over 10 minutes. Parent accepts the result.
- Original metadata code fails both new real-store regressions by dropping historical window fields.
- Device-sync metadata, storage, and hosted-runtime suites: 172 tests pass.
- Web runtime-authority suite: 89 tests pass, including real-store output through canonical apply after a rejected stale version.
- Changelog suite: 39 tests pass.
- Device-sync typecheck and build, Web typecheck, docs drift, and diff whitespace checks pass.

## Non-obvious affected surfaces

Coverage composition uses the same priority so adding its retained coverage slot cannot evict summary progress. Its capacity regression passes. Other providers keep the default patch-first policy; secret filtering, scalar limits, null clearing, and the 16-entry bound retain direct tests.

## Architecture and reuse

- Existing systems reused: the metadata sanitizer/merge, Junction's existing historical-key inventory, local sync-result store, and canonical Web apply.
- New logic: sanitize required keys first, then fill remaining capacity with patch fields and existing metadata.
- New abstractions: an optional key-priority argument on the existing pure functions; the provider owns the supplied keys.
- Complexity intentionally avoided: no dependency, table, persisted field, scheduler, retry, recovery service, or relaxed canonical fence.

## Complexity impact

- Guard: pass, `pnpm complexity:diff --base origin/main`; no added complexity debt.
- Hotspots: none above 20 in changed source files; maximum 19.
- Agent judgment: reusing the sanitizer removed duplicate truncation logic; further policy machinery is unnecessary.

## Hot reply path impact

Not applicable: this changes background device-sync metadata merging and adds no database, network, or awaited work to foreground replies.

## Murph initial provider input impact

- Murph runtime: Not applicable; no prompts, tools, or provider request assembly changes.
- Codex runtime: Not applicable for the same reason.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: content-only changelog entry using the existing archive; no renderer or interaction changes.
- Coverage: 39 changelog tests pass; the content-only proof route applies.

## Deployment concerns

- Deployment: applicable
- Supported skew: the metadata fields and wire shape are unchanged. Existing Web accepts corrected runtime updates; stale writers can retain the existing failure during rollout.
- Safe order: deploy Web's shared coverage-composition fix, then the Cloudflare runner bundle.
- Worker/container skew: old warm containers retain the old metadata merge until runner convergence.
- Rollback floor: no new schema or protocol floor; older code can reintroduce the rejection loop.
- Expected exposure: background refresh retries may continue until both artifacts converge.
- Reversibility: code-only; no data migration or irreversible write.
- Convergence proof: exact Web and runner release receipts plus active-container bundle convergence.
- Post-deploy checks: bounded device-sync pass logs show completed reconciliation and canonical cadence advances; do not infer recovery from Worker deployment alone.

## Changelog

- Changelog: updated
- Items: 2026-09-04/connected-health-sync-keeps-progress

## Change-shape breakdown

Base-to-head numstat; production TypeScript is source, executable proofs are tests, and Markdown/changelog content is docs. No binary changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 38 | 23 |
| Tests/fixtures | 199 | 0 |
| Docs | 81 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 318 | 23 |

ReviewGPT context sensitivity: sensitive

ReviewGPT first-reviewed head: e54727bdbdd9c60d2765be7be1d228e29670116c
