### PR TITLE
fix(runtime): recover stalled workspace snapshot downloads

### DIFF
--- a/.agents/friction-log/20260904202517-onboarding-predecessor-retry/friction.md
+++ b/.agents/friction-log/20260904202517-onboarding-predecessor-retry/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Onboarding predecessor retry assertion fails for a zero-jitter schedule'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The onboarding predecessor regression test should accept the preserved pending retry when a migrated daily schedule matches the legacy occurrence time.
+
+## Current Behavior
+
+The original legacy predecessor case can generate a daily schedule with zero jitter. Its assertion recognizes the preserved pending occurrence but then unconditionally expects the next daily run, failing assistant-engine coverage and the required release gate.
+
+## Possible Solution
+
+Reuse the test's existing transfersLegacyPendingOccurrence condition when choosing the expected next run. No scheduling implementation change is needed.
+
+## Minimal Reproducible Example
+
+Run the predecessor terminally stale cases in packages/assistant-engine/test/assistant-outbox-runtime.test.ts with a synthetic vault whose generated onboarding slot is 13:30. The pending retry is due at 13:31:30 on the same day, while the old assertion expects the following day's daily occurrence.
+
+## Context
+
+An unrelated runtime restore patch exposed this existing generated-fixture assertion failure during its final release checks. The correction is confined to test evidence.

--- a/agent-docs/exec-plans/active/2026-09-04-workspace-restore-stall.md
+++ b/agent-docs/exec-plans/active/2026-09-04-workspace-restore-stall.md
@@ -1,0 +1,52 @@
+# Bound stalled workspace snapshot downloads
+
+Status: active
+Created: 2026-09-04
+Updated: 2026-09-04
+
+## Goal
+
+Recover promptly from inactive snapshot response bodies while preserving
+authenticated restore and downloads that continue making progress.
+
+## Product UX
+
+- Outcome: returning conversations can recover from a stalled context download.
+- Reaches: cold hosted workspace restores; warm conversations are unaffected.
+- Proof: synthetic encrypted restore retries once after inactivity, preserves the
+  prior workspace on exhaustion/cancellation, and accepts a progressing stream.
+
+## Scope and decisions
+
+- Add an optional per-read idle budget to the existing body reader, enabled only
+  for snapshot downloads at 15 seconds. URL expiry remains the total deadline.
+- Keep inactivity distinct from ordinary non-retryable control deadlines; the
+  existing restore loop owns the same maximum of two attempts.
+- Preserve checksum/authentication, byte limits, cancellation, temporary cleanup,
+  and durable-root replacement ordering.
+- Emit bounded attempt timings through existing Cloudflare structured logs only;
+  no database, persisted wire field, provider input, or scheduler changes.
+- Read-wait includes event-loop scheduling; neither metric alone proves a network
+  root cause. Private production evidence stays out of repository artifacts.
+
+## Risks and proof
+
+- Progressing downloads must outlive the idle interval: test repeated progress
+  and slower consumer processing with a synthetic clock.
+- Do not broaden retry authority: prove caller abort, total timeout, scoped idle
+  classification, encrypted restore retry, and attempt exhaustion.
+- Preserve prior durable files when attempts fail; only authenticated extraction
+  may replace them.
+
+## Verification
+
+- Full response-reader and runner-platform suites: 211 tests passed.
+- Cloudflare typecheck, complexity guard, and added-content privacy review passed.
+- Diff-aware coverage and changelog validation are running.
+- Changelog copy is written; scoped PR and required final review remain pending.
+
+## Deployment
+
+One Cloudflare runner release; no ordered Web or Temporal contract migration.
+Old containers retain previous behavior until replaced. Use the existing deploy
+process; local proof does not establish production recovery.

--- a/agent-docs/exec-plans/completed/2026-09-04-workspace-restore-stall.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-workspace-restore-stall.md
@@ -69,3 +69,14 @@ One Cloudflare runner release; no ordered Web or Temporal contract migration.
 Old containers retain previous behavior until replaced. Use the existing deploy
 process; local proof does not establish production recovery.
 Completed: 2026-09-04
+
+## Final CI follow-up
+
+The final-head assistant-engine coverage job exposed an unrelated existing test
+expectation in the onboarding predecessor cases. A generated schedule at the
+legacy occurrence time preserves the pending retry, but the test expected the
+next daily occurrence. Reuse its existing `transfersLegacyPendingOccurrence`
+condition for that expectation. This correction changes only test evidence;
+no scheduler or reviewed restore implementation changes. All three focused
+predecessor cases and assistant-engine typecheck passed after the correction.
+The required release-gate rerun remains necessary before merge.

--- a/agent-docs/exec-plans/completed/2026-09-04-workspace-restore-stall.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-workspace-restore-stall.md
@@ -1,6 +1,6 @@
 # Bound stalled workspace snapshot downloads
 
-Status: active
+Status: completed
 Created: 2026-09-04
 Updated: 2026-09-04
 
@@ -41,12 +41,31 @@ authenticated restore and downloads that continue making progress.
 ## Verification
 
 - Full response-reader and runner-platform suites: 211 tests passed.
-- Cloudflare typecheck, complexity guard, and added-content privacy review passed.
-- Diff-aware coverage and changelog validation are running.
-- Changelog copy is written; scoped PR and required final review remain pending.
+- Diff-aware verification selected the Cloudflare owner: all guards passed,
+  with 2,927 tests passed and 2 existing skips across Node, container-helper,
+  and Worker suites.
+- Cloudflare typecheck and complexity guard passed. The existing upload hotspot
+  remains unchanged at 28; the response reader is 19 with no complexity debt.
+- Changelog archive: 9 tests passed. Web typecheck passed after building the
+  missing local device-syncd artifact; no unrelated source correction was needed.
+- Parent diff, added-content privacy, and merge-tree checks passed.
+- PR #2842, ReviewGPT round 1: PASS, zero findings, on
+  `9ae5239f1c6996ffc09ebf611f061ebf088d309e` using the Hercules lane and
+  verified `gpt-6-pro`. Response hash and committed-turn identity match.
+- Review took about 7 minutes 16 seconds from send to capture. Accepted under
+  the documented near-threshold rule: exact model, full snapshot, head and
+  eight-file patch identity, completion marker, source-level reasoning and
+  fourteen isolated checks provide substantive scope-appropriate evidence.
+  External checks are supplemental; the local suites ran the actual packages.
+- Changelog uses the documented content-only presentation exception; no renderer
+  changes require new screenshots.
+- Implementation and parent review are complete. This plan-only closing change
+  preserves the reviewed implementation. Required final-head CI remains the PR
+  merge gate; production rollout and recovery verification are separate.
 
 ## Deployment
 
 One Cloudflare runner release; no ordered Web or Temporal contract migration.
 Old containers retain previous behavior until replaced. Use the existing deploy
 process; local proof does not establish production recovery.
+Completed: 2026-09-04

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -3443,6 +3443,18 @@ snapshot planning, diagnostics, and mailbox-import policy; Cloudflare supplies
 only explicit platform capabilities such as mailbox payload decode, direct-R2
 ports, and the local encrypted archive writer.
 
+Direct-R2 snapshot body reads have a 15-second inactivity budget for each pending
+stream read. Consumer hash/decrypt work between reads does not spend that budget;
+the original signed-URL expiry still bounds the complete download. A body-idle
+timeout cancels that stream and uses the existing two-attempt restore read loop.
+Caller cancellation and the overall deadline remain terminal, and neither attempt
+replaces the durable root until byte counts, hashes, and authenticated decryption
+succeed. Other control-plane response readers retain their existing timeout policy.
+Each body attempt emits scalar-only read-wait, maximum read-wait, consumer-elapsed,
+byte-count, and completion diagnostics through the existing structured logger.
+Read-wait includes event-loop scheduling delay and must not be called pure network
+latency. The existing persisted restore timing fields keep their current meaning.
+
 True idle-shutdown maintenance also compacts closed
 `ledger/integration-ingests/YYYY/YYYY-MM.jsonl` shards in place before snapshot
 planning. The core owner streams each raw shard into deterministic level-6

--- a/apps/cloudflare/src/runtime-platform/diagnostics.ts
+++ b/apps/cloudflare/src/runtime-platform/diagnostics.ts
@@ -14,6 +14,7 @@ import {
   shouldRetryHostedRuntimeReplaySafeRead,
   sleepHostedReplaySafeReadRetryDelay,
 } from "./control-plane-fetch.ts";
+import { HostedRuntimeResponseBodyIdleTimeoutError } from "./hosted-response-body.ts";
 
 const HOSTED_WORKSPACE_SNAPSHOT_RESTORE_STEP_MARKER =
   "hostedWorkspaceSnapshotRestoreStep";
@@ -47,6 +48,7 @@ export function buildHostedWorkspaceSnapshotRestoreLogDetails(input: {
 
 export async function runHostedWorkspaceSnapshotRestoreReplaySafeReadStep<T>(input: {
   details: HostedExecutionStructuredLogDetails;
+  signal?: AbortSignal | null;
   onAttempt?(attempt: number): void;
   run(): Promise<T>;
   step: HostedWorkspaceSnapshotRestoreStep;
@@ -72,10 +74,11 @@ export async function runHostedWorkspaceSnapshotRestoreReplaySafeReadStep<T>(inp
       });
     } catch (error) {
       lastError = error;
-      const retrying = shouldRetryHostedRuntimeReplaySafeRead({
-        attempt,
-        error,
-      });
+      const retrying = !input.signal?.aborted && (
+        (error instanceof HostedRuntimeResponseBodyIdleTimeoutError
+          && attempt < HOSTED_REPLAY_SAFE_READ_RETRY_ATTEMPTS)
+        || shouldRetryHostedRuntimeReplaySafeRead({ attempt, error })
+      );
       if (!retrying) {
         throw error;
       }

--- a/apps/cloudflare/src/runtime-platform/hosted-response-body.ts
+++ b/apps/cloudflare/src/runtime-platform/hosted-response-body.ts
@@ -5,16 +5,26 @@ import {
   shouldPreserveHostedRuntimeFetchError,
 } from "./control-plane-fetch.ts";
 
+// Only the snapshot restore owner retries inactivity; ordinary control reads
+// retain their existing non-retryable timeout contract.
+export class HostedRuntimeResponseBodyIdleTimeoutError extends HostedRuntimeControlPlaneFetchError {}
+
 export async function* readHostedRuntimeResponseBodyChunks(input: {
   body: ReadableStream<Uint8Array>;
   description: string;
   signal?: AbortSignal | null;
   timeoutMs: number;
+  readTimeoutMs?: number;
+  timing?: { readWaitMs: number; maxReadWaitMs: number };
 }): AsyncIterable<Uint8Array> {
   const timeoutSignal = input.timeoutMs === 0
     ? AbortSignal.abort(new DOMException("The operation timed out.", "TimeoutError"))
     : AbortSignal.timeout(input.timeoutMs);
-  const readSignal = combineAbortSignalsWithCleanup(input.signal ?? null, timeoutSignal);
+  const idleTimeout = new AbortController();
+  const readSignal = combineAbortSignalsWithCleanup(
+    input.signal ?? null,
+    AbortSignal.any([timeoutSignal, idleTimeout.signal]),
+  );
   const reader = input.body.getReader();
   let streamDone = false;
 
@@ -23,6 +33,9 @@ export async function* readHostedRuntimeResponseBodyChunks(input: {
       const next = await readHostedRuntimeResponseBodyChunk({
         reader,
         signal: readSignal.signal,
+        idleTimeout,
+        readTimeoutMs: input.readTimeoutMs,
+        timing: input.timing,
       });
       if (next.done) {
         streamDone = true;
@@ -35,18 +48,25 @@ export async function* readHostedRuntimeResponseBodyChunks(input: {
       throw error;
     }
 
-    const wrappedError = new HostedRuntimeControlPlaneFetchError({
+    const FetchError = idleTimeout.signal.aborted
+        && !input.signal?.aborted && !timeoutSignal.aborted
+      ? HostedRuntimeResponseBodyIdleTimeoutError
+      : HostedRuntimeControlPlaneFetchError;
+    const wrappedError = new FetchError({
       cause: error,
       description: `${input.description} response body read`,
       signalState: {
         callerSignalAborted: input.signal?.aborted ?? false,
         requestSignalAborted: readSignal.signal.aborted,
-        timeoutMs: input.timeoutMs,
-        timeoutSignalAborted: timeoutSignal.aborted,
+        timeoutMs: idleTimeout.signal.aborted ? (input.readTimeoutMs ?? input.timeoutMs) : input.timeoutMs,
+        timeoutSignalAborted: timeoutSignal.aborted || idleTimeout.signal.aborted,
       },
     });
 
-    if (isRetryableHostedRuntimeReplaySafeReadTransportError(wrappedError)) {
+    if (
+      wrappedError instanceof HostedRuntimeResponseBodyIdleTimeoutError
+      || isRetryableHostedRuntimeReplaySafeReadTransportError(wrappedError)
+    ) {
       throw wrappedError;
     }
 
@@ -60,33 +80,50 @@ export async function* readHostedRuntimeResponseBodyChunks(input: {
   }
 }
 
-function readHostedRuntimeResponseBodyChunk(input: {
+async function readHostedRuntimeResponseBodyChunk(input: {
   reader: ReadableStreamDefaultReader<Uint8Array>;
   signal: AbortSignal;
+  idleTimeout: AbortController;
+  readTimeoutMs?: number;
+  timing?: { readWaitMs: number; maxReadWaitMs: number };
 }): Promise<ReadableStreamReadResult<Uint8Array>> {
   if (input.signal.aborted) {
     return Promise.reject(readHostedRuntimeResponseBodyAbortReason(input.signal));
   }
 
-  return new Promise<ReadableStreamReadResult<Uint8Array>>((resolve, reject) => {
-    let settled = false;
-    const settle = (run: () => void) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      input.signal.removeEventListener("abort", abort);
-      run();
-    };
-    const abort = () => {
-      settle(() => reject(readHostedRuntimeResponseBodyAbortReason(input.signal)));
-    };
-    input.signal.addEventListener("abort", abort, { once: true });
-    input.reader.read().then(
-      (result) => settle(() => resolve(result)),
-      (error: unknown) => settle(() => reject(error)),
-    );
-  });
+  // Cover only the pending read; consumer processing between yields is excluded.
+  const startedAt = Date.now();
+  const timer = input.readTimeoutMs === undefined ? undefined : setTimeout(() => {
+    input.idleTimeout.abort(new DOMException("Response body read timed out.", "TimeoutError"));
+  }, input.readTimeoutMs);
+  try {
+    return await new Promise<ReadableStreamReadResult<Uint8Array>>((resolve, reject) => {
+      let settled = false;
+      const settle = (run: () => void) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        input.signal.removeEventListener("abort", abort);
+        run();
+      };
+      const abort = () => {
+        settle(() => reject(readHostedRuntimeResponseBodyAbortReason(input.signal)));
+      };
+      input.signal.addEventListener("abort", abort, { once: true });
+      input.reader.read().then(
+        (result) => settle(() => resolve(result)),
+        (error: unknown) => settle(() => reject(error)),
+      );
+    });
+  } finally {
+    clearTimeout(timer);
+    if (input.timing) {
+      const elapsedMs = Math.max(0, Date.now() - startedAt);
+      input.timing.readWaitMs += elapsedMs;
+      input.timing.maxReadWaitMs = Math.max(input.timing.maxReadWaitMs, elapsedMs);
+    }
+  }
 }
 
 function readHostedRuntimeResponseBodyAbortReason(signal: AbortSignal): unknown {

--- a/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
+++ b/apps/cloudflare/src/runtime-platform/workspace-snapshot-port.ts
@@ -9,7 +9,7 @@ import type {
   HostedRuntimeWorkspaceSnapshotSessionCompleteResult,
   HostedRuntimeWorkspaceSnapshotSessionStart,
 } from "@murphai/assistant-runtime/hosted-runtime-contracts";
-import { readHostedRuntimeSafeErrorText } from "@murphai/hosted-execution";
+import { emitHostedExecutionStructuredLog, readHostedRuntimeSafeErrorText } from "@murphai/hosted-execution";
 import { parseHostedWorkspaceCheckpointResponse, parseHostedWorkspaceSnapshotV2Ref } from "@murphai/hosted-execution/parsers";
 import type { HostedWorkspaceCheckpointResponse } from "@murphai/hosted-execution/runtime-control";
 import {
@@ -61,6 +61,7 @@ import {
   readRequiredHostedRuntimeString,
 } from "./hosted-http.ts";
 
+const WORKSPACE_SNAPSHOT_READ_IDLE_TIMEOUT_MS = 15_000;
 const WORKSPACE_SNAPSHOT_HANDOFF_HEARTBEAT_INTERVAL_MS = 2_000;
 const WORKSPACE_SNAPSHOT_PRESIGN_PUT_MAX_ATTEMPTS = 2;
 const WORKSPACE_SNAPSHOT_HANDOFF_HEARTBEAT_TIMEOUT_MS = 2_000;
@@ -649,6 +650,7 @@ export function createCloudflareWorkspaceSnapshotPort(input: {
       const objectFetchStartedAt = Date.now();
       const archiveTimings = await runHostedWorkspaceSnapshotRestoreReplaySafeReadStep({
         details: restoreLogDetails,
+        signal: request.signal,
         onAttempt: noteReplaySafeReadAttempt,
         run: async () => {
           const objectFetchAttemptTiming = {
@@ -1436,22 +1438,46 @@ async function* readHostedWorkspaceSnapshotEncryptedObjectStream(input: {
   }
   const bodyReadStartedAt = Date.now();
   let byteCount = 0;
-  for await (const next of readHostedRuntimeResponseBodyChunks({
-    body: response.body,
-    description: "Hosted workspace snapshot fetch",
-    signal: input.signal ?? null,
-    timeoutMs: Math.max(1, input.deadlineMs - Date.now()),
-  })) {
-    byteCount += next.byteLength;
-    if (byteCount > input.expectedEncryptedByteSize) {
-      throw new Error("Hosted workspace snapshot fetch exceeded its ref byte count.");
+  const readTiming = { readWaitMs: 0, maxReadWaitMs: 0 };
+  let complete = false;
+  try {
+    for await (const next of readHostedRuntimeResponseBodyChunks({
+      body: response.body,
+      description: "Hosted workspace snapshot fetch",
+      signal: input.signal ?? null,
+      timeoutMs: Math.max(1, input.deadlineMs - Date.now()),
+      readTimeoutMs: WORKSPACE_SNAPSHOT_READ_IDLE_TIMEOUT_MS,
+      timing: readTiming,
+    })) {
+      byteCount += next.byteLength;
+      if (byteCount > input.expectedEncryptedByteSize) {
+        throw new Error("Hosted workspace snapshot fetch exceeded its ref byte count.");
+      }
+      yield next;
     }
-    yield next;
+    if (byteCount !== input.expectedEncryptedByteSize) {
+      throw new Error("Hosted workspace snapshot fetch byte count does not match its ref.");
+    }
+    complete = true;
+    input.timing.objectFetchBodyReadMs = readHostedRuntimeStepElapsedMs(bodyReadStartedAt);
+  } finally {
+    const durationMs = readHostedRuntimeStepElapsedMs(bodyReadStartedAt);
+    emitHostedExecutionStructuredLog({
+      component: "hosted.runtime.workspace-snapshot",
+      details: {
+        bytesRead: byteCount,
+        complete,
+        durationMs,
+        readWaitMs: readTiming.readWaitMs,
+        maxReadWaitMs: readTiming.maxReadWaitMs,
+        consumerElapsedMs: Math.max(0, durationMs - readTiming.readWaitMs),
+        readIdleTimeoutMs: WORKSPACE_SNAPSHOT_READ_IDLE_TIMEOUT_MS,
+      },
+      message: "Hosted workspace snapshot body read settled.",
+      phase: "runtime.starting",
+      userId: null,
+    });
   }
-  if (byteCount !== input.expectedEncryptedByteSize) {
-    throw new Error("Hosted workspace snapshot fetch byte count does not match its ref.");
-  }
-  input.timing.objectFetchBodyReadMs = readHostedRuntimeStepElapsedMs(bodyReadStartedAt);
 }
 
 async function cancelHostedWorkspaceSnapshotResponseBody(

--- a/apps/cloudflare/test/hosted-response-body.test.ts
+++ b/apps/cloudflare/test/hosted-response-body.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  isRetryableHostedRuntimeReplaySafeReadTransportError,
+  readHostedRuntimeControlPlaneFetchFailureDiagnostics,
+} from "../src/runtime-platform/control-plane-fetch.ts";
+import {
+  HostedRuntimeResponseBodyIdleTimeoutError,
+  readHostedRuntimeResponseBodyChunks,
+} from "../src/runtime-platform/hosted-response-body.ts";
+
+afterEach(() => vi.useRealTimers());
+
+describe("response body inactivity", () => {
+  it("cancels a stalled read and exposes a snapshot inactivity timeout with the idle budget", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({ cancel });
+    const timing = { readWaitMs: 0, maxReadWaitMs: 0 };
+    const chunks = readHostedRuntimeResponseBodyChunks({
+      body, description: "synthetic download", timeoutMs: 3_600_000,
+      readTimeoutMs: 15_000, timing,
+    })[Symbol.asyncIterator]();
+    const failure = chunks.next().catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(15_000);
+    const error = await failure;
+    expect(error).toBeInstanceOf(HostedRuntimeResponseBodyIdleTimeoutError);
+    // Snapshot retry admission is narrower than ordinary control-plane reads.
+    expect(isRetryableHostedRuntimeReplaySafeReadTransportError(error)).toBe(false);
+    expect(readHostedRuntimeControlPlaneFetchFailureDiagnostics(error)).toMatchObject({
+      fetchCauseKind: "timeout",
+      fetchTimeoutMs: 15_000,
+      fetchTimeoutSignalAborted: true,
+    });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(timing).toEqual({ readWaitMs: 15_000, maxReadWaitMs: 15_000 });
+    expect(body.locked).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("renews the budget for each read and excludes consumer time from read timing", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    let sent = 0;
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        setTimeout(() => {
+          controller.enqueue(new Uint8Array([++sent]));
+          if (sent === 3) controller.close();
+        }, 10_000);
+      },
+      cancel,
+    }, { highWaterMark: 0 });
+    const timing = { readWaitMs: 0, maxReadWaitMs: 0 };
+    const chunks = readHostedRuntimeResponseBodyChunks({
+      body, description: "synthetic download", timeoutMs: 3_600_000,
+      readTimeoutMs: 15_000, timing,
+    })[Symbol.asyncIterator]();
+    for (let expected = 1; expected <= 3; expected += 1) {
+      const next = chunks.next();
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(await next).toMatchObject({ done: false, value: new Uint8Array([expected]) });
+      // A slow consumer is not a stalled network read.
+      await vi.advanceTimersByTimeAsync(20_000);
+    }
+    expect(await chunks.next()).toMatchObject({ done: true });
+    expect(timing).toEqual({ readWaitMs: 30_000, maxReadWaitMs: 10_000 });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("honors caller cancellation before inactivity and does not retry it", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const controller = new AbortController();
+    const cancel = vi.fn();
+    const chunks = readHostedRuntimeResponseBodyChunks({
+      body: new ReadableStream<Uint8Array>({ cancel }),
+      description: "synthetic download", timeoutMs: 3_600_000,
+      readTimeoutMs: 15_000, signal: controller.signal,
+    })[Symbol.asyncIterator]();
+    const failure = chunks.next().catch((error: unknown) => error);
+    controller.abort(new Error("synthetic caller cancellation"));
+    const error = await failure;
+    expect(isRetryableHostedRuntimeReplaySafeReadTransportError(error)).toBe(false);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("keeps the total deadline authoritative when it expires before inactivity", async () => {
+    const cancel = vi.fn();
+    const chunks = readHostedRuntimeResponseBodyChunks({
+      body: new ReadableStream<Uint8Array>({ cancel }),
+      description: "synthetic download", timeoutMs: 10, readTimeoutMs: 15_000,
+    })[Symbol.asyncIterator]();
+    await expect(chunks.next()).rejects.toBeDefined();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -4016,7 +4016,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     }
   });
 
-  it("retries v2 workspace snapshot object fetch transport failures once", async () => {
+  it.each(["network", "idle"] as const)("retries v2 workspace snapshot %s failures once", async (failureKind) => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-r2-retry-"));
     const sourceRoot = path.join(tempRoot, "source");
     const durableRoot = path.join(tempRoot, "durable");
@@ -4051,10 +4051,13 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         outputDir: scratchRoot,
       });
       const encryptedBytes = await readFile(encrypted.encryptedFilePath);
-      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.useFakeTimers({ toFake: failureKind === "idle" ? ["Date", "setTimeout", "clearTimeout"] : ["Date"] });
       vi.setSystemTime(new Date("2026-05-20T00:00:00.000Z"));
       const getUrl = `https://r2.example.test/bundles/${objectKey}?X-Amz-Signature=fixture-get`;
       let objectFetchCount = 0;
+      const bodyCanceled = vi.fn();
+      let idleReadStarted!: () => void;
+      const idleRead = new Promise<void>((resolve) => { idleReadStarted = resolve; });
       const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
         const request = requireFetchRequest(args, "workspace snapshot restore retry fetch");
         if (request.url.includes(`/workspace-snapshots/${snapshotId}/data-key/unwrap`)) {
@@ -4082,11 +4085,16 @@ describe("buildHostedExecutionRuntimePlatform", () => {
             vi.setSystemTime(new Date(Date.now() + 80));
             let prefixSent = false;
             return new Response(new ReadableStream<Uint8Array>({
+              cancel: bodyCanceled,
               pull(controller) {
                 if (!prefixSent) {
                   prefixSent = true;
                   vi.setSystemTime(new Date(Date.now() + 70));
                   controller.enqueue(encryptedBytes.subarray(0, 32));
+                  return;
+                }
+                if (failureKind === "idle") {
+                  idleReadStarted();
                   return;
                 }
                 controller.error(new TypeError("connection reset"));
@@ -4126,7 +4134,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         fetchImpl: fetchMock as typeof fetch,
       });
 
-      const restoreTimings = await platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
+      const restorePromise = platform.workspaceSnapshotPort!.restoreWorkspaceSnapshot({
         durableRoot,
         ref: {
           archive: {
@@ -4154,9 +4162,34 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         },
       });
 
+      if (failureKind === "idle") {
+        await idleRead;
+        await vi.advanceTimersByTimeAsync(15_000);
+        await vi.waitFor(() => expect(readWorkspaceSnapshotDiagnosticLogs().some((log) =>
+          log.message === "Hosted workspace snapshot restore read step failed; retrying."
+        )).toBe(true));
+        await vi.advanceTimersByTimeAsync(100);
+      }
+      const restoreTimings = await restorePromise;
       expect(objectFetchCount).toBe(2);
+      if (failureKind === "idle") expect(bodyCanceled).toHaveBeenCalledOnce();
       expect(restoreTimings?.objectFetchResponseHeadersMs).toBe(7);
       expect(restoreTimings?.objectFetchBodyReadMs).toBe(11);
+      const bodyLogs = readWorkspaceSnapshotDiagnosticLogs().filter((log) =>
+        log.message === "Hosted workspace snapshot body read settled."
+      );
+      expect(bodyLogs).toHaveLength(2);
+      expect(bodyLogs[1]?.details).toMatchObject({
+        complete: true,
+        bytesRead: encrypted.encryptedByteSize,
+        readIdleTimeoutMs: 15_000,
+      });
+      if (failureKind === "idle") {
+        expect(bodyLogs[0]?.details).toMatchObject({
+          complete: false,
+          maxReadWaitMs: 15_000,
+        });
+      }
       await expect(access(path.join(durableRoot, "note.md"))).resolves.toBeUndefined();
       await expect(
         readdir(tempRoot).then((entries) =>
@@ -4169,7 +4202,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         );
       expect(retryLogs).toHaveLength(1);
       expect(retryLogs[0]?.details).toEqual(expect.objectContaining({
-        fetchCauseKind: "network",
+        fetchCauseKind: failureKind === "idle" ? "timeout" : "network",
         retrying: true,
         workspaceSnapshotRestoreAttempt: 1,
         workspaceSnapshotRestoreStep: "object_fetch",
@@ -4198,7 +4231,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
       expect(serializedLogs).not.toContain(objectKey);
       expect(serializedLogs).not.toContain(snapshotId);
       expect(serializedLogs).not.toContain(getUrl);
-      expect(serializedLogs).toContain("connection reset");
+      if (failureKind === "network") expect(serializedLogs).toContain("connection reset");
       expect(serializedLogs).not.toContain(dataKeyBase64);
       expect(serializedLogs).not.toContain(tempRoot);
     } finally {
@@ -4211,7 +4244,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     }
   });
 
-  it("aborts and cancels stalled v2 workspace snapshot object body reads", async () => {
+  it.each(["caller", "idle"] as const)("preserves the workspace after %s cancellation of stalled snapshot reads", async (interruption) => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "murph-runner-platform-r2-body-abort-"));
     const durableRoot = path.join(tempRoot, "durable");
     const dataKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
@@ -4229,6 +4262,11 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     });
 
     try {
+      await mkdir(durableRoot, { recursive: true });
+      await writeFile(path.join(durableRoot, "existing.md"), "keep the prior workspace");
+      if (interruption === "idle") {
+        vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+      }
       const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
         const request = requireFetchRequest(args, "workspace snapshot stalled body fetch");
         if (request.url.includes(`/workspace-snapshots/${ref.snapshotId}/data-key/unwrap`)) {
@@ -4279,18 +4317,32 @@ describe("buildHostedExecutionRuntimePlatform", () => {
         durableRoot,
         ref,
         signal: abortController.signal,
-      });
+      }).catch((error: unknown) => error);
       await objectBodyOpened;
-      abortController.abort(new Error("restore aborted while reading snapshot body"));
-
-      await expect(restore).rejects.toThrow("restore aborted while reading snapshot body");
-      expect(objectFetchCount).toBe(1);
-      expect(objectBodyCancelCount).toBe(1);
-      await expect(access(durableRoot)).rejects.toThrow();
+      if (interruption === "caller") {
+        abortController.abort(new Error("restore aborted while reading snapshot body"));
+        expect(await restore).toMatchObject({ message: "restore aborted while reading snapshot body" });
+      } else {
+        await vi.advanceTimersByTimeAsync(15_000);
+        await vi.waitFor(() => expect(readWorkspaceSnapshotDiagnosticLogs().some((log) =>
+          log.message === "Hosted workspace snapshot restore read step failed; retrying."
+        )).toBe(true));
+        await vi.advanceTimersByTimeAsync(100);
+        await vi.waitFor(() => expect(objectFetchCount).toBe(2));
+        await vi.advanceTimersByTimeAsync(15_000);
+        expect(await restore).toMatchObject({ code: "timeout" });
+      }
+      const expectedAttempts = interruption === "idle" ? 2 : 1;
+      expect(objectFetchCount).toBe(expectedAttempts);
+      expect(objectBodyCancelCount).toBe(expectedAttempts);
+      await expect(readFile(path.join(durableRoot, "existing.md"), "utf8"))
+        .resolves.toBe("keep the prior workspace");
       expect(readWorkspaceSnapshotDiagnosticLogs().filter((log) =>
         log.message === "Hosted workspace snapshot restore read step failed; retrying."
-      )).toHaveLength(0);
+      )).toHaveLength(expectedAttempts - 1);
+
     } finally {
+      vi.useRealTimers();
       dataKey.fill(0);
       await rm(tempRoot, {
         force: true,

--- a/apps/web/changelog/entries/2026-09-04/recover-stalled-conversation-context.json
+++ b/apps/web/changelog/entries/2026-09-04/recover-stalled-conversation-context.json
@@ -1,0 +1,17 @@
+{
+  "publishedOn": "2026-09-04",
+  "order": 100,
+  "item": {
+    "id": "recover-stalled-conversation-context",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Recover sooner when loading conversation context stalls",
+    "summary": "Murph retries a stalled context download when reopening your conversation, reducing waits caused by an inactive download.",
+    "details": "Downloads that keep making progress can continue, and an unsuccessful recovery preserves the saved workspace.",
+    "relevanceTags": [
+      "conversation",
+      "reliability"
+    ],
+    "sourcePullRequests": []
+  }
+}

--- a/apps/web/changelog/entries/2026-09-04/recover-stalled-conversation-context.json
+++ b/apps/web/changelog/entries/2026-09-04/recover-stalled-conversation-context.json
@@ -12,6 +12,8 @@
       "conversation",
       "reliability"
     ],
-    "sourcePullRequests": []
+    "sourcePullRequests": [
+      2842
+    ]
   }
 }

--- a/packages/assistant-engine/test/assistant-outbox-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-outbox-runtime.test.ts
@@ -5952,7 +5952,7 @@ describe('assistant outbox runtime', () => {
           pendingOccurrenceAt: occurrenceAt,
         }),
       }))
-      const expectedNextRunAt = schedule.kind === 'every'
+      const expectedNextRunAt = schedule.kind === 'every' && !transfersLegacyPendingOccurrence
         ? computeAssistantCronNextRunAt(
             {
               kind: 'dailyLocal',


### PR DESCRIPTION
## Why and outcome

A stalled snapshot response body can block a cold conversation restore until the signed download URL expires. Bound each pending body read to 15 seconds and let the existing restore owner retry inactivity once. Downloads that continue making progress retain their existing overall deadline.

Record scalar body-read timings to distinguish pending reads from consumer processing. Read wait includes event-loop scheduling and does not alone prove a network cause.

## Product UX

- Effort: Patch.
- Result: Ready to merge; required CI and routed review passed. Production recovery is not yet verified.
- Walkthrough: Synthetic encrypted restore recovers after one stalled download. Exhaustion and caller cancellation preserve the existing workspace. Progressing downloads and slow consumers can exceed the inactivity interval.

## Evidence

- Direct: Full response-reader and runner-platform suites pass: 211 tests. Cloudflare and Web typechecks pass. Changelog archive tests pass: 9 tests.
- Coverage: Tests exercise cancellation, retry exhaustion, authenticated extraction, successful-attempt timings, cleanup, privacy-safe logs, progressing reads, caller abort, and overall deadline handling. Existing integrity failure tests remain green.
- Web preparation: The first typecheck lacked the local device-syncd build artifact; building that package and rerunning `typecheck:prepared` passed without source changes.
- Diff-aware verification: `pnpm test:diff` for the five changed Cloudflare source/test paths passed all selected guards and full Cloudflare verification: 2,927 tests passed, 2 existing skips across Node, container-helper, and Worker suites.
- Final ReviewGPT: PASS, zero findings on `9ae5239f1c6996ffc09ebf611f061ebf088d309e`; verified gpt-6-pro on Hercules, matching response hash and committed turn, about 7m16s. The near-threshold result is accepted for its exact full-snapshot/head evidence and substantive owner-by-owner audit with fourteen isolated checks. [Review](https://chatgpt.com/c/6a9b575f-f278-83e9-856a-c7b2bc41b59e).
- Post-review changes close the authored task record and correct one unrelated onboarding predecessor assertion using its existing retry-preservation condition. All production source, restore tests, and changelog match the reviewed head. The isolated test-evidence correction requires no new runtime review.
- Follow-up proof: Three focused predecessor cases and assistant-engine typecheck pass after the correction. The Frog entry records the generated-fixture defect without private incident evidence.
- Final-head CI: All required checks passed on `21c3bd5077c78fc9bd4e231ac68458dc8c5fb7ac`, including Release checks, both CLI host matrices, and the hosted Stripe billing boundary. Assistant-engine coverage also passed. Current-base merge-tree proof is clean; the worktree and pushed head match. Production deployment and live recovery verification remain outstanding.

## Non-obvious affected surfaces

The shared response reader retains ordinary control timeout classification. Only the snapshot restore owner retries the new inactivity error; the generic transport classifier still rejects it. Existing persisted restore timing semantics remain unchanged.

One onboarding predecessor test now expects the preserved pending retry when its generated daily slot matches the legacy occurrence. This reuses the already-computed preservation condition and fixes an intermittent release-check assertion; no scheduler code changes.

## Architecture and reuse

- Existing systems reused: Response reader, abort signals, two-attempt snapshot replay-safe read loop, temporary authenticated restore, structured logger.
- New logic: Snapshot-only inactivity budget and bounded attempt timing metrics.
- New abstractions: One error subtype distinguishes retryable snapshot inactivity from terminal control deadlines; no new state owner.
- Complexity intentionally avoided: No new retry loop, storage, dependency, scheduler, persisted timing fields, or protocol migration.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`.
- Hotspots: Existing `putSnapshotObjectDirect` remains 28, unchanged. The response reader is 19; no new complexity debt.
- Agent judgment: Keep timer cleanup with the pending read and retry admission with the restore owner. Unrelated upload refactoring would expand scope.

## Hot reply path impact

- Path status: Touched during cold workspace restore before provider startup; warm conversations are unchanged.
- Database calls: None added.
- Network/provider calls: Inactivity can now use the existing second snapshot GET, maximum two attempts total. No added provider calls or increased attempt limit.
- Other awaited latency: Each pending snapshot body read has a 15-second inactivity budget. Existing 100ms retry delay and signed-URL total deadline remain; healthy downloads have no new total-duration cap.
- Before/after proof: Synthetic stalled stream is canceled at 15 seconds and the second encrypted download restores successfully; two stalled attempts stop and preserve prior files. Progressing reads and slower consumers succeed beyond 15 seconds.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no prompt, instructions, tool schemas, guidance, or provider-visible input builders changed. No input measurement claimed.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: Content-only changelog exception; archive tests render the authored copy through the existing component.
- Coverage: Copy reviewed directly; no renderer, style, interaction, or visual changes.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing Web/runner and Worker/container contracts are unchanged. Old containers retain prior timeout behavior; new containers enforce inactivity locally.
- Safe order: Release the Cloudflare runner through its existing deployment process. No ordered Web or Temporal migration.
- Rollback floor: Previous runner image; no persisted state or schema changes require a floor.
- Expected exposure: Snapshot downloads for cold restores; normal progressing downloads retain their deadline.
- Reversibility: Revert runner code to restore the previous timeout behavior.
- Convergence proof: Unchanged wire parsers, encrypted-ref fixtures, and full runner-platform tests pass. No mixed-version live deployment was run.
- Post-deploy checks: Confirm new containers, inspect scalar body-read and retry logs, and compare cold-restore latency and failures. Distinguish read wait from consumer processing.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source; tests are tests; plan/protocol and public changelog copy are docs. No binaries or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 110 | 44 |
| Tests / fixtures | 165 | 15 |
| Docs | 137 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **412** | **59** |

## Changelog

- Changelog: updated
- Items: 2026-09-04 · recover-stalled-conversation-context

ReviewGPT context sensitivity: sensitive
Classification reason: Hosted runtime restore cancellation and retry admission change.

ReviewGPT first-reviewed head: 9ae5239f1c6996ffc09ebf611f061ebf088d309e
