### PR TITLE
Fix Starter billing CI fixture messaging readiness

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-main-ci-regressions.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-main-ci-regressions.md
@@ -1,0 +1,49 @@
+# Repair main CI regressions
+
+## Goal
+
+Restore the hosted Stripe billing browser matrix by making its synthetic Starter
+member satisfy the existing messaging requirement. Preserve production behavior.
+
+## Root cause and scope
+
+- Host Support run 33902609005 failed two assistant-engine assertions after
+  the skill-router wording changed in PR #2814. PR #2818 independently corrected
+  those assertions while this investigation was running; all 104 focused tests
+  pass on main revision 7ed31fa5544309ade0988aacf84e79d5ffc6c072.
+- Temporal compatibility run 33916476356 subsequently passed.
+- Stripe run 33902608642 waited for starter enrollment without satisfying
+  messaging setup. Since PR #2521, verified email alone does not satisfy that
+  boundary. The fixture seeded only email and therefore correctly stayed on
+  messaging setup instead of mounting the auto-enrollment island.
+- Seed an optional synthetic verified phone through the canonical identity-field
+  helper, and opt in only the Starter-to-paid browser scenario.
+- Garmin run 33902608588 timed out connecting to its remote browser. Its fresh
+  main run is separate hosted-provider evidence, not a billing regression.
+
+## Verification
+
+- Exercise the real seed helper with stubbed database writes and the production
+  messaging-readiness function. Email alone must remain blocked; the synthetic
+  phone must unblock readiness and preserve the fixture's app-auth identity.
+- Run the existing billing support and messaging-state suites, Web and
+  Cloudflare typechecks, focused ESLint, and the complexity guard.
+- Required exact-head PR CI owns broad verification. The protected main Stripe
+  workflow owns the full live sandbox matrix; no secrets are downloaded locally.
+
+## Review and delivery
+
+This changes only test fixtures and proof. Final ReviewGPT, Product UX, and the
+public changelog are not applicable under the completion workflow's test-only
+route. Parent final review, required CI, current-base merge proof, merge, and
+post-merge verification remain required.
+
+## State
+
+Local validation passed: 26 focused tests, Web and Cloudflare typechecks,
+focused Web ESLint, and the complexity guard. Parent final review found no
+production behavior changes or unresolved defects. Exact-head PR CI and the
+post-merge protected Stripe matrix remain the delivery evidence owners.
+Status: completed
+Updated: 2026-09-04
+Completed: 2026-09-04

--- a/apps/cloudflare/test/hosted-local-stripe-billing-browser-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-stripe-billing-browser-e2e.test.ts
@@ -126,7 +126,11 @@ describe("hosted-local Stripe billing browser matrix", () => {
 });
 
 async function proveStarterUsageStartsPaidPulseThroughCheckout(): Promise<void> {
-  const member = await createMember("starter_to_paid_pulse");
+  const member = await createMember(
+    "starter_to_paid_pulse",
+    "not_started",
+    "+12025550173",
+  );
   const invite = await issueHostedWebInviteForTest({
     environment: requireScenario().runtimeEnv,
     memberId: member.memberId,
@@ -430,6 +434,7 @@ async function proveFamilyInviteActivation(input: {
 async function createMember(
   label: string,
   billingStatus: "canceled" | "not_started" = "not_started",
+  verifiedPhoneNumber?: string,
 ): Promise<{
   memberId: string;
   session: HostedAppSessionForTest;
@@ -444,6 +449,7 @@ async function createMember(
     previouslyActivated: billingStatus === "canceled",
     privyUserId,
     verifiedEmail,
+    verifiedPhoneNumber,
   });
   await seedHostedLaunchConsentForTest({
     environment: requireScenario().runtimeEnv,

--- a/apps/web/test/hosted-billing-member-seed.test.ts
+++ b/apps/web/test/hosted-billing-member-seed.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isHostedMemberMessagingSetupRequired } from "@/src/lib/hosted-onboarding/messaging-state";
+import { seedHostedBillingMemberForTest } from "./support/hosted-billing-live-testkit";
+
+const database = vi.hoisted(() => ({
+  createMember: vi.fn(async () => undefined),
+  disconnect: vi.fn(async () => undefined),
+  upsertEmail: vi.fn(async () => undefined),
+  upsertIdentity: vi.fn(async (_input: {
+    phoneLookupKey: string | null;
+    phoneNumber: string | null;
+    phoneNumberVerifiedAt: Date | null;
+    privyUserId: string | null;
+  }) => undefined),
+}));
+
+vi.mock("@/src/lib/prisma", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/src/lib/prisma")>(),
+  createPrismaClient: () => ({
+    $disconnect: database.disconnect,
+    $transaction: async (run: (tx: unknown) => Promise<unknown>) => run({
+      hostedMember: {
+        findUnique: async () => null,
+        update: async () => undefined,
+      },
+    }),
+  }),
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-member-store", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/src/lib/hosted-onboarding/hosted-member-store")>(),
+  createHostedMember: database.createMember,
+  upsertHostedMemberEmailAuthorization: database.upsertEmail,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/hosted-member-identity-store", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/src/lib/hosted-onboarding/hosted-member-identity-store")>(),
+  upsertHostedMemberIdentity: database.upsertIdentity,
+}));
+
+describe("billing fixture messaging readiness", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each([undefined, "+12025550173"])(
+    "preserves onboarding messaging requirements with phone %s",
+    async (verifiedPhoneNumber) => {
+      await seedHostedBillingMemberForTest({
+        billingStatus: "not_started",
+        environment: {
+          DATABASE_URL: "postgresql://postgres:postgres@127.0.0.1:5432/murph_test",
+          NODE_ENV: "test",
+        },
+        memberId: "member_billing_seed",
+        previouslyActivated: false,
+        privyUserId: "did:privy:billing_seed",
+        verifiedEmail: "billing-seed@example.invalid",
+        verifiedPhoneNumber,
+      });
+
+      expect(database.upsertIdentity).toHaveBeenCalledOnce();
+      const identity = database.upsertIdentity.mock.calls[0]?.[0];
+      expect(identity).toBeDefined();
+      if (!identity) throw new Error("Missing seeded identity");
+      expect(identity.privyUserId).toBe("did:privy:billing_seed");
+      expect(identity.phoneNumber).toBe(verifiedPhoneNumber ?? null);
+      expect(identity.phoneNumberVerifiedAt instanceof Date)
+        .toBe(verifiedPhoneNumber !== undefined);
+      expect(isHostedMemberMessagingSetupRequired({
+        identity: { ...identity, emailLinked: true },
+        routing: null,
+      })).toBe(verifiedPhoneNumber === undefined);
+      expect(database.disconnect).toHaveBeenCalledOnce();
+    },
+  );
+});

--- a/apps/web/test/support/hosted-billing-live-testkit.ts
+++ b/apps/web/test/support/hosted-billing-live-testkit.ts
@@ -22,6 +22,10 @@ const hostedCryptoDomainRootStoreModuleSpecifier = new URL(
   "../../src/lib/hosted-crypto/domain-root-store.ts",
   import.meta.url,
 ).href;
+const hostedMemberIdentityFieldsModuleSpecifier = new URL(
+  "../../src/lib/hosted-onboarding/member-identity-fields.ts",
+  import.meta.url,
+).href;
 const hostedInviteServiceModuleSpecifier = new URL(
   "../../src/lib/hosted-onboarding/invite-service.ts",
   import.meta.url,
@@ -78,6 +82,7 @@ export interface HostedBillingMemberSeedForTest {
   previouslyActivated: boolean;
   privyUserId?: string | null;
   verifiedEmail?: string | null;
+  verifiedPhoneNumber?: string;
 }
 
 export interface HostedBillingProjectionForTest {
@@ -324,6 +329,11 @@ interface HostedFamilyPlanModule {
 }
 
 interface HostedBillingTestModules {
+  buildHostedMemberPhoneIdentityFields(phoneNumber: string): Pick<
+    Parameters<HostedMemberIdentityStoreModule["upsertHostedMemberIdentity"]>[0],
+    "maskedPhoneNumberHint" | "phoneLookupKey" | "phoneNumber"
+    | "phoneNumberVerifiedAt" | "privyUserId"
+  >;
   createHostedMember: HostedMemberStoreModule["createHostedMember"];
   createPrismaClient: HostedPrismaModule["createPrismaClient"];
   issueHostedInvite: HostedInviteServiceModule["issueHostedInvite"];
@@ -386,6 +396,13 @@ export async function seedHostedBillingMemberForTest(
           walletChainType: null,
           walletCreatedAt: null,
           walletProvider: null,
+          ...(input.verifiedPhoneNumber
+            ? {
+                ...modules.buildHostedMemberPhoneIdentityFields(input.verifiedPhoneNumber),
+                phoneNumberVerifiedAt: new Date(),
+                privyUserId,
+              }
+            : {}),
         });
       }
 
@@ -660,6 +677,7 @@ async function loadHostedBillingTestModules(
     memberStoreModule,
     memberBillingStoreModule,
     memberIdentityStoreModule,
+    memberIdentityFieldsModule,
     cryptoDomainRootStoreModule,
     inviteServiceModule,
     familyPlanModule,
@@ -668,6 +686,7 @@ async function loadHostedBillingTestModules(
     import(hostedMemberStoreModuleSpecifier),
     import(hostedMemberBillingStoreModuleSpecifier),
     import(hostedMemberIdentityStoreModuleSpecifier),
+    import(hostedMemberIdentityFieldsModuleSpecifier),
     import(hostedCryptoDomainRootStoreModuleSpecifier),
     import(hostedInviteServiceModuleSpecifier),
     import(hostedFamilyPlanModuleSpecifier),
@@ -685,6 +704,8 @@ async function loadHostedBillingTestModules(
   const familyPlan = familyPlanModule as HostedFamilyPlanModule;
   return {
     createHostedMember: memberStore.createHostedMember,
+    buildHostedMemberPhoneIdentityFields:
+      memberIdentityFieldsModule.buildHostedMemberPhoneIdentityFields,
     createPrismaClient: prisma.createPrismaClient,
     issueHostedInvite: inviteService.issueHostedInvite,
     provisionHostedCryptoDomainRootsForUserTx:


### PR DESCRIPTION
The main Stripe browser matrix waits forever for Starter enrollment because its email-only test member no longer satisfies the phone-or-Telegram requirement introduced in #2521. Seed a synthetic verified phone for the Starter-to-Pulse scenario through the existing identity-field owner so the browser reaches enrollment and Checkout.

## Product UX

Not applicable: test fixture repair; no member-facing behavior changes.

## Evidence

- Main failure: https://github.com/cobuildwithus/murph/actions/runs/33902608642
- Focused billing fixture, billing browser support, and messaging-state suites: 26 tests passed.
- Web and Cloudflare typechecks, focused Web ESLint, and `pnpm complexity:diff`.
- Parent review traced fixture creation through production messaging readiness and Starter island mounting. Email-only fixtures remain blocked; verified-phone fixtures preserve the Privy identity and become ready.
- Exact-head CI and the protected post-merge live Stripe matrix provide broad and provider-backed proof respectively.

## Non-obvious affected surfaces

None. Changes are confined to billing test fixtures and their regression proof.

## Architecture and reuse

- Existing systems reused: billing member testkit, canonical phone identity fields, and production messaging-readiness predicate.
- New logic: an optional verified phone on initial fixture creation, requested only by the Starter browser scenario.
- New abstractions: none; the existing testkit owns fixture persistence.
- Complexity intentionally avoided: no production onboarding relaxation, browser retry, alternate enrollment path, or new test service.

## Complexity impact

- Guard: pass; `pnpm complexity:diff` passed; no authored production JavaScript or TypeScript changes to analyze.
- Hotspots: no production functions changed; the added optional fixture field stays with its existing owner.
- Agent judgment: the bounded fixture extension is proportional; further refactoring would widen this repair.

## Hot reply path impact

Not applicable: test-only changes add no production work.

## Murph initial provider input impact

- Individual: Not applicable; no prompt, tool, or provider-input change.
- Group: Not applicable; no prompt, tool, or provider-input change.

## Change-shape breakdown

Classified by file purpose; the browser scenario, testkit, and regression are tests/fixtures, and the execution plan is docs. No binaries or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 104 | 1 |
| Docs | 49 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 153 | 1 |

## Deployment concerns

- Deployment: not applicable
- Reason: test-only fixture correction; no production build, deployment order, runtime configuration, or protocol changes.

## Changelog

- Changelog: not applicable
- Reason: internal CI fixture repair with no member-visible behavior change.

Final ReviewGPT is not applicable under the test-only exemption; parent final review and required CI remain mandatory.
