### PR TITLE
perf(device-sync): reuse timeseries source admission read

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-junction-timeseries-source-reuse.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-junction-timeseries-source-reuse.md
@@ -1,0 +1,70 @@
+# Junction timeseries source-read reuse
+
+Status: completed
+Created: 2026-09-04
+Updated: 2026-09-04
+
+## Outcome and invariant
+
+Remove the duplicate source acquisition between adjacent timeseries historical
+evidence and canonical admission calculations. Preserve full-source canonical
+policy, scoped historical evidence, lifecycle fences, cheap exits, and fresh
+reads after provider work or canonical writes.
+
+## Evidence and architecture
+
+`importJunctionTimeseriesResourceSnapshot` already reuses lifecycle-fenced
+sources. Its unfenced source-scoped path calls the historical helper and then
+the canonical preparation wrapper, each acquiring sources. The hosted adapter
+fetches a full credential-free connection snapshot for either call and filters
+locally. Extend the existing reuse within this function only, with no new
+owner, state, cache, dependency, route, or protocol. Source authority remains
+with the existing reader; canonical writes remain importer-owned.
+
+## Product UX Patch
+
+Outcome: preserve imported data and recovery while removing one serial read.
+Reaches: connected sources, disconnected or unavailable sources, empty results,
+and lifecycle-fenced resources; local contexts retain their current fallback.
+Proof: provider-executor tests for reads, imported payload, freshness, denied
+admission, failure, cancellation, and unchanged continuation/lifecycle behavior.
+
+## Scope and risk
+
+One production function and focused regression proof. Workout, summary,
+checkpoint, orchestration, and wire contracts remain outside this task.
+Reuse expires at the end of the adjacent calculations. Keep source reads after
+provider fetches and before canonical import; never fall back after read failure.
+No database fanout or transaction is added: one bounded acquisition disappears
+per eligible window, with unchanged maximum cardinality and concurrency.
+No mixed-version dependency or migration is introduced.
+
+## Tasks
+
+1. Prove the duplicate with a focused failing regression.
+2. Extend existing source reuse and verify all changed branches.
+3. Run focused tests, package typecheck, complexity and parent review.
+4. Commit, open the PR, run final ReviewGPT alongside required CI, then merge
+   after the gates pass and retire the clean worktree.
+
+## Verification
+
+- Before the production edit, the new connected and disconnected scenarios
+  failed on the extra adjacent source read; four control cases passed.
+- `pnpm exec vitest run --config packages/device-syncd/vitest.config.ts
+  --no-coverage` with the source-reuse, provider-resources, provider-backfill,
+  provider-history, and fitbit-migration files: 180 passing tests. The final
+  source-reuse file adds two empty/skip cases and passes all eight cases.
+- `pnpm exec vitest run --config packages/assistant-runtime/vitest.config.ts
+  --no-coverage packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+  -t 'hosted Junction imports reread Web source state|hosted job source reads
+  fail closed'`: all three selected composed adapter tests pass.
+- `pnpm --dir packages/device-syncd typecheck`: pass.
+- `pnpm complexity:diff`: pass; file debt remains 493, maximum remains 145,
+  and the touched function remains 28. Removing the fallback branch is the
+  proportional simplification; unrelated large functions stay outside scope.
+- `git diff --check` and parent scope/privacy review: pass. Product UX: Ready
+  for the internal acquisition change; no member-facing behavior or measured
+  latency claim. No model input or assistant behavior changes.
+- Exact-head CI and final GPT-6 Pro review remain external completion gates.
+Completed: 2026-09-04

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -5135,13 +5135,13 @@ export function createJunctionDeviceSyncProvider(
       };
     }
 
-    const currentSources = sourceLifecycleFence && input.context.listConnectionSources
+    const currentSources = input.context.listConnectionSources
+      && (sourceLifecycleFence || records.length > 0 || input.authorizedLocalDay)
       ? await input.context.listConnectionSources()
-      : null;
+      : input.context.account.sources ?? [];
     if (
       sourceLifecycleFence
-      && (!currentSources
-        || !isJunctionSourceLifecycleFenceCurrent(sourceLifecycleFence, currentSources))
+      && !isJunctionSourceLifecycleFenceCurrent(sourceLifecycleFence, currentSources)
     ) {
       throw junctionTimeseriesSourceLifecycleSuperseded();
     }
@@ -5156,7 +5156,7 @@ export function createJunctionDeviceSyncProvider(
     const sourceScopedHistoricalRecordsSeen = input.sourceProviderSlug
       ? await hasJunctionSourceScopedAdmittedSnapshotRecords({
           context: input.context,
-          ...(currentSources ? { listedSources: currentSources } : {}),
+          listedSources: currentSources,
           options: { projectAccountSourceIdentities: calendarDayAggregate },
           snapshots: { [input.resource]: records },
           sourceProviderSlug: input.sourceProviderSlug,
@@ -5164,25 +5164,18 @@ export function createJunctionDeviceSyncProvider(
         })
       : false;
 
-    const preparedImport = currentSources
-      ? prepareJunctionImportSnapshotForSources(
-          { [input.resource]: records },
-          input.sourceProviders,
-          currentSources,
-          calendarDayAggregate
-            ? { sourceIdentities: resolveJunctionAccountSourceIdentities(currentSources) }
-            : {},
-          {
-            allowUnlistedSources: input.context.connectionSourceAdmissionMode !== "listed_only",
-            sourceStatusRequirement: "not_disconnected",
-          },
-        )
-      : await prepareJunctionImportSnapshot(
-          input.context,
-          { [input.resource]: records },
-          input.sourceProviders,
-          { projectAccountSourceIdentities: calendarDayAggregate },
-        );
+    const preparedImport = prepareJunctionImportSnapshotForSources(
+      { [input.resource]: records },
+      input.sourceProviders,
+      currentSources,
+      calendarDayAggregate
+        ? { sourceIdentities: resolveJunctionAccountSourceIdentities(currentSources) }
+        : {},
+      {
+        allowUnlistedSources: input.context.connectionSourceAdmissionMode !== "listed_only",
+        sourceStatusRequirement: "not_disconnected",
+      },
+    );
     if (!hasJunctionSnapshotRecords(preparedImport.snapshots) && !input.authorizedLocalDay) {
       return {
         historicalProviderRecordsSeen: providerRecordsSeen,

--- a/packages/device-syncd/test/junction-timeseries-source-reuse.test.ts
+++ b/packages/device-syncd/test/junction-timeseries-source-reuse.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  createAccount,
+  createConnectionSource,
+  createJob,
+  createJunctionJobContext,
+  createJunctionProvider,
+  executeJunctionJob,
+} from "./junction-provider.harness.ts";
+import { createJsonResponse, readUrl } from "./helpers.ts";
+import type { ProviderJobContext } from "../src/types.ts";
+
+test.each([
+  "connected", "disconnected", "unavailable", "empty", "fenced-empty", "skipped", "unscoped", "local",
+] as const)("Junction timeseries source reuse preserves %s behavior", async (scenario) => {
+  const events: string[] = [];
+  const resource = scenario === "fenced-empty" ? "heart_rate_alert" : "blood_oxygen";
+  const sample = { timestamp: "2026-04-02T14:00:00.000Z", unit: "%", value: 97 };
+  const originalSource = createConnectionSource();
+  let liveSource = originalSource;
+  const snapshots: Parameters<ProviderJobContext["importSnapshot"]>[0][] = [];
+  const readFailure = new Error("Synthetic source read unavailable");
+  const provider = createJunctionProvider(async (input) => {
+    const url = new URL(readUrl(input));
+    if (url.pathname === "/v2/user/providers/junction-user-1") {
+      return createJsonResponse({ providers: [{
+        slug: "garmin", name: "Garmin", status: "connected",
+        resource_availability: { blood_oxygen: true },
+      }] });
+    }
+    assert.equal(url.pathname, `/v2/timeseries/junction-user-1/${resource}/grouped`);
+    events.push("provider");
+    if (scenario === "skipped") return createJsonResponse({ error: "Not found" }, 404);
+    // The admission read must observe changes made during the provider fetch,
+    // rather than the account's earlier hydration snapshot.
+    if (scenario === "disconnected") {
+      liveSource = createConnectionSource({ status: "disconnected" });
+    }
+    return createJsonResponse({ groups: scenario === "empty" || scenario === "fenced-empty" ? {} : {
+      garmin: [{ data: [sample], source: { provider: "garmin", type: "watch" } }],
+    } });
+  }, { summaryResources: [], timeseriesResources: [resource] });
+  const context = createJunctionJobContext({
+    now: "2026-04-04T12:00:00.000Z",
+    account: createAccount({ sources: [{ ...originalSource, resourceCount: 1 }] }),
+    connectionSourceAdmissionMode: "listed_only",
+    listConnectionSources: scenario === "local" ? undefined : async (input) => {
+      events.push("sources");
+      if (scenario === "unavailable") throw readFailure;
+      assert.equal(input?.status, undefined);
+      assert.equal(input?.sourceProviderSlug, undefined);
+      return [liveSource];
+    },
+    importSnapshot: async (snapshot) => {
+      events.push("import");
+      snapshots.push(snapshot);
+      return { imported: true };
+    },
+  });
+  const job = createJob("reconcile", {
+    ...(scenario === "unscoped" ? {} : { sourceProviderSlug: "garmin" }),
+    timeseriesCursor: "2026-04-02T00:00:00.000Z",
+    timeseriesResourceCursor: resource,
+    windowEnd: "2026-04-03T00:00:00.000Z",
+    windowStart: "2026-04-02T00:00:00.000Z",
+  });
+  if (scenario === "unavailable") {
+    await assert.rejects(executeJunctionJob(provider, context, job), (error) => error === readFailure);
+    assert.deepEqual(events, ["provider", "sources"]);
+    assert.equal(snapshots.length, 0);
+    return;
+  }
+  const result = await executeJunctionJob(provider, context, job);
+  assert.equal(result.scheduledJobs?.length ?? 0, 0);
+  if (["empty", "fenced-empty", "skipped", "disconnected"].includes(scenario)) {
+    assert.deepEqual(events, scenario === "empty" || scenario === "skipped"
+      ? ["provider"] : ["provider", "sources"]);
+    assert.equal(snapshots.length, 0);
+    return;
+  }
+  const expectedEvents = scenario === "local"
+    ? ["provider", "import"]
+    : ["provider", "sources", "import"];
+  assert.deepEqual(events, expectedEvents);
+  assert.equal(snapshots.length, 1);
+  assert.ok(JSON.stringify(snapshots[0]).includes(sample.timestamp));
+  assert.ok(JSON.stringify(snapshots[0]).includes('"value":97'));
+  // A later execution must read again; the result is not cached across jobs.
+  await executeJunctionJob(provider, context, job);
+  assert.deepEqual(events, [...expectedEvents, ...expectedEvents]);
+  assert.deepEqual(snapshots[1], snapshots[0]);
+});


### PR DESCRIPTION
## Why and outcome

Source-scoped Junction timeseries imports acquired the same full connection
snapshot twice for adjacent historical-evidence and canonical-admission
calculations. Reuse one fresh result through the existing helpers, removing one
serial request per eligible import without a cache, batching delay, or protocol
change. The production function is seven lines smaller.

## Product UX

- Effort: Patch; internal request reduction with unchanged imported data and scheduling.
- Result: Ready.
- Walkthrough: Connected, disconnected-during-fetch, unavailable, empty, fenced-empty, skipped, unscoped, and local contexts preserve their outcomes. Existing history and Fitbit migration tests preserve scoped evidence and full-source canonical policy. No change from plan; workout and summary flows are excluded.

## Evidence

- Direct: The new regression failed before the edit on the second adjacent read. All eight final scenarios pass and prove provider-before-read-before-import ordering, fresh reads on another execution, and unchanged denied/empty behavior.
- Coverage: Five focused device-syncd files passed 180 tests; the final source-reuse file subsequently passed all eight cases, including two added empty/skip cases. Three selected hosted adapter tests pass for fresh Web source authority, credential-free full-connection reads, and missing-connection failure.
- Commands: `pnpm exec vitest run --config packages/device-syncd/vitest.config.ts --no-coverage` with `junction-timeseries-source-reuse`, `junction-provider-resources`, `junction-provider-backfill`, `junction-provider-history`, and `fitbit-migration` test files; `pnpm exec vitest run --config packages/assistant-runtime/vitest.config.ts --no-coverage packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts -t 'hosted Junction imports reread Web source state|hosted job source reads fail closed'`; `pnpm --dir packages/device-syncd typecheck`; `git diff --check`.
- Final ReviewGPT: PASS with no findings on `33f0d4cd80ff652c6d6e56a7f14fb10e590b1648`; ReviewGPT 0.5.145 captured and verified `gpt-6-pro` response metadata. The reviewer performed static inspection; the local and CI runs own executable proof. All required CI passed on the reviewed head, including the full release build/typecheck, Web/Cloudflare verification, package coverage, both CLI platforms, and billing boundary. Current-base merge-tree proof is clean. Production request-rate savings and milliseconds are not measured.

## Non-obvious affected surfaces

Full-source Fitbit/Google Health admission and lifecycle-fenced empty resources:
existing provider-history/migration/lifecycle tests plus the new empty-resource
case pass. No adjacent production owner changes.

## Architecture and reuse

- Existing systems reused: ProviderJobContext source reader, historical-evidence helper, pure canonical preparation helper, and existing lifecycle validation.
- New logic: One fresh full-source acquisition supplies adjacent calculations; their distinct admission policies remain intact.
- New abstractions: None; a function-local immutable result is sufficient.
- Complexity intentionally avoided: No cache, queue, timer, state owner, endpoint, dependency, or broader refactor. Later provider/import boundaries retain their reads.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`; debt 493 to 493, maximum 145 to 145.
- Hotspots: The changed `importJunctionTimeseriesResourceSnapshot` remains 28. Other reported functions are unchanged; the provider file's maximum remains `executeResourceJob` at 145.
- Agent judgment: Removing the fallback preparation branch is the proportional simplification. Splitting unrelated provider policies would expand this task without improving its invariant.

## Hot reply path impact

- Path status: Not applicable — background device-sync import acquisition only; no foreground message path changes.
- Database calls: None added; one existing bounded snapshot acquisition is removed per eligible window, with no new transaction or fanout.
- Network/provider calls: One fewer serial internal snapshot request; provider requests, credentials, payload bounds, timeout, and retry owners are unchanged.
- Other awaited latency: None added or moved onto the foreground path.
- Before/after proof: Executor regression observes two adjacent source reads before the fix and one afterward. No wall-clock improvement is claimed.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no prompt, tool schema,
guidance, history, or other model-input assembly changes. Input measurement was
not run because no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: The local runtime implementation uses the existing snapshot contract and canonical importer. No Web/Worker protocol, persisted representation, binding, migration, or deploy-order requirement changes; either runtime version uses the same Web endpoint.

## Change-shape breakdown

Classification rule: Production TypeScript is source, the regression file is
tests, and the archived execution record is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 17 | 24 |
| Tests / fixtures | 93 | 0 |
| Docs | 70 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **180** | **24** |

## Changelog

- Changelog: not applicable
- Reason: Internal duplicate-request removal preserves member-visible data, sync scheduling, and recovery; no measured member-facing performance change is claimed.

ReviewGPT first-reviewed head: 33f0d4cd80ff652c6d6e56a7f14fb10e590b1648
ReviewGPT context sensitivity: sensitive
Classification reason: Source authority is reused immediately before canonical health-data import, although the patch is confined to one function.
