### PR TITLE
refactor(core): collapse device event reconciliation bookkeeping

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-complexity-core-mutations.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-complexity-core-mutations.md
@@ -1,0 +1,54 @@
+# Collapse device-event reconciliation bookkeeping
+
+Status: completed
+Created: 2026-09-04
+Updated: 2026-09-04
+
+## Goal
+
+Reduce repeated state bookkeeping in the largest canonical device-event reconciliation function while preserving every public mutation result and persisted event revision.
+
+## Success criteria
+
+- Provider revision staging has one local implementation; no module or state owner is added.
+- Canonical lock, alias repair, legacy-reference cleanup, member overlays, tombstones, duplicate counts, and append order remain unchanged.
+- Focused device import tests and core typecheck pass; complexity debt decreases.
+- Scoped commit and draft PR have complete evidence; parent approves candidate before Ready and final ReviewGPT runs concurrently with required CI.
+
+## Scope
+
+Only `packages/core/src/mutations.ts`, focused device import proof, and this plan. Provider adapters, public APIs, exact-document reconciliation, and persistence orchestration are excluded.
+
+## Constraints
+
+Preserve mutations.ts as the canonical facade. Use the existing write lock, event index, append lists, and receipts. No new persisted state, dependencies, asynchronous operations, or provider calls.
+
+## Risks and mitigations
+
+1. Staging drift could put the member overlay below its provider baseline or lose revision ordering. Prove physical ledger order and exact revisions through public import calls.
+2. Retaining an existing record does not always count as a duplicate. Leave count increments and incomplete-spine decisions explicit at each existing decision branch.
+3. Alias cleanup could remove another owner. Preserve both historical and current owner checks and test sequential identity migration.
+
+## Tasks
+
+1. Inspect existing reconciliation branches and relevant tests.
+2. Collapse repeated staging and retention bookkeeping locally without changing decisions.
+3. Run focused tests, typecheck, complexity and parent candidate review.
+4. Commit, open draft PR, then drive final ReviewGPT and required CI after parent clearance.
+
+## Decisions
+
+- Parent approved a local staging helper with existing state ownership intact.
+- Graft is unavailable; use precise symbol reads and the documented canonical facade guidance.
+- Internal behavior-preserving change: no user-facing UX, provider-input, or changelog change.
+
+## Verification
+
+- `pnpm exec vitest run --config packages/core/vitest.config.ts --no-coverage packages/core/test/device-import.test.ts packages/core/test/device-import-session.test.ts packages/core/test/import-device-batch-validation.test.ts packages/core/test/canonical-mutations-boundary.test.ts`: 210 tests passed.
+- Added physical ledger-order and audit-count assertions pass for member overlays, authoritative retractions, and transitive in-batch identity migration. The same three cases pass against the unchanged pinned base, proving these assertions preserve existing behavior.
+- `pnpm --filter @murphai/core typecheck`: passed; no public-entrypoint or build-boundary change.
+- `pnpm complexity:diff --base 603ea873bf4d0652805d0577081c43d64d6e0f61 -- packages/core/src/mutations.ts`: passed, file debt 396 to 377 and reconciler complexity 154 to 135.
+- Parent preliminary review confirmed the original append/index order and unchanged prepared IDs. Final candidate review, exact-head CI, and ReviewGPT are tracked with the PR after the scoped implementation commit.
+- Frog inventory inspected after the frozen install; no new repository friction was encountered.
+
+Completed: 2026-09-04

--- a/packages/core/src/mutations.ts
+++ b/packages/core/src/mutations.ts
@@ -4701,6 +4701,51 @@ async function reconcileDeviceEventEntriesByExternalRef(
   let supersededCount = 0;
   let retractedCount = 0;
 
+  const retainRecord = (entryIndex: number, record: EventRecord, retainPreparedId = true) => {
+    if (retainPreparedId) {
+      retainedPreparedIds.add(entries[entryIndex]!.record.id);
+    }
+    recordsByEntryIndex.set(entryIndex, record);
+  };
+
+  // Keep the provider baseline and optional member overlay together in both
+  // the in-memory index and the ordered append list.
+  const stageProviderRevision = (input: {
+    refKey: string;
+    externalRef: ExternalRef;
+    providerEntry: PreparedJsonlEntry<EventRecord>;
+    memberEntry?: PreparedJsonlEntry<EventRecord>;
+    indexedRelativePath?: string;
+    matchedEntries?: ResolvedDeviceEventIdentity["matchedEntries"];
+  }) => {
+    const { refKey, externalRef, providerEntry, memberEntry } = input;
+    const current = memberEntry?.record ?? providerEntry.record;
+    forceAppendIds.add(providerEntry.record.id);
+    index.latestByRefKey.set(refKey, memberEntry
+      ? {
+          indexedExternalRef: externalRef,
+          indexedRecord: providerEntry.record,
+          relativePath: memberEntry.relativePath,
+          record: memberEntry.record,
+        }
+      : toIndexedExternalRefMatch(providerEntry.record, externalRef, input.indexedRelativePath));
+    for (const { refKey: matchedRefKey, indexedMatch } of input.matchedEntries ?? []) {
+      const currentMatch = index.latestByRefKey.get(matchedRefKey);
+      if (
+        matchedRefKey !== refKey
+        && indexedMatch.record.id === providerEntry.record.id
+        && currentMatch?.record.id === providerEntry.record.id
+      ) {
+        index.latestByRefKey.delete(matchedRefKey);
+      }
+    }
+    index.maxRevisionById.set(providerEntry.record.id, eventSpineRevision(current));
+    appendEntries.push(providerEntry);
+    if (memberEntry) {
+      appendEntries.push(memberEntry);
+    }
+  };
+
   const aliasRepairByEntryIndex = new Map<number, JunctionDailyAggregateAliasRepairPlan>();
   for (const [entryIndex, entry] of entries.entries()) {
     const aliasRepair = buildJunctionDailyAggregateAliasRepairPlan({
@@ -4754,11 +4799,10 @@ async function reconcileDeviceEventEntriesByExternalRef(
     retractedCount += 1;
   }
 
-  for (const [entryIndex, originalEntry] of entries.entries()) {
+  for (const [entryIndex, entry] of entries.entries()) {
     if (aliasRepairByEntryIndex.has(entryIndex)) {
       continue;
     }
-    let entry = originalEntry;
     const externalRef = entry.record.externalRef;
 
     if (!externalRef) {
@@ -4769,8 +4813,7 @@ async function reconcileDeviceEventEntriesByExternalRef(
         && deviceEventContentKey(current) === deviceEventContentKey(entry.record)
       ) {
         skippedDuplicateCount += 1;
-        retainedPreparedIds.add(entry.record.id);
-        recordsByEntryIndex.set(entryIndex, current);
+        retainRecord(entryIndex, current);
         continue;
       }
       appendEntries.push(entry);
@@ -4793,7 +4836,7 @@ async function reconcileDeviceEventEntriesByExternalRef(
       );
     }
     const { matchedEntries, refKey } = resolved;
-    let latest = resolved.latest;
+    const latest = resolved.latest;
     const migratesJunctionNoIdProfileIdentity = isIncomingJunctionNoIdProfile(entry.record)
       && matchedEntries.some((match) => match.refKey !== refKey);
 
@@ -4820,8 +4863,7 @@ async function reconcileDeviceEventEntriesByExternalRef(
       );
     if (replaysJunctionNoIdProfileTimestamp) {
       skippedDuplicateCount += 1;
-      retainedPreparedIds.add(entry.record.id);
-      recordsByEntryIndex.set(entryIndex, latest);
+      retainRecord(entryIndex, latest);
       continue;
     }
     const matchesIndexedProviderContent = indexedProviderMatch !== undefined
@@ -4847,8 +4889,7 @@ async function reconcileDeviceEventEntriesByExternalRef(
       && (migratesJunctionStableProfileTimestamp || retainsDeletedJunctionStableProfile)
     ) {
       skippedDuplicateCount += 1;
-      retainedPreparedIds.add(entry.record.id);
-      recordsByEntryIndex.set(entryIndex, latest);
+      retainRecord(entryIndex, latest);
       continue;
     }
 
@@ -4923,8 +4964,7 @@ async function reconcileDeviceEventEntriesByExternalRef(
       && !reassertsUnversionedSetMember
     ) {
       skippedDuplicateCount += 1;
-      retainedPreparedIds.add(entry.record.id);
-      recordsByEntryIndex.set(entryIndex, latest);
+      retainRecord(entryIndex, latest);
       continue;
     }
 
@@ -4955,28 +4995,12 @@ async function reconcileDeviceEventEntriesByExternalRef(
         };
         const retainedMemberPath = historicalUserEditMatch.indexedMatch.relativePath
           || toEventLedgerFile(latest.occurredAt);
-        forceAppendIds.add(latest.id);
-        index.latestByRefKey.set(refKey, {
-          indexedExternalRef: externalRef,
-          indexedRecord: providerBaseline,
-          relativePath: retainedMemberPath,
-          record: retainedMemberRevision,
-        });
-        for (const { refKey: matchedRefKey, indexedMatch } of matchedEntries) {
-          const currentMatch = index.latestByRefKey.get(matchedRefKey);
-          if (
-            matchedRefKey !== refKey
-            && indexedMatch.record.id === latest.id
-            && currentMatch?.record.id === latest.id
-          ) {
-            index.latestByRefKey.delete(matchedRefKey);
-          }
-        }
-        index.maxRevisionById.set(latest.id, providerRevision + 1);
-        appendEntries.push({ relativePath: entry.relativePath, record: providerBaseline });
-        appendEntries.push({
-          relativePath: retainedMemberPath,
-          record: retainedMemberRevision,
+        stageProviderRevision({
+          refKey,
+          externalRef,
+          providerEntry: { relativePath: entry.relativePath, record: providerBaseline },
+          memberEntry: { relativePath: retainedMemberPath, record: retainedMemberRevision },
+          matchedEntries,
         });
         appendRecordIdByPreparedRecordId.set(entry.record.id, providerBaseline.id);
         recordsByEntryIndex.set(entryIndex, retainedMemberRevision);
@@ -4985,8 +5009,7 @@ async function reconcileDeviceEventEntriesByExternalRef(
       }
       if (indexedSourceVersionComparison === null || indexedSourceVersionComparison === 0) {
         skippedDuplicateCount += 1;
-        retainedPreparedIds.add(entry.record.id);
-        recordsByEntryIndex.set(entryIndex, latest);
+        retainRecord(entryIndex, latest);
         continue;
       }
     }
@@ -5026,10 +5049,7 @@ async function reconcileDeviceEventEntriesByExternalRef(
       }
       if (sourceVersionComparison !== null && sourceVersionComparison < 0) {
         skippedDuplicateCount += 1;
-        if (eventSpineRevisionsAreComplete(index, latest.id)) {
-          retainedPreparedIds.add(entry.record.id);
-        }
-        recordsByEntryIndex.set(entryIndex, latest);
+        retainRecord(entryIndex, latest, eventSpineRevisionsAreComplete(index, latest.id));
         continue;
       }
       if (sourceVersionComparison === 0) {
@@ -5051,10 +5071,7 @@ async function reconcileDeviceEventEntriesByExternalRef(
       );
       if (sourceVersionComparison !== null && sourceVersionComparison < 0) {
         skippedDuplicateCount += 1;
-        if (eventSpineRevisionsAreComplete(index, latest.id)) {
-          retainedPreparedIds.add(entry.record.id);
-        }
-        recordsByEntryIndex.set(entryIndex, latest);
+        retainRecord(entryIndex, latest, eventSpineRevisionsAreComplete(index, latest.id));
         continue;
       }
       const sleepTypeBaselineRevision = sourceVersionComparison === 0
@@ -5088,10 +5105,7 @@ async function reconcileDeviceEventEntriesByExternalRef(
         // backfill it; preserving this row also lets unrelated snapshot
         // resources commit.
         skippedDuplicateCount += 1;
-        if (eventSpineRevisionsAreComplete(index, latest.id)) {
-          retainedPreparedIds.add(entry.record.id);
-        }
-        recordsByEntryIndex.set(entryIndex, latest);
+        retainRecord(entryIndex, latest, eventSpineRevisionsAreComplete(index, latest.id));
         continue;
       }
     }
@@ -5100,10 +5114,7 @@ async function reconcileDeviceEventEntriesByExternalRef(
     // Keep this comparison scoped to that closed source type: other providers
     // use timestamp-shaped versions whose ordering semantics are not universal.
     if (shouldKeepExistingJunctionCompanionHealthMetadata(latest, entry.record)) {
-      if (eventSpineRevisionsAreComplete(index, latest.id)) {
-        retainedPreparedIds.add(entry.record.id);
-      }
-      recordsByEntryIndex.set(entryIndex, latest);
+      retainRecord(entryIndex, latest, eventSpineRevisionsAreComplete(index, latest.id));
       continue;
     }
 
@@ -5116,8 +5127,7 @@ async function reconcileDeviceEventEntriesByExternalRef(
     );
     if (replaysProviderOwnedRetractionWithoutSetAuthority) {
       skippedDuplicateCount += 1;
-      retainedPreparedIds.add(entry.record.id);
-      recordsByEntryIndex.set(entryIndex, latest);
+      retainRecord(entryIndex, latest);
       continue;
     }
 
@@ -5127,8 +5137,7 @@ async function reconcileDeviceEventEntriesByExternalRef(
       // later empty-then-populated cadence cannot launder the deletion away.
       if (authoritativeSet && indexedSourceVersionComparison === null) {
         skippedDuplicateCount += 1;
-        retainedPreparedIds.add(entry.record.id);
-        recordsByEntryIndex.set(entryIndex, latest);
+        retainRecord(entryIndex, latest);
         continue;
       }
       index.latestByRefKey.set(refKey, toIndexedExternalRefMatch(entry.record, externalRef));
@@ -5142,10 +5151,7 @@ async function reconcileDeviceEventEntriesByExternalRef(
     // the next serialized event-spine revision over the retraction tombstone.
 
     if (shouldKeepExistingJunctionSleepStageSummaryObservation(latest, entry.record)) {
-      if (eventSpineRevisionsAreComplete(index, latest.id)) {
-        retainedPreparedIds.add(entry.record.id);
-      }
-      recordsByEntryIndex.set(entryIndex, latest);
+      retainRecord(entryIndex, latest, eventSpineRevisionsAreComplete(index, latest.id));
       continue;
     }
 
@@ -5188,30 +5194,15 @@ async function reconcileDeviceEventEntriesByExternalRef(
       : historicalUserEditMatch?.indexedMatch.relativePath
         || toEventLedgerFile(latest.occurredAt);
 
-    forceAppendIds.add(latest.id);
-    index.latestByRefKey.set(refKey, retainedMemberRevision
-      ? {
-          indexedExternalRef: externalRef,
-          indexedRecord: superseding,
-          relativePath: retainedMemberPath,
-          record: retainedMemberRevision,
-        }
-      : toIndexedExternalRefMatch(superseding, externalRef));
-    for (const { refKey: matchedRefKey, indexedMatch } of matchedEntries) {
-      const currentMatch = index.latestByRefKey.get(matchedRefKey);
-      if (
-        matchedRefKey !== refKey &&
-        indexedMatch.record.id === latest.id &&
-        currentMatch?.record.id === latest.id
-      ) {
-        index.latestByRefKey.delete(matchedRefKey);
-      }
-    }
-    index.maxRevisionById.set(latest.id, retainedMemberRevision ? revision + 1 : revision);
-    appendEntries.push({ relativePath: entry.relativePath, record: superseding });
-    if (retainedMemberRevision) {
-      appendEntries.push({ relativePath: retainedMemberPath, record: retainedMemberRevision });
-    }
+    stageProviderRevision({
+      refKey,
+      externalRef,
+      providerEntry: { relativePath: entry.relativePath, record: superseding },
+      memberEntry: retainedMemberRevision
+        ? { relativePath: retainedMemberPath, record: retainedMemberRevision }
+        : undefined,
+      matchedEntries,
+    });
     appendRecordIdByPreparedRecordId.set(entry.record.id, superseding.id);
     recordsByEntryIndex.set(entryIndex, retainedMemberRevision ?? superseding);
     supersededCount += 1;
@@ -5281,23 +5272,15 @@ async function reconcileDeviceEventEntriesByExternalRef(
         : null;
       const latestPath = latestMatch.relativePath || toEventLedgerFile(latest.occurredAt);
 
-      forceAppendIds.add(latest.id);
-      index.latestByRefKey.set(
+      stageProviderRevision({
         refKey,
-        retainedMemberRevision
-          ? {
-              indexedExternalRef: incomingRef,
-              indexedRecord: tombstone,
-              relativePath: latestPath,
-              record: retainedMemberRevision,
-            }
-          : toIndexedExternalRefMatch(tombstone, incomingRef, latestPath),
-      );
-      index.maxRevisionById.set(latest.id, retainedMemberRevision ? revision + 1 : revision);
-      appendEntries.push({ relativePath: latestPath, record: tombstone });
-      if (retainedMemberRevision) {
-        appendEntries.push({ relativePath: latestPath, record: retainedMemberRevision });
-      }
+        externalRef: incomingRef,
+        providerEntry: { relativePath: latestPath, record: tombstone },
+        memberEntry: retainedMemberRevision
+          ? { relativePath: latestPath, record: retainedMemberRevision }
+          : undefined,
+        indexedRelativePath: latestPath,
+      });
       retractedCount += 1;
     }
   }

--- a/packages/core/test/device-import.test.ts
+++ b/packages/core/test/device-import.test.ts
@@ -8442,6 +8442,21 @@ test("importDeviceBatch retains member edits while advancing provider siblings a
   assert.ok(update.applied);
   const shardPath = first.eventShardPaths[0] as string;
   const keptRows = (await readJsonlRecords({ vaultRoot, relativePath: shardPath })) as EventRecord[];
+  assert.deepEqual(
+    keptRows.filter((event) => event.id === edited.id).map((event) => ({
+      source: event.source,
+      revision: event.lifecycle?.revision ?? 1,
+      value: eventObservationValue(event),
+    })),
+    [
+      { source: "device", revision: 1, value: 1 },
+      { source: "manual", revision: 2, value: 7 },
+      { source: "device", revision: 3, value: 2 },
+      { source: "manual", revision: 4, value: 7 },
+    ],
+  );
+  const audits = await readJsonlRecords({ vaultRoot, relativePath: update.auditPath }) as AuditRecord[];
+  assert.match(audits.at(-1)?.summary ?? "", /2 event\(s\) updated in place by externalRef/);
   const keptLive = collapseEventSpines(keptRows);
   const keptEdited = keptLive.find((event) => event.id === edited.id);
   const keptSibling = keptLive.find((event) =>
@@ -8734,6 +8749,21 @@ test("importDeviceBatch retains omitted member edits above provider tombstones",
       readJsonlRecords({ vaultRoot, relativePath })
     ))
   ).flat() as EventRecord[];
+  assert.deepEqual(
+    rows.filter((event) => event.id === edited.id).map((event) => ({
+      source: event.source,
+      revision: event.lifecycle?.revision ?? 1,
+      deleted: isDeletedEventLifecycle(event.lifecycle),
+    })),
+    [
+      { source: "device", revision: 1, deleted: false },
+      { source: "manual", revision: 2, deleted: false },
+      { source: "device", revision: 3, deleted: true },
+      { source: "manual", revision: 4, deleted: false },
+    ],
+  );
+  const audits = await readJsonlRecords({ vaultRoot, relativePath: update.auditPath }) as AuditRecord[];
+  assert.match(audits.at(-1)?.summary ?? "", /1 omitted authoritative event\(s\) retracted/);
   const keptEdited = collapseEventSpines(rows).find((event) => event.id === edited.id);
   assert.equal(keptEdited?.note, "member context");
   assert.equal(keptEdited?.source, "manual");
@@ -9639,6 +9669,20 @@ test("importDeviceBatch replays a transitive in-batch legacy-ref migration and r
       ],
     }],
   );
+
+  const revisions = await readJsonlRecords({
+    vaultRoot,
+    relativePath: first.eventShardPaths[0] as string,
+  }) as EventRecord[];
+  assert.deepEqual(revisions.map((event) => ({
+    revision: event.lifecycle?.revision ?? 1,
+    resourceId: event.externalRef?.resourceId,
+    value: eventObservationValue(event),
+  })), [
+    { revision: 1, resourceId: externalRefA.resourceId, value: 90 },
+    { revision: 2, resourceId: externalRefB.resourceId, value: 92 },
+    { revision: 3, resourceId: externalRefC.resourceId, value: 94 },
+  ]);
 
   const watchedPaths = [
     first.eventShardPaths[0] as string,


### PR DESCRIPTION
## Why and outcome

Device-event reconciliation repeated the same provider baseline, member overlay, alias-index, revision, and append bookkeeping in three branches. One local staging helper now keeps those updates together; a second helper records retained results while every provider decision and duplicate-count increment stays explicit.

The canonical mutation facade, lock, receipt formats, rejection rules, alias repairs, and provider-before-member ledger order remain unchanged.

## Product UX

- Effort: Not applicable — internal behavior-preserving reconciliation cleanup.
- Result: Ready.
- Walkthrough: Existing import, replay, member correction, deletion, and identity-migration outcomes are preserved by public mutation tests; no presentation or interaction changes.

## Evidence

- Direct: Four focused core suites (`device-import`, `device-import-session`, `import-device-batch-validation`, `canonical-mutations-boundary`) passed, 210 tests. Command: `pnpm exec vitest run --config packages/core/vitest.config.ts --no-coverage packages/core/test/device-import.test.ts packages/core/test/device-import-session.test.ts packages/core/test/import-device-batch-validation.test.ts packages/core/test/canonical-mutations-boundary.test.ts`.
- Coverage: Added physical ledger-order and audit-count assertions for member overlays and authoritative retractions, plus successive revisions during an in-batch A-to-B-to-C alias migration. These three cases pass against both the original base and candidate. Existing tests cover stale deliveries, alias repair, incomplete spines, cross-shard corrections, immutable refs, and retry no-ops.
- Typecheck: `pnpm --filter @murphai/core typecheck` passed. No package import or emitted-boundary changes.
- Final review: parent candidate review and the full-patch ReviewGPT round-1 audit passed at `9efc6d30b16a599edacd3d0e0a99a0447a37d3eb`, with no qualifying findings. Required exact-head CI passed, including release coverage, host matrices, billing, and Temporal compatibility.

## Non-obvious affected surfaces

Provider baseline updates underneath manual edits and authoritative retraction tombstones share the staging helper. The physical ledger assertions prove the retained manual revision still follows its provider baseline, and the in-batch migration test proves later entries see the updated identity index.

## Architecture and reuse

- Existing systems reused: Canonical write lock, event identity index, append plan, lifecycle revision helper, and receipt/audit owners.
- New logic: None; existing decisions and counters remain at their original branches.
- New abstractions: Two function-local bookkeeping helpers using the existing accumulators; no shared API, module, or state owner.
- Complexity intentionally avoided: No facade split, framework, transaction wrapper, new persistence, or provider compatibility layer.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base 603ea873bf4d0652805d0577081c43d64d6e0f61 -- packages/core/src/mutations.ts`; file debt 396 to 377, maximum 154 to 135.
- Hotspots: Changed `reconcileDeviceEventEntriesByExternalRef` is 135 (was 154); both local helpers are below 20. Unchanged hotspots remain `inspectExactDocumentSourceSet` 62, `preparePersistence` 58, `reconcileEventImportDecisionsByExternalRef` 53, `importDeviceBatchWithExecutionOptions` 46, `parseJunctionDailyAggregateAliasEvidence` 44, `resolveJunctionFloatingFallbackTime` 41, `visit` 34, `mapCurrentDeviceEventOwners` 34, `resolveStructuralJunctionDailyAggregateAliasOwnerSplit` 32, `isExactJunctionProfileCreatedAtTimestampReplay` 31, `analyzeJunctionDailyAggregateAliasHistoryEvolution` 31, anonymous callback 27, `buildLegacyExternalRefReservations` 24, `dedupeDeviceEventsByExternalRef` 23, and `importEventBatch` 22.
- Agent judgment: Repeated state updates now have one implementation. Further provider-policy extraction is deferred because it would enlarge this bounded cleanup and obscure the existing coupled canonical decisions.

## Hot reply path impact

- Path status: Not applicable — this cleanup is synchronous bookkeeping within device import reconciliation and adds or moves no foreground awaited work.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved.
- Before/after proof: Public mutation tests preserve event order and outputs; the diff changes no asynchronous operation or lock boundary.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no instructions, tools, schemas, generated guidance, history, or provider request assembly changed.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

ReviewGPT first-reviewed head: 9efc6d30b16a599edacd3d0e0a99a0447a37d3eb
ReviewGPT context sensitivity: sensitive
Classification reason: Canonical event reconciliation refactor involving persisted revision and identity bookkeeping.

## Deployment concerns

- Deployment: not applicable
- Reason: Behavior-preserving function-local cleanup changes no deployed protocol, persisted shape, package interface, or independently deployed component contract.

## Change-shape breakdown

Classification rule: Production TypeScript is source, existing test assertions are tests, and the completed execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 82 | 99 |
| Tests / fixtures | 44 | 0 |
| Docs | 54 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **180** | **99** |

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving cleanup with no member-visible change.
