### PR TITLE
refactor(assistant): collapse Codex final-response selection

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-complexity-codex-process.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-complexity-codex-process.md
@@ -1,0 +1,85 @@
+# Collapse repeated Codex final-response selection
+
+Status: completed
+Created: 2026-09-04
+Updated: 2026-09-04
+
+## Goal
+
+- Delete repeated final-response selection and event guards in the existing
+  Codex process-turn owner without changing replies, authority, or lifecycle.
+
+## Success criteria
+
+- Reduce source and measured complexity with no new owner or abstraction.
+- Preserve retained and promoted replies, media/card fallback, no-reply scopes,
+  first-notification timing, and event/callback order.
+- Pass focused runtime proof, typecheck, a reviewed real-Codex journey, parent
+  candidate review, exact-head CI, and final ReviewGPT.
+
+## Scope
+
+- In scope: final candidate projection and accepted-event guard duplication in
+  assistant-codex.ts; focused regression and live verification.
+- Out of scope: tool execution/serialization, prompts, provider protocols,
+  process state or lifecycle changes, and open PRs #2485 and #2629.
+
+## Constraints
+
+- Technical constraints: retain ordering, callbacks, original candidate text,
+  error handling, and existing nullish fallback semantics; no new state owner.
+- Product/process constraints: internal refactor, Product UX not applicable.
+  Preserve an earlier answer when a later acknowledgement requests silence,
+  retain trailing attachments, and keep suppressed progress quiet. Use only
+  synthetic proof; parent reviews actual replies. Keep the PR open after gates.
+
+## Risks and mitigations
+
+1. Risk: factoring response selection loses an earlier response or leaks a
+   suppressed response into the latest accepted input.
+   Mitigation: prove full promotion control flow and exact output/context
+   assertions for text, media, cards, card fallback, and later no-reply.
+2. Risk: event simplification overwrites the first timestamp or skips callbacks.
+   Mitigation: duplicate-notification timing and existing runtime event suites.
+
+## Tasks
+
+1. Completed: inspect baseline, current docs/Frog, and exact open-PR hunks.
+2. Completed: strengthen deterministic and live proof before source edits.
+3. Completed: collapse duplicate selection/guards and pass focused verification.
+4. Completed: run focused real Codex, inspect actual output, and measure complexity.
+5. Delivery: scoped commit, draft PR, and parent candidate review.
+6. External gates: Ready, full exact-head ReviewGPT concurrently with CI, handoff.
+
+## Decisions
+
+- The final candidate is already cleared by promotion whenever the latest
+  context chooses no reply. Repeating that predicate for each projected field
+  is redundant; only the distinct earlier-no-reply suppression remains.
+- Keep the raw candidate used for final-message selection unchanged.
+- PR #2485 modifies required-response overlays and rendering after this
+  projection; #2629 modifies later tool classification. Proposed hunks avoid
+  both, and their branches remain untouched.
+- Graft is unavailable; use bounded baseline reads as authorized by the parent.
+
+## Verification
+
+- PASS: `pnpm --dir packages/assistant-engine exec vitest run
+  test/assistant-codex-runtime-steering.test.ts
+  test/assistant-codex-runtime-turns.test.ts
+  test/assistant-codex-runtime-events.test.ts
+  test/assistant-codex-runtime-tools.test.ts
+  test/assistant-codex-runtime-config.test.ts
+  test/assistant-codex-runtime-process.test.ts --no-coverage` — 247 tests.
+- PASS: `pnpm --filter @murphai/assistant-engine typecheck` and `git diff --check`.
+- PASS: `pnpm complexity:diff` — debt 244 to 229; main turn function 113 to
+  102; accepted-event handler 67 to 63; production source net deletion 34 lines.
+- PASS: `pnpm test:assistant:live -- --test 'keeps the earlier answer and stays
+  quiet for the later acknowledgement'` with an authenticated alternate local
+  subscription home and gpt-5.6-terra. The original synthetic answer remains in
+  context 0; context 1 is quiet, with exactly one finish-without-reply call,
+  no extra tools, no final/provider/transcript text, and no media/card.
+  Actual reply reviewed Ready; no production credentials or effects.
+- Parent candidate review, exact-head CI, and final ReviewGPT remain PR
+  admission/delivery gates, recorded with the final immutable head in PR evidence.
+Completed: 2026-09-04

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -5212,30 +5212,13 @@ async function runCodexAppServerTurnOnProcess(
       currentTurnStartedNotificationObserved =
         turnId !== null && extractCodexTurnIdFromMessage(message) === turnId
     }
-    const shouldCaptureTurnStartedNotification =
-      providerRequestStartedAtMs !== null &&
-      isTurnStartedNotification &&
-      codexTimingTurnStartedNotificationElapsedMs === null
-    const shouldCaptureTurnCompletedNotification =
-      providerRequestStartedAtMs !== null &&
-      isTurnCompletedNotification &&
-      codexTimingTurnCompletedNotificationElapsedMs === null
-    if (
-      providerRequestStartedAtMs !== null &&
-      (shouldCaptureTurnStartedNotification ||
-        shouldCaptureTurnCompletedNotification)
-    ) {
-      if (shouldCaptureTurnStartedNotification) {
-        codexTimingTurnStartedNotificationElapsedMs = Math.max(
-          0,
-          observedAtMs - providerRequestStartedAtMs,
-        )
+    if (providerRequestStartedAtMs !== null) {
+      const elapsedMs = Math.max(0, observedAtMs - providerRequestStartedAtMs)
+      if (isTurnStartedNotification) {
+        codexTimingTurnStartedNotificationElapsedMs ??= elapsedMs
       }
-      if (shouldCaptureTurnCompletedNotification) {
-        codexTimingTurnCompletedNotificationElapsedMs = Math.max(
-          0,
-          observedAtMs - providerRequestStartedAtMs,
-        )
+      if (isTurnCompletedNotification) {
+        codexTimingTurnCompletedNotificationElapsedMs ??= elapsedMs
       }
     }
     lastEventError = extractCodexErrorMessage(message) ?? lastEventError
@@ -5395,20 +5378,19 @@ async function runCodexAppServerTurnOnProcess(
     }
 
     const progressEvent = extractCodexProgressEventFromNormalized(normalizedEvent)
-    if (progressEvent) {
-      if (suppressDeliveryContext && progressEvent.kind === 'message') {
-        // A completed no-reply context must not leak later text progress.
-      } else {
-        if (progressEvent.kind === 'message') {
-          if (
-            input.onProgress &&
-            normalizeStreamingText(progressEvent.text)
-          ) {
-            markExternallyVisibleAssistantOutput(deliveryContextOrdinal)
-          }
-        }
-        input.onProgress?.(progressEvent)
+    // A completed no-reply context must not leak later text progress.
+    if (
+      progressEvent &&
+      !(suppressDeliveryContext && progressEvent.kind === 'message')
+    ) {
+      if (
+        progressEvent.kind === 'message' &&
+        input.onProgress &&
+        normalizeStreamingText(progressEvent.text)
+      ) {
+        markExternallyVisibleAssistantOutput(deliveryContextOrdinal)
       }
+      input.onProgress?.(progressEvent)
     }
 
     if (isTurnStartedNotification) {
@@ -6131,18 +6113,12 @@ async function runCodexAppServerTurnOnProcess(
   }
   const selectedFinalMessage =
     finalTrailingSteerCandidate?.response ?? extractedFinalMessage
-  const finalResponseMedia =
-    latestFinalActionPatch?.kind === 'none'
-      ? responseMedia
-      : suppressTrailingSteerCandidateForEarlierNoReply
-        ? responseMedia
-        : finalTrailingSteerCandidate?.media ?? responseMedia
-  const finalResponseCard =
-    latestFinalActionPatch?.kind === 'none'
-      ? responseCard
-      : suppressTrailingSteerCandidateForEarlierNoReply
-        ? responseCard
-        : finalTrailingSteerCandidate?.card ?? responseCard
+  // A latest-context no-reply already promoted and cleared the candidate above.
+  const finalResponseCandidate = suppressTrailingSteerCandidateForEarlierNoReply
+    ? null
+    : finalTrailingSteerCandidate
+  const finalResponseMedia = finalResponseCandidate?.media ?? responseMedia
+  const finalResponseCard = finalResponseCandidate?.card ?? responseCard
   if (finalResponseCard !== null && finalResponseMedia.length > 0) {
     throw new VaultCliError(
       'ASSISTANT_RESPONSE_CARD_MEDIA_CONFLICT',
@@ -6150,19 +6126,9 @@ async function runCodexAppServerTurnOnProcess(
     )
   }
   const finalDeliveryContextOrdinal =
-    latestFinalActionPatch?.kind === 'none'
-      ? latestDeliveryContextOrdinal
-      : suppressTrailingSteerCandidateForEarlierNoReply
-        ? latestDeliveryContextOrdinal
-        : finalTrailingSteerCandidate?.deliveryContextOrdinal ??
-          latestDeliveryContextOrdinal
+    finalResponseCandidate?.deliveryContextOrdinal ?? latestDeliveryContextOrdinal
   const finalResponseCardTextFallback =
-    latestFinalActionPatch?.kind === 'none'
-      ? responseCardTextFallback
-      : suppressTrailingSteerCandidateForEarlierNoReply
-        ? responseCardTextFallback
-        : finalTrailingSteerCandidate?.cardTextFallback
-          ?? responseCardTextFallback
+    finalResponseCandidate?.cardTextFallback ?? responseCardTextFallback
   if (finalResponseCardTextFallback !== null && finalResponseMedia.length > 0) {
     throw new VaultCliError(
       'ASSISTANT_RESPONSE_CARD_MEDIA_CONFLICT',

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -26225,9 +26225,13 @@ describeRealCodex('real Codex steered acknowledgement no-reply e2e', () => {
       expect(result.finalAction).toEqual({ kind: 'none' })
       expect(result.finalActionExplicit).toBe(true)
       expect(result.finalMessage).toBe('')
+      expect(result.providerAuthoredFinalMessage).toBe('')
+      expect(result.transcriptMessage).toBeNull()
+      expect(result.responseDeliveryContextOrdinal).toBe(1)
       expect(result.responseMedia).toEqual([])
       expect(result.responseCard).toBeNull()
       expect(finishAttempts).toHaveLength(1)
+      expect(readDynamicToolAttempts(result.jsonEvents)).toEqual(finishAttempts)
     } finally {
       await removeRealCodexTemporaryPaths([
         workingDirectory,

--- a/packages/assistant-engine/test/assistant-codex-runtime-steering.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime-steering.test.ts
@@ -1656,6 +1656,60 @@ describe('steered final segments', () => {
     expect(result.precedingAgentMessageSegments).toEqual([])
   })
 
+  it.each([
+    {
+      card: DAILY_NUTRITION_RESPONSE_CARD,
+      expectedText: 'response card attached',
+      label: 'response card',
+    },
+    {
+      card: OVERSIZED_TRACKED_WORKOUT_RESPONSE_CARD,
+      expectedText: 'workout card envelope too large; full text recovery selected',
+      label: 'oversized card text recovery',
+    },
+  ])('retains trailing $label and its delivery context after commentary', async ({ card, expectedText }) => {
+    const result = await runScriptedSteeredFinalSegmentsTurn([
+      completedItemEvent({
+        id: 'user-retained-card',
+        type: 'user_message',
+        message: 'Show the saved summary.',
+      }),
+      { card, expectedText, id: 82, kind: 'attach-response-card' },
+      completedItemEvent({
+        id: 'assistant-retained-card',
+        type: 'assistant_message',
+        message: 'Saved summary.',
+      }),
+      completedItemEvent({
+        id: 'user-after-retained-card',
+        type: 'user_message',
+        message: 'One more detail.',
+      }),
+      completedItemEvent({
+        id: 'assistant-after-retained-card',
+        type: 'assistant_message',
+        message: 'Considering the detail.',
+        phase: 'commentary',
+      }),
+    ], { responseCardsAvailable: true })
+
+    expect(result.responseDeliveryContextOrdinal).toBe(0)
+    expect(result.precedingAgentMessageSegments).toEqual([])
+    expect(result.responseMedia).toEqual([])
+    expect(result.providerAuthoredFinalMessage).toBe('Saved summary.')
+    expect(result.finalMessage).not.toContain('Considering the detail.')
+    if (card === DAILY_NUTRITION_RESPONSE_CARD) {
+      expect(result.responseCard).toEqual(card)
+      expect(result.finalMessage).toContain('1,490.25 calories')
+    } else {
+      expect(result.responseCard).toBeNull()
+      expect(result.finalMessage).toContain('Capacity exercise 16:')
+      expect(result.finalMessage).toContain('Exercise 16 set 16 target')
+      expect(result.finalMessage).not.toContain('evt_')
+      expect(result.transcriptMessage).toContain('[Murph tracked workout source:')
+    }
+  })
+
   it('keeps steered final answers while commentary remains internal', async () => {
     const progressDelivery = createProgressDeliveryMock()
     const result = await runScriptedSteeredFinalSegmentsTurn([

--- a/packages/assistant-engine/test/assistant-codex-runtime-turns.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime-turns.test.ts
@@ -315,7 +315,7 @@ describe('assistant codex runtime', () => {it('rejects alternate current-turn id
     expect(secondPersistCanonicalWrite).toHaveBeenCalled()
   })
 
-  it('trusts tagged turn/started when the turn/start response omits the turn id', async () => {
+  it('trusts tagged starts and retains first notification timing across duplicates', async () => {
     const workingDirectory = await createTempDir('assistant-codex-local-prestart-tagged-work-')
     const codexHome = await createTempDir('assistant-codex-local-prestart-tagged-home-')
     const realDateNow = Date.now.bind(Date)
@@ -406,6 +406,16 @@ describe('assistant codex runtime', () => {it('rejects alternate current-turn id
               },
             },
           }))
+          controlledNowMs = secondProviderStartedAtMs + 60
+          child.stdout.write(jsonLine({
+            method: 'turn/completed',
+            params: {
+              turn: {
+                id: 'turn-local-prestart-tagged-2',
+                status: 'completed',
+              },
+            },
+          }))
         })()
       })
 
@@ -456,7 +466,7 @@ describe('assistant codex runtime', () => {it('rejects alternate current-turn id
       .at(-1)
     expect(secondTurnCompletedTiming).toEqual(expect.objectContaining({
       codexTimingProviderRequestOrdinal: 7,
-      codexTimingTurnCompleteElapsedMs: 50,
+      codexTimingTurnCompleteElapsedMs: 60,
       codexTimingTurnCompletedNotificationElapsedMs: 50,
       codexTimingTurnStartAckElapsedMs: 30,
       codexTimingTurnStartedNotificationElapsedMs: 10,


### PR DESCRIPTION
## Why and outcome

Collapse repeated final-response selection and event guards inside the existing Codex turn owner. Retained answers, cards, text recovery, delivery context, silence, callbacks, and first-notification timing keep their existing behavior while production source shrinks by 34 lines.

## Product UX

- Effort: Not applicable — internal behavior-preserving refactor.
- Result: Ready.
- Walkthrough: Synthetic regression journeys cover an earlier answer followed by a silent acknowledgement, retained cards and oversized-card recovery after commentary, and duplicate timing notifications. No product changes or excluded affected journeys.

## Evidence

- Direct: Six focused assistant-codex runtime suites (steering, turns, events, tools, config, process), 247 tests passed; `pnpm --filter @murphai/assistant-engine typecheck` and `git diff --check` passed.
- Coverage: Existing text/media/no-reply and event/callback tests plus added exact card, fallback, context, and duplicate-notification assertions exercise the changed branches.
- Live: `pnpm test:assistant:live -- --test 'keeps the earlier answer and stays quiet for the later acknowledgement'`, gpt-5.6-terra, alternate authenticated local subscription home. Passed with earlier answer retained in context 0, context 1 silent, exactly one finish-without-reply call and no other tools, final/provider/transcript text, media, or card. Actual reply reviewed Ready; synthetic data only.
- Evidence provenance: Recovered successful command results from the original implementation session; the committed candidate and tested runtime inputs remain unchanged. All four required GitHub checks pass on the exact head. Final full-patch ReviewGPT round 1 passed on Phlebas with gpt-6-pro after 556 seconds; exact turn, response hash, model metadata, attachment scope, and completion marker verified. An earlier 256-second Mountain capture is diagnostic only and does not count. Parent candidate review passed; current-base merge-tree proof is clean.

## Non-obvious affected surfaces

First accepted turn-start/completed notification timing and suppressed text progress use simpler guards. Duplicate timing proof and runtime event suites cover them. No process-lifecycle, prompt, tool contract, or serialization change.

## Architecture and reuse

- Existing systems reused: Existing trailing-candidate promotion, no-reply state, response projection, and accepted-event owner.
- New logic: None; share the already-derived candidate across output fields and preserve nullish fallback semantics.
- New abstractions: None; one local derived value replaces repeated selection predicates.
- Complexity intentionally avoided: No new state owner, helper layer, transport, or compatibility machinery.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; changed-file debt 244 to 229, maximum 113 to 102.
- Hotspots: `runCodexAppServerTurnOnProcess` 102 and `handleAcceptedEvent` 63 decrease. Other existing hotspots are `handleAcceptedServerRequest` 50, anonymous handlers 49 and 40, `isSerializedDynamicToolRequest` 30, `handleParsedMessage` 25, `buildCodexTransportDiagnosticsTraceEvent` 24, `onParsedMessage` 23, `executeCodexManagedAccountOperation` 22, and `assertCodexResumeContextMatches` 21. Their unrelated responsibilities remain outside this bounded change.
- Agent judgment: The removed latest-context no-reply predicates are redundant because promotion already clears the candidate. Preserve distinct earlier-context suppression and raw text selection. Further broad extraction would exceed the proven cleanup.

## Hot reply path impact

- Path status: Touched — final output projection and accepted-event callbacks.
- Database calls: None added or moved; maximum delta 0.
- Network/provider calls: None added or moved; maximum delta 0.
- Other awaited latency: None added or moved; existing order, timeout, retry, and fallback behavior unchanged.
- Before/after proof: Diff preserves awaited operations and callback order; 247 focused tests and live one-finish-call silence journey pass. No latency claim measured.

## Murph initial provider input impact

Not applicable to individual or group runtimes: provider request builders, assembled instructions, tool/schema/generated guidance, and other provider-visible input are unchanged. No provider-input measurement run.

ReviewGPT first-reviewed head: ea4bcd6794eeda0b02dec246ea146c98354c4c02
ReviewGPT context sensitivity: sensitive
Classification reason: Runtime reply selection and no-reply delivery ownership require cross-cutting review.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal turn-local derivation changes no persisted shape, cross-app protocol, deployment configuration, or consumer compatibility requirement.

## Change-shape breakdown

Classification rule: Runtime implementation is source; test paths are tests; the completed plan is docs. No binaries or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 26 | 60 |
| Tests / fixtures | 70 | 2 |
| Docs | 85 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **181** | **62** |

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving simplification with no member-visible feature or fix.
