### PR TITLE
refactor: collapse repeated Linq delivery callback arguments

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-complexity2-callbacks.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-complexity2-callbacks.md
@@ -1,0 +1,86 @@
+# Collapse repeated Linq callback arguments
+
+Status: completed
+Created: 2026-09-04
+Updated: 2026-09-04
+
+## Goal
+
+Reduce duplicated authority and receipt wiring in the hosted Linq send callback
+without changing delivery, route authority, fallback, or retry behavior.
+
+## Scope and ownership
+
+The existing `createHostedAssistantLinqSendDependency` owner in `callbacks.ts`
+remains responsible for each send. Consolidate repeated private Assistant Ask
+route-assertion inputs, resolved-route engagement inputs, and outcome inputs.
+Keep the Telegram authority and delivery-drain loops outside this bounded task.
+Use the isolated `refactor/complexity2-callbacks` branch. No state, schema,
+provider/tool contract, prompt, dependency, or deployment change is intended.
+
+## Protected boundaries
+
+- Keep initial and provider-entry private-completion authority checks.
+- Preserve the preflight `thread` and resolved-provider `explicit` defaults.
+- Read request and invocation values when each helper is called, including after
+  intervening awaits; never turn current authority into a cached assertion.
+- Keep capability reads separate from provider claims, and preserve optional
+  property omission, callback receiver, effect count and call ordering.
+- Preserve card-rejection settlement before fallback identity claim, receipt
+  write ownership, attachment reservation uncertainty, and partial-send recovery.
+
+## Product UX and proof
+
+Internal mechanical refactor: no product-owned behavior change. Replay normal
+and private/reviewed completion sends, participant/thread routes, authority loss,
+card fallback, attachment denial, receipt failure and ambiguous provider outcomes
+through existing composed callback and Assistant Ask suites. Inspect synthetic
+provider requests and owned effects. The real-Codex skill was read; stochastic
+reply proof is applicable only if the final diff alters interpretation, tools,
+silence, context or prose, rather than mechanically unchanged callback wiring.
+
+## Tasks
+
+- [x] Inspect baseline source, current workflow, domain contracts, Frog and tests.
+- [x] Consolidate concrete duplication without adding authority or state owners.
+- [x] Run focused tests, package typecheck, complexity guard and source-derived
+  base/current differential proof.
+- [ ] Review complete diff/privacy; close plan with scoped neutral-identity commit.
+- [ ] Open draft PR and obtain parent candidate review before Ready.
+- [ ] Run exact-head ReviewGPT alongside CI; hand off the clean open PR.
+
+## Verification
+
+Passed locally:
+
+- `MURPH_VITEST_MAX_WORKERS=2 pnpm --dir packages/assistant-runtime test
+  test/hosted-runtime-callbacks.test.ts
+  test/hosted-runtime-current-sender-assistant-ask.test.ts
+  test/hosted-runtime-assistant-ask-completion.integration.test.ts
+  test/hosted-runtime-linq-outbox-regression.test.ts`: 4 files, 306 tests.
+- `pnpm --dir packages/assistant-runtime typecheck`.
+- `pnpm complexity:diff --base b6454467652310f7abdd63676dab0f769c340ae8 --
+  packages/assistant-runtime/src/hosted-runtime/callbacks.ts`: debt 180 to 169;
+  send callback 84 to 73. Source change: +73/-120 lines.
+- A local source-derived probe executed the complete base/head send factory with
+  identical synthetic ports and deterministic dates: 384 traces matched ordered
+  owner calls, property presence, arguments, return values and error markers.
+  Cases include ordinary/private/reviewed completions, thread/participant/default
+  routes, card capability and fallback, revocation, vault attachments, failed and
+  ambiguous provider outcomes, partial rich links, and rejected receipt writes.
+  Mutations after authority, preload, provider liveness, reviewed preparation and
+  fallback awaits change the request payload and input route context/intent/effects
+  to prove the helpers preserve live reads instead of capturing stale authority.
+
+The existing callback tests exercise the actual composed delivery owner and
+provider-shaped requests; the differential probe isolates the changed wiring.
+No prompts, model inputs, tools, replies or decision rules change, so stochastic
+real-Codex reply proof does not add coverage for this mechanical refactor.
+Required CI and final ReviewGPT remain PR admission/handoff gates.
+
+## Risks and decisions
+
+Every authority check and external effect keeps its existing position. Helpers
+only construct existing owner inputs. No broad split is justified solely by file
+size or complexity score. No new qualifying Frog friction has occurred.
+Completed: 2026-09-04

--- a/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
@@ -4600,7 +4600,14 @@ function createHostedAssistantLinqSendDependency(input: {
     ) === true;
     const includesVaultFile =
       request.media?.some((media) => media.kind === "vault_file") === true;
-    if (privateAssistantAskCompletion) {
+    const assertPrivateAssistantAskCompletionRoute = async (route: {
+      fromPhoneNumber: string | null;
+      kind: HostedExecutionAssistantNotificationRoute["delivery"]["kind"];
+      target: string;
+    }) => {
+      if (!privateAssistantAskCompletion) {
+        return;
+      }
       const routeContext = input.deliveryRouteContext;
       if (!routeContext) {
         throw new VaultCliError(
@@ -4609,22 +4616,21 @@ function createHostedAssistantLinqSendDependency(input: {
           { retryable: false },
         );
       }
-      const targetKind = request.targetKind ?? "thread";
       await assertHostedPrivateAssistantAskCompletionAtProviderEntry({
         actualRoute: {
           actorId: routeContext.actorId,
           channel: "linq",
           delivery: {
-            kind: targetKind,
-            ...(targetKind === "participant" && candidateFromPhoneNumber
+            kind: route.kind,
+            ...(route.kind === "participant" && route.fromPhoneNumber
               ? {
                   source: {
-                    fromPhoneNumber: candidateFromPhoneNumber,
+                    fromPhoneNumber: route.fromPhoneNumber,
                     kind: "linq" as const,
                   },
                 }
               : {}),
-            target: deliveryContext?.target ?? request.target,
+            target: route.target,
           },
           identityId: routeContext.identityId,
           threadId: routeContext.threadId,
@@ -4637,6 +4643,13 @@ function createHostedAssistantLinqSendDependency(input: {
         now: new Date(),
         signal: signal ?? null,
         vaultRoot: input.vaultRoot ?? null,
+      });
+    };
+    if (privateAssistantAskCompletion) {
+      await assertPrivateAssistantAskCompletionRoute({
+        fromPhoneNumber: candidateFromPhoneNumber,
+        kind: request.targetKind ?? "thread",
+        target: deliveryContext?.target ?? request.target,
       });
     }
     const engagement =
@@ -4707,54 +4720,36 @@ function createHostedAssistantLinqSendDependency(input: {
     const hasVerifiedVaultAttachment =
       verifiedVaultFiles.size > 0 || verifiedVaultImages.size > 0;
     const readProviderAttempt = () => providerAttempt;
-    const assertPrivateAssistantAskCompletionAtProviderEntry = async () => {
-      if (!privateAssistantAskCompletion) {
-        return;
-      }
-      const routeContext = input.deliveryRouteContext;
-      if (!routeContext) {
-        throw new VaultCliError(
-          "ASSISTANT_ASK_PRIVATE_COMPLETION_ROUTE_UNAVAILABLE",
-          "Private Assistant Ask completion route is unavailable.",
-          { retryable: false },
-        );
-      }
-      await assertHostedPrivateAssistantAskCompletionAtProviderEntry({
-        actualRoute: {
-          actorId: routeContext.actorId,
-          channel: "linq",
-          delivery: {
-            kind: providerTargetKind ?? "explicit",
-            ...(providerTargetKind === "participant" && fromPhoneNumber
-              ? {
-                  source: {
-                    fromPhoneNumber,
-                    kind: "linq" as const,
-                  },
-                }
-              : {}),
-            target: providerTarget,
-          },
-          identityId: routeContext.identityId,
-          threadId: routeContext.threadId,
-          threadIsDirect: routeContext.threadIsDirect,
-        },
-        effectsPort: input.effectsPort ?? null,
-        intentId: input.intentId ?? null,
-        media: request.media ?? [],
-        message: request.message,
-        now: new Date(),
-        signal: signal ?? null,
-        vaultRoot: input.vaultRoot ?? null,
-      });
-    };
+    const readResolvedEngagementInput = () => ({
+      answeredMailboxItemIds: request.answeredMailboxItemIds,
+      assistantAskFallback: reviewedAssistantAskCompletion
+        ? isHostedReviewedAssistantAskFallbackPayload({
+            media: request.media,
+            message: request.message,
+          })
+        : undefined,
+      directRecipientPhoneNumber,
+      effectsPort: input.effectsPort ?? null,
+      expectedResolvedRoute: resolvedRoute,
+      fromPhoneNumber,
+      homeRouteFallbackAllowed: false,
+      intentId: input.intentId ?? null,
+      replyToMessageId: request.replyToMessageId ?? null,
+      signal: signal ?? null,
+      target: providerTarget,
+      targetKind: providerTargetKind,
+    });
     const createMessageFetchBoundary = (
       deliveryIdempotencyKey: string | null,
     ): typeof fetch => createHostedProviderFetchBoundary({
       assertProviderEntryLive: async () => {
         try {
           await assertHostedDeliveryCanEnterProvider(input);
-          await assertPrivateAssistantAskCompletionAtProviderEntry();
+          await assertPrivateAssistantAskCompletionRoute({
+            fromPhoneNumber,
+            kind: providerTargetKind ?? "explicit",
+            target: providerTarget,
+          });
         } catch (error) {
           if (providerAttempt && hasVerifiedVaultAttachment) {
             throw markHostedLinqAttachmentReservationMayHaveSucceeded(error);
@@ -4775,28 +4770,11 @@ function createHostedAssistantLinqSendDependency(input: {
             : undefined;
           const providerEntry =
             await assertHostedAssistantLinqRecentInboundEngagementForDelivery({
-              answeredMailboxItemIds: request.answeredMailboxItemIds,
+              ...readResolvedEngagementInput(),
               assistantAskCompletionExpiresAt: reviewedCompletionExpiresAt,
-              assistantAskFallback:
-                reviewedAssistantAskCompletion
-                  ? isHostedReviewedAssistantAskFallbackPayload({
-                      media: request.media,
-                      message: request.message,
-                    })
-                  : undefined,
               authorityCheckOnly: false,
-              directRecipientPhoneNumber,
-              effectsPort: input.effectsPort ?? null,
-              expectedResolvedRoute: resolvedRoute,
-              fromPhoneNumber,
-              homeRouteFallbackAllowed: false,
               idempotencyKey: deliveryIdempotencyKey,
-              intentId: input.intentId ?? null,
-              replyToMessageId: request.replyToMessageId ?? null,
               providerDispatchRetrySafe: true,
-              signal: signal ?? null,
-              target: providerTarget,
-              targetKind: providerTargetKind,
             });
           if (providerEntry.assistantAskFallbackRequired === true) {
             if (!input.intentId || !input.vaultRoot) {
@@ -4839,28 +4817,15 @@ function createHostedAssistantLinqSendDependency(input: {
       assertProviderEntryLive: async () => {
         try {
           await assertHostedDeliveryCanEnterProvider(input);
-          await assertPrivateAssistantAskCompletionAtProviderEntry();
-          await assertHostedAssistantLinqRecentInboundEngagementForDelivery({
-            answeredMailboxItemIds: request.answeredMailboxItemIds,
-            assistantAskFallback:
-              reviewedAssistantAskCompletion
-                ? isHostedReviewedAssistantAskFallbackPayload({
-                    media: request.media,
-                    message: request.message,
-                  })
-                : undefined,
-            authorityCheckOnly: true,
-            directRecipientPhoneNumber,
-            effectsPort: input.effectsPort ?? null,
-            expectedResolvedRoute: resolvedRoute,
+          await assertPrivateAssistantAskCompletionRoute({
             fromPhoneNumber,
-            homeRouteFallbackAllowed: false,
-            idempotencyKey,
-            intentId: input.intentId ?? null,
-            replyToMessageId: request.replyToMessageId ?? null,
-            signal: signal ?? null,
+            kind: providerTargetKind ?? "explicit",
             target: providerTarget,
-            targetKind: providerTargetKind,
+          });
+          await assertHostedAssistantLinqRecentInboundEngagementForDelivery({
+            ...readResolvedEngagementInput(),
+            authorityCheckOnly: true,
+            idempotencyKey,
           });
         } catch (error) {
           throw markHostedDeliveryPreProvider(error);
@@ -4884,6 +4849,25 @@ function createHostedAssistantLinqSendDependency(input: {
       fetchImplementation: createMessageFetchBoundary(idempotencyKey),
       ...(signal ? { signal } : {}),
     }, "Hosted assistant Linq delivery");
+    const buildDeliveryOutcome = (outcome: Omit<
+      Parameters<typeof buildHostedAssistantLinqDeliveryOutcomeRequest>[0],
+      | "directRecipientPhoneNumber"
+      | "fromPhoneNumber"
+      | "intentId"
+      | "providerTarget"
+      | "target"
+      | "targetKind"
+      | "threadIsDirect"
+    >) => buildHostedAssistantLinqDeliveryOutcomeRequest({
+      ...outcome,
+      directRecipientPhoneNumber: originalParticipantRecipientPhoneNumber,
+      fromPhoneNumber,
+      intentId: input.intentId ?? null,
+      providerTarget,
+      target: providerTarget,
+      targetKind: providerTargetKind,
+      threadIsDirect: resolvedRoute.threadIsDirect,
+    });
     let result: HostedRuntimeLinqSendResponse;
     try {
       result = await sendHostedProviderLinqMessage({
@@ -4953,24 +4937,15 @@ function createHostedAssistantLinqSendDependency(input: {
                 ) {
                   await recordHostedAssistantLinqDeliveryOutcomeRequired({
                     effectsPort: input.effectsPort ?? null,
-                    outcome: buildHostedAssistantLinqDeliveryOutcomeRequest({
+                    outcome: buildDeliveryOutcome({
                       attemptedAt: providerAttempt.attemptedAt,
                       answeredMailboxItemIds: [],
-                      directRecipientPhoneNumber:
-                        originalParticipantRecipientPhoneNumber,
                       failedAt: new Date(),
                       failureCode: HOSTED_LINQ_APP_CARD_REJECTED_FAILURE_CODE,
                       failureReason: null,
-                      fromPhoneNumber,
                       idempotencyKey: providerAttempt.idempotencyKey,
-                      intentId: input.intentId ?? null,
-                      providerTarget,
                       providerThreadId: null,
                       result: null,
-                      target: providerTarget,
-                      targetKind: providerTargetKind,
-                      threadIsDirect:
-                        resolvedRoute.threadIsDirect,
                     }),
                   });
                   providerAttempt = null;
@@ -4991,23 +4966,15 @@ function createHostedAssistantLinqSendDependency(input: {
       if (partialRichLinkResult) {
         await recordHostedAssistantLinqDeliveryOutcomeOrQueueBestEffort({
           effectsPort: input.effectsPort ?? null,
-          outcome: buildHostedAssistantLinqDeliveryOutcomeRequest({
+          outcome: buildDeliveryOutcome({
             attemptedAt: failedProviderAttempt.attemptedAt,
             answeredMailboxItemIds: [],
-            directRecipientPhoneNumber: originalParticipantRecipientPhoneNumber,
             failedAt: new Date(),
             failureCode: readHostedAssistantLinqDeliveryFailureCode(error),
             failureReason: null,
-            fromPhoneNumber,
             idempotencyKey: failedProviderAttempt.idempotencyKey,
-            intentId: input.intentId ?? null,
-            providerTarget,
             providerThreadId: partialRichLinkResult.providerThreadId ?? null,
             result: partialRichLinkResult,
-            target: providerTarget,
-            targetKind: providerTargetKind,
-            threadIsDirect:
-              resolvedRoute.threadIsDirect,
           }),
         });
         throw markHostedDeliveryMayHaveSucceeded(error);
@@ -5023,22 +4990,15 @@ function createHostedAssistantLinqSendDependency(input: {
       }
       queueHostedAssistantLinqDeliveryOutcomeWrite({
         effectsPort: input.effectsPort ?? null,
-        outcome: buildHostedAssistantLinqDeliveryOutcomeRequest({
+        outcome: buildDeliveryOutcome({
           attemptedAt: failedProviderAttempt.attemptedAt,
           answeredMailboxItemIds: request.answeredMailboxItemIds ?? [],
-          directRecipientPhoneNumber: originalParticipantRecipientPhoneNumber,
           failedAt: new Date(),
           failureCode: readHostedAssistantLinqDeliveryFailureCode(error),
           failureReason: readTrustedHostedAssistantLinqDeliveryFailureReason(error),
-          fromPhoneNumber,
           idempotencyKey: failedProviderAttempt.idempotencyKey,
-          intentId: input.intentId ?? null,
-          providerTarget,
           providerThreadId: null,
           result: null,
-          target: providerTarget,
-          targetKind: providerTargetKind,
-          threadIsDirect: resolvedRoute.threadIsDirect,
         }),
       });
       throw error;
@@ -5055,22 +5015,15 @@ function createHostedAssistantLinqSendDependency(input: {
     });
     await recordHostedAssistantLinqDeliveryOutcomeOrQueueBestEffort({
       effectsPort: input.effectsPort ?? null,
-      outcome: buildHostedAssistantLinqDeliveryOutcomeRequest({
+      outcome: buildDeliveryOutcome({
         acceptedAt,
         attemptedAt: requireHostedLinqProviderAttemptedAt(
           acceptedProviderAttempt?.attemptedAt ?? null,
         ),
         answeredMailboxItemIds: request.answeredMailboxItemIds ?? [],
-        directRecipientPhoneNumber: originalParticipantRecipientPhoneNumber,
-        fromPhoneNumber,
         idempotencyKey: acceptedIdempotencyKey,
-        intentId: input.intentId ?? null,
-        providerTarget,
         providerThreadId: result.providerThreadId ?? null,
         result,
-        target: providerTarget,
-        targetKind: providerTargetKind,
-        threadIsDirect: resolvedRoute.threadIsDirect,
       }),
     });
     await assertHostedDeliveryLiveNow(input);


### PR DESCRIPTION
## Why and outcome

The hosted Linq send callback repeated private-completion authority arguments, resolved-route engagement arguments, and receipt route arguments. Consolidate that wiring in three local helpers while preserving both live authority checks, action-specific defaults, fallback settlement and receipt ownership. The callback drops from cyclomatic complexity 84 to 73, with 47 fewer production lines.

## Product UX

- Effort: Not applicable — internal behavior-preserving refactor.
- Result: Parent candidate review complete; behavior preservation confirmed.
- Walkthrough: Existing composed tests replay normal/private/reviewed sends, participant/thread routing, revoked authority, card fallback, secure attachments and failure recovery. No product experience, prompts, tools or generated replies change; no difference from plan.

## Evidence

- Direct: 306 tests passed across `hosted-runtime-callbacks.test.ts`, `hosted-runtime-current-sender-assistant-ask.test.ts`, `hosted-runtime-assistant-ask-completion.integration.test.ts`, and `hosted-runtime-linq-outbox-regression.test.ts`, using `MURPH_VITEST_MAX_WORKERS=2 pnpm --dir packages/assistant-runtime test` with those four `test/` paths.
- Direct: `pnpm --dir packages/assistant-runtime typecheck` passed.
- Direct: 384 local source-derived full-factory base/head traces matched ordered owner calls, argument property presence, returns and errors. Synthetic cases cover capability reads versus dispatch claims, preflight/provider route defaults, card rejection before fallback claims, attachment uncertainty, partial delivery, receipt failure, and request/route-context mutations between awaits.
- Coverage: Existing tests exercise the real composed delivery owner and provider-shaped requests; differential traces isolate the changed wiring. No interpretation, model-input, reply or tool behavior changes, so stochastic real-Codex reply proof is not applicable. All four required GitHub checks pass on `14386e6d5c878ce6bf103f9269954d0be8b8a314`: both CLI host matrices, Release checks, and the hosted Stripe billing boundary. [Release CI](https://github.com/cobuildwithus/murph/actions/runs/33934041464), [billing CI](https://github.com/cobuildwithus/murph/actions/runs/33934041488).

- ReviewGPT: [Round 1 full-snapshot PASS](https://chatgpt.com/c/6a9b7e07-050c-83e9-abc3-b42f1fd1333d) on Mountain using `gpt-6-pro`, captured after 495.695 seconds (8m15.7s). Exact head, attachment, committed turn, model, response digest, and round metadata verified; zero findings. Parent reviewed and accepted the result. Review traced authority, mutable reads after awaits, dispatch and retry boundaries, fallback settlement, attachment ambiguity, and receipt ownership; reviewer additionally reported 149 matching differential scenarios. Two earlier responses were retained only as diagnostics because they fell below the review-duration floor.

## Non-obvious affected surfaces

Private/reviewed Assistant Ask completion, card fallback and Linq outcome recording share this callback. The composed suites and differential traces cover their authority, settlement, idempotency and receipt boundaries.

## Architecture and reuse

- Existing systems reused: Current private-completion authority, engagement authority, provider fetch boundaries, attachment preloads and receipt writers remain the owners.
- New logic: None; the existing operations and branches retain their order and decisions.
- New abstractions: Three invocation-local argument helpers; mutable input fields are read per call after awaits.
- Complexity intentionally avoided: No new state, manager, shared framework, policy table, retry layer or cross-file reorganization.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff --base b6454467652310f7abdd63676dab0f769c340ae8 -- packages/assistant-runtime/src/hosted-runtime/callbacks.ts`; debt 180 → 169, maximum 84 → 73.
- Hotspots: Changed Linq send callback 84 → 73. Unchanged owners: Telegram authority 47, delivery drain 37, prepared delivery 35, side-effect collection 33, ambiguous Linq outcome 32, vault-file reconciliation 28, Telegram send callback 26, resolved-route normalization 25, delivery outcome construction 25, intent payload construction 21, email send 24, dispatch preflight 21, progress dependencies 21, vault-file preload 21.
- Agent judgment: Concrete repetition was removed without moving authority or effects. The remaining branches enforce distinct routing, attachment, fallback or failure boundaries; splitting them solely to lower the metric is not justified in this patch.

## Hot reply path impact

- Path status: Touched — hosted Linq delivery callback wiring only.
- Database calls: None added or moved; existing authority and receipt owners remain in place.
- Network/provider calls: None added or moved; capability and effect calls retain their boundaries and ordering.
- Other awaited latency: No new external work; the initial private assertion is wrapped by the same local helper used at provider entry. Existing timeouts, retries, fallback and serial ordering are unchanged.
- Before/after proof: 384 matching traces preserve call counts and order, including capability revalidation and failed-card settlement before fallback dispatch. No latency improvement is claimed.

## Murph initial provider input impact

Not applicable to individual and group runtimes: this callback processes an already-chosen delivery and changes no model instructions, histories, schemas or generated guidance.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no initial model-provider input surface changed.

ReviewGPT first-reviewed head: 14386e6d5c878ce6bf103f9269954d0be8b8a314
ReviewGPT context sensitivity: sensitive
Classification reason: Delivery authorization and externally visible effects share the refactored callback.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal callback argument consolidation changes no persisted state, protocol, deployment configuration or Web/Worker/container compatibility contract.

## Change-shape breakdown

Classification rule: Production TypeScript is source; the archived execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 73 | 120 |
| Tests / fixtures | 0 | 0 |
| Docs | 86 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **159** | **120** |

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving cleanup with no member-visible feature or behavior change.
