### PR TITLE
refactor(cli): simplify experiment edit orchestration

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-complexity2-experiment-cli.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-complexity2-experiment-cli.md
@@ -1,0 +1,66 @@
+# Simplify experiment edit orchestration
+
+Status: completed
+Created: 2026-09-04
+Updated: 2026-09-04
+
+## Goal
+
+- Remove repeated experiment edit dispatch logic while preserving public flags,
+  canonical payloads, write ordering, and failure timing.
+
+## Success criteria
+
+- Focused CLI experiment tests, package typecheck, and complexity guard pass.
+- Direct proof covers scalar, structured, hydration, mixed edits, and failure cutoffs.
+- Parent candidate review, exact-head ReviewGPT, and required CI pass on the open PR.
+
+## Scope
+
+- In scope: experiment edit handler and focused registered-CLI proof.
+- Out of scope: protocol startup defaults, schemas, core mutations, new CLI behavior.
+
+## Constraints
+
+- Preserve hydration then structured mutation then scalar update ordering.
+- Keep option normalization at its existing effect boundary; retain error messages.
+- Internal refactor: no Product UX change. Existing canonical readback journeys
+  and focused dispatch proof establish unchanged behavior.
+
+## Risks and mitigations
+
+1. Scalar status could replay after structured writes. Preserve its omission on
+   structured routes and assert service payloads and order.
+2. Eager normalization could fail before a previously completed write. Keep the
+   scalar payload inside an invocation-local closure called at the same exits.
+
+## Tasks
+
+1. Consolidate the duplicated analysis-field predicate and scalar write payload.
+2. Delete guards proved unreachable from the earlier admission predicate.
+3. Add focused dispatch and failure proof; run existing composed experiment tests.
+4. Review, commit, open draft, obtain parent review, and run ReviewGPT with CI.
+
+## Decisions
+
+- Keep protocol plan construction intact; its complexity represents separate
+  defaults and validation rules, not the repeated edit orchestration being removed.
+- Use one local closure to replace three copies without adding mutable result state.
+
+## Verification
+
+- The existing 44 tests in the composed experiment/journal/vault phase-two suite
+  passed. The added dispatch regression passed in a focused rerun after its
+  synthetic fixture recorded the required completed safety screen.
+- Registered-CLI proof covers eight scalar/structured/hydration combinations,
+  status omission after structured writes, failure at each write stage, and
+  canonical readback after a scalar failure preserves the earlier structured write.
+- `pnpm --dir packages/cli typecheck` and `pnpm --dir packages/cli build` passed.
+- Built `packages/cli/dist/bin.js` proof passed for protocol start, scalar and
+  hydrated mixed edits, empty/invalid-tag rejection, and canonical title, paused
+  status, and target-session readback through `experiment show`.
+- `pnpm complexity:diff` passed: changed-file debt 172 to 154, with edit handler
+  complexity 65. Remaining domain-default builders retain their existing owners.
+- Parent source and final test review approved; exact-head ReviewGPT and required
+  broad CI remain PR completion gates.
+Completed: 2026-09-04

--- a/packages/cli/src/commands/experiment.ts
+++ b/packages/cli/src/commands/experiment.ts
@@ -2082,6 +2082,21 @@ export function registerExperimentCommands(
     output: experimentUpdateResultSchema,
     async run({ args, options }) {
       const hasStructuredHydration = options.hydrateProtocolDefaults === true
+      const hasAnalysisFields =
+        options.primaryBiomarkerKey !== undefined ||
+        options.primaryOutcomeKey !== undefined ||
+        options.primaryOutcomeKind !== undefined ||
+        options.primaryOutcomeLabel !== undefined ||
+        options.primaryOutcomeSessionField !== undefined ||
+        options.primaryOutcomeSourceMetricKey !== undefined ||
+        options.primaryOutcomeUnit !== undefined ||
+        options.comparisonStatistic !== undefined ||
+        options.secondaryBiomarkerKey !== undefined ||
+        options.desiredDirection !== undefined ||
+        options.expectedDirection !== undefined ||
+        options.analysisAnchor !== undefined ||
+        options.plannedMeasurement !== undefined ||
+        options.analysisNote !== undefined
       const hasTypedSetupFields =
         options.protocolKey !== undefined ||
         options.pageRevisionId !== undefined ||
@@ -2102,20 +2117,7 @@ export function registerExperimentCommands(
         options.sessionField !== undefined ||
         options.confounderField !== undefined ||
         options.stopCondition !== undefined ||
-        options.primaryBiomarkerKey !== undefined ||
-        options.primaryOutcomeKey !== undefined ||
-        options.primaryOutcomeKind !== undefined ||
-        options.primaryOutcomeLabel !== undefined ||
-        options.primaryOutcomeSessionField !== undefined ||
-        options.primaryOutcomeSourceMetricKey !== undefined ||
-        options.primaryOutcomeUnit !== undefined ||
-        options.comparisonStatistic !== undefined ||
-        options.secondaryBiomarkerKey !== undefined ||
-        options.desiredDirection !== undefined ||
-        options.expectedDirection !== undefined ||
-        options.analysisAnchor !== undefined ||
-        options.plannedMeasurement !== undefined ||
-        options.analysisNote !== undefined ||
+        hasAnalysisFields ||
         options.onboardingCompletedAt !== undefined ||
         options.setupAnswer !== undefined ||
         options.safetyCautionLevel !== undefined ||
@@ -2138,36 +2140,27 @@ export function registerExperimentCommands(
         (options.status !== undefined && !hasStructuredFields) ||
         options.body !== undefined ||
         options.tag !== undefined
-      const hasAnyUserField =
-        hasScalarWriteFields ||
-        options.status !== undefined ||
-        hasStructuredFields
-
-      if (!hasAnyUserField) {
+      if (!hasScalarWriteFields && !hasStructuredFields) {
         throw new VaultCliError(
           'invalid_option',
           'experiment edit requires at least one typed field to change.',
         )
       }
 
+      const updateScalarFields = () => services.core.updateExperiment({
+        vault: String(options.vault ?? ''),
+        requestId: requestIdFromOptions(options),
+        lookup: args.id,
+        title: options.title,
+        hypothesis: options.hypothesis,
+        startedOn: options.startedOn,
+        ...(hasStructuredFields ? {} : { status: options.status }),
+        body: options.body,
+        tags: normalizeRepeatableFlagOption(options.tag, 'tag'),
+      })
+
       if (!hasStructuredFields) {
-        if (!hasScalarWriteFields) {
-          throw new VaultCliError(
-            'invalid_option',
-            'experiment edit requires at least one typed field to change.',
-          )
-        }
-        return services.core.updateExperiment({
-          vault: String(options.vault ?? ''),
-          requestId: requestIdFromOptions(options),
-          lookup: args.id,
-          title: options.title,
-          hypothesis: options.hypothesis,
-          startedOn: options.startedOn,
-          status: options.status,
-          body: options.body,
-          tags: normalizeRepeatableFlagOption(options.tag, 'tag'),
-        })
+        return updateScalarFields()
       }
 
       const hydrationResult = hasStructuredHydration
@@ -2196,21 +2189,7 @@ export function registerExperimentCommands(
               ),
               safetyNote: normalizeRepeatableTextFlagOption(options.safetyNote),
               contextNote: normalizeRepeatableTextFlagOption(options.contextNote),
-              skipAnalysisPlanDefaults:
-                options.primaryBiomarkerKey !== undefined ||
-                options.primaryOutcomeKey !== undefined ||
-                options.primaryOutcomeKind !== undefined ||
-                options.primaryOutcomeLabel !== undefined ||
-                options.primaryOutcomeSessionField !== undefined ||
-                options.primaryOutcomeSourceMetricKey !== undefined ||
-                options.primaryOutcomeUnit !== undefined ||
-                options.comparisonStatistic !== undefined ||
-                options.secondaryBiomarkerKey !== undefined ||
-                options.desiredDirection !== undefined ||
-                options.expectedDirection !== undefined ||
-                options.analysisAnchor !== undefined ||
-                options.plannedMeasurement !== undefined ||
-                options.analysisNote !== undefined,
+              skipAnalysisPlanDefaults: hasAnalysisFields,
             },
           })
         : undefined
@@ -2225,16 +2204,7 @@ export function registerExperimentCommands(
         if (!hasScalarWriteFields) {
           return hydrationResult
         }
-        return services.core.updateExperiment({
-          vault: String(options.vault ?? ''),
-          requestId: requestIdFromOptions(options),
-          lookup: args.id,
-          title: options.title,
-          hypothesis: options.hypothesis,
-          startedOn: options.startedOn,
-          body: options.body,
-          tags: normalizeRepeatableFlagOption(options.tag, 'tag'),
-        })
+        return updateScalarFields()
       }
 
       const structuredResult = await services.core.applyExperimentOnboarding({
@@ -2310,16 +2280,7 @@ export function registerExperimentCommands(
         return structuredResult
       }
 
-      return services.core.updateExperiment({
-        vault: String(options.vault ?? ''),
-        requestId: requestIdFromOptions(options),
-        lookup: args.id,
-        title: options.title,
-        hypothesis: options.hypothesis,
-        startedOn: options.startedOn,
-        body: options.body,
-        tags: normalizeRepeatableFlagOption(options.tag, 'tag'),
-      })
+      return updateScalarFields()
     },
   })
 

--- a/packages/cli/test/cli-expansion-experiment-journal-vault-phase2.test.ts
+++ b/packages/cli/test/cli-expansion-experiment-journal-vault-phase2.test.ts
@@ -3,7 +3,7 @@ import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promise
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { Cli } from 'incur'
-import { test } from 'vitest'
+import { test, vi } from 'vitest'
 import { incurErrorBridge } from '../src/incur-error-bridge.js'
 import {
   buildEffectiveSnapshotFromCommonsProtocol,
@@ -14,7 +14,7 @@ import { registerMeasurementCommands } from '../src/commands/measurement.js'
 import { registerProtocolCommands } from '../src/commands/protocol.js'
 import { registerReadCommands } from '../src/commands/read.js'
 import { registerVaultCommands } from '../src/commands/vault.js'
-import { createIntegratedVaultServices } from '@murphai/vault-usecases'
+import { createIntegratedVaultServices, type VaultServices } from '@murphai/vault-usecases'
 import { createIntegratedInboxServices } from '@murphai/inbox-services'
 import { commonsProtocolRefSchema } from '@murphai/contracts'
 import { loadGeneratedHealthCommonsProtocolRunSpecs } from '@murphai/health-commons/runtime'
@@ -28,7 +28,7 @@ import {
 import type { CliEnvelope } from './cli-test-helpers.js'
 import { requireData } from './cli-test-helpers.js'
 
-function createSliceCli(input: { config?: boolean } = {}) {
+function createSliceCli(input: { config?: boolean; services?: VaultServices } = {}) {
   const cli = Cli.create('vault-cli', {
     ...(input.config
       ? {
@@ -42,7 +42,7 @@ function createSliceCli(input: { config?: boolean } = {}) {
     version: '0.0.0-test',
   })
   cli.use(incurErrorBridge)
-  const services = createIntegratedVaultServices()
+  const services = input.services ?? createIntegratedVaultServices()
 
   registerVaultCommands(cli, services, createIntegratedInboxServices())
   registerExperimentCommands(cli, services)
@@ -56,7 +56,7 @@ function createSliceCli(input: { config?: boolean } = {}) {
 
 async function runSliceCli<TData>(
   args: string[],
-  input: { config?: boolean } = {},
+  input: { config?: boolean; services?: VaultServices } = {},
 ): Promise<CliEnvelope<TData>> {
   const cli = createSliceCli(input)
   const output: string[] = []
@@ -2687,6 +2687,92 @@ test.sequential(
     }
   },
 )
+
+test.sequential('experiment edit preserves canonical write order and failure cutoffs', async () => {
+  const vaultRoot = await mkdtemp(path.join(tmpdir(), 'murph-cli-experiment-edit-order-'))
+  const services = createIntegratedVaultServices()
+  const run = (args: string[]) => runSliceCli(args, { services })
+  const edit = (options: string[]) => run([
+    'experiment', 'edit', 'dispatch-proof', ...options, '--vault', vaultRoot,
+  ])
+  const calls: { kind: string; hasStatus: boolean; status: string | undefined }[] = []
+  const update = services.core.updateExperiment.bind(services.core)
+  const apply = services.core.applyExperimentOnboarding.bind(services.core)
+  const updateSpy = vi.spyOn(services.core, 'updateExperiment').mockImplementation((input) => {
+    calls.push({
+      kind: input.runPlan ? 'hydrate' : 'scalar',
+      hasStatus: Object.hasOwn(input, 'status'),
+      status: input.status,
+    })
+    return update(input)
+  })
+  const applySpy = vi.spyOn(services.core, 'applyExperimentOnboarding').mockImplementation((input) => {
+    calls.push({ kind: 'structured', hasStatus: Object.hasOwn(input, 'status'), status: input.status })
+    return apply(input)
+  })
+  try {
+    assert.equal((await run(['init', '--vault', vaultRoot, '--timezone', 'UTC'])).ok, true)
+    const created = await run([
+      'experiment', 'start', 'dispatch-proof',
+      '--from-protocol', 'protocol_variant:dry-sauna/murph-finnish-standard-3x-week',
+      '--test-plan-id', 'rhr-21d', '--intervention-start', '2026-04-08',
+      '--onboarding-completed-at', '2026-04-07T15:00:00.000Z',
+      '--vault', vaultRoot,
+    ])
+    assert.equal(created.ok, true, created.ok ? undefined : created.error.message)
+
+    const scenarios = [
+      { flags: ['--title', 'Dispatch proof'], kinds: ['scalar'] },
+      { flags: ['--status', 'paused'], kinds: ['scalar'] },
+      { flags: ['--target-sessions', '8'], kinds: ['structured'] },
+      { flags: ['--target-sessions', '9', '--title', 'Mixed proof', '--status', 'active'], kinds: ['structured', 'scalar'] },
+      { flags: ['--hydrate-protocol-defaults'], kinds: ['hydrate'] },
+      { flags: ['--hydrate-protocol-defaults', '--title', 'Hydrated proof'], kinds: ['hydrate', 'scalar'] },
+      { flags: ['--hydrate-protocol-defaults', '--status', 'paused'], kinds: ['hydrate', 'structured'] },
+      { flags: ['--hydrate-protocol-defaults', '--analysis-note', 'Synthetic analysis note', '--title', 'Full proof', '--status', 'active'], kinds: ['hydrate', 'structured', 'scalar'] },
+    ]
+    for (const scenario of scenarios) {
+      calls.length = 0
+      assert.equal((await edit(scenario.flags)).ok, true, scenario.flags.join(' '))
+      assert.deepEqual(calls.map((call) => call.kind), scenario.kinds)
+      const scalar = calls.find((call) => call.kind === 'scalar')
+      if (scalar) {
+        assert.equal(scalar.hasStatus, scenario.kinds.length === 1)
+      }
+      for (const call of calls) {
+        if (call.kind !== 'scalar' && scenario.flags.includes('--status')) {
+          assert.equal(call.status, scenario.flags[scenario.flags.indexOf('--status') + 1])
+        }
+      }
+    }
+
+    calls.length = 0
+    assert.equal((await edit([])).ok, false)
+    assert.equal(calls.length, 0)
+
+    calls.length = 0
+    applySpy.mockRejectedValueOnce(new Error('Synthetic structured write failure'))
+    assert.equal((await edit(['--hydrate-protocol-defaults', '--target-sessions', '10', '--title', 'Must not write'])).ok, false)
+    assert.deepEqual(calls.map((call) => call.kind), ['hydrate'])
+
+    calls.length = 0
+    updateSpy.mockRejectedValueOnce(new Error('Synthetic hydration failure'))
+    assert.equal((await edit(['--hydrate-protocol-defaults', '--target-sessions', '11', '--title', 'Must not write'])).ok, false)
+    assert.equal(calls.length, 0)
+
+    calls.length = 0
+    updateSpy.mockRejectedValueOnce(new Error('Synthetic scalar write failure'))
+    assert.equal((await edit(['--target-sessions', '12', '--title', 'Must not write'])).ok, false)
+    assert.deepEqual(calls.map((call) => call.kind), ['structured'])
+    const shown = await services.query.showExperiment({ vault: vaultRoot, requestId: null, lookup: 'dispatch-proof' })
+    assert.equal(requireRecord(shown.entity.data.runPlan, 'run plan').targetSessions, 12)
+    assert.equal(shown.entity.title, 'Full proof')
+  } finally {
+    updateSpy.mockRestore()
+    applySpy.mockRestore()
+    await rm(vaultRoot, { recursive: true, force: true })
+  }
+})
 
 test.sequential(
   'experiment edit, checkpoint, and stop mutate the experiment page and append lifecycle events',


### PR DESCRIPTION
## Why and outcome

Experiment edits repeated the same scalar payload three times and the same analysis-field predicate twice. Consolidate those expressions and delete redundant admission checks while preserving public flags, payloads, hydration/structured/scalar write ordering, and failure timing.

## Product UX

- Effort: Not applicable — internal refactor with unchanged experiment behavior.
- Result: Ready.
- Walkthrough: Scalar, structured, hydration, and mixed edits retain their canonical readback and status handling; failures stop subsequent writes.

## Evidence

- Direct: Built `packages/cli/dist/bin.js` proof covers protocol start, scalar edit, hydration plus structured/scalar edit, empty/invalid-tag rejection, and canonical title/status/target-session readback.
- Coverage: The existing 44 experiment/journal/vault tests passed. The added focused registered-CLI test passes after fixture correction and proves eight dispatch combinations, all three write-stage failures, status omission after structured writes, and canonical readback after a later scalar failure.
- Commands: `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/cli-expansion-experiment-journal-vault-phase2.test.ts`; focused rerun with `-t 'preserves canonical write order'`; `pnpm --dir packages/cli typecheck`; `pnpm --dir packages/cli build`; `pnpm complexity:diff`.
- Final ReviewGPT: PASS on this exact head, gpt-6-pro on Vonneumann. The full-snapshot retry took 433.6 seconds (7m13.6s) and qualifies under the documented near-threshold discretion: exact committed-turn identity, requested model, matching capture hashes, completion marker, and substantive owner-level comparison evidence all verified. The initial faster capture is diagnostic only.
- Required exact-head CI passed: Ubuntu release aggregation, Linux/macOS CLI host matrices, and hosted Stripe billing boundary. The release run also passed full CLI/package coverage, all Web shards, Cloudflare verification, build/typecheck, runner budget, and fixtures. Current-base `git merge-tree --write-tree HEAD origin/main` is clean against `9041e047ca3a5aaee87f42f10ca4f97b9ac954f9`; the reviewed candidate is unchanged.

## Non-obvious affected surfaces

Experiment hydration still suppresses default analysis fields whenever an explicit analysis field is supplied. Structured status is not replayed in the later scalar write. The tests exercise real integrated services behind the registered command.

## Architecture and reuse

- Existing systems reused: Existing experiment command, hydration helper, canonical mutation services, and integrated CLI fixture.
- New logic: None; consolidate equivalent dispatch expressions and payload construction.
- New abstractions: One invocation-local scalar closure replaces three identical payloads and keeps normalization at its original effect boundary.
- Complexity intentionally avoided: No new dispatch table, result state, service, or shared generic helper.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; changed-file debt 172 → 154 (-18).
- Hotspots: Edit `run` is 65 after removing duplicated branches. Unchanged domain builders remain `buildExperimentPlanPayloadFromTypedOptions` 95, `buildPrimaryOutcomeFromOptions` 35, `hydrateExperimentProtocolDefaults` 34, and `resolveStartWindows` 25.
- Agent judgment: Further splitting would move the protocol defaults and validation rules rather than remove repeated orchestration; keep those existing owners intact.

## Hot reply path impact

- Path status: No new or moved work; this refactor preserves the invoked CLI experiment write path.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved; hydration, structured mutation, and optional scalar mutation remain sequential.
- Before/after proof: Registered-CLI write order and failure cutoffs, plus built canonical readback.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no prompt, tool schema, command metadata, or generated guidance changes.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

ReviewGPT first-reviewed head: bff00ffad7fe66528a1bb49235128dce807d235b
ReviewGPT context sensitivity: sensitive
Classification reason: Refactor of canonical experiment mutation orchestration and failure ordering.

## Deployment concerns

- Deployment: not applicable
- Reason: No schema, protocol, configuration, or cross-app compatibility change; ordinary CLI artifact deployment suffices.

## Change-shape breakdown

Classification rule: Production TypeScript is source, CLI proof is tests, and the execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 33 | 72 |
| Tests / fixtures | 91 | 5 |
| Docs | 66 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **190** | **77** |

## Changelog

- Changelog: not applicable
- Reason: Internal orchestration cleanup preserves member-visible behavior.
