### PR TITLE
fix(test): start Garmin canary without restored tabs

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-garmin-blank-start.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-garmin-blank-start.md
@@ -1,0 +1,40 @@
+# Start wearable canaries without restored tabs
+
+## Outcome and invariant
+
+Let the canary attach to its remote browser before opening the current isolated
+Web fixture. Preserve the dedicated profile's login state, disabled telemetry,
+protected credentials, authorization assertions, and owned cleanup.
+
+## Evidence and ownership
+
+Kernel's profile contract restores saved tabs unless start_url is specified.
+The canary creates a new page and persists the profile without closing its tabs.
+Those tabs refer to old isolated servers. The pinned Playwright CDP connector
+waits for every target to initialize. A loopback Chromium reproduction proved
+that a target awaiting its initial HTTP response causes attachment timeout,
+while closing that target allows the same browser to attach successfully.
+This proves the mechanism; the protected Garmin canary must confirm the repair.
+
+## Smallest correction
+
+Set start_url to about:blank in createAutomationBrowser, which is called only
+by the wearable test runner. Kernel already owns clearing restored tabs while
+preserving profile auth state. No new state, transport, retries, or dependency.
+Keep the bounded diagnostic from the preceding candidate for remaining failures.
+
+## Proof and delivery
+
+Run the Kernel client and browser-runner tests, Web typecheck, and complexity
+check. Remove the temporary loopback diagnostic after recording its result.
+Review the diff, publish the new PR candidate, then require exact-head CI and
+the protected-main live canary. This is internal test infrastructure; Product
+UX and public changelog do not apply. The production browser path is unchanged.
+
+Local proof passed: 58 Kernel client and browser-runner tests, Web typecheck,
+complexity guard, and diff whitespace check. Parent final review confirmed the
+automation method has only the wearable-runner caller and the production
+computer-use browser creation method is unchanged. Live confirmation is pending.
+Status: completed
+Updated: 2026-09-04
+Completed: 2026-09-04

--- a/agent-docs/exec-plans/completed/2026-09-04-garmin-browser-diagnostic.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-garmin-browser-diagnostic.md
@@ -1,0 +1,39 @@
+# Diagnose Garmin canary browser attachment
+
+## Outcome and invariant
+
+Identify whether the repeated remote CDP attachment timeout also affects
+Kernel's server-side browser transport. Keep the dedicated protected canary,
+credential isolation, authorization assertions, and exact-session cleanup intact.
+This diagnostic does not claim to fix the browser timeout.
+
+## Evidence and owner
+
+The latest protected canary connects its WebSocket but times out before browser
+attachment completes. The browser runner, Kernel client, and workflow match the
+last successful revision. Existing logs cannot distinguish browser failure from
+client-to-provider CDP attachment failure.
+
+## Implementation
+
+Use the existing Kernel client only after failed CDP attachment to execute a
+constant-return probe. Publish only a fixed responsive/unavailable outcome;
+never publish provider result values, errors, capabilities, or page content.
+Rethrow the original failure and retain the existing owned cleanup path.
+No new state, dependency, production behavior, or deployment contract is needed.
+
+## Verification and next step
+
+Focused browser-runner tests cover successful, malformed, and rejected probe
+responses, original failure preservation, and cleanup. Run Web typecheck and
+complexity guard, parent review, then exact-head PR CI. After merging, inspect
+the protected canary's diagnostic and use that evidence to select the repair.
+Product UX and changelog are not applicable to this internal diagnostic.
+
+Local proof: 49 browser-runner tests passed, Web typecheck passed after building
+the device-syncd package prerequisite, and complexity guard passed with unchanged
+existing hotspots. Parent review confirmed the fixed-vocabulary diagnostic
+preserves the original failure and exact owned cleanup.
+Status: completed
+Updated: 2026-09-04
+Completed: 2026-09-04

--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -400,7 +400,13 @@ them. The credential-free setup must also install and smoke-check a
 checksum-pinned Kernel CLI plus checksum-pinned `websocat`, which the CLI uses
 for a reverse SSH tunnel from the Kernel browser VM to hosted-local Web. The
 unattended proof uses a headed remote stealth browser with telemetry disabled
-and a dedicated persistent Garmin canary profile. Headed Chromium is the narrow
+and a dedicated persistent Garmin canary profile. Automation browser creation
+sets `start_url: "about:blank"` to discard restored tabs while preserving saved
+login state: old tabs can point at retired hosted-local servers, and CDP
+attachment waits for every existing target to initialize. A failed attachment
+also runs a constant-return probe through Kernel's server-side transport and
+reports only responsive/unavailable before the existing owned cleanup.
+Headed Chromium is the narrow
 mitigation that cleared the provider challenge observed in headless automation;
 only a successful protected-main run proves the complete result. On Garmin's
 exact `/partner/oauthConfirm` route, the unattended runner requires exactly

--- a/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
+++ b/apps/web/scripts/run-hosted-local-junction-wearable-browser.ts
@@ -271,6 +271,16 @@ async function openBrowserSession(config: BrowserConfig): Promise<BrowserSession
     });
     const browser = await chromium.connectOverCDP(kernelBrowser.cdpWsUrl, {
       timeout: config.timeoutMs,
+    }).catch(async (error: unknown) => {
+      // Probe through Kernel's server-side transport without reading page content.
+      // Keep the original CDP failure and emit only the fixed diagnostic outcome.
+      const remoteResponsive = await kernelClient.executePlaywright({
+        code: "return true;",
+        sessionId: kernelBrowser.sessionId,
+        timeoutMs: 10_000,
+      }).then(({ result }) => result === true).catch(() => false);
+      process.stderr.write(`Kernel server-side browser probe: ${remoteResponsive ? "responsive" : "unavailable"}\n`);
+      throw error;
     });
     const context = browser.contexts()[0];
     if (!context) {

--- a/apps/web/src/lib/computer-use/kernel-client.ts
+++ b/apps/web/src/lib/computer-use/kernel-client.ts
@@ -284,6 +284,8 @@ export class KernelComputerClient implements ComputerKernelClient {
         name: input.profileName,
         save_changes: input.saveChanges,
       },
+      // Profiles restore old tabs; canaries need only their saved login state.
+      start_url: "about:blank",
       stealth: true,
       telemetry: { enabled: false },
       timeout_seconds: input.timeoutSeconds,

--- a/apps/web/test/hosted-computer-kernel-client.test.ts
+++ b/apps/web/test/hosted-computer-kernel-client.test.ts
@@ -94,7 +94,7 @@ describe("KernelComputerClient", () => {
     });
   });
 
-  it("creates stealth automation browsers without recording the canary session", async () => {
+  it("starts automation on a blank page while preserving login state and disabling telemetry", async () => {
     kernelSdkMocks.browserCreate.mockResolvedValueOnce({
       cdp_ws_url: "wss://cdp.test-browser.onkernel.com/session/1",
       session_id: "kernel-session-1",
@@ -117,6 +117,7 @@ describe("KernelComputerClient", () => {
         name: "profile-1",
         save_changes: true,
       },
+      start_url: "about:blank",
       stealth: true,
       telemetry: { enabled: false },
       timeout_seconds: 480,

--- a/apps/web/test/hosted-local-junction-wearable-browser.test.ts
+++ b/apps/web/test/hosted-local-junction-wearable-browser.test.ts
@@ -8,6 +8,7 @@ const kernelLifecycleMocks = vi.hoisted(() => {
   const createAutomationBrowser = vi.fn();
   const deleteBrowserByIdOrName = vi.fn();
   const ensureProfile = vi.fn();
+  const executePlaywright = vi.fn();
   const launch = vi.fn();
   const spawn = vi.fn();
 
@@ -15,6 +16,7 @@ const kernelLifecycleMocks = vi.hoisted(() => {
     createAutomationBrowser = createAutomationBrowser;
     deleteBrowserByIdOrName = deleteBrowserByIdOrName;
     ensureProfile = ensureProfile;
+    executePlaywright = executePlaywright;
   }
 
   return {
@@ -22,6 +24,7 @@ const kernelLifecycleMocks = vi.hoisted(() => {
     createAutomationBrowser,
     deleteBrowserByIdOrName,
     ensureProfile,
+    executePlaywright,
     KernelComputerClient,
     launch,
     spawn,
@@ -501,6 +504,53 @@ describe("hosted-local Junction wearable browser authorization", () => {
       }
     }
   });
+
+  it.each([true, false, "private-provider-result", new Error("private-provider-error")])(
+    "probes a failed CDP attachment without publishing provider data: %s",
+    async (result) => {
+      const child = createKernelTunnelChild();
+      const config = createConfig({
+        KERNEL_API_KEY: "kernel-test-key",
+        MURPH_E2E_KERNEL_CLI_PATH: "/opt/kernel-tools/kernel",
+        MURPH_E2E_PROVIDER_BROWSER: "kernel",
+        MURPH_E2E_PROVIDER_SOURCE: "garmin",
+        MURPH_E2E_CONNECT_URL: "http://localhost:43123/connect#deviceConnectIntent=opaque&connectSource=garmin",
+        MURPH_E2E_PROVIDER_HEADLESS: "0",
+        MURPH_E2E_WEB_BASE_URL: "http://localhost:43123",
+      });
+      const failure = new Error("CDP attachment timed out");
+      kernelLifecycleMocks.createAutomationBrowser.mockResolvedValueOnce({
+        cdpWsUrl: "wss://cdp.example.test/private-capability",
+        sessionId: "synthetic-session",
+      });
+      kernelLifecycleMocks.spawn.mockReturnValueOnce(child);
+      kernelLifecycleMocks.connectOverCDP.mockRejectedValueOnce(failure);
+      kernelLifecycleMocks.deleteBrowserByIdOrName.mockResolvedValueOnce(undefined);
+      if (result instanceof Error) {
+        kernelLifecycleMocks.executePlaywright.mockRejectedValueOnce(result);
+      } else {
+        kernelLifecycleMocks.executePlaywright.mockResolvedValueOnce({ result });
+      }
+      const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+      try {
+        await expect(openHostedLocalJunctionBrowserSessionForTest(config))
+          .rejects.toBe(failure);
+        expect(kernelLifecycleMocks.executePlaywright).toHaveBeenCalledWith({
+          code: "return true;",
+          sessionId: "synthetic-session",
+          timeoutMs: 10_000,
+        });
+        expect(stderr).toHaveBeenCalledWith(
+          `Kernel server-side browser probe: ${result === true ? "responsive" : "unavailable"}\n`,
+        );
+        expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+        expect(kernelLifecycleMocks.deleteBrowserByIdOrName)
+          .toHaveBeenCalledWith("synthetic-session");
+      } finally {
+        stderr.mockRestore();
+      }
+    },
+  );
 
   it("deletes the created Kernel browser when CDP exposes no context", async () => {
     const child = createKernelTunnelChild();


### PR DESCRIPTION
## Why and outcome

The Garmin canary restores old profile tabs pointing at retired hosted-local servers, then adds and saves another tab each run. Playwright waits for every existing target to initialize during CDP attachment. Start the automation browser with `start_url: "about:blank"` so Kernel clears restored tabs while retaining the dedicated login profile.

A synthetic loopback Chromium reproduction timed out during CDP attachment with a target waiting for its first HTTP response, then attached successfully after that target closed. This proves the failure mechanism; the protected Garmin run must confirm the observed timeout is repaired. A failed attachment retains a constant-return server-side probe reporting only responsive/unavailable.

## Product UX
- Effort: Not applicable — internal wearable proof infrastructure.
- Result: Not applicable.
- Walkthrough: Member UI, Garmin permissions, and production computer-use behavior are unchanged.

## Evidence
- Direct: 58 tests passed with `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-computer-kernel-client.test.ts apps/web/test/hosted-local-junction-wearable-browser.test.ts`.
- Coverage: SDK request preserves profile auth and disabled telemetry while selecting a blank start. Probe tests preserve original failures and owned cleanup without publishing provider values or errors. Temporary loopback reproduction passed and was removed after use.
- Web `typecheck:prepared`, `pnpm complexity:diff`, and `git diff --check` passed. Protected-main live confirmation is pending.
- Provider contract: [Kernel profile start_url behavior](https://www.kernel.sh/docs/auth/profiles#override-opening-existing-tabs-in-a-new-session).

## Non-obvious affected surfaces
`createAutomationBrowser` is called only by the wearable test runner. The production `createBrowser` method is unchanged. Operator Kernel wearable proofs receive the same clean start.

## Architecture and reuse
- Existing systems reused: Kernel's profile start_url contract, existing client, protected canary, and owned cleanup.
- New logic: Clear restored tabs at browser creation; failed CDP attachment runs a constant-return probe with a ten-second server limit and existing bounded SDK request policy.
- New abstractions: None; Kernel owns tab restoration and saved login state.
- Complexity intentionally avoided: No new transport, retry loop, profile reset, state owner, dependency, or credential path.

## Complexity impact
- Guard: Pass — `pnpm complexity:diff`.
- Hotspots: Existing `readBrowserConfig` (35) and `completeExternalAuthorization` (26) are unchanged; unrelated refactoring would not improve this repair.
- Agent judgment: A native browser option is the smallest correction; the fixed diagnostic remains bounded and private.

## Hot reply path impact
- Path status: Not applicable — test runner only; individual and group reply paths are unchanged.
- Database calls: None.
- Network/provider calls: None on the reply path.
- Other awaited latency: None on the reply path.
- Before/after proof: Caller inventory and diff confirm only wearable proof infrastructure invokes the changed method.

## Murph initial provider input impact
Not applicable. Individual and group prompts, tools, schemas, and provider-request assembly are unchanged.

## Deployment concerns
- Deployment: not applicable
- Reason: Test-only browser creation and diagnostics; no production deployment or configuration changes.

## Change-shape breakdown
Classification: client code is source; runner diagnostic is tooling; tests and Markdown are classified by purpose. No binaries.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 2 | 0 |
| Tests / fixtures | 52 | 1 |
| Docs | 86 | 1 |
| Config / tooling | 10 | 0 |
| Generated / other | 0 | 0 |
| Total | 150 | 2 |

## Changelog
- Changelog: not applicable
- Reason: Internal CI repair with no member-visible behavior change.

Final ReviewGPT is not applicable: the changed automation method has only test-runner callers and does not alter production behavior. Parent final review is complete; exact-head CI remains pending.
