### PR TITLE
Speed up Temporal E2E process scheduling and Web compilation

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-04-temporal-ci-speed.md
+++ b/agent-docs/exec-plans/active/2026-09-04-temporal-ci-speed.md
@@ -1,0 +1,37 @@
+# Reduce Temporal CI build and E2E latency
+
+Status: active
+Created: 2026-09-04
+Updated: 2026-09-04
+
+## Goal and invariant
+
+Reduce the cross-repository Temporal hosted gate from roughly 30–35 minutes toward a measured under-ten-minute result. Preserve every test, source binding, standby allocation, production-like priority timing, and live deployment admission check.
+
+## Evidence and current owners
+
+Private integration run 33922621756 used 839 seconds for serial runner/Web preparation, then 992 seconds for foreground E2E. Compatibility readers took 30 seconds. Run 33930847337 used 815 seconds preparation and 715 seconds foreground E2E. Its first nine foreground tests took 458 seconds including startup; the independent two-test checkpoint group took 112 seconds. The alert test consumes earlier probe results, so arbitrary test-level sharding would invalidate proof.
+
+Private Murph Cloud owns build scheduling and exact-source handoffs. Public Web owns compiler behavior. Public hosted-local harness owns scenario selection and cleanup. Compiler caches are disposable, never proof or source identity.
+
+## Work
+
+1. Consult ReviewGPT on both repositories and measure the existing job/step critical path.
+2. In the private workflow, pin source once, overlap independent Web/runner builds, and restore compiler metadata while retaining full validation.
+3. Add explicit Webpack cache opt-in for CI; preserve the existing cold-build default and heap limits.
+4. Evaluate independent scenario-process parallelism and generated-input reuse without weakening coverage.
+5. Run focused tests/typecheck, cold and warm build proof, and actual CI timing. Complete review and record any remaining gap to ten minutes.
+
+## Verification
+
+Use existing Web config and production-build-runner tests, Web typecheck, and standalone build. Private changes require `pnpm verify` and the real integration matrix. Larger-runner use remains pending user preference and available runner permissions. No deployment is part of this optimization task.
+
+## Candidate evidence and remaining acceptance
+
+ReviewGPT completed the cross-repository design consultation. It endorsed the existing two-process boundary and identified redundant generated-input preparation for a single scenario with two processes. That preparation now runs once; isolated CI shards still earn their own setup. Completed-output and E2E-evidence reuse require separate provenance work and are not implemented in this candidate.
+
+Focused Web tests (53) and harness tests (52), Web/harness typechecks, and the complexity guard pass. The full standalone Web build could not acquire the shared-host slot within ten minutes; the documented SSH fallback is unavailable because no worker address is configured. Cold/warm compiler time, peak memory, and complete GitHub admission time remain unmeasured for this candidate. The under-ten-minute target is not yet achieved.
+
+Private controller fixtures also passed unchanged assertions with two concurrent isolated subprocesses: 127 tests in 742 seconds versus the local serial baseline of 1674 seconds (56% less wall time). All 687 private Temporal coverage tests passed with two file workers. This is separate from the hosted E2E critical path and does not establish under-ten-minute release admission.
+
+Prepared candidates proceed through exact-head PR/CI review; public support must land before private consumption. The initial ReviewGPT consultation is design input, not a final PR gate. The complete admission performance target remains open until measured in private GitHub CI.

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -122,7 +122,7 @@ not a guarantee that every claim was checked in this cleanup.
 | `agent-docs/operations/agent-workflow-routing.md` | Task scope, authority, checkout, commits, and instruction ownership. | Agent workflow routing | High | 2026-09-04 |
 | `agent-docs/operations/product-ux.md` | Product UX workflow. | Product UX workflow | High | 2026-08-31 |
 | `agent-docs/operations/native-android-hosted-e2e.md` | Native Android verification operations. | Native Android verification operations | High | 2026-09-01 |
-| `agent-docs/operations/verification-and-runtime.md` | Verification ownership by delivery path. | Verification policy | High | 2026-09-01 |
+| `agent-docs/operations/verification-and-runtime.md` | Verification ownership by delivery path and Temporal integration build/process-shard proof. | Verification policy | High | 2026-09-01 |
 | `agent-docs/operations/database-transaction-starvation-audit.md` | Database critical-section reliability. | Database critical-section reliability | High | 2026-08-09 |
 | `agent-docs/operations/typescript-verification-performance.md` | Verification performance policy. | Verification performance policy | Medium | 2026-07-29 |
 | `agent-docs/operations/completion-workflow.md` | Completion workflow. | Completion workflow | High | 2026-09-02 |

--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -789,6 +789,26 @@ change did not cause a pre-existing failure, and the best focused evidence.
 This does not turn a required red check green or permit bypassing CI. Do not run
 an unrelated broad command merely to establish that a baseline is already red.
 
+### Temporal integration build performance
+
+`pnpm hosted-local e2e foreground-reply-priority --process-shard 1/2` and
+`--process-shard 2/2` run the two existing isolated Vitest processes separately.
+The private workflow requires both jobs; an omitted flag retains the complete
+serial command. Sharding requires exactly one scenario and a denominator equal
+to its declared process count, failing before setup if that inventory changes.
+The nine priority tests retain their order and shared latency evidence.
+
+Private integration pins one public source before independent runner-bundle and
+Web builds. Its Web job may set `MURPH_HOSTED_WEB_WEBPACK_CACHE=1` and persist the
+Next compiler cache plus `.next/cache` TypeScript metadata. The full Web build,
+route type generation, and both TypeScript checks still run after restoration.
+Vercel and ordinary builds retain cold Webpack compilation unless explicitly
+opted in; heap and static-generation limits are unchanged. Focused proof lives
+in `apps/web/test/next-config.test.ts` and
+`apps/web/test/production-next-build-runner.test.ts`. Cross-repository timing
+must be measured in the actual private integration workflow, including queue,
+artifact preparation, E2E, and attestation time.
+
 ## Hosted Temporal Replay Proof
 
 Private `cobuildwithus/murph-cloud` owns the Temporal Workflows, Activities,

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -1170,6 +1170,20 @@ keep the one-second presentation-only deadline and late-result rejection.
   R2 resources.
 - The tag-driven release workflow is present and uses npm trusted publishing for package publication. Its preflight mode validates release metadata, syntax-checks and tests the final-tarball secret guard, performs the clean workspace build, and runs typecheck plus doc gardening; isolated required jobs then own package coverage, fixture coverage, hosted-web build and test shards, and Cloudflare verification before the final clean pack checkout may run. The full local `release:check` command remains the monolithic `pnpm verify:acceptance` extension used outside that tag DAG. The guard's focused Node tests cover accepted source literals, exact public metadata and placeholders, declaration-only `.d.ts` colon syntax, invalid `.d.ts` equals assignments, and the existing external pack-output contract. Negative cases cover sensitive filenames, provider tokens, private key/JWK/wallet material, credentialed URLs and form/query parameters including JWT-shaped values, separator- and camel-case credential names, JSON/bracket/setter/tuple authorization serialization, quoted and unquoted generic assignments with command prefixes, shell operators, terminators, and comments, credential-bearing archive segments and tarball names with all artifact names hidden by default, archive links, and tarball-inventory drift. `incur` remains an explicit bundled `@murphai/murph` runtime dependency so the reviewed Murph error-envelope and canonical skill-hash patch plus the framework's runtime and source entrypoints ship together; Incur 0.5.1 now owns lazy optional YAML and MCP loading upstream. The three proven non-runtime upstream test sources that previously required scanner exceptions are omitted so every shipped file receives one unconditional scan policy. The CLI release-workflow guard locks the scan ordering ahead of manifest write, npm provider access, and GitHub Release upload plus the handoff's one-day retention. The workflow is only exercised on real `v*.*.*` tag pushes rather than during ordinary repo verification. npm trust is package-level rather than repo-level, so this monorepo also ships `pnpm release:trust:github` for the one-time bootstrap that binds every publishable `@murphai/*` package to `cobuildwithus/murph` and `.github/workflows/release.yml`; if a package already has the wrong trusted publisher entry, that npm-side state still needs manual revoke-and-recreate repair, which local repo checks cannot fully prove.
 
+## Temporal integration compiler cache
+
+The harness suite and CLI tests prove that the explicit `--process-shard i/n`
+invocations partition the original foreground Vitest commands exactly once,
+reject invalid or stale inventories before setup, and preserve the default
+complete run. Private CI requires both foreground process results.
+
+`MURPH_HOSTED_WEB_WEBPACK_CACHE=1` retains Next's compiler-owned cache for CI
+jobs that persist it. Default production builds keep caching disabled. Existing
+Web config and production-build-runner tests cover opt-in/default behavior,
+route type generation, and the independently earned TypeScript gate. Private
+integration restores compiler inputs while retaining full builds, exact-source
+handoffs, and every hosted E2E assertion.
+
 ## Update Rule
 
 When real source code, CI, or deployment automation is added, update this file and `agent-docs/operations/verification-and-runtime.md` in the same change.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -306,11 +306,11 @@ export function buildHostedWebTurbopackConfig(): NextConfig["turbopack"] {
 export function configureHostedWebWebpack(
   config: HostedWebWebpackConfig,
   context: HostedWebWebpackContext,
+  environment: NodeJS.ProcessEnv = process.env,
 ): HostedWebWebpackConfig {
-  if (!context.dev) {
-    // The production runner deliberately starts every Webpack compile cold, so
-    // a generated filesystem cache can never produce a later hit. Do not spend
-    // several gigabytes of memory and page cache writing that dead artifact.
+  if (!context.dev && environment.MURPH_HOSTED_WEB_WEBPACK_CACHE !== "1") {
+    // Vercel keeps cold compilation. CI jobs that persist the compiler cache
+    // explicitly opt in and let Webpack validate its source dependencies.
     config.cache = false;
   }
 
@@ -480,7 +480,7 @@ export function buildHostedWebNextConfig(
           === HOSTED_WEB_PREPARED_TYPECHECK_COMPLETE,
       tsconfigPath: HOSTED_WEB_NEXT_TSCONFIG_PATH,
     },
-    webpack: configureHostedWebWebpack,
+    webpack: (config, context) => configureHostedWebWebpack(config, context, environment),
     headers: async () => [
       {
         source: HOSTED_WEB_HEADER_SOURCE,

--- a/apps/web/scripts/run-production-next-build.sh
+++ b/apps/web/scripts/run-production-next-build.sh
@@ -7,6 +7,10 @@ typecheck_old_space_mb=3584
 build_cache_epoch=webpack-next-16.3-v6-isolated-worker-no-webpack-cache
 build_cache_stamp=.next/cache/murph-production-build-epoch
 prepared_typecheck_env=MURPH_HOSTED_WEB_PREPARED_TYPECHECK
+webpack_cache_policy=disabled
+if [[ "${MURPH_HOSTED_WEB_WEBPACK_CACHE:-}" == "1" ]]; then
+  webpack_cache_policy=persistent
+fi
 
 # Never trust an inherited bypass. This runner earns the build-only flag again
 # after its own route-aware TypeScript check succeeds.
@@ -41,10 +45,11 @@ if [[ ! -f "$build_cache_stamp" ]] || [[ "$(< "$build_cache_stamp")" != "$build_
   cache_reset=1
 fi
 
-printf '[apps/web build] Next memory policy: compiler=webpack parent_old_space_mb=%s build_worker_old_space_mb=%s typecheck_old_space_mb=%s webpack_cache=disabled webpack_build_worker=on\n' \
+printf '[apps/web build] Next memory policy: compiler=webpack parent_old_space_mb=%s build_worker_old_space_mb=%s typecheck_old_space_mb=%s webpack_cache=%s webpack_build_worker=on\n' \
   "$parent_old_space_mb" \
   "$build_worker_old_space_mb" \
-  "$typecheck_old_space_mb"
+  "$typecheck_old_space_mb" \
+  "$webpack_cache_policy"
 
 # Generate the route declarations before running Next's app-local TypeScript 5
 # compatibility check. Keeping that check separate gives validation its own

--- a/apps/web/test/next-config.test.ts
+++ b/apps/web/test/next-config.test.ts
@@ -361,7 +361,7 @@ test("hosted web dev filesystem cache defaults off and allows explicit opt-in", 
 
 test("next.config keeps both bundlers focused without custom workspace rewrite rules", () => {
   assert.equal(productionNextConfig.turbopack?.root, process.cwd());
-  assert.equal(productionNextConfig.webpack, configureHostedWebWebpack);
+  assert.equal(typeof productionNextConfig.webpack, "function");
   assert.deepEqual(productionNextConfig.typescript, {
     ignoreBuildErrors: false,
     tsconfigPath: HOSTED_WEB_NEXT_TSCONFIG_PATH,
@@ -647,6 +647,24 @@ test("configureHostedWebWebpack disables the production cache and aliases Privy'
         "apps/web/src/lib/empty-module.ts",
       ),
     });
+  }
+});
+
+test("the Webpack callback retains Next compiler caching only for explicit CI opt-in", () => {
+  const cache = {
+    type: "filesystem",
+    version: "next-owned",
+    buildDependencies: { config: ["next.config.ts"] },
+  };
+  for (const value of [undefined, "0", "true", "1"]) {
+    const config = { cache, resolve: {} };
+    const environment = createProcessEnv(
+      value === undefined ? {} : { MURPH_HOSTED_WEB_WEBPACK_CACHE: value },
+    );
+    const { webpack } = buildHostedWebNextConfig(PHASE_PRODUCTION_BUILD, environment);
+    assert(webpack);
+    webpack(config, { dev: false } as Parameters<typeof webpack>[1]);
+    assert.equal(config.cache, value === "1" ? cache : false);
   }
 });
 

--- a/packages/hosted-local-harness/src/cli.ts
+++ b/packages/hosted-local-harness/src/cli.ts
@@ -398,12 +398,20 @@ async function runUp(
   }
 }
 
-async function runE2e(args: readonly string[], io: HostedLocalCliIo): Promise<void> {
-  const parsed = parseProfileArgs(args, "e2e:stub");
+function parseE2eOptions(args: readonly string[]) {
   let prepareRunnerBundle = true;
+  let processShard: string | undefined;
   let listOnly = false;
   const positional: string[] = [];
-  for (const arg of parsed.args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (arg === "--process-shard") {
+      if (processShard !== undefined || !args[index + 1]) {
+        throw new Error("Pass --process-shard i/n exactly once with a value.");
+      }
+      processShard = args[++index];
+      continue;
+    }
     if (arg === "--no-bundle") {
       prepareRunnerBundle = false;
       continue;
@@ -413,10 +421,19 @@ async function runE2e(args: readonly string[], io: HostedLocalCliIo): Promise<vo
       continue;
     }
     if (arg === "--help" || arg === "-h") {
-      printE2eHelp(io.stdout ?? process.stdout);
-      return;
+      return { prepareRunnerBundle, processShard, listOnly, positional, help: true };
     }
     positional.push(arg);
+  }
+  return { prepareRunnerBundle, processShard, listOnly, positional, help: false };
+}
+
+async function runE2e(args: readonly string[], io: HostedLocalCliIo): Promise<void> {
+  const parsed = parseProfileArgs(args, "e2e:stub");
+  const { prepareRunnerBundle, processShard, listOnly, positional, help } = parseE2eOptions(parsed.args);
+  if (help) {
+    printE2eHelp(io.stdout ?? process.stdout);
+    return;
   }
   if (listOnly) {
     printE2eScenarios(io.stdout ?? process.stdout);
@@ -444,6 +461,7 @@ async function runE2e(args: readonly string[], io: HostedLocalCliIo): Promise<vo
     const result = await runHostedLocalE2eSuite({
       env,
       prepareRunnerBundle,
+      ...(processShard === undefined ? {} : { processShard }),
       scenario: scenarioNames,
     });
     if (result.terminationSignal) {
@@ -680,11 +698,12 @@ function printWorktreeHelp(stdout: NodeJS.WritableStream): void {
 function printE2eHelp(stdout: NodeJS.WritableStream): void {
   stdout.write(
     [
-      "Usage: hosted-local e2e [scenario ...] [--profile e2e:stub|e2e:live] [--no-bundle] [--list]",
+      "Usage: hosted-local e2e [scenario ...] [--profile e2e:stub|e2e:live] [--no-bundle] [--process-shard i/n] [--list]",
       "",
       "The command prepares one hosted-local runner bundle, runs the selected Vitest files,",
       "and cleans stale Cloudflare runner containers once in a finally block. Named scenarios",
       "run serially in one prepared suite so they can reuse the runner image and smoke proof.",
+      "--process-shard i/n isolates one declared process; all n shards are required for full proof.",
       "",
     ].join("\n"),
   );

--- a/packages/hosted-local-harness/src/e2e.ts
+++ b/packages/hosted-local-harness/src/e2e.ts
@@ -470,6 +470,7 @@ export interface HostedLocalE2eSuiteInput {
   env?: NodeJS.ProcessEnv;
   injectSkipRunnerBundleEnv?: boolean;
   prepareRunnerBundle?: boolean;
+  processShard?: string;
   scenario?: HostedLocalE2eScenarioSelection;
 }
 
@@ -555,12 +556,35 @@ function partitionLiveWearableEnvironment(input: {
   return { genericEnv, vitestEnvOverlay };
 }
 
+function selectHostedLocalE2eProcessShard(
+  scenarios: readonly HostedLocalE2eScenario[],
+  shard: string | undefined,
+): readonly HostedLocalE2eScenario[] {
+  if (shard === undefined) return scenarios;
+  const match = /^([1-9][0-9]*)\/([1-9][0-9]*)$/u.exec(shard);
+  const scenario = scenarios[0];
+  const patterns = scenario?.vitestProcessTestNamePatterns;
+  const index = Number(match?.[1]);
+  const count = Number(match?.[2]);
+  if (
+    !match || scenarios.length !== 1 || !patterns
+    || !Number.isSafeInteger(index) || count !== patterns.length
+    || index > count
+  ) {
+    throw new Error("E2E process shard must select i/n from one scenario's complete declared process inventory.");
+  }
+  return [{ ...scenario, vitestProcessTestNamePatterns: [patterns[index - 1]!] }];
+}
+
 export async function runHostedLocalE2eSuite(
   input: HostedLocalE2eSuiteInput = {},
 ): Promise<HostedLocalE2eSuiteResult> {
   const env = sanitizeHostedLocalGenericEnvironment(input.env ?? process.env);
   removeHostedLocalWebAuthorityFromProcessEnvironment();
-  const scenarios = resolveHostedLocalE2eScenarios(input.scenario ?? "all");
+  const scenarios = selectHostedLocalE2eProcessShard(
+    resolveHostedLocalE2eScenarios(input.scenario ?? "all"),
+    input.processShard,
+  );
   const liveWearableEnvironment = partitionLiveWearableEnvironment({ env, scenarios });
   const liveStripeEnvironment = partitionHostedStripeBillingLiveEnvironment({
     environment: liveWearableEnvironment.genericEnv,
@@ -708,9 +732,11 @@ async function prepareHostedLocalWebGeneratedArtifacts(input: {
   env: NodeJS.ProcessEnv;
   scenarios: readonly HostedLocalE2eScenario[];
 }): Promise<void> {
-  if (input.scenarios.length <= 1) {
-    return;
-  }
+  const sharesGeneratedArtifacts = input.scenarios.length > 1
+    || input.scenarios.some((scenario) =>
+      (scenario.vitestProcessTestNamePatterns?.length ?? 1) > 1
+    );
+  if (!sharesGeneratedArtifacts) return;
 
   if (input.env[HOSTED_WEB_PRISMA_GENERATED_PREPARED_ENV] !== "1") {
     input.assertWorkAdmission();

--- a/packages/hosted-local-harness/test/cli.test.ts
+++ b/packages/hosted-local-harness/test/cli.test.ts
@@ -551,6 +551,17 @@ describe("hosted-local run CLI", () => {
     }
   });
 
+  test("passes an explicit process shard through the canonical E2E command", async () => {
+    await runHostedLocalCli(["e2e", "foreground-reply-priority", "--no-bundle", "--process-shard", "2/2"], {
+      env: {}, stdout: createBufferedStdout().stdout,
+    });
+    expect(runHostedLocalE2eSuite).toHaveBeenCalledWith(expect.objectContaining({
+      prepareRunnerBundle: false,
+      processShard: "2/2",
+      scenario: ["foreground-reply-priority"],
+    }));
+  });
+
   test("marks interrupted hosted-local e2e runs as stopped", async () => {
     runHostedLocalE2eSuite.mockResolvedValueOnce({ terminationSignal: "SIGINT" });
     const output = createBufferedStdout();

--- a/packages/hosted-local-harness/test/e2e-suite.test.ts
+++ b/packages/hosted-local-harness/test/e2e-suite.test.ts
@@ -104,6 +104,67 @@ describe("hosted-local E2E suite preparation", () => {
     vi.unstubAllEnvs();
   });
 
+  test("process shards partition the actual unsharded Vitest invocations exactly once", async () => {
+    const commands = () => runForegroundCommand.mock.calls
+      .map(([input]) => input)
+      .filter((input) => input.args.includes("vitest"))
+      .map((input) => input.args);
+    await runHostedLocalE2eSuite({ env: {}, prepareRunnerBundle: false, scenario: "foreground-reply-priority" });
+    const complete = commands();
+    expect(complete).toHaveLength(2);
+    runForegroundCommand.mockClear();
+    for (const processShard of ["1/2", "2/2"]) {
+      await runHostedLocalE2eSuite({ env: {}, prepareRunnerBundle: false, scenario: "foreground-reply-priority", processShard });
+    }
+    expect(commands()).toEqual(complete);
+  });
+
+  test.each(["", "0/2", "3/2", "1/1", "1/3", "1/2junk", "9007199254740993/2"])(
+    "rejects invalid or stale process inventory %s before setup",
+    async (processShard) => {
+      await expect(runHostedLocalE2eSuite({ env: {}, scenario: "foreground-reply-priority", processShard })).rejects.toThrow("complete declared process inventory");
+      expect(runForegroundCommand).not.toHaveBeenCalled();
+      expect(cleanupHostedRunnerContainers).not.toHaveBeenCalled();
+    },
+  );
+
+  test("does not shard an aggregate suite or a scenario without process groups", async () => {
+    for (const scenario of ["all", "linq-webhook"]) {
+      await expect(runHostedLocalE2eSuite({ env: {}, scenario, processShard: "1/2" })).rejects.toThrow("complete declared process inventory");
+    }
+    expect(runForegroundCommand).not.toHaveBeenCalled();
+  });
+
+  test("prepares generated inputs once for one scenario with two processes", async () => {
+    await runHostedLocalE2eSuite({
+      env: {}, prepareRunnerBundle: false, scenario: "foreground-reply-priority",
+    });
+    const calls = runForegroundCommand.mock.calls.map(([call]) => call);
+    expect(calls.filter((call) => call.args.includes("prisma:generate"))).toHaveLength(1);
+    expect(calls.filter((call) => call.args.includes("health-commons:generate"))).toHaveLength(1);
+    const children = calls.filter((call) => call.args.includes("vitest"));
+    expect(children).toHaveLength(2);
+    for (const child of children) {
+      expect(child.env).toEqual(expect.objectContaining({
+        MURPH_HOSTED_WEB_PRISMA_GENERATED_PREPARED: "1",
+        MURPH_HEALTH_COMMONS_GENERATED_PREPARED: "1",
+      }));
+    }
+  });
+
+  test.each(["prisma:generate", "health-commons:generate"])(
+    "does not launch either foreground process when %s preparation fails",
+    async (failedCommand) => {
+      runForegroundCommand.mockImplementation(async (input) => {
+        if (input.args.includes(failedCommand)) throw new Error("generation failed");
+      });
+      await expect(runHostedLocalE2eSuite({
+        env: {}, prepareRunnerBundle: false, scenario: "foreground-reply-priority",
+      })).rejects.toThrow("generation failed");
+      expect(runForegroundCommand.mock.calls.some(([call]) => call.args.includes("vitest"))).toBe(false);
+    },
+  );
+
   test("prepares generated web artifacts once for aggregate scenario runs", async () => {
     const env: NodeJS.ProcessEnv = {};
 


### PR DESCRIPTION
## Why and outcome

Temporal admission has a measured 30–35 minute cross-repository critical path. This adds the public support for independent foreground E2E process shards and an explicit production Webpack cache opt-in. It also prepares generated Web inputs once for a single scenario that runs multiple processes. The complete under-ten-minute target remains unverified.

## Product UX

- Effort: Not applicable — internal CI and verification controls.
- Result: Not applicable — internal build and verification controls. CI and cold/warm performance proof are pending.
- Walkthrough: Maintainers can select one existing process with `--process-shard i/n`; complete proof requires all n shards. Default scenario invocations still run the full inventory.

## Evidence

- Direct: 52 harness tests and 53 Web configuration/build-runner tests pass. Web and harness typechecks pass.
- Coverage: The combined shard commands equal the unsharded inventory; malformed, incomplete, aggregate, and stale shard selections fail before setup. Generation failures prevent both processes from launching.
- Commands: `pnpm --dir packages/hosted-local-harness test test/e2e-suite.test.ts test/cli.test.ts`; `pnpm exec vitest run --config apps/web/vitest.config.ts apps/web/test/next-config.test.ts apps/web/test/production-next-build-runner.test.ts --no-coverage`; `pnpm --dir packages/hosted-local-harness typecheck`; `pnpm --dir apps/web typecheck:prepared`; `pnpm complexity:diff`; `pnpm docs:drift`.
- Full Web build: shared-host admission remained occupied beyond ten minutes. `MURPH_VERIFY_EXECUTOR=ssh pnpm test:diff apps/web/next.config.ts apps/web/scripts/run-production-next-build.sh packages/hosted-local-harness/src/cli.ts packages/hosted-local-harness/src/e2e.ts` could not start because no SSH worker address is configured. No cold/warm speed or memory claim is made.

## Non-obvious affected surfaces

The nine priority tests share evidence with their final alert test and remain one sequential group. Only the existing separate checkpoint process is independently selectable. Web keeps its current heap limits, compiler worker, and both source/route-aware typechecks; the cache opt-in preserves Next's own cache configuration.

## Architecture and reuse

- Existing systems reused: canonical hosted-local CLI, scenario process inventory, generated-input preparation, and Next's compiler cache.
- New logic: validate i/n against the complete declared process count; retain Webpack cache only for an explicit value of 1.
- New abstractions: two small CLI/selection helpers at the existing owners; no new service or dependency.
- Complexity intentionally avoided: no arbitrary test-level scheduling or reusable release-attestation system.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: existing `runWorktree` remains 34; unchanged by this E2E patch. No new complexity debt.
- Agent judgment: E2E option parsing is extracted to keep the changed command below the threshold; unrelated worktree dispatch refactoring is unnecessary.

## Hot reply path impact

- Path status: Not applicable — test execution and build controls only.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None added to production.
- Before/after proof: the E2E command inventory remains complete; production runtime test assertions are unchanged.

## Murph initial provider input impact

Not applicable for individual or group runtimes: no assembled instructions, tools, schemas, or provider-visible inputs change. No token measurement is claimed.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old private CI continues using the default complete suite.
- Safe order: Merge public support before enabling the private workflow's shard flag and cache opt-in.
- Rollback floor: Revert private shard consumption before removing the public flag.
- Expected exposure: The private workflow fails closed if its declared process count differs from the public inventory.
- Reversibility: Disable the private cache opt-in and revert parallel shard consumption.
- Convergence proof: Both private process shards must pass using the same planner-pinned public SHA.
- Post-deploy checks: Measure full GitHub admission elapsed time and cold/warm Web peak memory before declaring the target met.

ReviewGPT context sensitivity: sensitive
Classification reason: Cross-repository build and E2E proof controls.

## Changelog

- Changelog: not applicable
- Reason: Internal CI performance work; no member-visible product behavior.

## Change-shape breakdown

Classification rule: tests by test paths, Markdown as docs, workflows/config/scripts as tooling, remaining authored code as source. No binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 55 | 10 |
| Tests / fixtures | 91 | 1 |
| Docs | 72 | 1 |
| Config / tooling | 12 | 7 |
| Generated / other | 0 | 0 |
| **Total** | **230** | **19** |

ReviewGPT first-reviewed head: 1e37c5bce312a753ec2b79fbbef7a02006912d7f
