### PR TITLE
refactor(health-metrics): collapse duplicate card validation

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-complexity-age-validation.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-complexity-age-validation.md
@@ -1,0 +1,79 @@
+# Collapse duplicate Murph Age card validation
+
+Status: completed
+Created: 2026-09-04
+Updated: 2026-09-04
+
+## Goal
+
+- Delete duplicate card-validation bookkeeping while preserving accepted inputs,
+  scientific and authorization boundaries, and exact warning/read order.
+
+## Success criteria
+
+- Shared aggregate checks retain explicit schema-owned key sets and subjects.
+- The three target validators have lower complexity without a new validation framework.
+- Focused tests, typecheck, and a base/head validation matrix pass.
+- Parent candidate review, final ReviewGPT, and exact-head CI pass for an open PR.
+
+## Scope
+
+- In scope: aggregate warning helpers and frozen-boolean validation used by the
+  increment, wearable-shadow, and activity-benchmark card validators; focused proof.
+- Out of scope: scientific calculations, model parameters, schemas, field readers,
+  source-route policy, product authorization, public APIs, and research.
+
+## Constraints
+
+- Preserve missing versus malformed optional fields, nullable metric rules,
+  separate schema key sets, unknown-field ordering, and strict boolean checks.
+- Use the existing warning accumulators and public validator entrypoints.
+- No dependencies, persisted state, helper factory, schema engine, or new owner.
+
+## Risks and mitigations
+
+1. Consolidation could reorder warnings or weaken a scientific/export restriction.
+   Mitigation: exact ordered-warning regressions, unchanged field reads, and an
+   independent base/head matrix including malformed and multi-error candidates.
+
+## Tasks
+
+1. Inspect each duplicated block and its public tests.
+2. Consolidate warning loops and remove duplicated finite-delta predicate.
+3. Run package tests/typecheck, base/head comparison, and complexity checks.
+4. Commit through finish-task, open draft PR, then run final review and CI after
+   parent candidate clearance. Keep the new PR open.
+
+## Decisions
+
+- Parent approved this bounded validator-only scope at baseline
+  `b6454467652310f7abdd63676dab0f769c340ae8`.
+- Keep scientific semantics and error/read order explicit; no research is needed.
+- Graft is unavailable, so inspection used exact baseline symbol ranges.
+
+## Verification
+
+- Focused health-metrics tests and package typecheck.
+- Exact base/head public-validator result and property-read comparison matrix.
+- Cyclomatic complexity diff, parent candidate review, final ReviewGPT, and CI.
+
+## Results
+
+- Shared aggregate warning loops retain separate schema key sets; duplicate
+  finite-delta predicate deleted. Four frozen-boolean loops now share one helper.
+- The existing aggregate-receipt model-metric caller uses the same consolidated
+  unknown-field/numeric check with its original label and ordering.
+- Package tests: 10 files, 80 tests passed. Package typecheck passed.
+- Independent source-bundled baseline/head comparison: 5,477 cases matched exact
+  validator results and Proxy get/ownKeys/descriptor traces (shadow 641,
+  increment 1,068, benchmark 1,959, receipt 1,809). Cases include omitted,
+  malformed, nonfinite, nullable, unknown-field, and simultaneous errors.
+- Ordered warning regressions cover numeric/schema errors, nullable AUC/c-index,
+  and strict frozen booleans across all four benchmark policy sections.
+- Complexity guard passed: file debt 158 to 136; increment validator 51 to 45,
+  benchmark validator 40 to 28, shadow validator 39 to 35. Other listed hotspots
+  retain distinct scientific/calculation/parameter-validation decisions outside
+  this duplicate-loop scope; no further generic validation framework is justified.
+- Frog inventory inspected; no new repository friction required a workaround.
+- Parent candidate review and exact-head ReviewGPT/CI remain PR completion gates.
+Completed: 2026-09-04

--- a/packages/health-metrics/src/murph-age.ts
+++ b/packages/health-metrics/src/murph-age.ts
@@ -5791,15 +5791,13 @@ export function validateMurphAgeWearableActivityBenchmarkCard(
       message: `${subject} output boundary must block rows, identifiers, split memberships, predictions, coefficients, model parameters, local paths, source text, and product display egress.`,
     });
   }
-  if (artifactBoundary) {
-    appendUnknownObjectKeyWarnings({
-      allowedKeys: MURPH_AGE_INCREMENT_EVALUATION_OUTPUT_BOUNDARY_KEYS,
-      label: "output boundary",
-      object: artifactBoundary,
-      subject,
-      warnings,
-    });
-  }
+  appendUnknownObjectKeyWarnings({
+    allowedKeys: MURPH_AGE_INCREMENT_EVALUATION_OUTPUT_BOUNDARY_KEYS,
+    label: "output boundary",
+    object: artifactBoundary,
+    subject,
+    warnings,
+  });
   if (denominatorPolicy) {
     appendUnknownObjectKeyWarnings({
       allowedKeys: MURPH_AGE_WEARABLE_ACTIVITY_BENCHMARK_DENOMINATOR_POLICY_KEYS,
@@ -5830,86 +5828,77 @@ export function validateMurphAgeWearableActivityBenchmarkCard(
         });
       }
     }
-    for (const key of [
-      "eligibleLinkedMortalityRequired",
-      "labBodyAnchorDenominatorRequired",
-      "objectiveActivityWindowRequired",
-      "publicUseRowsOnly",
-      "sameDenominatorRequired",
-    ]) {
-      if (denominatorPolicy[key] !== true) {
-        warnings.push({
-          code: "MODEL_CARD_POLICY_VIOLATION",
-          message: `${subject} denominator policy ${key} must be true.`,
-        });
-      }
-    }
+    appendFrozenBooleanWarnings({
+      object: denominatorPolicy,
+      label: "denominator policy",
+      expected: [
+        ["eligibleLinkedMortalityRequired", true],
+        ["labBodyAnchorDenominatorRequired", true],
+        ["objectiveActivityWindowRequired", true],
+        ["publicUseRowsOnly", true],
+        ["sameDenominatorRequired", true],
+      ],
+      subject,
+      warnings,
+    });
   }
   if (endpoint) {
     validateWearableLabAggregateReceiptEndpoint({ endpoint, subject, warnings });
   }
-  if (splitPolicy) {
-    appendUnknownObjectKeyWarnings({
-      allowedKeys: MURPH_AGE_WEARABLE_ACTIVITY_BENCHMARK_SPLIT_POLICY_KEYS,
-      label: "split policy",
-      object: splitPolicy,
-      subject,
-      warnings,
-    });
-    for (const [key, expected] of [
+  appendUnknownObjectKeyWarnings({
+    allowedKeys: MURPH_AGE_WEARABLE_ACTIVITY_BENCHMARK_SPLIT_POLICY_KEYS,
+    label: "split policy",
+    object: splitPolicy,
+    subject,
+    warnings,
+  });
+  appendFrozenBooleanWarnings({
+    object: splitPolicy,
+    label: "split policy",
+    expected: [
       ["aggregateSplitCountsExportOnly", true],
       ["frozenBeforeScoring", true],
       ["participantIdsExportAllowed", false],
       ["splitMembershipExportAllowed", false],
-    ] as const) {
-      if (splitPolicy[key] !== expected) {
-        warnings.push({
-          code: "MODEL_CARD_POLICY_VIOLATION",
-          message: `${subject} split policy ${key} must be ${String(expected)}.`,
-        });
-      }
-    }
-  }
-  if (negativeControlPolicy) {
-    appendUnknownObjectKeyWarnings({
-      allowedKeys: MURPH_AGE_WEARABLE_ACTIVITY_BENCHMARK_NEGATIVE_CONTROL_POLICY_KEYS,
-      label: "negative control policy",
-      object: negativeControlPolicy,
-      subject,
-      warnings,
-    });
-    for (const key of MURPH_AGE_WEARABLE_ACTIVITY_BENCHMARK_NEGATIVE_CONTROL_POLICY_KEYS) {
-      if (negativeControlPolicy[key] !== true) {
-        warnings.push({
-          code: "MODEL_CARD_POLICY_VIOLATION",
-          message: `${subject} negative control policy ${key} must be true.`,
-        });
-      }
-    }
-  }
-  if (selectionPolicy) {
-    appendUnknownObjectKeyWarnings({
-      allowedKeys: MURPH_AGE_WEARABLE_ACTIVITY_BENCHMARK_SELECTION_POLICY_KEYS,
-      label: "selection policy",
-      object: selectionPolicy,
-      subject,
-      warnings,
-    });
-    for (const [key, expected] of [
+    ],
+    subject,
+    warnings,
+  });
+  appendUnknownObjectKeyWarnings({
+    allowedKeys: MURPH_AGE_WEARABLE_ACTIVITY_BENCHMARK_NEGATIVE_CONTROL_POLICY_KEYS,
+    label: "negative control policy",
+    object: negativeControlPolicy,
+    subject,
+    warnings,
+  });
+  appendFrozenBooleanWarnings({
+    object: negativeControlPolicy,
+    label: "negative control policy",
+    expected: [...MURPH_AGE_WEARABLE_ACTIVITY_BENCHMARK_NEGATIVE_CONTROL_POLICY_KEYS]
+      .map((key) => [key, true] as const),
+    subject,
+    warnings,
+  });
+  appendUnknownObjectKeyWarnings({
+    allowedKeys: MURPH_AGE_WEARABLE_ACTIVITY_BENCHMARK_SELECTION_POLICY_KEYS,
+    label: "selection policy",
+    object: selectionPolicy,
+    subject,
+    warnings,
+  });
+  appendFrozenBooleanWarnings({
+    object: selectionPolicy,
+    label: "selection policy",
+    expected: [
       ["calibrationFirst", true],
       ["discriminationOnlySelectionAllowed", false],
       ["properScoresRequired", true],
       ["sameDenominatorComparisonsRequired", true],
       ["testSetMutationAuthorized", false],
-    ] as const) {
-      if (selectionPolicy[key] !== expected) {
-        warnings.push({
-          code: "MODEL_CARD_POLICY_VIOLATION",
-          message: `${subject} selection policy ${key} must be ${String(expected)}.`,
-        });
-      }
-    }
-  }
+    ],
+    subject,
+    warnings,
+  });
   validateWearableActivityBenchmarkArrayField({
     allowedValues: MURPH_AGE_ORDINARY_LAB_WEARABLE_EVIDENCE_TEMPLATE_DELTA_FIELDS,
     key: "acceptedAggregateMetricDeltaFields",
@@ -6456,43 +6445,28 @@ export function validateMurphAgeWearableShadowIncrementResultCard(
     object: card,
     warnings,
   });
-  if (evaluation) {
-    appendUnknownObjectKeyWarnings({
-      allowedKeys: MURPH_AGE_WEARABLE_SHADOW_RESULT_EVALUATION_KEYS,
-      label: "evaluation",
-      object: evaluation,
-      warnings,
-    });
-  }
-  if (aggregateMetricDeltas) {
-    appendUnknownObjectKeyWarnings({
-      allowedKeys: MURPH_AGE_WEARABLE_SHADOW_RESULT_DELTA_KEYS,
-      label: "aggregate metric deltas",
-      object: aggregateMetricDeltas,
-      warnings,
-    });
-    appendAggregateMetricDeltaValueWarnings({ deltas: aggregateMetricDeltas, warnings });
-  }
-  if (aggregateSample) {
-    appendUnknownObjectKeyWarnings({
-      allowedKeys: MURPH_AGE_WEARABLE_SHADOW_RESULT_SAMPLE_KEYS,
-      label: "aggregate sample",
-      object: aggregateSample,
-      warnings,
-    });
-    appendAggregateSampleValueWarnings({
-      sample: aggregateSample,
-      warnings,
-    });
-  }
-  if (outputBoundary) {
-    appendUnknownObjectKeyWarnings({
-      allowedKeys: MURPH_AGE_WEARABLE_SHADOW_OUTPUT_BOUNDARY_KEYS,
-      label: "output boundary",
-      object: outputBoundary,
-      warnings,
-    });
-  }
+  appendUnknownObjectKeyWarnings({
+    allowedKeys: MURPH_AGE_WEARABLE_SHADOW_RESULT_EVALUATION_KEYS,
+    label: "evaluation",
+    object: evaluation,
+    warnings,
+  });
+  appendAggregateMetricDeltaWarnings({
+    allowedKeys: MURPH_AGE_WEARABLE_SHADOW_RESULT_DELTA_KEYS,
+    deltas: aggregateMetricDeltas,
+    warnings,
+  });
+  appendAggregateSampleWarnings({
+    allowedKeys: MURPH_AGE_WEARABLE_SHADOW_RESULT_SAMPLE_KEYS,
+    sample: aggregateSample,
+    warnings,
+  });
+  appendUnknownObjectKeyWarnings({
+    allowedKeys: MURPH_AGE_WEARABLE_SHADOW_OUTPUT_BOUNDARY_KEYS,
+    label: "output boundary",
+    object: outputBoundary,
+    warnings,
+  });
 
   if (schemaVersion !== MURPH_AGE_WEARABLE_SHADOW_RESULT_CARD_SCHEMA_VERSION) {
     warnings.push({
@@ -6526,7 +6500,7 @@ export function validateMurphAgeWearableShadowIncrementResultCard(
       message: "Wearable shadow result card risk effect is not supported.",
     });
   }
-  if (riskEffect === "aggregate-estimated" && (!aggregateMetricDeltas || !hasFiniteAggregateMetricDelta(aggregateMetricDeltas))) {
+  if (riskEffect === "aggregate-estimated" && (!aggregateMetricDeltas || !hasFiniteIncrementEvaluationMetricDelta(aggregateMetricDeltas))) {
     warnings.push({
       code: "MODEL_CARD_POLICY_VIOLATION",
       message: "Aggregate-estimated wearable shadow result cards require at least one finite aggregate metric delta.",
@@ -6744,64 +6718,44 @@ export function validateMurphAgeIncrementEvaluationCard(
     subject,
     warnings,
   });
-  if (evaluation) {
-    appendUnknownObjectKeyWarnings({
-      allowedKeys: MURPH_AGE_INCREMENT_EVALUATION_KEYS,
-      label: "evaluation",
-      object: evaluation,
-      subject,
-      warnings,
-    });
-  }
-  if (aggregateMetricDeltas) {
-    appendUnknownObjectKeyWarnings({
-      allowedKeys: MURPH_AGE_INCREMENT_EVALUATION_DELTA_KEYS,
-      label: "aggregate metric deltas",
-      object: aggregateMetricDeltas,
-      subject,
-      warnings,
-    });
-    appendIncrementEvaluationMetricDeltaValueWarnings({ deltas: aggregateMetricDeltas, subject, warnings });
-  }
-  if (aggregateSample) {
-    appendUnknownObjectKeyWarnings({
-      allowedKeys: MURPH_AGE_INCREMENT_EVALUATION_SAMPLE_KEYS,
-      label: "aggregate sample",
-      object: aggregateSample,
-      subject,
-      warnings,
-    });
-    appendIncrementEvaluationAggregateSampleValueWarnings({ sample: aggregateSample, subject, warnings });
-  }
-  if (anchorMetrics) {
-    appendUnknownObjectKeyWarnings({
-      allowedKeys: MURPH_AGE_INCREMENT_EVALUATION_METRIC_KEYS,
-      label: "anchor metrics",
-      object: anchorMetrics,
-      subject,
-      warnings,
-    });
-    appendIncrementEvaluationAggregateMetricValueWarnings({ metrics: anchorMetrics, subject, warnings });
-  }
-  if (candidateMetrics) {
-    appendUnknownObjectKeyWarnings({
-      allowedKeys: MURPH_AGE_INCREMENT_EVALUATION_METRIC_KEYS,
-      label: "candidate metrics",
-      object: candidateMetrics,
-      subject,
-      warnings,
-    });
-    appendIncrementEvaluationAggregateMetricValueWarnings({ metrics: candidateMetrics, subject, warnings });
-  }
-  if (outputBoundary) {
-    appendUnknownObjectKeyWarnings({
-      allowedKeys: MURPH_AGE_INCREMENT_EVALUATION_OUTPUT_BOUNDARY_KEYS,
-      label: "output boundary",
-      object: outputBoundary,
-      subject,
-      warnings,
-    });
-  }
+  appendUnknownObjectKeyWarnings({
+    allowedKeys: MURPH_AGE_INCREMENT_EVALUATION_KEYS,
+    label: "evaluation",
+    object: evaluation,
+    subject,
+    warnings,
+  });
+  appendAggregateMetricDeltaWarnings({
+    allowedKeys: MURPH_AGE_INCREMENT_EVALUATION_DELTA_KEYS,
+    deltas: aggregateMetricDeltas,
+    subject,
+    warnings,
+  });
+  appendAggregateSampleWarnings({
+    allowedKeys: MURPH_AGE_INCREMENT_EVALUATION_SAMPLE_KEYS,
+    sample: aggregateSample,
+    subject,
+    warnings,
+  });
+  appendIncrementEvaluationAggregateMetricValueWarnings({
+    label: "anchor metrics",
+    metrics: anchorMetrics,
+    subject,
+    warnings,
+  });
+  appendIncrementEvaluationAggregateMetricValueWarnings({
+    label: "candidate metrics",
+    metrics: candidateMetrics,
+    subject,
+    warnings,
+  });
+  appendUnknownObjectKeyWarnings({
+    allowedKeys: MURPH_AGE_INCREMENT_EVALUATION_OUTPUT_BOUNDARY_KEYS,
+    label: "output boundary",
+    object: outputBoundary,
+    subject,
+    warnings,
+  });
 
   if (schemaVersion !== MURPH_AGE_INCREMENT_EVALUATION_CARD_SCHEMA_VERSION) {
     warnings.push({
@@ -9928,16 +9882,35 @@ function readBooleanField(input: {
 function appendUnknownObjectKeyWarnings(input: {
   allowedKeys: ReadonlySet<string>;
   label: string;
-  object: object;
+  object: object | null;
   subject?: string;
   warnings: MurphAgeWarning[];
 }): void {
+  if (input.object === null) return;
   for (const key of Object.keys(input.object)) {
     if (input.allowedKeys.has(key)) continue;
     input.warnings.push({
       code: "MODEL_CARD_POLICY_VIOLATION",
       message: `${input.subject ?? "Wearable shadow result card"} ${input.label} contains unsupported field ${key}.`,
     });
+  }
+}
+
+function appendFrozenBooleanWarnings(input: {
+  object: Readonly<Record<string, unknown>> | null;
+  label: string;
+  expected: readonly (readonly [string, boolean])[];
+  subject: string;
+  warnings: MurphAgeWarning[];
+}): void {
+  if (input.object === null) return;
+  for (const [key, expected] of input.expected) {
+    if (input.object[key] !== expected) {
+      input.warnings.push({
+        code: "MODEL_CARD_POLICY_VIOLATION",
+        message: `${input.subject} ${input.label} ${key} must be ${String(expected)}.`,
+      });
+    }
   }
 }
 
@@ -10204,14 +10177,8 @@ function validateWearableLabAggregateReceiptModels(input: {
       warnings: input.warnings,
     });
     if (metrics) {
-      appendUnknownObjectKeyWarnings({
-        allowedKeys: MURPH_AGE_INCREMENT_EVALUATION_METRIC_KEYS,
-        label: "model metrics",
-        object: metrics,
-        subject: input.subject,
-        warnings: input.warnings,
-      });
       appendIncrementEvaluationAggregateMetricValueWarnings({
+        label: "model metrics",
         metrics,
         subject: input.subject,
         warnings: input.warnings,
@@ -10240,26 +10207,46 @@ function hasWearableLabAggregateReceiptProperScore(
     || typeof metrics.logLoss === "number" && Number.isFinite(metrics.logLoss);
 }
 
-function appendAggregateMetricDeltaValueWarnings(input: {
-  deltas: Readonly<Record<string, unknown>>;
+function appendAggregateMetricDeltaWarnings(input: {
+  allowedKeys: ReadonlySet<string>;
+  deltas: Readonly<Record<string, unknown>> | null;
+  subject?: string;
   warnings: MurphAgeWarning[];
 }): void {
-  for (const key of MURPH_AGE_WEARABLE_SHADOW_RESULT_DELTA_KEYS) {
+  if (input.deltas === null) return;
+  appendUnknownObjectKeyWarnings({
+    allowedKeys: input.allowedKeys,
+    label: "aggregate metric deltas",
+    object: input.deltas,
+    subject: input.subject,
+    warnings: input.warnings,
+  });
+  for (const key of input.allowedKeys) {
     const value = input.deltas[key];
     if (value === undefined) continue;
     if (typeof value === "number" && Number.isFinite(value)) continue;
     input.warnings.push({
       code: "INVALID_INPUT",
-      message: `Wearable shadow result card aggregate metric delta ${key} must be a finite number.`,
+      message: `${input.subject ?? "Wearable shadow result card"} aggregate metric delta ${key} must be a finite number.`,
     });
   }
 }
 
-function appendAggregateSampleValueWarnings(input: {
-  sample: Readonly<Record<string, unknown>>;
+function appendAggregateSampleWarnings(input: {
+  allowedKeys: ReadonlySet<string>;
+  sample: Readonly<Record<string, unknown>> | null;
+  subject?: string;
   warnings: MurphAgeWarning[];
 }): void {
-  for (const key of MURPH_AGE_WEARABLE_SHADOW_RESULT_SAMPLE_KEYS) {
+  if (input.sample === null) return;
+  appendUnknownObjectKeyWarnings({
+    allowedKeys: input.allowedKeys,
+    label: "aggregate sample",
+    object: input.sample,
+    subject: input.subject,
+    warnings: input.warnings,
+  });
+  for (const key of input.allowedKeys) {
     const value = input.sample[key];
     if (value === undefined) continue;
     if (typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value >= 0) {
@@ -10267,32 +10254,25 @@ function appendAggregateSampleValueWarnings(input: {
     }
     input.warnings.push({
       code: "INVALID_INPUT",
-      message: `Wearable shadow result card aggregate sample ${key} must be a nonnegative integer.`,
-    });
-  }
-}
-
-function appendIncrementEvaluationMetricDeltaValueWarnings(input: {
-  deltas: Readonly<Record<string, unknown>>;
-  subject: string;
-  warnings: MurphAgeWarning[];
-}): void {
-  for (const key of MURPH_AGE_INCREMENT_EVALUATION_DELTA_KEYS) {
-    const value = input.deltas[key];
-    if (value === undefined) continue;
-    if (typeof value === "number" && Number.isFinite(value)) continue;
-    input.warnings.push({
-      code: "INVALID_INPUT",
-      message: `${input.subject} aggregate metric delta ${key} must be a finite number.`,
+      message: `${input.subject ?? "Wearable shadow result card"} aggregate sample ${key} must be a nonnegative integer.`,
     });
   }
 }
 
 function appendIncrementEvaluationAggregateMetricValueWarnings(input: {
-  metrics: Readonly<Record<string, unknown>>;
+  metrics: Readonly<Record<string, unknown>> | null;
+  label: string;
   subject: string;
   warnings: MurphAgeWarning[];
 }): void {
+  if (input.metrics === null) return;
+  appendUnknownObjectKeyWarnings({
+    allowedKeys: MURPH_AGE_INCREMENT_EVALUATION_METRIC_KEYS,
+    label: input.label,
+    object: input.metrics,
+    subject: input.subject,
+    warnings: input.warnings,
+  });
   for (const key of MURPH_AGE_INCREMENT_EVALUATION_METRIC_KEYS) {
     const value = input.metrics[key];
     if (value === undefined) continue;
@@ -10301,24 +10281,6 @@ function appendIncrementEvaluationAggregateMetricValueWarnings(input: {
     input.warnings.push({
       code: "INVALID_INPUT",
       message: `${input.subject} aggregate metric ${key} must be a finite number${MURPH_AGE_INCREMENT_EVALUATION_NULLABLE_METRIC_KEYS.has(key) ? " or null" : ""}.`,
-    });
-  }
-}
-
-function appendIncrementEvaluationAggregateSampleValueWarnings(input: {
-  sample: Readonly<Record<string, unknown>>;
-  subject: string;
-  warnings: MurphAgeWarning[];
-}): void {
-  for (const key of MURPH_AGE_INCREMENT_EVALUATION_SAMPLE_KEYS) {
-    const value = input.sample[key];
-    if (value === undefined) continue;
-    if (typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value >= 0) {
-      continue;
-    }
-    input.warnings.push({
-      code: "INVALID_INPUT",
-      message: `${input.subject} aggregate sample ${key} must be a nonnegative integer.`,
     });
   }
 }
@@ -10362,19 +10324,6 @@ function isLockedSourceRouteArtifactBoundary(
     && boundary.rowMaterializationAuthorized === false
     && boundary.rowValueExportAllowed === false
     && boundary.sourceTextStorageAllowed === false;
-}
-
-function hasFiniteAggregateMetricDelta(
-  deltas: Readonly<Record<string, unknown>>,
-): boolean {
-  return [
-    deltas.aucDelta,
-    deltas.brierDelta,
-    deltas.calibrationInterceptDelta,
-    deltas.calibrationSlopeDelta,
-    deltas.cIndexDelta,
-    deltas.logLossDelta,
-  ].some((value) => value !== undefined && Number.isFinite(value));
 }
 
 function hasFiniteIncrementEvaluationMetricDelta(

--- a/packages/health-metrics/test/index.test.ts
+++ b/packages/health-metrics/test/index.test.ts
@@ -4628,39 +4628,43 @@ test("validates aggregate wearable shadow result cards as blocked research evide
       aggregateMetricDeltas: {
         brierDelta: -0.0012,
         logLossDelta: "bad-delta",
+        unexpectedDelta: 1,
       },
       aggregateSample: {
         evaluatedRowCount: 12.5,
         eventCount: -1,
         minimumCellCount: Number.POSITIVE_INFINITY,
+        unexpectedSample: 1,
       },
     },
   });
   assert.equal(malformedValueValidation.status, "invalid");
-  assert.equal(
-    malformedValueValidation.warnings.some((warning) =>
-      warning.message.includes("logLossDelta must be a finite number")
-    ),
-    true,
-  );
-  assert.equal(
-    malformedValueValidation.warnings.some((warning) =>
-      warning.message.includes("evaluatedRowCount must be a nonnegative integer")
-    ),
-    true,
-  );
-  assert.equal(
-    malformedValueValidation.warnings.some((warning) =>
-      warning.message.includes("eventCount must be a nonnegative integer")
-    ),
-    true,
-  );
-  assert.equal(
-    malformedValueValidation.warnings.some((warning) =>
-      warning.message.includes("minimumCellCount must be a nonnegative integer")
-    ),
-    true,
-  );
+  assert.deepEqual(malformedValueValidation.warnings, [
+    {
+      code: "MODEL_CARD_POLICY_VIOLATION",
+      message: "Wearable shadow result card aggregate metric deltas contains unsupported field unexpectedDelta.",
+    },
+    {
+      code: "INVALID_INPUT",
+      message: "Wearable shadow result card aggregate metric delta logLossDelta must be a finite number.",
+    },
+    {
+      code: "MODEL_CARD_POLICY_VIOLATION",
+      message: "Wearable shadow result card aggregate sample contains unsupported field unexpectedSample.",
+    },
+    {
+      code: "INVALID_INPUT",
+      message: "Wearable shadow result card aggregate sample evaluatedRowCount must be a nonnegative integer.",
+    },
+    {
+      code: "INVALID_INPUT",
+      message: "Wearable shadow result card aggregate sample eventCount must be a nonnegative integer.",
+    },
+    {
+      code: "INVALID_INPUT",
+      message: "Wearable shadow result card aggregate sample minimumCellCount must be a nonnegative integer.",
+    },
+  ]);
 });
 
 test("validates aggregate increment evaluation cards across biomarker routes", () => {
@@ -4728,6 +4732,28 @@ test("validates aggregate increment evaluation cards across biomarker routes", (
   const validation = validateMurphAgeIncrementEvaluationCard(evidenceCard);
   assert.equal(validation.status, "valid");
   assert.deepEqual(validation.warnings, []);
+
+  const malformedMetrics = validateMurphAgeIncrementEvaluationCard({
+    ...evidenceCard,
+    evaluation: {
+      ...evidenceCard.evaluation,
+      aggregateMetricDeltas: { brierDelta: -0.001, aucDelta: null, unexpectedDelta: 1 },
+      aggregateSample: { eventCount: -1, unexpectedSample: 1 },
+      anchorMetrics: { auc: null, cIndex: null, brier: null, unexpectedAnchor: 1 },
+      candidateMetrics: { auc: null, cIndex: null, logLoss: Number.NaN, unexpectedCandidate: 1 },
+    },
+  });
+  assert.equal(malformedMetrics.status, "invalid");
+  assert.deepEqual(malformedMetrics.warnings.map((warning) => warning.message), [
+    "Increment evaluation card aggregate metric deltas contains unsupported field unexpectedDelta.",
+    "Increment evaluation card aggregate metric delta aucDelta must be a finite number.",
+    "Increment evaluation card aggregate sample contains unsupported field unexpectedSample.",
+    "Increment evaluation card aggregate sample eventCount must be a nonnegative integer.",
+    "Increment evaluation card anchor metrics contains unsupported field unexpectedAnchor.",
+    "Increment evaluation card aggregate metric brier must be a finite number.",
+    "Increment evaluation card candidate metrics contains unsupported field unexpectedCandidate.",
+    "Increment evaluation card aggregate metric logLoss must be a finite number.",
+  ]);
 
   const ordinaryRoutes = listMurphAgeOrdinaryLabWearableSourceRoutes().slice(0, 2);
   assert.deepEqual(ordinaryRoutes.map((route) => route.routeId), [

--- a/packages/health-metrics/test/murph-age-wearable-benchmark.test.ts
+++ b/packages/health-metrics/test/murph-age-wearable-benchmark.test.ts
@@ -151,3 +151,26 @@ test("locks the NHANES activity wearable shadow benchmark card before local adap
     );
   }
 });
+
+test("reports frozen benchmark policy errors in order and requires literal booleans", () => {
+  const card = listMurphAgeWearableActivityBenchmarkCards()[0];
+  if (!card) throw new Error("Expected activity benchmark card.");
+  const validation = validateMurphAgeWearableActivityBenchmarkCard({
+    ...card,
+    denominatorPolicy: { ...card.denominatorPolicy, sameDenominatorRequired: 1, unexpected: true },
+    splitPolicy: { ...card.splitPolicy, participantIdsExportAllowed: 0, unexpected: true },
+    negativeControlPolicy: { ...card.negativeControlPolicy, earlyEventWashoutRequired: "true", unexpected: true },
+    selectionPolicy: { ...card.selectionPolicy, testSetMutationAuthorized: null, unexpected: true },
+  });
+  assert.equal(validation.status, "invalid");
+  assert.deepEqual(validation.warnings.map((warning) => warning.message), [
+    "Wearable activity benchmark card denominator policy contains unsupported field unexpected.",
+    "Wearable activity benchmark card denominator policy sameDenominatorRequired must be true.",
+    "Wearable activity benchmark card split policy contains unsupported field unexpected.",
+    "Wearable activity benchmark card split policy participantIdsExportAllowed must be false.",
+    "Wearable activity benchmark card negative control policy contains unsupported field unexpected.",
+    "Wearable activity benchmark card negative control policy earlyEventWashoutRequired must be true.",
+    "Wearable activity benchmark card selection policy contains unsupported field unexpected.",
+    "Wearable activity benchmark card selection policy testSetMutationAuthorized must be false.",
+  ]);
+});


### PR DESCRIPTION
## Why and outcome

Murph Age card validators repeat aggregate-value and frozen-policy warning loops. Consolidate those loops within the existing validator owner and remove a duplicate finite-delta predicate, preserving schemas, scientific calculations, accepted inputs, exact warning order, and property-read order. Source shrinks by 51 lines; complexity debt falls from 158 to 136.

## Product UX

- Effort: Not applicable; internal validation refactor with unchanged results and warnings.
- Result: Ready.
- Walkthrough: No user-facing journey, model, authorization, or display changes.

## Evidence

- Direct: `pnpm --filter @murphai/health-metrics test` passed 80 tests across 10 files; package `typecheck` passed. Ordered-warning regressions cover unsupported fields before numeric errors, nullable AUC/c-index, and literal boolean policies.
- Coverage: Independent source-bundled baseline/head comparison against `b6454467652310f7abdd63676dab0f769c340ae8` matched exact public-validator results and Proxy get/ownKeys/descriptor traces for 5,477 cases: shadow 641, increment 1,068, benchmark 1,959, aggregate receipt 1,809. Cases include absent/malformed objects, unknown fields, nonfinite numbers, nullable metrics, strict booleans, and simultaneous errors. All four required exact-head CI checks passed. Final ReviewGPT round 1 passed with zero findings on `f2d694f413459b729c36953525f1f23401733f01`.

- Final review: [Round 1 PASS](https://chatgpt.com/c/6a9b804e-7930-83ea-9775-93adec4fa364), Mountain lane, attested `gpt-6-pro`, 8m12s send-to-capture; exact response identity verified.

## Non-obvious affected surfaces

The existing aggregate-receipt model-metric caller uses the consolidated metric check with its original label and ordering; package tests and 1,809 differential cases cover it. Separate schema-owned key sets remain separate.

## Architecture and reuse

- Existing systems reused: Current warning accumulators, schema key sets, field readers, and public validators in `murph-age.ts`.
- New logic: No new validation rules or scientific behavior; duplicate loops and finite-delta predicate removed.
- New abstractions: One local frozen-boolean warning helper replaces four repeated loops; existing aggregate helpers are consolidated without a new state owner.
- Complexity intentionally avoided: No validator factory, schema engine, dependency, model change, or module split.

## Complexity impact

- Guard: PASS — `pnpm complexity:diff --base b6454467652310f7abdd63676dab0f769c340ae8 -- packages/health-metrics/src/murph-age.ts`; debt 158→136, max 51→45.
- Hotspots: Changed validators: `validateMurphAgeIncrementEvaluationCard` 51→45, `validateMurphAgeWearableActivityBenchmarkCard` 40→28, `validateMurphAgeWearableShadowIncrementResultCard` 39→35. Unchanged decision bodies: `validateMurphAgeWearableResidualParameterPackForContract` 38, `validateMurphAgeFunctionResidualParameterPackForAnchor` 37, `evaluateFeature` 33, `summarizeMurphAgeWearableLabAggregateReceipt` 30, `applyMurphAgeWearableResidualLayer` 29, `validateMurphAgeWearableLabAggregateReceipt` 26, `calculateMurphAgeFromInputBundle` 26, `buildMurphAgeResearchLayeredPathStatus` 26, `applyMurphAgeFunctionResidualLayer` 21, `readIncrementEvaluationAggregateMetricSummary` 21, `parseMurphAgeRiskModelArtifact` 21.
- Agent judgment: Remaining branches represent distinct schema, source-route, scientific, or authorization checks. Further extraction would obscure those decisions; no generic validation framework is justified for this bounded duplicate-loop cleanup.

## Hot reply path impact

- Path status: Not applicable; synchronous card validation only, with unchanged inputs and results.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Exact results and read traces matched across the baseline/head matrix.

## Murph initial provider input impact

Not applicable to individual or group runtimes: no prompts, tools, schemas exposed to providers, or request assembly changed. Input measurement not run.

<!-- ReviewGPT context sensitivity: sensitive -->
<!-- Classification reason: Health-model and export-policy validator boundaries require full-patch context despite unchanged scientific semantics. -->

## Deployment concerns

- Deployment: not applicable
- Reason: No deployment contract, schema, persistent state, or cross-service interface changes.

## Change-shape breakdown

Classification rule: runtime TypeScript is source; test files are tests; the archived plan is docs. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 185 | 236 |
| Tests / fixtures | 73 | 24 |
| Docs | 79 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **337** | **260** |

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving validation cleanup with no member-visible change.


ReviewGPT first-reviewed head: f2d694f413459b729c36953525f1f23401733f01

