### PR TITLE
refactor: consolidate hosted group summary response parsing

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-complexity-runtime-group-responses.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-complexity-runtime-group-responses.md
@@ -1,0 +1,49 @@
+# Simplify hosted runtime group response parsing
+
+Status: completed
+Created: 2026-09-04
+Updated: 2026-09-04
+
+## Goal
+
+- Remove repeated group-summary response validation while preserving the hosted wire contract exactly.
+
+## Success criteria
+
+- Preserve accepted values, normalized results, rejected values and error labels across the changed actions.
+- Focused parser tests, package typecheck and complexity guard pass; parent candidate review, exact-head ReviewGPT and required CI pass before completion.
+
+## Scope
+
+- In scope: read_current, create_join_link, update_display_name and post_join_offer response parsing and direct boundary proof.
+- Out of scope: request parsing, authorization, effect delivery, schema changes and new parser frameworks.
+
+## Constraints
+
+- Technical constraints: retain action-specific success shapes, keysets, validation order and nullish semantics. No dependencies or new owners.
+- Product/process constraints: internal behavior-preserving refactor; no product UX change, provider-input change or changelog entry. Keep isolated draft PR until parent review.
+
+## Risks and mitigations
+
+1. Risk: merging action paths accidentally accepts a sibling status or changes validation order.
+   Mitigation: retain explicit success guards and exercise cross-action status/keyset boundaries plus baseline differential proof.
+
+## Tasks
+
+1. Consolidate common result/status and unavailable handling within the current parser.
+2. Add protocol boundary tests and run focused tests, typecheck, complexity and differential proof.
+3. Review and commit the candidate; open draft PR and obtain parent review before Ready, ReviewGPT and CI.
+
+## Decisions
+
+- Group-unavailable responses intentionally normalize any group value to null; this refactor must not tighten that established contract.
+
+## Verification
+
+- Passed: `pnpm exec vitest run --config packages/hosted-execution/vitest.config.ts --no-coverage` with parsers, hosted-runtime-control, disclosure-contracts, group-context-handoff, group-journal-fact and signup-referral-link-parser test paths: 169 tests across six suites.
+- Passed: `pnpm --filter @murphai/hosted-execution typecheck` and `pnpm complexity:diff` (debt 194 and maximum 149 unchanged).
+- Passed: 10,284 synthetic baseline/head differential comparisons of values and exact error names/messages. The temporary comparison harness was removed after verification.
+- Added 43 permanent boundary cases. An initial broader package run passed 626 cases and exposed four incorrect expected primitive error labels in new tests; corrected expectations and final focused proof passed.
+- Outcome: 82 net production lines removed; no parse result or error changes observed. Final ReviewGPT and required CI remain PR gates.
+- Frog: inspected existing entries after the ordinary frozen install; no new qualifying repository friction.
+Completed: 2026-09-04

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -3355,59 +3355,159 @@ export function parseHostedRuntimeGroupToolResponse(
     }
   }
 
-  if (action === "read_current") {
-    const result = requireObject(
-      record.result,
-      "Hosted runtime group tool read_current response result",
-    );
-    const status = requireString(
-      result.status,
-      "Hosted runtime group tool read_current response status",
-    );
-    if (status === "ok") {
-      assertAllowedObjectKeys(
-        result,
-        new Set([
-          "disclosureGrantsTruncated",
-          "group",
-          "nextDisclosureGrantCursor",
-          "status",
-        ]),
-        "Hosted runtime group tool read_current ok response result",
-      );
-      return {
-        action,
-        result: {
-          status,
-          ...(result.disclosureGrantsTruncated === undefined
-            ? {}
-            : {
-                disclosureGrantsTruncated: requireBoolean(
-                  result.disclosureGrantsTruncated,
-                  "Hosted runtime group tool read_current disclosureGrantsTruncated",
-                ),
-              }),
-          group: parseHostedRuntimeGroupSummary(result.group),
-          ...parseHostedRuntimeGroupDisclosureNextCursor(
-            result.nextDisclosureGrantCursor,
-            "Hosted runtime group tool read_current nextDisclosureGrantCursor",
-          ),
-        },
-      };
-    }
-    if (status === "none") {
-      assertAllowedObjectKeys(
-        result,
-        new Set(["status", "group"]),
-        "Hosted runtime group tool read_current none response result",
-      );
-      return { action, result: { status, group: null } };
+  if (
+    action === "read_current" ||
+    action === "create_join_link" ||
+    action === "update_display_name" ||
+    action === "post_join_offer"
+  ) {
+    const label = `Hosted runtime group tool ${action}`;
+    const result = requireObject(record.result, `${label} response result`);
+    const status = requireString(result.status, `${label} response status`);
+    if (action === "read_current") {
+      if (status === "ok") {
+        assertAllowedObjectKeys(
+          result,
+          new Set([
+            "disclosureGrantsTruncated",
+            "group",
+            "nextDisclosureGrantCursor",
+            "status",
+          ]),
+          "Hosted runtime group tool read_current ok response result",
+        );
+        return {
+          action,
+          result: {
+            status,
+            ...(result.disclosureGrantsTruncated === undefined
+              ? {}
+              : {
+                  disclosureGrantsTruncated: requireBoolean(
+                    result.disclosureGrantsTruncated,
+                    "Hosted runtime group tool read_current disclosureGrantsTruncated",
+                  ),
+                }),
+            group: parseHostedRuntimeGroupSummary(result.group),
+            ...parseHostedRuntimeGroupDisclosureNextCursor(
+              result.nextDisclosureGrantCursor,
+              "Hosted runtime group tool read_current nextDisclosureGrantCursor",
+            ),
+          },
+        };
+      }
+      if (status === "none") {
+        assertAllowedObjectKeys(
+          result,
+          new Set(["status", "group"]),
+          "Hosted runtime group tool read_current none response result",
+        );
+        return { action, result: { status, group: null } };
+      }
+    } else if (action === "create_join_link") {
+      if (status === "ok") {
+        assertAllowedObjectKeys(
+          result,
+          new Set(["status", "group", "joinUrl", "offeredAt"]),
+          "Hosted runtime group tool create_join_link ok response result",
+        );
+        const offeredAt =
+          result.offeredAt === undefined
+            ? undefined
+            : parseHostedRuntimeGroupCanonicalTimestamp(
+                result.offeredAt,
+                "Hosted runtime group tool create_join_link offeredAt",
+              );
+        return {
+          action,
+          result: {
+            status,
+            group: parseHostedRuntimeGroupSummary(result.group),
+            joinUrl: requireString(
+              result.joinUrl,
+              "Hosted runtime group tool create_join_link joinUrl",
+            ),
+            ...(offeredAt === undefined ? {} : { offeredAt }),
+          },
+        };
+      }
+    } else if (action === "update_display_name") {
+      if (status === "ok") {
+        assertAllowedObjectKeys(
+          result,
+          new Set(["status", "group"]),
+          "Hosted runtime group tool update_display_name ok response result",
+        );
+        return {
+          action,
+          result: {
+            status,
+            group:
+              result.group === null
+                ? null
+                : parseHostedRuntimeGroupSummary(result.group),
+          },
+        };
+      }
+    } else {
+      if (status === "sent") {
+        assertAllowedObjectKeys(
+          result,
+          new Set(["status", "group", "joinUrl", "offeredAt", "offerState"]),
+          "Hosted runtime group tool post_join_offer sent response result",
+        );
+        const offeredAt =
+          result.offeredAt === undefined
+            ? undefined
+            : parseHostedRuntimeGroupCanonicalTimestamp(
+                result.offeredAt,
+                "Hosted runtime group tool post_join_offer offeredAt",
+              );
+        const offerState =
+          result.offerState === undefined
+            ? undefined
+            : requireString(
+                result.offerState,
+                "Hosted runtime group tool post_join_offer offerState",
+              );
+        if (
+          offerState !== undefined &&
+          offerState !== "existing" &&
+          offerState !== "posted"
+        ) {
+          throw new TypeError(
+            "Hosted runtime group tool post_join_offer offerState is invalid.",
+          );
+        }
+        if (offeredAt !== undefined && offerState === undefined) {
+          throw new TypeError(
+            "Hosted runtime group tool post_join_offer offeredAt requires offerState.",
+          );
+        }
+        return {
+          action,
+          result: {
+            status,
+            group: parseHostedRuntimeGroupSummary(result.group),
+            joinUrl: requireString(
+              result.joinUrl,
+              "Hosted runtime group tool post_join_offer joinUrl",
+            ),
+            ...(offerState === undefined
+              ? {}
+              : {
+                  offerState,
+                  ...(offeredAt === undefined ? {} : { offeredAt }),
+                }),
+          },
+        };
+      }
     }
     if (status === "unavailable") {
       assertAllowedObjectKeys(
         result,
         new Set(["status", "unavailableReason", "group"]),
-        "Hosted runtime group tool read_current unavailable response result",
+        `${label} unavailable response result`,
       );
       return {
         action,
@@ -3994,188 +4094,6 @@ export function parseHostedRuntimeGroupToolResponse(
             result.unavailableReason,
             "Hosted runtime group tool leave_membership unavailableReason",
           ),
-        },
-      };
-    }
-  }
-
-  if (action === "create_join_link") {
-    const result = requireObject(
-      record.result,
-      "Hosted runtime group tool create_join_link response result",
-    );
-    const status = requireString(
-      result.status,
-      "Hosted runtime group tool create_join_link response status",
-    );
-    if (status === "ok") {
-      assertAllowedObjectKeys(
-        result,
-        new Set(["status", "group", "joinUrl", "offeredAt"]),
-        "Hosted runtime group tool create_join_link ok response result",
-      );
-      const offeredAt =
-        result.offeredAt === undefined
-          ? undefined
-          : parseHostedRuntimeGroupCanonicalTimestamp(
-              result.offeredAt,
-              "Hosted runtime group tool create_join_link offeredAt",
-            );
-      return {
-        action,
-        result: {
-          status,
-          group: parseHostedRuntimeGroupSummary(result.group),
-          joinUrl: requireString(
-            result.joinUrl,
-            "Hosted runtime group tool create_join_link joinUrl",
-          ),
-          ...(offeredAt === undefined ? {} : { offeredAt }),
-        },
-      };
-    }
-    if (status === "unavailable") {
-      assertAllowedObjectKeys(
-        result,
-        new Set(["status", "unavailableReason", "group"]),
-        "Hosted runtime group tool create_join_link unavailable response result",
-      );
-      return {
-        action,
-        result: {
-          status,
-          unavailableReason: requireString(
-            result.unavailableReason,
-            "Hosted runtime group unavailableReason",
-          ),
-          group: null,
-        },
-      };
-    }
-  }
-
-  if (action === "update_display_name") {
-    const result = requireObject(
-      record.result,
-      "Hosted runtime group tool update_display_name response result",
-    );
-    const status = requireString(
-      result.status,
-      "Hosted runtime group tool update_display_name response status",
-    );
-    if (status === "ok") {
-      assertAllowedObjectKeys(
-        result,
-        new Set(["status", "group"]),
-        "Hosted runtime group tool update_display_name ok response result",
-      );
-      return {
-        action,
-        result: {
-          status,
-          group:
-            result.group === null
-              ? null
-              : parseHostedRuntimeGroupSummary(result.group),
-        },
-      };
-    }
-    if (status === "unavailable") {
-      assertAllowedObjectKeys(
-        result,
-        new Set(["status", "unavailableReason", "group"]),
-        "Hosted runtime group tool update_display_name unavailable response result",
-      );
-      return {
-        action,
-        result: {
-          status,
-          unavailableReason: requireString(
-            result.unavailableReason,
-            "Hosted runtime group unavailableReason",
-          ),
-          group: null,
-        },
-      };
-    }
-  }
-
-  if (action === "post_join_offer") {
-    const result = requireObject(
-      record.result,
-      "Hosted runtime group tool post_join_offer response result",
-    );
-    const status = requireString(
-      result.status,
-      "Hosted runtime group tool post_join_offer response status",
-    );
-    if (status === "sent") {
-      assertAllowedObjectKeys(
-        result,
-        new Set(["status", "group", "joinUrl", "offeredAt", "offerState"]),
-        "Hosted runtime group tool post_join_offer sent response result",
-      );
-      const offeredAt =
-        result.offeredAt === undefined
-          ? undefined
-          : parseHostedRuntimeGroupCanonicalTimestamp(
-              result.offeredAt,
-              "Hosted runtime group tool post_join_offer offeredAt",
-            );
-      const offerState =
-        result.offerState === undefined
-          ? undefined
-          : requireString(
-              result.offerState,
-              "Hosted runtime group tool post_join_offer offerState",
-            );
-      if (
-        offerState !== undefined &&
-        offerState !== "existing" &&
-        offerState !== "posted"
-      ) {
-        throw new TypeError(
-          "Hosted runtime group tool post_join_offer offerState is invalid.",
-        );
-      }
-      if (offeredAt !== undefined && offerState === undefined) {
-        throw new TypeError(
-          "Hosted runtime group tool post_join_offer offeredAt requires offerState.",
-        );
-      }
-      return {
-        action,
-        result: {
-          status,
-          group: parseHostedRuntimeGroupSummary(result.group),
-          joinUrl: requireString(
-            result.joinUrl,
-            "Hosted runtime group tool post_join_offer joinUrl",
-          ),
-          ...(offerState === undefined
-            ? {}
-            : {
-                offerState,
-                ...(offeredAt === undefined ? {} : { offeredAt }),
-              }),
-        },
-      };
-    }
-    if (status === "unavailable") {
-      assertAllowedObjectKeys(
-        result,
-        new Set(["status", "unavailableReason", "group"]),
-        "Hosted runtime group tool post_join_offer unavailable response result",
-      );
-      return {
-        action,
-        result: {
-          status,
-          unavailableReason: requireString(
-            result.unavailableReason,
-            "Hosted runtime group unavailableReason",
-          ),
-          group: null,
         },
       };
     }

--- a/packages/hosted-execution/test/parsers.test.ts
+++ b/packages/hosted-execution/test/parsers.test.ts
@@ -1643,6 +1643,54 @@ describe("parseHostedRuntimeGroupTool", () => {
     })).toThrow(/at most 25 entries/u);
   });
 
+  describe.each([
+    "read_current",
+    "create_join_link",
+    "update_display_name",
+    "post_join_offer",
+  ])("%s group-summary response boundary", (action) => {
+    it.each([undefined, null, false, 0, "ignored", {}, []])(
+      "normalizes unavailable group payload %j without widening result keys",
+      (group) => {
+        expect(parseHostedRuntimeGroupToolResponse({
+          action,
+          result: { group, status: "unavailable", unavailableReason: "offline" },
+        })).toEqual({
+          action,
+          result: { group: null, status: "unavailable", unavailableReason: "offline" },
+        });
+      },
+    );
+
+    it("preserves unavailable key and reason validation order", () => {
+      expect(() => parseHostedRuntimeGroupToolResponse({
+        action,
+        result: { status: "unavailable", unavailableReason: null, extra: true },
+      })).toThrow(`Hosted runtime group tool ${action} unavailable response result.extra is not allowed.`);
+      expect(() => parseHostedRuntimeGroupToolResponse({
+        action,
+        result: { status: "unavailable", unavailableReason: null },
+      })).toThrow("Hosted runtime group unavailableReason must be a non-empty string.");
+      expect(() => parseHostedRuntimeGroupToolResponse({ action, result: null }))
+        .toThrow(`Hosted runtime group tool ${action} response result must be an object.`);
+      expect(() => parseHostedRuntimeGroupToolResponse({ action, result: {} }))
+        .toThrow(`Hosted runtime group tool ${action} response status must be a non-empty string.`);
+    });
+
+    const acceptedStatuses = action === "read_current"
+      ? ["ok", "none"]
+      : [action === "post_join_offer" ? "sent" : "ok"];
+    it.each(["none", "sent", "ok", "unknown"].filter((status) => !acceptedStatuses.includes(status)))(
+      "keeps status %s specific to its action",
+      (status) => {
+        expect(() => parseHostedRuntimeGroupToolResponse({
+          action,
+          result: { group: null, status },
+        })).toThrow("Hosted runtime group tool response action/status is not supported.");
+      },
+    );
+  });
+
   it("parses create_join_link responses", () => {
     expect(parseHostedRuntimeGroupToolResponse({
       action: "create_join_link",


### PR DESCRIPTION
## Why and outcome

Four group-summary response actions repeated the same object/status validation and unavailable normalization. Keep their action-specific success contracts together and share the common parsing path, removing 82 production lines without changing accepted inputs, outputs or errors.

## Product UX

- Effort: Not applicable — internal behavior-preserving parser consolidation.
- Result: Not applicable.
- Walkthrough: Group reads, join links, display-name updates and join offers retain their existing success and unavailable results; no user-facing behavior changes.

## Evidence

- Direct: 10,284 synthetic differential comparisons against the base parser passed, checking parsed values and exact error names/messages across the changed actions, optional fields, malformed inputs and unaffected controls.
- Coverage: 43 new permanent boundary cases cover unavailable normalization, validation ordering, exact keys and action-specific status rejection; existing tests cover success projections and join-offer timestamp/offer-state requirements.
- Validation: 169 tests across six focused parser suites and package typecheck passed. All four required checks pass on exact head `110c19b7905ae624bf93f6e53cfe3e45eedb443c`.
- Final ReviewGPT: [Round 1 PASS](https://chatgpt.com/c/6a9b7b0b-f678-83ea-87fb-8d10fe6a3bb7), Hercules lane, verified `gpt-6-pro`, 10m19.589s from send to capture. Full sensitive snapshot, exact-turn identity, response hashes and immutable baseline verified; zero findings. The earlier response was discarded for completing below the 6.5-minute trust floor; the fresh full-snapshot retry remains substantive round 1.

## Non-obvious affected surfaces

None. Request parsing, authorization, effect execution, legacy usage projections and all other response actions are unchanged.

## Architecture and reuse

- Existing systems reused: Existing group response parser, object/string validators, allowed-key validation and group-summary parser.
- New logic: None; common validation replaces four copies.
- New abstractions: None; the existing parser retains ownership.
- Complexity intentionally avoided: No parser registry, schema framework, new module or duplicate compatibility owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; file debt remains 194 and maximum function complexity remains 149.
- Hotspots: `parseHostedRuntimeGroupToolResponse` 149, `parseHostedRuntimeGroupToolRequest` 83, `parseHostedRuntimeGroupSharedProjection` 22. Response duplication is reduced; request/shared projection contracts are outside this bounded scope.
- Agent judgment: 82 net production lines removed while preserving explicit action discrimination. Further metric reduction alone would encourage extracting or generalizing distinct protocol contracts without a demonstrated benefit.

## Hot reply path impact

- Path status: Touched only through synchronous response parsing; no scheduling or effect ownership changes.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved.
- Before/after proof: Differential parser results and exact errors match; no asynchronous operations occur in the changed path.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no assembled instructions, tools, schemas, guidance, history or other initial provider-visible input changes. Measurements were not run because this changes only response parsing after tool execution and preserves its results.

## Deployment concerns

- Deployment: not applicable
- Reason: The same wire inputs, normalized values and rejection behavior are preserved across existing readers; no writer, schema, deploy configuration or version contract changes.

## Change-shape breakdown

Classification rule: runtime parser is source, parser tests are tests, execution plan is docs. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 148 | 230 |
| Tests / fixtures | 48 | 0 |
| Docs | 49 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | 245 | **230** |

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving parsing cleanup with no member-visible change.

ReviewGPT context sensitivity: sensitive
Classification reason: Hosted runtime protocol parsing is a trust boundary.

ReviewGPT first-reviewed head: 110c19b7905ae624bf93f6e53cfe3e45eedb443c
