### PR TITLE
Simplify Junction timeseries identity construction

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-junction-identity-complexity.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-junction-identity-complexity.md
@@ -1,0 +1,32 @@
+# Junction timeseries identity complexity cleanup
+
+## Outcome and scope
+
+Reduce duplicated alias selection and unreachable resource branches in the existing Junction provider identity owner. Keep provider requests, pagination, source admission, canonical import ordering, row identities, conflict rejection, and recovery unchanged. No state owner, public API, dependency, or product promise changes.
+
+## Evidence and plan
+
+- Open PR inventory contains no existing change to the provider file; this task owns an isolated branch and worktree.
+- The temporal-authority set contains blood oxygen and stress level. Their early return makes the later point branches unreachable. Body identity returns before the redundant weight provider-id branch.
+- Replace repeated flat nullish chains with ordered field selection preserving empty strings, zero, false, alias order, and string coercion.
+- Prove equivalent deduplication at the provider import boundary, including contradictory alias values and source revision differences; retain existing sparse/body conflict tests.
+- Run focused Junction provider suites, package typecheck, complexity guard, and diff review. Close this plan through finish-task, open a draft PR, obtain parent candidate review, then run final ReviewGPT concurrently with required CI.
+
+## Product UX and architecture
+
+Internal behavior-preserving refactor; no changed member journey or assistant input. Existing provider and importer remain the authority owners. Changelog is not applicable because no member-visible behavior changes.
+
+## Status
+
+Local implementation complete. The identity function falls from complexity 120 to 33; file debt falls from 493 to 406, with the unchanged resource job maximum remaining 145.
+
+- `pnpm --dir packages/device-syncd test test/junction-provider-identity.test.ts test/junction-provider-resources.test.ts test/junction-provider-history.test.ts test/junction-provider-history-recovery.test.ts test/junction-provider-backfill.test.ts test/junction-blood-pressure-backfill.test.ts`: 319 tests pass across six files.
+- The new identity suite also passes all 34 cases against the untouched base implementation, establishing behavior preservation at the provider import callback.
+- `pnpm --dir packages/device-syncd typecheck`: pass; no import/export or package boundary changes require an emitted build.
+- `pnpm complexity:diff --base 603ea873bf4d0652805d0577081c43d64d6e0f61 -- packages/device-syncd/src/providers/junction.ts`: pass.
+- Diff and privacy readback complete; existing Frog inventory inspected, with no new qualifying repository friction.
+
+The local plan is complete. Draft PR, parent candidate review, final ReviewGPT, and required exact-head CI are the remaining external gates; no merge is authorized.
+Status: completed
+Updated: 2026-09-04
+Completed: 2026-09-04

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -9104,9 +9104,6 @@ function junctionTimeseriesRecordValueIdentity(
     return providerRowId ? [providerRowId] : [];
   }
   if (resource === "weight") {
-    if (includeProviderRowId && providerRowId) {
-      return [providerRowId];
-    }
     const { weightKilograms } = resolveJunctionWeightProviderRecordIdentity(entry);
     return weightKilograms === undefined ? [] : [`kg:${weightKilograms}`];
   }
@@ -9125,105 +9122,74 @@ function junctionTimeseriesRecordValueIdentity(
     ];
   }
 
-  const fidelityPointResource = resource === "glucose"
-    || resource === "blood_oxygen"
-    || resource === "stress_level";
   const fidelityIntervalResource = resource === "caffeine"
     || resource === "water"
     || resource === "mindfulness_minutes";
   const rowId = includeProviderRowId ? providerRowId : "";
-  const fidelitySourceRevision = String(
-    entry.recordedAt
-      ?? entry.recorded_at
-      ?? entry.updatedAt
-      ?? entry.updated_at
-      ?? "",
-  );
+  const fidelitySourceRevision = readJunctionTimeseriesIdentityField(entry, [
+    "recordedAt",
+    "recorded_at",
+    "updatedAt",
+    "updated_at",
+  ]);
   const timeZoneIdentity = [
-    String(entry.timeZone ?? entry.timezone ?? entry.time_zone ?? ""),
-    String(
-      entry.timeZoneOffsetMinutes
-        ?? entry.time_zone_offset_minutes
-        ?? entry.timezoneOffsetMinutes
-        ?? entry.timezone_offset_minutes
-        ?? entry.utcOffsetMinutes
-        ?? entry.utc_offset_minutes
-        ?? "",
-    ),
-    String(
-      entry.timezone_offset
-        ?? entry.timezoneOffset
-        ?? entry.timeZoneOffset
-        ?? entry.time_zone_offset
-        ?? entry.timezoneOffsetSeconds
-        ?? entry.timezone_offset_seconds
-        ?? entry.timeZoneOffsetSeconds
-        ?? entry.time_zone_offset_seconds
-        ?? entry.utcOffsetSeconds
-        ?? entry.utc_offset_seconds
-        ?? "",
-    ),
+    readJunctionTimeseriesIdentityField(entry, ["timeZone", "timezone", "time_zone"]),
+    readJunctionTimeseriesIdentityField(entry, [
+      "timeZoneOffsetMinutes",
+      "time_zone_offset_minutes",
+      "timezoneOffsetMinutes",
+      "timezone_offset_minutes",
+      "utcOffsetMinutes",
+      "utc_offset_minutes",
+    ]),
+    readJunctionTimeseriesIdentityField(entry, [
+      "timezone_offset",
+      "timezoneOffset",
+      "timeZoneOffset",
+      "time_zone_offset",
+      "timezoneOffsetSeconds",
+      "timezone_offset_seconds",
+      "timeZoneOffsetSeconds",
+      "time_zone_offset_seconds",
+      "utcOffsetSeconds",
+      "utc_offset_seconds",
+    ]),
   ];
   const providerDayIdentity = [
-    String(
-      entry.calendarDate
-        ?? entry.calendar_date
-        ?? entry.localDate
-        ?? entry.local_date
-        ?? "",
-    ),
-    String(entry.timestampSemantics ?? entry.timestamp_semantics ?? ""),
+    readJunctionTimeseriesIdentityField(entry, ["calendarDate", "calendar_date", "localDate", "local_date"]),
+    readJunctionTimeseriesIdentityField(entry, ["timestampSemantics", "timestamp_semantics"]),
   ];
 
   if (fidelityIntervalResource) {
-    const intervalValue = resource === "mindfulness_minutes"
-      ? entry.value ?? entry.mindfulnessMinutes ?? entry.mindfulness_minutes
-      : resource === "caffeine"
-        ? entry.value ?? entry.caffeine
-        : entry.value ?? entry.water;
+    const intervalValueKeys = resource === "mindfulness_minutes"
+      ? ["value", "mindfulnessMinutes", "mindfulness_minutes"]
+      : ["value", resource];
     return [
       rowId,
-      String(entry.start ?? entry.startAt ?? entry.start_at ?? entry.timeStart ?? entry.time_start ?? ""),
-      String(entry.end ?? entry.endAt ?? entry.end_at ?? entry.timeEnd ?? entry.time_end ?? ""),
-      String(entry.unit ?? entry.valueUnit ?? entry.value_unit ?? ""),
-      String(intervalValue ?? ""),
+      readJunctionTimeseriesIdentityField(entry, ["start", "startAt", "start_at", "timeStart", "time_start"]),
+      readJunctionTimeseriesIdentityField(entry, ["end", "endAt", "end_at", "timeEnd", "time_end"]),
+      readJunctionTimeseriesIdentityField(entry, ["unit", "valueUnit", "value_unit"]),
+      readJunctionTimeseriesIdentityField(entry, intervalValueKeys),
       ...providerDayIdentity,
       ...timeZoneIdentity,
       fidelitySourceRevision,
     ];
   }
 
-  if (fidelityPointResource) {
+  if (resource === "glucose") {
     return [
       rowId,
-      String(
-        entry.observedAt
-          ?? entry.observed_at
-          ?? entry.observed_at_utc
-          ?? entry.timestamp
-          ?? entry.time
-          ?? entry.date
-          ?? entry.day
-          ?? "",
-      ),
-      String(entry.value ?? (resource === "glucose"
-        ? entry.glucose ?? entry.bloodGlucose ?? entry.blood_glucose
-        : resource === "blood_oxygen"
-          ? entry.spo2
-            ?? entry.spO2
-            ?? entry.bloodOxygen
-            ?? entry.blood_oxygen
-            ?? entry.oxygenSaturation
-            ?? entry.oxygen_saturation
-          : entry.stressLevel
-            ?? entry.stress_level
-            ?? entry.averageStressLevel
-            ?? entry.average_stress_level
-            ?? readPlainObject(entry.stress)?.average
-            ?? entry.stressLevelValue
-            ?? entry.stress_level_value
-            ?? entry.score) ?? ""),
-      String(entry.unit ?? entry.valueUnit ?? entry.value_unit ?? ""),
+      readJunctionTimeseriesIdentityField(entry, [
+        "observedAt",
+        "observed_at",
+        "observed_at_utc",
+        "timestamp",
+        "time",
+        "date",
+        "day",
+      ]),
+      readJunctionTimeseriesIdentityField(entry, ["value", "glucose", "bloodGlucose", "blood_glucose"]),
+      readJunctionTimeseriesIdentityField(entry, ["unit", "valueUnit", "value_unit"]),
       ...providerDayIdentity,
       ...timeZoneIdentity,
       fidelitySourceRevision,
@@ -9243,10 +9209,25 @@ function junctionTimeseriesRecordValueIdentity(
     String(entry.value ?? ""),
     String(entry.unit ?? ""),
     String(entry.type ?? ""),
-    String(entry.bolus_purpose ?? entry.bolusPurpose ?? ""),
-    String(entry.delivery_form ?? entry.deliveryForm ?? ""),
-    String(entry.delivery_mode ?? entry.deliveryMode ?? ""),
+    readJunctionTimeseriesIdentityField(entry, ["bolus_purpose", "bolusPurpose"]),
+    readJunctionTimeseriesIdentityField(entry, ["delivery_form", "deliveryForm"]),
+    readJunctionTimeseriesIdentityField(entry, ["delivery_mode", "deliveryMode"]),
   ];
+}
+
+// Identity aliases use nullish precedence: empty strings, zero, and false are
+// values and must not fall through to a later provider spelling.
+function readJunctionTimeseriesIdentityField(
+  entry: Record<string, unknown>,
+  keys: readonly string[],
+): string {
+  for (const key of keys) {
+    const value = entry[key];
+    if (value !== null && value !== undefined) {
+      return String(value);
+    }
+  }
+  return "";
 }
 
 function firstJunctionTimeseriesIdentityValue(

--- a/packages/device-syncd/test/junction-provider-identity.test.ts
+++ b/packages/device-syncd/test/junction-provider-identity.test.ts
@@ -75,19 +75,19 @@ for (const [field, alias] of [
 ] as const) {
   test(`Junction glucose identity preserves ${field} precedence over ${alias}`, async () => {
     const rows: Record<string, unknown>[] = [];
-    for (const [index, value] of ["", 0, false, "selected"].entries()) {
-      const common = { ...baseRow, value: undefined, unit: undefined, id: `row-${index}` };
+    for (const value of ["", 0, false, "selected"]) {
+      const common = { ...baseRow, value: undefined, unit: undefined, id: "same-row" };
       rows.push(
         { ...common, [field]: value, [alias]: "ignored" },
         { ...common, [field]: value, [alias]: "different-ignored" },
       );
     }
     assert.equal((await importTimeseriesRows("glucose", rows)).length, 4);
-    const fallback = { ...baseRow, value: undefined, unit: undefined, [alias]: "selected" };
+    const fallback = { ...baseRow, id: "same-row", value: undefined, unit: undefined, [alias]: "selected" };
     assert.equal((await importTimeseriesRows("glucose", [
       { ...fallback, [field]: null },
-      { ...fallback, [field]: undefined },
-    ])).length, 1);
+      { ...fallback, [field]: undefined, [alias]: "different" },
+    ])).length, 2);
   });
 }
 
@@ -104,8 +104,8 @@ for (const resource of ["caffeine", "water", "mindfulness_minutes"]) {
     const valueAlias = resource === "mindfulness_minutes" ? "mindfulness_minutes" : resource;
     const interval = { timestamp, start: timestamp, end: "2026-04-02T12:05:00.000Z" };
     const records: Record<string, unknown>[] = [];
-    for (const [index, value] of ["", 0, false, 12].entries()) {
-      const row = { ...interval, id: `interval-${index}`, value, unit: "" };
+    for (const value of ["", 0, false, 12]) {
+      const row = { ...interval, id: "same-interval", value, unit: "" };
       records.push(
         { ...row, [valueAlias]: 100, valueUnit: "ignored" },
         { ...row, [valueAlias]: 200, valueUnit: "different-ignored" },

--- a/packages/device-syncd/test/junction-provider-identity.test.ts
+++ b/packages/device-syncd/test/junction-provider-identity.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  createJob,
+  createJunctionJobContext,
+  createJunctionProvider,
+  executeJunctionJob,
+} from "./junction-provider.harness.ts";
+import { createJsonResponse, readUrl } from "./helpers.ts";
+
+async function importTimeseriesRows(resource: string, records: Record<string, unknown>[]) {
+  const imported: unknown[] = [];
+  const requests: string[] = [];
+  const provider = createJunctionProvider(async (input) => {
+    const url = new URL(readUrl(input));
+    requests.push(url.pathname);
+    if (url.pathname === `/v2/timeseries/junction-user-1/${resource}/grouped`) {
+      return createJsonResponse({
+        groups: {
+          oura: [{ data: records, source: { provider: "oura", type: "ring" } }],
+        },
+      });
+    }
+    throw new Error(`Unexpected request path: ${url.pathname}`);
+  }, { summaryResources: [], timeseriesResources: [resource] });
+  await executeJunctionJob(provider, createJunctionJobContext({
+    now: "2026-04-03T12:00:00.000Z",
+    importSnapshot: async (snapshot) => { imported.push(snapshot); },
+  }), createJob("reconcile", {
+    timeseriesCursor: "2026-04-02T00:00:00.000Z",
+    timeseriesResourceCursor: resource,
+    windowStart: "2026-04-02T00:00:00.000Z",
+    windowEnd: "2026-04-03T00:00:00.000Z",
+  }));
+  assert.deepEqual(requests, [`/v2/timeseries/junction-user-1/${resource}/grouped`]);
+  assert.equal(imported.length, 1);
+  // The callback receives the production provider snapshot; only its timeseries
+  // collection is inspected, before the importer can arbitrate revisions.
+  const snapshot = imported[0] as { timeseries: Record<string, unknown[]> };
+  return snapshot.timeseries[resource];
+}
+
+const timestamp = "2026-04-02T12:00:00.000Z";
+const baseRow = { timestamp, value: 90, unit: "mg/dL" };
+
+for (const [field, alias] of [
+  ["recordedAt", "recorded_at"],
+  ["recorded_at", "updatedAt"],
+  ["updatedAt", "updated_at"],
+  ["timeZone", "timezone"],
+  ["timezone", "time_zone"],
+  ["timeZoneOffsetMinutes", "time_zone_offset_minutes"],
+  ["time_zone_offset_minutes", "timezoneOffsetMinutes"],
+  ["timezoneOffsetMinutes", "timezone_offset_minutes"],
+  ["timezone_offset_minutes", "utcOffsetMinutes"],
+  ["utcOffsetMinutes", "utc_offset_minutes"],
+  ["timezone_offset", "timezoneOffset"],
+  ["timezoneOffset", "timeZoneOffset"],
+  ["timeZoneOffset", "time_zone_offset"],
+  ["time_zone_offset", "timezoneOffsetSeconds"],
+  ["timezoneOffsetSeconds", "timezone_offset_seconds"],
+  ["timezone_offset_seconds", "timeZoneOffsetSeconds"],
+  ["timeZoneOffsetSeconds", "time_zone_offset_seconds"],
+  ["time_zone_offset_seconds", "utcOffsetSeconds"],
+  ["utcOffsetSeconds", "utc_offset_seconds"],
+  ["calendarDate", "calendar_date"],
+  ["calendar_date", "localDate"],
+  ["localDate", "local_date"],
+  ["timestampSemantics", "timestamp_semantics"],
+  ["value", "glucose"],
+  ["glucose", "bloodGlucose"],
+  ["bloodGlucose", "blood_glucose"],
+  ["unit", "valueUnit"],
+  ["valueUnit", "value_unit"],
+] as const) {
+  test(`Junction glucose identity preserves ${field} precedence over ${alias}`, async () => {
+    const rows: Record<string, unknown>[] = [];
+    for (const [index, value] of ["", 0, false, "selected"].entries()) {
+      const common = { ...baseRow, value: undefined, unit: undefined, id: `row-${index}` };
+      rows.push(
+        { ...common, [field]: value, [alias]: "ignored" },
+        { ...common, [field]: value, [alias]: "different-ignored" },
+      );
+    }
+    assert.equal((await importTimeseriesRows("glucose", rows)).length, 4);
+    const fallback = { ...baseRow, value: undefined, unit: undefined, [alias]: "selected" };
+    assert.equal((await importTimeseriesRows("glucose", [
+      { ...fallback, [field]: null },
+      { ...fallback, [field]: undefined },
+    ])).length, 1);
+  });
+}
+
+test("Junction glucose retains distinct revisions for the canonical importer", async () => {
+  const records = [
+    { ...baseRow, id: "same-row", recordedAt: "2026-04-02T13:00:00Z" },
+    { ...baseRow, id: "same-row", recordedAt: "2026-04-02T14:00:00Z" },
+  ];
+  assert.equal((await importTimeseriesRows("glucose", records)).length, 2);
+});
+
+for (const resource of ["caffeine", "water", "mindfulness_minutes"]) {
+  test(`Junction ${resource} interval identity retains aliases and falsey values`, async () => {
+    const valueAlias = resource === "mindfulness_minutes" ? "mindfulness_minutes" : resource;
+    const interval = { timestamp, start: timestamp, end: "2026-04-02T12:05:00.000Z" };
+    const records: Record<string, unknown>[] = [];
+    for (const [index, value] of ["", 0, false, 12].entries()) {
+      const row = { ...interval, id: `interval-${index}`, value, unit: "" };
+      records.push(
+        { ...row, [valueAlias]: 100, valueUnit: "ignored" },
+        { ...row, [valueAlias]: 200, valueUnit: "different-ignored" },
+      );
+    }
+    assert.equal((await importTimeseriesRows(resource, records)).length, 4);
+    assert.equal((await importTimeseriesRows(resource, [
+      { ...interval, value: null, [valueAlias]: 12, start: null, startAt: timestamp },
+      { ...interval, value: undefined, [valueAlias]: 12, end: null, end_at: interval.end },
+    ])).length, 1);
+  });
+}
+
+for (const resource of ["blood_oxygen", "stress_level"]) {
+  test(`Junction ${resource} retains temporal identity before point alias fields`, async () => {
+    const rows = await importTimeseriesRows(resource, [
+      { ...baseRow, id: "temporal-row", timeZone: "UTC", observedAt: timestamp },
+      { ...baseRow, id: "temporal-row", timeZone: "different", observedAt: "ignored" },
+    ]);
+    assert.equal(rows.length, 1);
+  });
+}


### PR DESCRIPTION
## Why and outcome

Junction timeseries identities repeated long provider-alias chains and retained branches made unreachable by earlier resource dispatch. Collapse alias selection into one local ordered-field reader and delete the unreachable blood-oxygen, stress-level, and weight cases. Identity tuple order, nullish precedence, row conflict handling, provider requests, and canonical import ordering remain unchanged.

## Product UX

- Effort: Not applicable — internal behavior-preserving provider refactor.
- Result: Not applicable.
- Walkthrough: No member journey, permissions, scheduling, recovery, or presentation changes; synthetic import-boundary proof preserves existing results.

## Evidence

- Direct: Focused identity tests exercise real provider execution through its import callback, preserving aliases, empty strings, zero, false, nullish fallback, revisions, intervals, and temporal early returns; same-ID rows prove selected primary and fallback values contribute to identity, with exactly one timeseries request per scenario.
- Coverage: Existing resources, history, history-recovery, backfill, and blood-pressure-backfill suites cover canonical importer identities, stable-row conflicts in both orders, source fencing, and recovery. Six focused files / 319 tests pass; the 34 new identity cases also pass against untouched base. `pnpm --dir packages/device-syncd typecheck` passes. All exact-head CI checks passed, including Release checks (ubuntu), both host platforms, all six package coverage shards, Web/Cloudflare verification, billing, hygiene, viewport, cardinality, and Temporal compatibility. Current-base merge-tree proof is clean.
- ReviewGPT: [Round 1](https://chatgpt.com/c/6a9b5587-100c-83ea-9feb-c45fb0f88aef) PASS with zero findings on `9fd4b3d8e2defd1fee3fc0e1a65853126015ed5b`; verified gpt-6-pro model and captured response identity. The review reports 151,164 base/head identity comparisons with zero mismatches. Its 7m16 response qualifies for the documented near-threshold discretion based on the exact model/turn/attachment evidence and substantive differential proof.
- Command: `pnpm --dir packages/device-syncd test test/junction-provider-identity.test.ts test/junction-provider-resources.test.ts test/junction-provider-history.test.ts test/junction-provider-history-recovery.test.ts test/junction-provider-backfill.test.ts test/junction-blood-pressure-backfill.test.ts`.

## Non-obvious affected surfaces

Timeseries transport deduplication feeds canonical importer revision arbitration. Existing sparse body/blood-pressure tests and new glucose revision proof cover that boundary. No other production file changes.

## Architecture and reuse

- Existing systems reused: Junction provider resource dispatch, source admission, timeseries deduplication, and canonical importer remain the owners.
- New logic: None; ordered alias lookup preserves the existing nullish chains and string coercion exactly.
- New abstractions: One private ordered-field reader replaces repeated flat alias chains; no public export, package boundary, dependency, or persisted state.
- Complexity intentionally avoided: No resource framework, new state owner, file relocation, scheduling layer, or compatibility shim.

## Complexity impact

- Guard: PASS — `pnpm complexity:diff --base 603ea873bf4d0652805d0577081c43d64d6e0f61 -- packages/device-syncd/src/providers/junction.ts`; file debt 493 → 406 (-87), maximum 145 unchanged.
- Hotspots: Changed `junctionTimeseriesRecordValueIdentity` drops 120 → 33; its remaining branches express distinct resource identity policies. Unchanged hotspots: executeResourceJob 145; executeJob 103; executeFullJobTimeseriesContinuation 46; projectJunctionSources 45; importTimeseriesPreciseSnapshots 44; withJunctionExtendedTimeseriesBackfillFollowUp 40; recordAcceptedJunctionFitbitCoverage and evaluateJunctionHistoricalBackfillCoverage 35 each; importJunctionWorkoutStreamWindow 32; isBlockedJunctionSourceAvailabilityKey 29; importJunctionTimeseriesResourceSnapshot and buildJunctionWebhookWindow 28 each; importTimeseriesDailyAggregateSnapshots and selectJunctionElectrocardiogramRecordingCandidates 26 each; classifyClearOptionalJunctionResourceCode and extractJunctionWebhookSourceProviderSlugFallback 24 each; filterJunctionTimeseriesRecordsToWindow callback 23.
- Agent judgment: The identity owner benefits from direct duplicate removal. Remaining job orchestration and authority hotspots need separate behavior-specific changes; splitting them here would broaden the refactor into scheduling and recovery without improving this identity contract.

## Hot reply path impact

- Path status: Not applicable — synchronous identity construction in background device sync; no foreground conversation flow change.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved.
- Before/after proof: Diff preserves every awaited operation; import-boundary tests assert one unchanged timeseries request per case.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no prompts, tools, schemas, generated guidance, messages, or provider input builders change.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Existing synchronous provider identity logic retains the same inputs and outputs; no schema, wire contract, runtime configuration, or independently deployed consumer changes.

## Change-shape breakdown

Classification rule: Provider implementation is source; focused provider proof is tests; completed execution plan is docs. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 66 | 85 |
| Tests / fixtures | 130 | 0 |
| Docs | 32 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **228** | **85** |

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving complexity reduction with no member-visible behavior change.

ReviewGPT context sensitivity: sensitive
Classification reason: Health-record identity and deduplication are sensitive even though this refactor preserves behavior.

ReviewGPT first-reviewed head: 9fd4b3d8e2defd1fee3fc0e1a65853126015ed5b
