### PR TITLE
docs: cap ReviewGPT at three rounds

### DIFF
--- a/.agents/friction-log/20260904193709-production-next-typescript/friction.md
+++ b/.agents/friction-log/20260904193709-production-next-typescript/friction.md
@@ -1,0 +1,28 @@
+---
+title: 'Production Next TypeScript check exceeds its fixed cold-check heap'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The canonical production Web build should complete its route-aware TypeScript check on the current source tree without requiring a separately warmed incremental cache.
+
+## Current Behavior
+
+The build runner fixes its TypeScript 5 heap at 3584 MiB and removes inherited heap overrides. The check exhausts that limit both during acceptance and when run alone with incremental caching disabled. The same project passes with a 6144 MiB heap and reports approximately 4.4 GiB of compiler memory. After that successful check writes incremental state, the unchanged canonical runner passes its TypeScript stage at its original limit.
+
+## Minimal Reproducible Example
+
+From apps/web, generate current route declarations, then run:
+
+```sh
+node --max-old-space-size=3584 node_modules/typescript/bin/tsc -p tsconfig.next.json --pretty false --incremental false
+node --max-old-space-size=6144 node_modules/typescript/bin/tsc -p tsconfig.next.json --pretty false --extendedDiagnostics
+bash scripts/run-production-next-build.sh
+```
+
+The first command exhausts its heap. The larger-heap check succeeds and permits the canonical build to reuse valid incremental state.
+
+## Context
+
+A documentation-only change cannot complete direct-push acceptance when the independently owned production build needs more cold-check memory. Workspace TypeScript 7 checks, package coverage, Web tests, lint, and dev smoke pass. Preserve the route-aware check and production build memory controls when addressing this gap.

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -129,7 +129,7 @@ not a guarantee that every claim was checked in this cleanup.
 | `agent-docs/operations/imessage-deliverability.md` | Phone-number messaging policy. | Phone-number messaging policy | High | 2026-08-11 |
 | `agent-docs/operations/local-storage-lifecycle.md` | Local rebuildable-storage lifecycle. | Local rebuildable-storage lifecycle | High | 2026-08-10 |
 | `agent-docs/operations/hosted-local-worktree-dev.md` | Local hosted runtime workflow. | Local hosted runtime workflow | Medium | 2026-08-20 |
-| `agent-docs/operations/pr-reviewgpt-loop.md` | PR review for realistic serious bugs and material Complexity Collapse. | Final PR ReviewGPT loop | Medium | 2026-09-02 |
+| `agent-docs/operations/pr-reviewgpt-loop.md` | PR review for realistic serious bugs and material Complexity Collapse, with a three-round cap. | Final PR ReviewGPT loop | Medium | 2026-09-04 |
 | `agent-docs/operations/device-sync-ingestion-invariants.md` | Device-sync push/pull ingestion invariants. | Device-sync ingestion contract | High | 2026-08-20 |
 | `agent-docs/PLANS.md` | Execution-plan lifecycle and storage rules. | Plan workflow | Medium | 2026-03-31 |
 | `agent-docs/exec-plans/completed/README.md` | Completed-plan archive interpretation. | Completed-plan archive interpretation | Medium | 2026-07-22 |

--- a/agent-docs/operations/pr-reviewgpt-loop.md
+++ b/agent-docs/operations/pr-reviewgpt-loop.md
@@ -155,7 +155,7 @@ Use the ordinary turn-ending pause when an accepted finding does not qualify,
 the correction expands beyond the proven boundary, requested behavior or the
 intended outcome would change, scope or authority would expand, or a destructive
 or external action needs new approval. Neither exception bypasses a required
-scope decision or the seven-round hard cap.
+scope decision or the three-round hard cap.
 
 `INVALID` stops for an evidence gap. Older review results may contain
 `RETROSPECTIVE_REQUIRED`; triage their concrete evidence under the current
@@ -588,13 +588,13 @@ worktree active, and stop. Do not poll for a quiet base.
 - A concrete requirement or authority gap pauses dependent remediation until
   the parent resolves the scope decision under step 5. The reviewer reports
   qualifying findings or evidence gaps, not escalation by size or round number.
-- Hard cap: 7 rounds per PR. There is no automatic eighth substantive round. An
-  accepted round-seven finding may still be reproduced and fixed; do not leave a
-  known bug in place merely because the review counter reached seven. After that
+- Hard cap: 3 rounds per PR. There is no automatic fourth substantive round. An
+  accepted round-three finding may still be reproduced and fixed; do not leave a
+  known bug in place merely because the review counter reached three. After that
   fix, pause the ReviewGPT loop and confirm parent final review, verification,
   and PR CI are all complete. Record the cap
   retrospective and obtain an explicit continuation decision before starting
-  round eight; the answer may be delete, revert, shrink, split, redesign,
+  round four; the answer may be delete, revert, shrink, split, redesign,
   continue, or abandon. A green non-ReviewGPT gate does not make the PR
   merge-ready without the required later resolved result.
 - Report a per-round summary at handoff: findings received, accepted, rejected


### PR DESCRIPTION
## Why and outcome

Cap substantive ReviewGPT review at three rounds per PR instead of seven. Findings from round three may still be fixed, but starting round four requires an explicit continuation decision. Preserve the current serious-bug and Complexity Collapse review policy.

## Product UX

- Effort: Not applicable; internal review-process documentation.
- Result: Not applicable.
- Walkthrough: Read the round-three finding and round-four continuation boundaries; no member-facing journey changes.

## Evidence

- Direct: `pnpm docs:drift` and `pnpm docs:gardening` pass on this candidate. Readback confirms all live cap references use three rounds and the continuation boundary uses round four.
- Coverage: Before base reconciliation, workspace/app typechecks, all package coverage, Web tests/lint/smoke, Cloudflare verification, and fixture smoke coverage passed. The original acceptance command hit a production Next TypeScript heap limit; a larger-heap diagnostic passed, followed by the unchanged canonical build using its valid incremental state. Required CI owns broad proof of this PR head.

## Non-obvious affected surfaces

A required Frog entry records the independently reproduced production-build cold-check heap limit. No production source, build settings, tests, or dependencies change in this PR.

## Architecture and reuse

- Existing systems reused: The canonical ReviewGPT runbook, its index entry, and the existing Frog log.
- New logic: None; the existing review policy changes only its round limit and continuation boundary.
- New abstractions: None; the existing document remains the policy owner.
- Complexity intentionally avoided: No counter implementation, duplicated policy tests, or build-memory configuration changes.

## Complexity impact

- Guard: Not applicable; no authored JavaScript or TypeScript changes.
- Hotspots: None; documentation only.
- Agent judgment: The policy remains with its existing owner; no further simplification is needed for this change.

## Hot reply path impact

- Path status: Not applicable; developer review documentation does not affect runtime replies.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: The diff contains only Markdown documentation.

## Murph initial provider input impact

Not applicable to either individual or group Murph runtime input; this changes developer review documentation, not runtime prompts, tools, schemas, or generated guidance. No token measurement is claimed.

## Deployment concerns

- Deployment: not applicable
- Reason: Documentation and a developer-friction record do not change deployed code, data contracts, or service compatibility.

## Change-shape breakdown

Classification rule: All three changed Markdown files are documentation, including the Frog record. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 0 | 0 |
| Docs | 34 | 6 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **34** | **6** |

## Changelog

- Changelog: not applicable
- Reason: Internal developer review policy has no member-visible product outcome.
