### PR TITLE
refactor(importers): simplify Junction daily aggregation

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-junction-import-complexity.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-junction-import-complexity.md
@@ -1,0 +1,65 @@
+# Junction importer complexity
+
+## Outcome and scope
+
+Reduce branching in daily aggregation and sparse interval parsing without changing
+provider normalization, canonical facts, evidence, or errors. Source owner remains
+`packages/importers/src/device-providers/junction.ts`; no new abstraction or state
+owner. Baseline: `b6454467652310f7abdd63676dab0f769c340ae8`.
+
+## Protected behavior
+
+Preserve record selection and ordering, floating-point accumulation order, signed
+zero handling, timestamp and alias precedence, source authority, legacy day keys,
+all response/source-day/output caps, and atomic rejection of incomplete days.
+No UI, policy, health-model, database, or deployment contract changes.
+
+## Steps and evidence
+
+- [x] Inspect current owners, Frog entries, caller flow, and exact-path open PR overlap (none).
+- [x] Prove both temporal resources admit 25,000 rows across source instances and reject 25,001 before accumulation.
+- [x] Delete only unreachable import-counter state, simplify repeated diagnostics and terminal temporal branches, and remove sparse predicates excluded by prior returns.
+- [x] Run public-normalizer baseline/head proof, focused Junction suites, importer typecheck, and complexity comparison.
+- [ ] Inspect complete diff/privacy, archive with scoped commit, open draft PR, and obtain parent candidate review.
+- [ ] Run exact-head ReviewGPT concurrently with CI and report results; keep PR open.
+
+## Reasoning and risks
+
+`buildJunctionDailyTimeseriesAggregates` has one row loop and two internal callers;
+all calls pass the same pre-loop fidelity response bound. Both temporal resources
+use the dense 25,000-row policy, while the removed counter can increment only once
+per entry. Its greater-than-25,000 branch is unreachable. Preserve independent
+per-source-day, per-vault-day, and temporal output limits. Sparse instant/interval
+body branches return before generic interval handling; generic inputs always need
+start/end, and only three resource types permit an omitted timestamp.
+
+The main risk is changing subtle numeric or timestamp behavior during control-flow
+cleanup. Do not replace ordered arithmetic or daily min/max comparisons with
+shared initialization or Math helpers. Existing canonical replay and error tests
+plus direct boundary tests own behavioral proof. No new Frog entry is warranted
+by the routine clean worktree setup.
+
+## Completion evidence
+
+- Five focused Junction importer suites pass: 288 tests covering canonical replay,
+  source authority, bounded features, activity and companion metadata, sparse
+  parsing, and the two new 25,000/25,001 cross-source response boundaries.
+- `pnpm --dir packages/importers typecheck`: pass.
+- `pnpm complexity:diff --base b6454467652310f7abdd63676dab0f769c340ae8 -- packages/importers/src/device-providers/junction.ts`: pass; file debt 174 to 153,
+  daily aggregation 106 to 98.
+- An ignored synthetic public-normalizer harness captured 350 cases against the
+  base and candidate; serialized outputs and errors match byte for byte, including
+  explicit signed-zero preservation. It covers sparse/body timestamp rules,
+  malformed values, source-day errors, ordering, duplicate records, and timezones.
+- Temporal resources are exactly blood oxygen and stress level; both use the dense
+  25,000 response policy, matching the removed counter limit. Admission precedes
+  the single row loop. Independent per-source-day and output caps remain intact.
+- Parent candidate review accepted the source shape. Diff/privacy readback passes;
+  existing Frog inventory reviewed, no new qualifying repository friction.
+
+Local implementation is complete. Draft PR, final ReviewGPT and required exact-head
+CI remain external gates. No merge is authorized. No changelog or Product UX work
+is required because this preserves existing member-visible behavior.
+Status: completed
+Updated: 2026-09-04
+Completed: 2026-09-04

--- a/packages/importers/src/device-providers/junction.ts
+++ b/packages/importers/src/device-providers/junction.ts
@@ -129,7 +129,6 @@ import {
   isJunctionTemporalFeatureResource,
   JUNCTION_TEMPORAL_FEATURE_MAX_OBSERVATIONS_PER_DAY,
   JUNCTION_TEMPORAL_FEATURE_MAX_SAMPLES_PER_DAY,
-  JUNCTION_TEMPORAL_FEATURE_MAX_SAMPLES_PER_IMPORT,
   type JunctionTemporalFeatureObservationQualifiers,
   type JunctionTemporalFeatureResult,
   type JunctionTemporalFeatureSample,
@@ -3410,30 +3409,22 @@ function parseJunctionSparseTimeseriesRecord(
       value,
     });
   }
-  const requiresTimestamp = !intervalBodyResource
-    && resource !== "carbohydrates"
+  const requiresTimestamp = resource !== "carbohydrates"
     && resource !== "heart_rate_alert"
     && resource !== "insulin_injection";
-  const requiresInterval = resource !== "fat";
-  if ((requiresTimestamp && !timestampRaw) || (requiresInterval && (!startRaw || !endRaw))) {
+  if ((requiresTimestamp && !timestampRaw) || !startRaw || !endRaw) {
     return null;
   }
 
   const timestamp = timestampRaw ? normalizeTimestamp(timestampRaw) : undefined;
-  const startAt = startRaw ? normalizeTimestamp(startRaw) : undefined;
-  const endAt = endRaw ? normalizeTimestamp(endRaw) : undefined;
+  const startAt = normalizeTimestamp(startRaw);
+  const endAt = normalizeTimestamp(endRaw);
   if (
-    (!intervalBodyResource && timestampRaw && !timestamp)
-    || (startRaw && !startAt)
-    || (endRaw && !endAt)
-    || (requiresInterval && (!startAt || !endAt))
-    || (startAt && endAt && Date.parse(endAt) < Date.parse(startAt))
+    (timestampRaw && !timestamp)
+    || !startAt
+    || !endAt
+    || Date.parse(endAt) < Date.parse(startAt)
   ) {
-    return null;
-  }
-
-  const observedAtRaw = timestampRaw ?? startRaw;
-  if (!observedAtRaw) {
     return null;
   }
 
@@ -3441,7 +3432,7 @@ function parseJunctionSparseTimeseriesRecord(
     descriptor,
     endAt,
     entry,
-    observedAtRaw,
+    observedAtRaw: timestampRaw ?? startRaw,
     resource,
     startAt,
     value,
@@ -4195,8 +4186,6 @@ function buildJunctionDailyTimeseriesAggregates(input: {
     : undefined;
   const ownsTemporalFeatures = temporalFeatureResource !== undefined
     && input.context.temporalFeatureSourceDay?.resources.includes(input.resource) === true;
-  let temporalFeatureInputCount = 0;
-  let temporalFeatureImportSuppressed = false;
   // A complete-source-day payload is always grouped; its rows are exactly the
   // grouped rows, so an empty grouped envelope or an explicitly empty group
   // data array is a valid authoritative empty rather than a lossy row.
@@ -4281,6 +4270,14 @@ function buildJunctionDailyTimeseriesAggregates(input: {
           resourceContext.sourceProviderSlug,
           JUNCTION_INTERVAL_START_OWNED_TIMESTAMP_PATHS,
         );
+    const resolvedRowDiagnostic = {
+      ...rowDiagnostic,
+      sourceProvider: normalizeKnownJunctionSourceProviderSlug(resourceContext.sourceProviderSlug),
+      timestampKind: classifyJunctionNormalizationTimestampKind(
+        timestamp.observedAtRaw ?? providerTimestamp,
+      ),
+      timestampSemantics: timestamp.timestampSemantics,
+    };
     const sampleAt = resolveJunctionDailyAggregateSampleAt(
       timestamp,
       input.requireExplicitTimestamp,
@@ -4322,16 +4319,7 @@ function buildJunctionDailyTimeseriesAggregates(input: {
         } else {
           reason = "daily.timestamp_or_day_unresolved";
         }
-        throw junctionCalendarRefreshNormalizationError(reason, {
-          ...rowDiagnostic,
-          sourceProvider: normalizeKnownJunctionSourceProviderSlug(
-            resourceContext.sourceProviderSlug,
-          ),
-          timestampKind: classifyJunctionNormalizationTimestampKind(
-            timestamp.observedAtRaw ?? providerTimestamp,
-          ),
-          timestampSemantics: timestamp.timestampSemantics,
-        });
+        throw junctionCalendarRefreshNormalizationError(reason, resolvedRowDiagnostic);
       }
       continue;
     }
@@ -4405,7 +4393,7 @@ function buildJunctionDailyTimeseriesAggregates(input: {
           value,
       })
       : undefined;
-    const legacyDayKeys = new Set<string>();
+    const legacyDayKeys = existing?.legacyDayKeys ?? new Set<string>();
     if (legacyDayKey && legacyDayKey !== dayKey) {
       legacyDayKeys.add(legacyDayKey);
     }
@@ -4445,9 +4433,6 @@ function buildJunctionDailyTimeseriesAggregates(input: {
       }
       existing.sum += value;
       existing.sumSquares += value * value;
-      if (legacyDayKey && legacyDayKey !== dayKey) {
-        existing.legacyDayKeys.add(legacyDayKey);
-      }
       if (sampleAt < existing.firstSampleAt) {
         existing.firstSampleAt = sampleAt;
       }
@@ -4467,127 +4452,100 @@ function buildJunctionDailyTimeseriesAggregates(input: {
       }
     }
 
-    const temporalSourceDay = ownsTemporalFeatures && !temporalFeatureImportSuppressed
+    const temporalSourceDay = ownsTemporalFeatures
       ? input.context.temporalFeatureSourceDay
       : undefined;
     const temporalSampleAt = temporalSourceDay
       ? resolveJunctionTemporalFeatureInstant(
           timestamp,
           temporalSourceDay.timeZone,
-          {
-            ...rowDiagnostic,
-            sourceProvider: normalizeKnownJunctionSourceProviderSlug(
-              resourceContext.sourceProviderSlug,
-            ),
-            timestampKind: classifyJunctionNormalizationTimestampKind(
-              timestamp.observedAtRaw ?? providerTimestamp,
-            ),
-            timestampSemantics: timestamp.timestampSemantics,
-          },
+          resolvedRowDiagnostic,
         )
       : null;
-    if (temporalSourceDay && temporalSampleAt !== null) {
-      temporalFeatureInputCount += 1;
-      if (temporalFeatureInputCount > JUNCTION_TEMPORAL_FEATURE_MAX_SAMPLES_PER_IMPORT) {
-        temporalFeatureImportSuppressed = true;
-        for (const current of temporalAggregates.values()) {
-          delete current.temporalFeatureSamples;
-        }
-      } else {
-        const sourceDay = temporalSourceDay;
-        const vaultDayKey = toLocalDayKey(temporalSampleAt, sourceDay.timeZone);
-        if (vaultDayKey !== sourceDay.dayKey) {
-          // The provider fetched the exact authorized window, so a row that
-          // normalizes outside the target vault day (for example a fallback
-          // timestamp) is a lossy normalization, not out-of-scope data.
-          throw junctionCalendarRefreshNormalizationError(
-            "source_day.outside_authorized_day",
-            {
-              ...rowDiagnostic,
-              sourceProvider: normalizeKnownJunctionSourceProviderSlug(
-                resourceContext.sourceProviderSlug,
-              ),
-              timestampKind: classifyJunctionNormalizationTimestampKind(
-                timestamp.observedAtRaw ?? providerTimestamp,
-              ),
-              timestampSemantics: timestamp.timestampSemantics,
-            },
-          );
-        }
-        const temporalKey = [
-          resourceContext.externalRefResourceType,
-          resourceContext.origin.sourceType ?? "",
-          resourceContext.origin.sourceInstanceId ?? "",
-          sourceDay.dayKey,
-        ].join("\u0000");
-        let temporalAggregate = temporalAggregates.get(temporalKey);
-        if (!temporalAggregate) {
-          const sourceFacet = shortHash([
-            resourceContext.sourceProviderSlug,
-            resourceContext.origin.sourceType ?? "",
-            resourceContext.origin.sourceInstanceId ?? "",
-          ]);
-          temporalAggregate = {
-            authoritativeEmptyCalendarSet: false,
-            dayKey: sourceDay.dayKey,
-            duplicateSampleCount: 0,
-            entry,
-            fidelitySamples: [],
-            firstSampleAt: temporalSampleAt,
-            lastRecordedAt: recordedAt,
-            lastSampleAt: temporalSampleAt,
-            legacyDayKeys: new Set(),
-            maxValue: value,
-            minValue: value,
-            evidencePartRole:
-              `junction-timeseries-temporal-${input.resourceSlug}:${sourceDay.dayKey}:${sourceFacet}`,
-            resourceContext,
-            sampleCount: 0,
-            sum: 0,
-            sumSquares: 0,
-            timestamp,
-            timeZone: sourceDay.timeZone,
-          };
-          temporalAggregates.set(temporalKey, temporalAggregate);
-        }
-        temporalAggregate.sampleCount += 1;
-        temporalAggregate.sum += value;
-        if (temporalSampleAt < temporalAggregate.firstSampleAt) {
-          temporalAggregate.firstSampleAt = temporalSampleAt;
-        }
-        if (temporalSampleAt >= temporalAggregate.lastSampleAt) {
-          temporalAggregate.lastSampleAt = temporalSampleAt;
-          temporalAggregate.lastRecordedAt = recordedAt;
-          temporalAggregate.timestamp = timestamp;
-        }
-        temporalAggregate.minValue = Math.min(temporalAggregate.minValue, value);
-        temporalAggregate.maxValue = Math.max(temporalAggregate.maxValue, value);
-        const temporalFeatureSamples = temporalAggregate.temporalFeatureSamples ?? [];
-        if (temporalFeatureSamples.length >= JUNCTION_TEMPORAL_FEATURE_MAX_SAMPLES_PER_DAY) {
-          temporalAggregate.temporalFeatureInputSuppressed = true;
-          delete temporalAggregate.temporalFeatureSamples;
-        } else {
-          temporalFeatureSamples.push(stripUndefined({
-            recordedAt: temporalSampleAt,
-            value,
-            localMinuteOfDay: resolveJunctionTemporalFeatureVaultLocalMinuteOfDay(
-              temporalSampleAt,
-              sourceDay.timeZone,
-            ),
-          }));
-          temporalAggregate.temporalFeatureSamples = temporalFeatureSamples;
-        }
-      }
+    if (!temporalSourceDay || temporalSampleAt === null) continue;
+
+    const sourceDay = temporalSourceDay;
+    const vaultDayKey = toLocalDayKey(temporalSampleAt, sourceDay.timeZone);
+    if (vaultDayKey !== sourceDay.dayKey) {
+      // The provider fetched the exact authorized window, so a row that
+      // normalizes outside the target vault day (for example a fallback
+      // timestamp) is a lossy normalization, not out-of-scope data.
+      throw junctionCalendarRefreshNormalizationError(
+        "source_day.outside_authorized_day",
+        resolvedRowDiagnostic,
+      );
+    }
+    const temporalKey = [
+      resourceContext.externalRefResourceType,
+      resourceContext.origin.sourceType ?? "",
+      resourceContext.origin.sourceInstanceId ?? "",
+      sourceDay.dayKey,
+    ].join("\u0000");
+    let temporalAggregate = temporalAggregates.get(temporalKey);
+    if (!temporalAggregate) {
+      const sourceFacet = shortHash([
+        resourceContext.sourceProviderSlug,
+        resourceContext.origin.sourceType ?? "",
+        resourceContext.origin.sourceInstanceId ?? "",
+      ]);
+      temporalAggregate = {
+        authoritativeEmptyCalendarSet: false,
+        dayKey: sourceDay.dayKey,
+        duplicateSampleCount: 0,
+        entry,
+        fidelitySamples: [],
+        firstSampleAt: temporalSampleAt,
+        lastRecordedAt: recordedAt,
+        lastSampleAt: temporalSampleAt,
+        legacyDayKeys: new Set(),
+        maxValue: value,
+        minValue: value,
+        evidencePartRole:
+          `junction-timeseries-temporal-${input.resourceSlug}:${sourceDay.dayKey}:${sourceFacet}`,
+        resourceContext,
+        sampleCount: 0,
+        sum: 0,
+        sumSquares: 0,
+        timestamp,
+        timeZone: sourceDay.timeZone,
+      };
+      temporalAggregates.set(temporalKey, temporalAggregate);
+    }
+    temporalAggregate.sampleCount += 1;
+    temporalAggregate.sum += value;
+    if (temporalSampleAt < temporalAggregate.firstSampleAt) {
+      temporalAggregate.firstSampleAt = temporalSampleAt;
+    }
+    if (temporalSampleAt >= temporalAggregate.lastSampleAt) {
+      temporalAggregate.lastSampleAt = temporalSampleAt;
+      temporalAggregate.lastRecordedAt = recordedAt;
+      temporalAggregate.timestamp = timestamp;
+    }
+    temporalAggregate.minValue = Math.min(temporalAggregate.minValue, value);
+    temporalAggregate.maxValue = Math.max(temporalAggregate.maxValue, value);
+    const temporalFeatureSamples = temporalAggregate.temporalFeatureSamples ?? [];
+    if (temporalFeatureSamples.length >= JUNCTION_TEMPORAL_FEATURE_MAX_SAMPLES_PER_DAY) {
+      temporalAggregate.temporalFeatureInputSuppressed = true;
+      delete temporalAggregate.temporalFeatureSamples;
+    } else {
+      temporalFeatureSamples.push(stripUndefined({
+        recordedAt: temporalSampleAt,
+        value,
+        localMinuteOfDay: resolveJunctionTemporalFeatureVaultLocalMinuteOfDay(
+          temporalSampleAt,
+          sourceDay.timeZone,
+        ),
+      }));
+      temporalAggregate.temporalFeatureSamples = temporalFeatureSamples;
     }
   }
 
-  const sortedAggregates = [...aggregates.values()].sort(compareJunctionDailyTimeseriesAggregates);
-  if (temporalFeatureResource && ownsTemporalFeatures) {
+  if (ownsTemporalFeatures) {
     for (const aggregate of [...temporalAggregates.values()].sort(
       compareJunctionDailyTimeseriesAggregates,
     )) {
       const result: JunctionTemporalFeatureResult =
-        temporalFeatureImportSuppressed || aggregate.temporalFeatureInputSuppressed
+        aggregate.temporalFeatureInputSuppressed
           ? { observations: [], status: "suppressed_input_cap" }
           : buildJunctionTemporalFeatures({
             resource: temporalFeatureResource,
@@ -4620,16 +4578,15 @@ function buildJunctionDailyTimeseriesAggregates(input: {
       }
       delete aggregate.temporalFeatureSamples;
     }
-  }
 
-  // A complete-source-day import owns only temporal facets. Its vault-window
-  // samples cover partial provider days, so emitting ordinary observations,
-  // aggregate artifacts, or dense envelopes would supersede the calendar-day
-  // owner's full-day facts with partial revisions.
-  if (ownsTemporalFeatures) {
+    // A complete-source-day import owns only temporal facets. Its vault-window
+    // samples cover partial provider days, so emitting ordinary observations,
+    // aggregate artifacts, or dense envelopes would supersede the calendar-day
+    // owner's full-day facts with partial revisions.
     return [];
   }
 
+  const sortedAggregates = [...aggregates.values()].sort(compareJunctionDailyTimeseriesAggregates);
   if (sortedAggregates.length === 0) {
     pushJunctionEmptyDailyTimeseriesAggregateArtifact(input.context, input.resource, input.resourceSlug);
     return sortedAggregates;

--- a/packages/importers/test/device-providers-junction-missing-resources.test.ts
+++ b/packages/importers/test/device-providers-junction-missing-resources.test.ts
@@ -886,6 +886,34 @@ test("Junction missing-resource slice rejects malformed values, units, intervals
   assert.deepEqual(payload.evidenceParts, []);
 });
 
+test("Junction generic sparse intervals retain timestamp requirements and zero-duration acceptance", () => {
+  for (const [resource, unit, extras, timestampRequired] of [
+    ["carbohydrates", "g", {}, false],
+    ["heart_rate_alert", "count", { type: "irregular_rhythm" }, false],
+    ["insulin_injection", "unit", { type: "insulin_lispro" }, false],
+    ["inhaler_usage", "count", {}, true],
+  ] as const) {
+    const normalize = (overrides: Record<string, unknown>) => normalizeJunctionSnapshot({
+      importedAt: "2026-02-02T00:00:00.000Z",
+      timeseries: {
+        [resource]: grouped("apple_health_kit", "phone", "synthetic-device", [{
+          id: "synthetic-reading", start: START, end: END, timestamp: TIMESTAMP,
+          value: 1, unit, ...extras, ...overrides,
+        }]),
+      },
+    });
+    assert.equal(normalize({}).events?.length, 1, resource);
+    assert.equal(normalize({ timestamp: undefined }).events?.length, timestampRequired ? 0 : 1, resource);
+    assert.equal(normalize({ end: START }).events?.length, 1, resource);
+    for (const malformed of [
+      { start: undefined }, { end: undefined }, { start: "invalid" },
+      { end: "invalid" }, { timestamp: "invalid" }, { start: END, end: START },
+    ]) {
+      assert.deepEqual(normalize(malformed).events, [], `${resource}: ${JSON.stringify(malformed)}`);
+    }
+  }
+});
+
 test("Junction body resources require canonical zoned timestamps and positive intervals", () => {
   const payload = normalizeJunctionSnapshot({
     importedAt: "2026-02-02T00:00:00.000Z",

--- a/packages/importers/test/device-providers-junction.test.ts
+++ b/packages/importers/test/device-providers-junction.test.ts
@@ -8483,6 +8483,41 @@ test("Junction temporal feature import accepts the dense fidelity bound and reje
   );
 });
 
+for (const resource of ["blood_oxygen", "stress_level"] as const) {
+  test(`Junction ${resource} temporal response bound includes every source instance`, () => {
+    const buildPayload = (length: number) => normalizeCompleteTemporalSourceDay({
+      importedAt: "2026-04-08T12:00:00.000Z",
+      timeseries: {
+        [resource]: {
+          groups: {
+            garmin: Array.from({ length: Math.ceil(length / 1_440) }, (_, sourceIndex) => ({
+              source: { provider: "garmin", type: "watch", device_id: `synthetic-watch-${sourceIndex}` },
+              data: Array.from({ length: Math.min(1_440, length - sourceIndex * 1_440) }, (_, index) => ({
+                timestamp: new Date(Date.UTC(2026, 3, 1) + index * 60_000).toISOString(),
+                value: resource === "blood_oxygen" ? 98 : index % 2 === 0 ? 20 : 80,
+              })),
+            })),
+          },
+        },
+      },
+    }, "2026-04-01");
+    const payload = buildPayload(25_000);
+    const artifacts = findJunctionTemporalFeatureArtifacts(payload, resource.replaceAll("_", "-"));
+    assert.equal(artifacts.length, 18);
+    assert.equal(artifacts.reduce((count, artifact) => {
+      const content = artifact.content as Record<string, unknown>;
+      assert.notEqual(content.status, "suppressed_input_cap");
+      return count + Number(content.sampleCount);
+    }, 0), 25_000);
+    assert.equal(payload.samples?.length ?? 0, 0);
+    assert.ok((payload.events?.length ?? 0) <= JUNCTION_TEMPORAL_FEATURE_MAX_OBSERVATIONS_PER_DAY);
+    assert.throws(
+      () => buildPayload(25_001),
+      new RegExp(`Junction ${resource} response has 25001 records; maximum admitted is 25000`, "u"),
+    );
+  }, 180_000);
+}
+
 test("Junction temporal source day rejects an over-bound sibling day without partial facts", () => {
   const overBoundDaySamples = Array.from({ length: 1_441 }, (_, index) => ({
     timestamp: new Date(Date.UTC(2026, 3, 22) + index * 10_000).toISOString(),


### PR DESCRIPTION
## Why and outcome

Junction daily aggregation repeats diagnostics and tracks an import suppression state that its earlier 25,000-row admission bound makes unreachable. Remove that state, flatten the terminal temporal branch, reuse the existing legacy-day set, and remove sparse predicates already excluded by earlier returns. Canonical normalization, ordering, bounds, and errors remain unchanged.

## Product UX

- Effort: Not applicable — internal behavior-preserving importer cleanup.
- Result: Not applicable.
- Walkthrough: Existing connected-device records, partial-day rejection, and recovery retain their current behavior; no member flow or UI changes.

## Evidence

- Direct: Public normalizer tests admit 25,000 rows across 18 source instances for both temporal resources and reject 25,001 before accumulation. Sparse interval proof covers missing/invalid timestamps, missing/reversed intervals, and zero-duration acceptance.
- Coverage: Five Junction importer suites pass (288 tests): `pnpm --dir packages/importers test test/device-providers-junction.test.ts test/device-providers-junction-missing-resources.test.ts test/device-providers-junction-activity-resources.test.ts test/device-providers-junction-bounded-features.test.ts test/device-providers-junction-companion-health-metadata.test.ts`. A 350-case public-normalizer baseline/head comparison covers sparse/body timestamps, malformed values, source-day errors, record ordering, duplicates, UTC/local timezones, and signed zero. All 350 serialized results and errors match byte for byte.
- Typecheck: `pnpm --dir packages/importers typecheck` passes.
- Final ReviewGPT round 1: PASS on `80825b5eeab763485d51778c589f78bcdeb12419`, verified `gpt-6-pro` capture, no findings, and independently measured 675-second send-to-capture duration. The reviewer ran 7,096 additional base/head differential checks across both aggregation callers, all sparse descriptors, and temporal admission boundaries.
- CI: [Full exact-head release verification](https://github.com/cobuildwithus/murph/actions/runs/33938926138) and every required GitHub check pass, including both CLI platforms and the hosted billing boundary.

## Non-obvious affected surfaces

Complete-source-day imports still emit only temporal facets, preserving calendar-day ownership. Existing canonical replay, source authority, per-day input/output limits, and error tests cover this boundary.

## Architecture and reuse

- Existing systems reused: The existing Junction importer, fidelity admission policy, temporal feature reducer, and canonical import boundary.
- New logic: None; remove predicates and state proved unreachable by existing admission and early-return rules.
- New abstractions: None; keep aggregation in its current owner.
- Complexity intentionally avoided: No replacement counter, manager, generic reducer, or additional state owner.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff --base b6454467652310f7abdd63676dab0f769c340ae8 -- packages/importers/src/device-providers/junction.ts`; debt 174→153 and maximum 106→98.
- Hotspots: Changed daily aggregation is 98 and sparse parsing is 29. Other unchanged hotspots are workout stream features 33, sparse timestamp resolution 32, menstrual cycle summary 31, sparse calendar repair validation and raw payload construction 27 each, sparse record output 26, interval readings 25, distance normalization 23, and daily aggregate artifacts 22.
- Agent judgment: Preserve ordered arithmetic and distinct timestamp, authority, and cap rules. Further extraction would move complexity without proving a smaller current contract.

## Hot reply path impact

- Path status: Not applicable — synchronous background device-record normalization.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved.
- Before/after proof: The diff changes no awaited operations or foreground conversation owner.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no assistant prompt, tool, schema, message, or input builder changes.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Same importer inputs, outputs, stored facts, and error contracts; no independent consumer or deployment configuration changes.

## Change-shape breakdown

Classification rule: Importer implementation is source, importer tests are tests/fixtures, and the completed plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 103 | 146 |
| Tests / fixtures | 63 | 0 |
| Docs | 65 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **231** | **146** |

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving complexity reduction with no member-visible outcome change.

ReviewGPT context sensitivity: sensitive
Classification reason: Health-record normalization and source-day authority are sensitive despite preserved behavior.

ReviewGPT first-reviewed head: 80825b5eeab763485d51778c589f78bcdeb12419
