### PR TITLE
Collapse repeated dynamic-tool dispatch mechanics

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-complexity-dynamic-tools.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-complexity-dynamic-tools.md
@@ -1,0 +1,65 @@
+# Collapse repeated dynamic-tool dispatch mechanics
+
+Status: completed
+
+## Outcome and protected invariants
+
+Reduce repeated parser probing and group request preparation inside the existing
+dynamic-tool owner. Preserve first-match parsing, contextual parser inputs,
+fresh-input authority, preflight-before-generation ordering, capture identities,
+usage accounting, response payloads, and model-visible errors.
+
+## Evidence and architecture
+
+The dispatcher repeats ten parser call/return blocks after automation parsing.
+The group executor repeats avatar preparation result handling and private direct
+authority checks for ask and handoff. Collapse these at the existing owner;
+introduce no state, dependency, framework, transport, or deployment contract.
+Existing PRs 2485 and 2629 touch other device and response-card sections.
+
+## Product UX
+
+Internal refactor with no intended product change. Preserve private ask/handoff,
+contact-card publication, group-avatar preflight denial, and parser recovery.
+Focused deterministic proof covers admitted and denied authority plus exact
+request identity. A synthetic real-Codex handoff journey supplements it; inspect
+the actual reply for truthful queued-versus-delivered status.
+
+## Tasks
+
+- [x] Collapse parser and group executor duplication.
+- [x] Run focused boundary suites, package typecheck, and complexity diff.
+- [x] Extend and run focused real-Codex proof; inspect reply.
+- [x] Prepare the scoped implementation candidate for parent review.
+
+Exact-head CI and ReviewGPT remain external PR gates and are tracked in the PR.
+
+## Failure and rollout
+
+No changed retries, request counts, storage, wire contracts, or rollout order.
+Keep action-specific authority and preflights before expensive work. Preserve
+the task worktree while its PR remains open.
+
+## Verification and review evidence
+
+- Group/domain/parser/clinical suites: 139 passing tests across four files.
+- Eight additional parser-owner suites: 135 passing tests.
+- Assistant Engine package typecheck and diff whitespace check passed.
+- Complexity guard passed: file debt 553 to 538; parser 88 to 80 and group
+  executor 174 to 167. Production source deletes 105 net lines; no new owner.
+- Focused real Codex handoff recovery uses production instructions and tools,
+  a synthetic hosted port, gpt-5.6-terra, and local subscription authentication.
+  The selected-route failure made exactly two calls with trusted origin, no
+  queued result, and a concise truthful manual fallback. The unavailable-inventory
+  case made only one inventory call and offered truthful no-queue recovery.
+  Both actual replies were inspected. Reply review: Ready.
+- Earlier subscription homes failed before any action, including explicit usage
+  limits. An authorized alternate completed the journey; no auth was copied,
+  production boundary weakened, or model changed. Temporary metadata diagnostics
+  were removed from the candidate.
+- Parent review inspected parser input preservation and merged avatar result,
+  usage, preflight and identity handling; final candidate review follows the
+  scoped commit and exact evidence.
+- Internal refactor: no changelog item or deployment ordering requirement.
+Updated: 2026-09-04
+Completed: 2026-09-04

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -1670,86 +1670,22 @@ export function readMurphDynamicToolRequest(
     return automationRequest
   }
 
-  const deviceRequest = readDeviceDynamicToolRequest({
-    arguments: request.arguments,
-    tool: request.tool,
-  })
-  if (deviceRequest) {
-    return deviceRequest
-  }
-
-  const labsRequest = readLabsDynamicToolRequest({
-    arguments: request.arguments,
-    tool: request.tool,
-  })
-  if (labsRequest) {
-    return labsRequest
-  }
-
-  const pendingVaultFilesRequest = readPendingVaultFilesDynamicToolRequest({
-    arguments: request.arguments,
-    tool: request.tool,
-  })
-  if (pendingVaultFilesRequest) {
-    return pendingVaultFilesRequest
-  }
-
-  const groupRoomModelRequest = readGroupRoomModelDynamicToolRequest({
-    arguments: request.arguments,
-    tool: request.tool,
-  })
-  if (groupRoomModelRequest) {
-    return groupRoomModelRequest
-  }
-
-  const memberMemoryRequest = readMemberMemoryDynamicToolRequest({
-    arguments: request.arguments,
-    tool: request.tool,
-  })
-  if (memberMemoryRequest) {
-    return memberMemoryRequest
-  }
-
-  const connectedAppsRequest = readConnectedAppsDynamicToolRequest({
-    arguments: request.arguments,
-    tool: request.tool,
-  })
-  if (connectedAppsRequest) {
-    return connectedAppsRequest
-  }
-
-  const assistantStyleRequest = readAssistantStyleDynamicToolRequest({
-    arguments: request.arguments,
-    tool: request.tool,
-    toolCallId: request.toolCallId,
-  })
-  if (assistantStyleRequest) {
-    return assistantStyleRequest
-  }
-
-  const phoneCallRequest = readPhoneCallDynamicToolRequest({
-    arguments: request.arguments,
-    tool: request.tool,
-  })
-  if (phoneCallRequest) {
-    return phoneCallRequest
-  }
-
-  const physicalNoteRequest = readPhysicalNoteDynamicToolRequest({
-    arguments: request.arguments,
-    tool: request.tool,
-  })
-  if (physicalNoteRequest) {
-    return physicalNoteRequest
-  }
-
-  const clinicalRecordsConnectLinkRequest =
-    readClinicalRecordsConnectLinkDynamicToolRequest({
-      arguments: request.arguments,
-      tool: request.tool,
-    })
-  if (clinicalRecordsConnectLinkRequest) {
-    return clinicalRecordsConnectLinkRequest
+  for (const readRequest of [
+    readDeviceDynamicToolRequest,
+    readLabsDynamicToolRequest,
+    readPendingVaultFilesDynamicToolRequest,
+    readGroupRoomModelDynamicToolRequest,
+    readMemberMemoryDynamicToolRequest,
+    readConnectedAppsDynamicToolRequest,
+    readAssistantStyleDynamicToolRequest,
+    readPhoneCallDynamicToolRequest,
+    readPhysicalNoteDynamicToolRequest,
+    readClinicalRecordsConnectLinkDynamicToolRequest,
+  ]) {
+    const parsed = readRequest(request)
+    if (parsed) {
+      return parsed
+    }
   }
 
   switch (request.tool) {
@@ -5197,123 +5133,90 @@ async function executeGroupTool(
       input.request,
       repostOriginAssistantInputId,
     );
-  } else if (isPreparedContactCardRequest(input.request)) {
-    const userActionScope =
-      input.hostedToolContext?.currentUserActionScope?.() ?? null;
-    if (
-      userActionScope?.conversationScope !== "direct" ||
-      userActionScope.acceptedInputIds.length === 0
-    ) {
-      return toolTextResult(
-        false,
-        "personalized contact cards require a fresh user request in a personal direct conversation",
-      );
-    }
-    // Refuse a route that can never carry the attachment before paying for
-    // generation, capture, and publication. The post-generation binding below
-    // still owns the authoritative thread.
-    const routeStatus = groupTool.directAttachmentRouteStatus?.() ?? null;
-    if (routeStatus && routeStatus.status !== "ok") {
-      return toolTextResult(
-        true,
-        safeToolPayloadText({
-          action: "share_contact_card",
-          result: routeStatus,
-        }),
-      );
-    }
-    const contactCardShareKey = userActionScope.acceptedInputIds.at(-1) ?? null;
-    if (!contactCardShareKey) {
-      return toolTextResult(
-        false,
-        "personalized contact cards require fresh user-sourced input for this turn",
-      );
-    }
-    const prepared = await prepareGroupAvatarRuntimeRequest({
-      abortSignal: input.abortSignal,
-      // The accepted request, not the tool call: a replay must reuse this
-      // capture rather than pay for a second stochastic generation.
-      captureRequestId: contactCardShareKey,
-      captureScope: "contact-card-avatar",
-      env: input.env,
-      fetchImpl: input.fetchImpl,
-      hostedToolContext: input.hostedToolContext,
-      materializeWorkspaceArtifacts: input.materializeWorkspaceArtifacts,
-      nextUsageOrdinal: input.nextUsageOrdinal,
-      request: {
-        action: "set_chat_avatar",
-        avatar: input.request.avatar,
-      },
-      vaultRoot: input.vaultRoot,
-    });
-    if (!prepared.rpcSuccess) {
-      return {
-        rpcResult: {
-          contentItems: [{ text: prepared.rpcText, type: "inputText" }],
-          success: false,
-        },
-        usageDraft: prepared.usageDraft ?? null,
-      };
-    }
-    request = {
-      action: "share_contact_card",
-      contactCardImageUrl: prepared.request.groupChatIconUrl,
-      // Trusted-host request identity, so a retried or replayed turn collapses
-      // to one card while a genuinely new accepted request has its own send
-      // identity. Deliberately not the tool call id: a retry re-emits the
-      // call with a new id but keeps the same accepted input.
-      contactCardShareKey,
-    };
-    usageDraft = prepared.usageDraft ?? null;
-    generatedAvatarCapture = prepared.savedImageRef
-      ? {
-          savedCaptureId: prepared.savedCaptureId ?? null,
-          savedImageRef: prepared.savedImageRef,
+  } else if (
+    isPreparedContactCardRequest(input.request) ||
+    isPreparedGroupAvatarRequest(input.request)
+  ) {
+    let contactCardShareKey: string | null = null;
+    if (input.request.action === "share_contact_card") {
+      const userActionScope =
+        input.hostedToolContext?.currentUserActionScope?.() ?? null;
+      if (
+        userActionScope?.conversationScope !== "direct" ||
+        userActionScope.acceptedInputIds.length === 0
+      ) {
+        return toolTextResult(
+          false,
+          "personalized contact cards require a fresh user request in a personal direct conversation",
+        );
+      }
+      // Refuse a route that can never carry the attachment before paying for
+      // generation, capture, and publication. The post-generation binding below
+      // still owns the authoritative thread.
+      const routeStatus = groupTool.directAttachmentRouteStatus?.() ?? null;
+      if (routeStatus && routeStatus.status !== "ok") {
+        return toolTextResult(
+          true,
+          safeToolPayloadText({
+            action: "share_contact_card",
+            result: routeStatus,
+          }),
+        );
+      }
+      contactCardShareKey = userActionScope.acceptedInputIds.at(-1) ?? null;
+      if (!contactCardShareKey) {
+        return toolTextResult(
+          false,
+          "personalized contact cards require fresh user-sourced input for this turn",
+        );
+      }
+    } else {
+      let preflight: Extract<
+        HostedRuntimeGroupToolResponse,
+        { action: "preflight_set_chat_avatar" }
+      >;
+      try {
+        const preflightRequest = { action: "preflight_set_chat_avatar" } as const;
+        const preflightResult = input.abortSignal
+          ? await groupTool.request(preflightRequest, {
+              signal: input.abortSignal,
+            })
+          : await groupTool.request(preflightRequest);
+        if (preflightResult.action !== "preflight_set_chat_avatar") {
+          return groupAvatarUnavailableToolResult(
+            "group_avatar_preflight_unavailable",
+          );
         }
-      : null;
-  } else if (isPreparedGroupAvatarRequest(input.request)) {
-    let preflight: Extract<
-      HostedRuntimeGroupToolResponse,
-      { action: "preflight_set_chat_avatar" }
-    >;
-    try {
-      const preflightRequest = { action: "preflight_set_chat_avatar" } as const;
-      const preflightResult = input.abortSignal
-        ? await groupTool.request(preflightRequest, {
-            signal: input.abortSignal,
-          })
-        : await groupTool.request(preflightRequest);
-      if (preflightResult.action !== "preflight_set_chat_avatar") {
+        preflight = preflightResult;
+      } catch {
         return groupAvatarUnavailableToolResult(
           "group_avatar_preflight_unavailable",
         );
       }
-      preflight = preflightResult;
-    } catch {
-      return groupAvatarUnavailableToolResult(
-        "group_avatar_preflight_unavailable",
-      );
+      if (preflight.result.status !== "ok") {
+        return toolTextResult(
+          true,
+          safeToolPayloadText({
+            action: "set_chat_avatar",
+            result: preflight.result,
+          }),
+        );
+      }
     }
-    if (preflight.result.status !== "ok") {
-      return toolTextResult(
-        true,
-        safeToolPayloadText({
-          action: "set_chat_avatar",
-          result: preflight.result,
-        }),
-      );
-    }
-
     const prepared = await prepareGroupAvatarRuntimeRequest({
       abortSignal: input.abortSignal,
-      captureRequestId: input.toolCallId,
-      captureScope: "group-avatar",
+      // Contact-card replays keep the accepted-input identity; group avatar
+      // requests retain their tool-call identity.
+      captureRequestId: contactCardShareKey ?? input.toolCallId,
+      captureScope: contactCardShareKey !== null
+        ? "contact-card-avatar"
+        : "group-avatar",
       env: input.env,
       fetchImpl: input.fetchImpl,
       hostedToolContext: input.hostedToolContext,
       materializeWorkspaceArtifacts: input.materializeWorkspaceArtifacts,
       nextUsageOrdinal: input.nextUsageOrdinal,
-      request: input.request,
+      request: { action: "set_chat_avatar", avatar: input.request.avatar },
       vaultRoot: input.vaultRoot,
     });
     if (!prepared.rpcSuccess) {
@@ -5325,7 +5228,13 @@ async function executeGroupTool(
         usageDraft: prepared.usageDraft ?? null,
       };
     }
-    request = prepared.request;
+    request = contactCardShareKey !== null
+      ? {
+          action: "share_contact_card",
+          contactCardImageUrl: prepared.request.groupChatIconUrl,
+          contactCardShareKey,
+        }
+      : prepared.request;
     usageDraft = prepared.usageDraft ?? null;
     generatedAvatarCapture = prepared.savedImageRef
       ? {
@@ -5333,13 +5242,15 @@ async function executeGroupTool(
           savedImageRef: prepared.savedImageRef,
         }
       : null;
-  } else if (input.request.action === "ask") {
+  } else if (
+    input.request.action === "ask" || input.request.action === "handoff"
+  ) {
     const userActionScope =
       input.hostedToolContext?.currentUserActionScope?.() ?? null;
     if (userActionScope?.conversationScope !== "direct") {
       return toolTextResult(
         false,
-        "group ask requires a fresh user request in a personal direct conversation",
+        `group ${input.request.action} requires a fresh user request in a personal direct conversation`,
       );
     }
     const originAssistantInputId =
@@ -5347,39 +5258,23 @@ async function executeGroupTool(
     if (!originAssistantInputId) {
       return toolTextResult(
         false,
-        "group ask requires fresh user-sourced input for this turn",
+        `group ${input.request.action} requires fresh user-sourced input for this turn`,
       );
     }
-    request = {
-      action: "ask",
-      membershipId: input.request.membershipId,
-      originAssistantInputId,
-      originSessionId: userActionScope.originSessionId,
-      question: input.request.question,
-    };
-  } else if (input.request.action === "handoff") {
-    const userActionScope =
-      input.hostedToolContext?.currentUserActionScope?.() ?? null;
-    if (userActionScope?.conversationScope !== "direct") {
-      return toolTextResult(
-        false,
-        "group handoff requires a fresh user request in a personal direct conversation",
-      );
-    }
-    const originAssistantInputId =
-      userActionScope.acceptedInputIds.at(-1) ?? null;
-    if (!originAssistantInputId) {
-      return toolTextResult(
-        false,
-        "group handoff requires fresh user-sourced input for this turn",
-      );
-    }
-    request = {
-      action: "handoff",
-      context: input.request.context,
-      membershipId: input.request.membershipId,
-      originAssistantInputId,
-    };
+    request = input.request.action === "ask"
+      ? {
+          action: "ask",
+          membershipId: input.request.membershipId,
+          originAssistantInputId,
+          originSessionId: userActionScope.originSessionId,
+          question: input.request.question,
+        }
+      : {
+          action: "handoff",
+          context: input.request.context,
+          membershipId: input.request.membershipId,
+          originAssistantInputId,
+        };
   } else if (input.request.action === "ask_current_sender") {
     const userActionScope =
       input.hostedToolContext?.currentUserActionScope?.() ?? null;

--- a/packages/assistant-engine/test/assistant-codex-group-tool.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-group-tool.test.ts
@@ -2594,48 +2594,67 @@ describe("murph.group dynamic tool", () => {
     });
   });
 
-  it.each([
-    ["missing", () => null],
-    [
-      "group",
-      () => ({
-        acceptedInputIds: [FRESH_ASSISTANT_INPUT_ID],
-        conversationId: "conversation_group",
-        conversationScope: "group" as const,
-        inboundMailboxItemIds: ["mailbox_group"],
-        originSessionId: "session_group",
-        recipientKey: "recipient_group",
-      }),
-    ],
-  ])("does not admit a context handoff with %s private-user authority", async (
-    _case,
-    currentUserActionScope,
-  ) => {
-    const request = readMurphDynamicToolRequest(groupToolCall({
-      action: "handoff",
-      context: "A bounded fact.",
-      membershipId: "membership_lifting_club",
-    }));
-    if (!request || request.kind !== "group") {
-      throw new Error("Expected group request.");
-    }
-    const groupRequest = vi.fn<GroupToolRequest>();
+  describe.each(["ask", "handoff"] as const)("%s direct authority", (action) => {
+    it.each([
+      ["missing", () => null],
+      ["empty direct", () => ({
+        acceptedInputIds: [],
+        conversationId: "conversation_private",
+        conversationScope: "direct" as const,
+        inboundMailboxItemIds: [],
+        originSessionId: "session_private",
+        recipientKey: "recipient_private",
+      })],
+      [
+        "group",
+        () => ({
+          acceptedInputIds: [FRESH_ASSISTANT_INPUT_ID],
+          conversationId: "conversation_group",
+          conversationScope: "group" as const,
+          inboundMailboxItemIds: ["mailbox_group"],
+          originSessionId: "session_group",
+          recipientKey: "recipient_group",
+        }),
+      ],
+    ])("rejects %s authority before the hosted request", async (
+      _case,
+      currentUserActionScope,
+    ) => {
+      const request = readMurphDynamicToolRequest(groupToolCall({
+        action,
+        ...(action === "handoff"
+          ? { context: "A bounded fact." }
+          : { question: "Which day is planned?" }),
+        membershipId: "membership_lifting_club",
+      }));
+      if (!request || request.kind !== "group") {
+        throw new Error("Expected group request.");
+      }
+      const groupRequest = vi.fn<GroupToolRequest>();
 
-    const result = await executeMurphDynamicToolRequest({
-      env: {},
-      fetchImpl: fetch,
-      hostedToolContext: createGroupHostedToolContext({
-        currentUserActionScope,
-        groupRequest,
-      }),
-      nextUsageOrdinal: () => 1,
-      progressDelivery: null,
-      request,
-      vaultRoot: null,
+      const result = await executeMurphDynamicToolRequest({
+        env: {},
+        fetchImpl: fetch,
+        hostedToolContext: createGroupHostedToolContext({
+          currentUserActionScope,
+          groupRequest,
+        }),
+        nextUsageOrdinal: () => 1,
+        progressDelivery: null,
+        request,
+        vaultRoot: null,
+      });
+
+      expect(result.rpcResult.success).toBe(false);
+      expect(groupRequest).not.toHaveBeenCalled();
+      expect(result.rpcResult.contentItems).toEqual([{
+        type: "inputText",
+        text: _case === "empty direct"
+          ? `group ${action} requires fresh user-sourced input for this turn`
+          : `group ${action} requires a fresh user request in a personal direct conversation`,
+      }]);
     });
 
-    expect(result.rpcResult.success).toBe(false);
-    expect(groupRequest).not.toHaveBeenCalled();
   });
 
   it("enforces group ask bounds in Unicode code points", () => {

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -9389,7 +9389,7 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
       targetAvailability: 'available' as const,
     },
   ])(
-    'gives truthful no-queue recovery when $label',
+    'keeps dynamic-tool handoff recovery truthful when $label',
     async ({ targetAvailability }) => {
       const config = await resolveRealCodexE2eConfig()
       const workingDirectory = await mkdtemp(
@@ -9517,6 +9517,13 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
           workingDirectory,
         })
 
+        process.stdout.write(
+          `[dynamic-tool-handoff-recovery] ${JSON.stringify({
+            scenario: targetAvailability,
+            requestCount: groupRequests.length,
+            reply: result.finalMessage.trim(),
+          })}\n`,
+        )
         const expectedRequestCount = targetAvailability === 'available' ? 2 : 1
         expect(groupRequests).toHaveLength(expectedRequestCount)
         expect(groupRequests[0]).toEqual({ action: 'list_memberships' })
@@ -9524,6 +9531,7 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
           expect(groupRequests[1]).toMatchObject({
             action: 'handoff',
             membershipId: 'membership_former_trail_crew',
+            originAssistantInputId: 'input_group_unavailable_recovery',
           })
         }
         expect(result.finalMessage).toMatch(/Former Trail Crew/iu)


### PR DESCRIPTION
## Why and outcome

The dynamic-tool owner repeats parser probing and avatar-result handling, making the same mechanics harder to review consistently. Collapse those blocks and the identical fresh-direct-input checks for group asks/handoffs while preserving all action-specific authority, preflights, identities, and results. Production source shrinks by 105 lines.

## Product UX

- Effort: Not applicable — internal refactor with unchanged product behavior.
- Result: Ready — both focused live replies inspected.
- Walkthrough: Preserve private ask/handoff admission, truthful unavailable-group recovery, contact-card replay identity, and avatar preflight denial. No new audience or capability.

## Evidence

- Direct: `pnpm --filter @murphai/assistant-engine typecheck` passes; `git diff --check` passes.
- Coverage: 139 tests in group-tool, group-parser-compatibility, hosted-domain-tools, and clinical-records-connect-link suites; 135 tests across style, phone, labs, group-room-model, member-memory, connected-apps, vault-file-cancellation, and physical-notes suites. Group proof checks exact hosted requests, denied authority, preflight/no-upload behavior, generated capture scopes, replay identity, generated results and usage propagation. Parser owners read only tool/arguments and style's toolCallId; the ordered loop preserves first-match behavior and automation's separate date context.
- Live: Both focused `pnpm test:assistant:live` runs passed with `--test 'keeps dynamic-tool handoff recovery truthful.*the selected route'` and `--test 'keeps dynamic-tool handoff recovery truthful.*an exact inventory'`, using `gpt-5.6-terra`, an authenticated alternate local subscription home, and synthetic ports only. Exactly two calls for route failure and one for unavailable inventory; both actual replies were concise and truthful about nothing being queued. Reply review: Ready. Earlier homes failed before actions, including usage limits; no model or production configuration changes.
- ReviewGPT: PASS, no findings, on the exact first-reviewed head. The fresh round-1 full audit used `gpt-6-pro` and completed in 496 seconds; exact turn, attachment, model, response hash, completion marker, and substantive before/after checks were inspected and accepted by the parent. [Review](https://chatgpt.com/c/6a9b5989-a914-83ea-98da-93cfc726dfb5). An earlier 374-second capture is diagnostic-only and does not count.
- Required exact-head GitHub checks: PASS, including Linux/macOS CLI, release checks (build/typecheck, all package coverage shards, all Web shards, Cloudflare and Web build), and hosted billing. [Release run](https://github.com/cobuildwithus/murph/actions/runs/33930438621). Current-base merge-tree is clean against `e107e98febe2703c48bfd852ac1376c3666d09b6`; no base refresh or candidate mutation.

## Non-obvious affected surfaces

The parser sequence covers ten existing tool families. Existing owner suites cover valid requests and invalid-argument recovery. No parser, tool schema, prompt, or transport implementation changes.

## Architecture and reuse

- Existing systems reused: Existing parser functions, group avatar preparation, hosted group port, and tool-result projection.
- New logic: None; merge repeated mechanics while preserving action-specific values and failure text.
- New abstractions: None; one local ordered parser list and the current group executor remain sufficient.
- Complexity intentionally avoided: No registry, dispatch framework, policy owner, module split, new state, or transport wrapper.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`; file debt 553 → 538 (-15), maximum unchanged at 193.
- Hotspots: Changed `readMurphDynamicToolRequest` 88 → 80 and `executeGroupTool` 174 → 167. Unchanged hotspots: executeMurphDynamicToolRequest 193; executeSendPhysicalNoteDynamicTool 65; executeGenerateImageDynamicTool 57; parseGroupArguments 44; executeCreatePhoneCallDynamicTool 41; executeResolvePhysicalNoteDynamicTool 36; executeGroupEmailEffect 26; executeClinicalRecordsConnectLinkDynamicTool 23; executeAssistantConfigurationTool 23; classifyGroupToolFailure 22; groupSharedWorkoutsModelProjection 21.
- Agent judgment: The changed blocks remove duplicated mechanics. Remaining branches retain concrete action and authority distinctions; broader rewriting is outside this bounded cleanup and overlaps active device/card work.

## Hot reply path impact

- Path status: Touched — existing dynamic-tool parsing and group execution.
- Database calls: None added or moved.
- Network/provider calls: None added or moved; avatar preflight still precedes generation/publication, contact route probe still precedes generation, and one final hosted request remains.
- Other awaited latency: None added or moved; retry, cancellation, timeout and fallback owners are unchanged.
- Before/after proof: Focused suites preserve exact request counts/order, no generation/upload after rejected preflight, accepted-input contact identity, and result/usage propagation. No latency benchmark claim.

## Murph initial provider input impact

Not applicable for individual and group runtimes: assembled prompts, eager/deferred tools, schemas, generated guidance, and initial provider requests are unchanged. The refactor handles tool calls after provider entry. No input-token measurement claimed.

ReviewGPT first-reviewed head: 267ec9bb7fb6bc39c1bd2908ad9f9940d5a73adf
ReviewGPT context sensitivity: sensitive
Classification reason: Refactor inside dynamic-tool effect and group authority execution.

## Deployment concerns

- Deployment: not applicable
- Reason: Behavior-preserving changes within one existing package; no wire, persisted-state, environment, or cross-deployment contract changes.

## Change-shape breakdown

Classification rule: Production TypeScript is source; test paths are tests/fixtures; the execution plan is docs. No binaries or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 113 | 218 |
| Tests / fixtures | 67 | 40 |
| Docs | 65 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **245** | **258** |

## Changelog

- Changelog: not applicable
- Reason: Internal simplification preserves member-visible behavior.
