### PR TITLE
refactor(web): converge Linq webhook group planning

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-complexity-webhook-planning.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-complexity-webhook-planning.md
@@ -1,0 +1,52 @@
+# Simplify webhook chat classification convergence
+
+Status: completed
+Created: 2026-09-04
+Updated: 2026-09-04
+
+## Goal
+
+- Delete duplicated group-roster result construction from the webhook chat-classification resolver while preserving ingress behavior.
+
+## Success criteria
+
+- Preserve provider/route authority, lookup count and ordering, error/retry behavior, and explicit-group event identity.
+- Pass composed webhook tests, Web typecheck, complexity guard, parent review, exact-head CI, and ReviewGPT.
+
+## Scope
+
+- In scope: `webhook-service.ts` planning resolver and composed thread-route proof.
+- Out of scope: provider planner, admission, delivery, transaction ownership, prompts, and existing PR 444's participant-removal/provider-echo work.
+
+## Constraints
+
+- Technical constraints: no new abstraction, state, query, provider call, transaction, or dependency.
+- Product/process constraints: isolated task branch; synthetic fixtures; draft PR until parent candidate review; leave the new PR open.
+
+## Risks and mitigations
+
+1. Explicit groups, canonical groups, and self echoes intentionally take different authority paths.
+   Mitigation: preserve classification diagnostics before the shared route read, skip canonical reads for proven groups/routes, preserve early self-message handling, and retain explicit-group event identity.
+
+## Tasks
+
+1. Completed: converge group classification into one roster lookup and result construction.
+2. Completed: extend composed handler tests across explicit and inferred group classification and self echoes.
+3. Completed: focused verification and candidate inspection; close this implementation plan in the scoped commit and open a draft PR.
+4. Obtain parent review, then run ReviewGPT concurrently with exact-head CI; external completion remains tracked on the PR.
+
+## Decisions
+
+- Product UX: internal behavior-preserving cleanup. Replay established group routes, first-group admission, self echoes, direct messages, and unavailable canonical/roster authority. No model-visible input or reply policy changes.
+- The inspected old PR 444 patch changes provider-event ingestion outside this resolver.
+- Changelog is not applicable because no member-visible behavior changes.
+
+## Verification
+
+- `pnpm --dir apps/web test:prepared -- test/hosted-onboarding-linq-thread-route.test.ts test/hosted-onboarding-linq-dispatch.test.ts`: 368 tests passed.
+- The 11 strengthened route/roster/self-echo cases also pass against baseline source. They prove existing routes skip canonical reads, pending groups reuse one provider summary, and unbound self echoes skip provider reads while preserving direct/group planner behavior.
+- `pnpm complexity:diff`: pass; resolver 35 to 27, file debt 163 to 155, maximum unchanged at 151. Source deletes 33 net lines; other owner functions are untouched.
+- Initial Web typecheck lacked the generated `@murphai/device-syncd/service` declaration in an unrelated existing test. The existing device-syncd build succeeded; `pnpm --dir apps/web typecheck:prepared` now passes.
+- `git diff --check`: pass. Product UX replay preserves group-route authority, canonical classification failure, roster failure/retry, and direct/self-message handling without changing model input, delivery policy, or transaction ownership.
+- Takeover verification reran both composed suites (368 passing tests), Web typecheck, and complexity guard against the unchanged source/test candidate. Parent review, exact-head CI, and ReviewGPT remain tracked on the PR.
+Completed: 2026-09-04

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -1411,43 +1411,6 @@ async function resolveHostedLinqPlanningEvent(input: {
   const webhookIsGroup = messageEvent.data.chat?.is_group;
   if (webhookIsGroup === true) {
     logHostedLinqChatClassification("webhook-group");
-    const threadRoute = await readHostedThreadRouteByThreadIdentity({
-      channel: "linq",
-      prisma: input.prisma,
-      threadId: messageEvent.data.chat_id,
-    });
-    const pendingGroupRoster =
-      !messageEvent.data.is_from_me && !threadRoute
-        ? await resolveHostedLinqPendingGroupParticipantMemberIds({
-            chatId: messageEvent.data.chat_id,
-            prisma: input.prisma,
-            signal: input.signal,
-          })
-        : null;
-    return {
-      event: messageEvent,
-      ...(pendingGroupRoster?.initialGroupDisplayName
-        ? { initialGroupDisplayName: pendingGroupRoster.initialGroupDisplayName }
-        : {}),
-      ...(pendingGroupRoster?.participantMemberIds == null
-        ? {}
-        : {
-            pendingGroupParticipantMemberIds:
-              pendingGroupRoster.participantMemberIds,
-          }),
-      ...(pendingGroupRoster?.unavailable === true
-        ? { pendingGroupRosterUnavailable: true }
-        : {}),
-      ...(pendingGroupRoster?.handles == null
-        ? {}
-        : {
-            requestLocalGroupRoster: {
-              chatId: messageEvent.data.chat_id,
-              handles: pendingGroupRoster.handles,
-            },
-          }),
-      threadRoute,
-    };
   }
 
   const threadRoute = await readHostedThreadRouteByThreadIdentity({
@@ -1464,7 +1427,9 @@ async function resolveHostedLinqPlanningEvent(input: {
 
   let resolvedIsGroup: boolean;
   let canonicalSummary: HostedLinqChatSummary | null = null;
-  if (threadRoute) {
+  if (webhookIsGroup === true) {
+    resolvedIsGroup = true;
+  } else if (threadRoute) {
     logHostedLinqChatClassification("thread-route-group");
     resolvedIsGroup = true;
   } else {
@@ -1515,17 +1480,19 @@ async function resolveHostedLinqPlanningEvent(input: {
         })
       : null;
   return {
-    event: {
-      ...messageEvent,
-      data: {
-        ...messageEvent.data,
-        chat: {
-          id: messageEvent.data.chat_id,
-          ...(messageEvent.data.chat ?? {}),
-          is_group: resolvedIsGroup,
+    event: webhookIsGroup === true
+      ? messageEvent
+      : {
+          ...messageEvent,
+          data: {
+            ...messageEvent.data,
+            chat: {
+              id: messageEvent.data.chat_id,
+              ...(messageEvent.data.chat ?? {}),
+              is_group: resolvedIsGroup,
+            },
+          },
         },
-      },
-    },
     ...(pendingGroupRoster?.initialGroupDisplayName
       ? { initialGroupDisplayName: pendingGroupRoster.initialGroupDisplayName }
       : {}),

--- a/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-thread-route.test.ts
@@ -6517,6 +6517,10 @@ describe("Linq group chat auto-provision", () => {
 
   it.each([
     {
+      description: "reported group",
+      webhookIsGroup: true,
+    },
+    {
       description: "reported direct",
       webhookIsGroup: false,
     },
@@ -6580,7 +6584,7 @@ describe("Linq group chat auto-provision", () => {
           "Hosted onboarding diagnostic: hosted-onboarding.webhook.linq.chat-classification.",
           {
             diagnostic: "hosted-onboarding.webhook.linq.chat-classification",
-            outcome: "thread-route-group",
+            outcome: webhookIsGroup === true ? "webhook-group" : "thread-route-group",
           },
         );
       } finally {
@@ -6734,6 +6738,11 @@ describe("Linq group chat auto-provision", () => {
 
   it.each([
     {
+      description: "says group",
+      service: "iMessage",
+      webhookIsGroup: true,
+    },
+    {
       description: "incorrectly says direct",
       service: "iMessage",
       webhookIsGroup: false,
@@ -6753,7 +6762,7 @@ describe("Linq group chat auto-provision", () => {
       service: "RCS",
       webhookIsGroup: null,
     },
-  ] as const)("uses canonical chat metadata when a $service webhook $description", async ({
+  ] as const)("uses group roster metadata when a $service webhook $description", async ({
     service,
     webhookIsGroup,
   }) => {
@@ -6795,6 +6804,7 @@ describe("Linq group chat auto-provision", () => {
         chatId: "chat_group_123",
         timeoutMs: 1_500,
       });
+      expect(linqClient.getHostedLinqChatSummary).toHaveBeenCalledTimes(1);
       expect(
         memberRoutingStore.demoteHostedMemberLinqGroupChatBindingsTx,
       ).toHaveBeenCalledWith({
@@ -6833,7 +6843,7 @@ describe("Linq group chat auto-provision", () => {
         "Hosted onboarding diagnostic: hosted-onboarding.webhook.linq.chat-classification.",
         {
           diagnostic: "hosted-onboarding.webhook.linq.chat-classification",
-          outcome: "canonical-group",
+          outcome: webhookIsGroup === true ? "webhook-group" : "canonical-group",
         },
       );
     } finally {
@@ -9284,20 +9294,26 @@ describe("Linq group chat auto-provision", () => {
     }
   });
 
-  it("ignores echoed own messages in unbound group threads without provisioning", async () => {
+  it.each([true, false, null] as const)("ignores unbound own-message echoes without provider reads when group flag is %s", async (isGroup) => {
     const prisma = createStatefulThreadRoutePrisma();
+    vi.mocked(prismaModule.getPrisma).mockReturnValue(prisma as never);
+    vi.mocked(linqModule.verifyAndParseHostedLinqWebhookRequest)
+      .mockReturnValue(buildLinqMessageReceivedEvent({ isFromMe: true, isGroup }) as never);
 
-    const plan = await planHostedOnboardingLinqWebhook({
-      event: buildLinqMessageReceivedEvent({ isFromMe: true }),
-      prisma: prisma as never,
+    const response = await handleHostedOnboardingLinqWebhook({
+      rawBody: "{}",
+      signature: null,
+      timestamp: null,
     });
 
-    expect(plan.response).toMatchObject({
+    expect(response).toMatchObject({
       ignored: true,
       ok: true,
-      reason: "group-chat",
+      reason: isGroup === true ? "group-chat" : "own-message",
     });
-    expect(memberIdentityStore.lookupHostedMemberIdentityByPhoneNumber).not.toHaveBeenCalled();
+    expect(linqClient.getHostedLinqChatSummary).not.toHaveBeenCalled();
+    expect(memberIdentityStore.lookupHostedMemberIdentityByPhoneNumber)
+      .toHaveBeenCalledTimes(isGroup === true ? 0 : 1);
     expect(prisma.hostedThreadContainer.create).not.toHaveBeenCalled();
     expect(mailboxStore.appendHostedMailboxEnvelopeTx).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Why and outcome

Linq webhook chat classification constructed the same pending-group roster result in two branches. Converge those branches into one route read and roster result while preserving classification authority, diagnostic ordering, retry behavior, and explicit-group event identity.

## Product UX

- Effort: Not applicable — internal behavior-preserving refactor.
- Result: Ready.
- Walkthrough: Composed handler proof preserves established group routes, first-group admission, direct-message classification, own-message echoes, and unavailable canonical/roster authority. No changes to consent, replies, delivery, or model input.

## Evidence

- Direct: `pnpm --dir apps/web test:prepared -- test/hosted-onboarding-linq-thread-route.test.ts test/hosted-onboarding-linq-dispatch.test.ts` — 368 passed.
- Coverage: Strengthened route/roster/self-echo matrices exercise the actual handler, with provider-read counts and mailbox effects. The 11 strengthened cases also pass against baseline source.
- `pnpm --dir apps/web typecheck:prepared` — passed after preparing the existing device-syncd declaration build.
- `pnpm complexity:diff` and `git diff --check` — passed. Final [ReviewGPT round 1](https://chatgpt.com/c/6a9b7eea-ad84-83ea-b317-98dcef1a5a88) passed on the exact head: Mountain lane, verified GPT-6 Pro, 681.4 seconds, matching committed-turn and response-hash evidence, no findings. The earlier sub-floor response is diagnostic only.
- Required exact-head CI: [release checks and platform matrix](https://github.com/cobuildwithus/murph/actions/runs/33938510612) and [Stripe boundary](https://github.com/cobuildwithus/murph/actions/runs/33938510597) passed. [Temporal compatibility](https://github.com/cobuildwithus/murph/actions/runs/33938692308) also passed.
- Current-base mergeability: `git merge-tree --write-tree HEAD origin/main` passed against base `18b498bc49435c49adb99588754a8a2bf72c4ce6` without changing the reviewed head.

## Non-obvious affected surfaces

Existing route authority bypasses canonical provider reads for all webhook group flags; unbound own-message echoes retain their direct/group ignore result without provider reads. Pending groups reuse a single provider summary. Composed tests cover these interactions.

## Architecture and reuse

- Existing systems reused: Existing thread-route read, canonical classification, and pending-group roster resolver.
- New logic: None; the shared result preserves existing branch behavior.
- New abstractions: None; the current resolver remains the owner.
- Complexity intentionally avoided: Deleted duplicate roster/result construction without adding state, providers, transactions, queries, or dependencies.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; file debt 163 to 155, maximum unchanged at 151.
- Hotspots: Changed `resolveHostedLinqPlanningEvent` falls from 35 to 27. Unchanged hotspots are `handleHostedOnboardingLinqWebhook` (151), `maybeSendHostedLinqIngressReadReceipt` (31), `runHostedThreadRoutingPreparedTransaction` (24), and `prepareHostedDirectTelegramThreadRoutingCrypto` (22).
- Agent judgment: The remaining classification branches encode distinct authority/failure behavior. Further extraction would move existing complexity without simplifying this change; other owners are outside scope.

## Hot reply path impact

- Path status: Not applicable — classification remains before durable message acceptance; the accepted-input-to-provider/reply path is unchanged.
- Database calls: None added or moved. The resolver still reads one thread route before any required roster resolution.
- Network/provider calls: None added or moved. Existing routes and unbound self echoes use zero summary reads; pending groups use one summary read, reused for inferred groups. The existing serial order, 1,500 ms timeout, and failure/retry behavior remain unchanged.
- Other awaited latency: None added or moved; no new transaction or concurrency.
- Before/after proof: The strengthened baseline/head composed cases assert summary call counts, route authority, mailbox effects, and self-echo behavior.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no instructions, tools, schemas, generated guidance, conversation fields, or other provider-visible input changes.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

ReviewGPT first-reviewed head: e911d286f01c5f35db90fd07e7707eb6a305f579
ReviewGPT context sensitivity: sensitive
Classification reason: Hosted ingress classification and group routing authority.

## Deployment concerns

- Deployment: not applicable
- Reason: Behavior-preserving Web-local refactor with no schema, wire, runtime protocol, or independently deployed consumer changes.

## Change-shape breakdown

Classification rule: Production TypeScript is source; test paths are tests; the closed execution plan is docs. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 15 | 48 |
| Tests / fixtures | 26 | 10 |
| Docs | 52 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **93** | **58** |

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving cleanup with no member-visible change.
