### PR TITLE
test(web): trim redundant Linq dispatch assertions

### DIFF
--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -31,7 +31,6 @@ import {
   encryptHostedLinqLinePhoneNumber,
 } from "@/src/lib/hosted-onboarding/linq-line-phone-codec";
 import {
-  buildHostedInviteReply,
   type HostedLinqWebhookEvent,
   parseHostedLinqWebhookEvent,
   requireHostedLinqMessageReceivedEvent,
@@ -1266,18 +1265,6 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     });
   });
 
-  it("builds inactive signup invites from the rotating signup copy bank", () => {
-    const reply = buildHostedInviteReply({
-      joinUrl: "https://join.example.test/join/code_first_text",
-      seed: "first-text-signup:test",
-    });
-
-    expect(reply).toContain("https://join.example.test/join/code_first_text");
-    expect(reply.trim().length).toBeGreaterThan(
-      "https://join.example.test/join/code_first_text".length,
-    );
-  });
-
   it.each([
     { expectedTruncated: false, label: "exactly bounded text", suffix: "" },
     { expectedTruncated: false, label: "trailing whitespace", suffix: "   " },
@@ -1444,7 +1431,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(mocks.resolveHostedLinqTypingPrewarmMemberId).not.toHaveBeenCalled();
   });
 
-  it("routes message edits through the narrow correction planner without a read receipt", async () => {
+  it("accepts message edits without sending a read receipt or another message", async () => {
     const prisma = asPrismaTransactionClient({});
     const scheduleAfterResponse = vi.fn();
     const response = await handleHostedOnboardingLinqWebhook({
@@ -1482,24 +1469,16 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       ok: true,
       reason: "wake-appended-message-edit",
     });
-    expect(mocks.planHostedLinqMessageEditedWebhook).toHaveBeenCalledWith({
+    expect(mocks.planHostedLinqMessageEditedWebhook).toHaveBeenCalledWith(expect.objectContaining({
       event: expect.objectContaining({
         event_id: "evt_edit_123",
         event_type: "message.edited",
       }),
-      preparation: expect.objectContaining({
-        rows: [],
-        sourceMessageLookupKeys: [
-          createHostedLinqMessageLookupKey("msg_123"),
-        ],
-      }),
-      prisma,
-    });
+    }));
     expectHostedLinqPointerSignalAccepted("evt_edit_123");
     expect(mocks.sendHostedLinqReadReceipt).not.toHaveBeenCalled();
     expect(mocks.incrementHostedLinqInboundDailyState).not.toHaveBeenCalled();
     expect(mocks.sendHostedLinqChatMessage).not.toHaveBeenCalled();
-    expect(scheduleAfterResponse).toHaveBeenCalledTimes(2);
   });
 
   it.each([
@@ -2076,67 +2055,6 @@ describe("handleHostedOnboardingLinqWebhook", () => {
         prisma,
       });
       expect(mocks.checkHostedAiUsageGate).not.toHaveBeenCalled();
-      expect(mocks.startHostedOnboardingTiming).toHaveBeenCalledWith(
-        "hosted-onboarding.webhook.linq.plan",
-        expect.objectContaining({
-          eventIdSuffix: "vt_123",
-          eventType: "message.received",
-        }),
-      );
-      expect(mocks.finishHostedOnboardingTiming).toHaveBeenCalledWith(
-        expect.objectContaining({
-          step: "hosted-onboarding.webhook.linq.plan",
-        }),
-        "wake-appended-active-member",
-        expect.objectContaining({
-          desiredSideEffectCount: 0,
-          duplicate: false,
-          ok: true,
-          wakeUserPresent: true,
-        }),
-      );
-      expect(mocks.startHostedOnboardingTiming).toHaveBeenCalledWith(
-        "hosted-onboarding.webhook.linq.verify-request",
-        expect.objectContaining({
-          signaturePresent: false,
-          timestampPresent: false,
-        }),
-      );
-      expect(mocks.startHostedOnboardingTiming).not.toHaveBeenCalledWith(
-        "hosted-onboarding.webhook.linq.receipt",
-        expect.anything(),
-      );
-      expect(mocks.finishHostedOnboardingTiming).toHaveBeenCalledWith(
-        expect.objectContaining({
-          step: "hosted-onboarding.webhook.linq",
-        }),
-        "completed",
-        expect.objectContaining({
-          duplicate: false,
-          eventIdSuffix: "vt_123",
-          eventType: "message.received",
-          responseReason: "wake-appended-active-member",
-          signalAbortedBeforeReturn: false,
-        }),
-      );
-      expect(mocks.finishHostedOnboardingTiming).toHaveBeenCalledWith(
-        expect.objectContaining({
-          step: "hosted-onboarding.webhook.linq.wake-handoff",
-        }),
-        "temporal-signaled",
-        expect.objectContaining({
-          workflowIdSuffix: expect.any(String),
-        }),
-      );
-      expect(mocks.startHostedOnboardingTiming).toHaveBeenCalledWith(
-        "hosted-onboarding.webhook.linq.wake-handoff",
-        expect.objectContaining({
-          eventIdSuffix: "vt_123",
-          responseReason: "wake-appended-active-member",
-          userIdPresent: true,
-          userIdSuffix: "er_123",
-        }),
-      );
     },
   );
 
@@ -3461,70 +3379,6 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(JSON.stringify(envelope)).not.toContain("signed-voice-url");
   });
 
-  it("signals Temporal after an active-member mailbox append", async () => {
-    const prewarmRuntimeShell = vi.fn(async () => ({ accepted: true as const }));
-    mocks.resolveHostedLinqMailboxPayloadRootPrewarmMemberId
-      .mockResolvedValueOnce("member_123");
-    mocks.readHostedExecutionControlClientIfConfigured.mockReturnValue({
-      ensureRuntimeProcessing: vi.fn(async () => ({ accepted: true as const })),
-      prewarmRuntimeShell,
-    });
-    const prisma = asPrismaTransactionClient({
-      hostedWebhookReceipt: {
-        create: vi.fn().mockResolvedValue({}),
-        findUnique: vi.fn().mockResolvedValue({
-          payloadJson: {
-            eventType: "message.received",
-            receiptAttemptCount: 1,
-            receiptStatus: "processing",
-          },
-        }),
-        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
-      },
-      hostedMember: {
-        findUnique: vi.fn().mockResolvedValue({
-          accountGroupMemberships: [],
-          billingStatus: HostedBillingStatus.active,
-          id: "member_123",
-          invites: [],
-          linqChatId: "chat_123",
-          phoneLookupKey: "+15551234567",
-        }),
-      },
-    });
-
-    await expect(handleHostedOnboardingLinqWebhook({
-      prisma,
-      rawBody: buildHostedLinqWebhookBody({
-        eventId: "evt_required_nudge_failed",
-      }),
-      signature: null,
-      timestamp: null,
-    })).resolves.toMatchObject({
-      ok: true,
-      reason: "wake-appended-active-member",
-    });
-
-    expectHostedLinqPointerSignalAccepted("evt_required_nudge_failed");
-    expect(prewarmRuntimeShell).toHaveBeenCalledOnce();
-    expect(prewarmRuntimeShell).toHaveBeenCalledWith(expect.objectContaining({
-      orchestrationAttemptId: expect.stringMatching(/^web-prewarm-/u),
-      requestStartedAtEpochMs: expect.any(Number),
-      source: "linq-message-routing",
-      userId: "member_123",
-    }));
-    expectHostedLinqReadReceiptSent();
-    expect(mocks.finishHostedOnboardingTiming).toHaveBeenCalledWith(
-      expect.objectContaining({
-        step: "hosted-onboarding.webhook.linq.wake-handoff",
-      }),
-      "temporal-signaled",
-      expect.objectContaining({
-        workflowIdSuffix: expect.any(String),
-      }),
-    );
-  });
-
   it("sends active-member Linq read receipts without durable thread-route authority", async () => {
     const prisma = asPrismaTransactionClient({
       hostedWebhookReceipt: {
@@ -3927,58 +3781,6 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     );
   });
 
-  it("fails webhook success when Temporal signaling fails after mailbox append", async () => {
-    mocks.signalHostedMailboxAppendRuntime.mockRejectedValueOnce(new Error("Temporal unavailable"));
-    const prisma = asPrismaTransactionClient({
-      hostedWebhookReceipt: {
-        create: vi.fn().mockResolvedValue({}),
-        findUnique: vi.fn().mockResolvedValue({
-          payloadJson: {
-            eventType: "message.received",
-            receiptAttemptCount: 1,
-            receiptStatus: "processing",
-          },
-        }),
-        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
-      },
-      hostedMember: {
-        findUnique: vi.fn().mockResolvedValue({
-          accountGroupMemberships: [],
-          billingStatus: HostedBillingStatus.active,
-          id: "member_123",
-          invites: [],
-          linqChatId: "chat_123",
-          phoneLookupKey: "+15551234567",
-        }),
-      },
-    });
-
-    await expect(handleHostedOnboardingLinqWebhook({
-      prisma,
-      rawBody: buildHostedLinqWebhookBody({
-        eventId: "evt_ingress_read_receipt_skipped",
-      }),
-      signature: null,
-      timestamp: null,
-    })).rejects.toThrow("Temporal unavailable");
-
-    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledWith({
-      abortSignal: expect.any(AbortSignal),
-      expectedUserId: "member_123",
-      mailboxItemId: "mailbox_evt_ingress_read_receipt_skipped",
-    });
-    expect(mocks.sendHostedLinqReadReceipt).not.toHaveBeenCalled();
-    expect(mocks.finishHostedOnboardingTiming).toHaveBeenCalledWith(
-      expect.objectContaining({
-        step: "hosted-onboarding.webhook.linq.wake-handoff",
-      }),
-      "failed",
-      expect.objectContaining({
-        errorName: "Error",
-      }),
-    );
-  });
-
   it("opens a Prisma transaction when dispatching an active-member Linq message from a root client", async () => {
     const transactionReceiptUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
     const hostedMemberRouting = createStatefulHostedMemberRoutingMock();
@@ -4036,9 +3838,6 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       reason: "wake-appended-active-member",
     });
     expect(prisma.$transaction).toHaveBeenCalledTimes(1);
-    // Initial access, exact post-lock admission, and the route-owner recheck all
-    // run on the transaction client.
-    expect(transactionHostedMemberFindUnique).toHaveBeenCalledTimes(3);
     expect(mocks.enqueueHostedExecutionOutbox).toHaveBeenCalledWith(
       expect.objectContaining({
         tx: transactionClient,
@@ -7610,8 +7409,6 @@ describe("handleHostedOnboardingLinqWebhook", () => {
       ok: true,
       reason: "sent-signup-link",
     });
-    expect(prismaMocks.hostedMember.findUnique).toHaveBeenCalledTimes(2);
-    expect(prismaMocks.hostedInvite.findFirst).toHaveBeenCalledTimes(1);
     expect(prismaMocks.hostedInvite.create).toHaveBeenCalledTimes(1);
     expect(prismaMocks.hostedInvite.update).toHaveBeenCalledWith({
       where: {
@@ -7642,6 +7439,10 @@ describe("handleHostedOnboardingLinqWebhook", () => {
         message: expect.stringContaining("https://join.example.test/join/code_first_text"),
         replyToMessageId: "msg_123",
       }),
+    );
+    const deliveredInvite = mocks.sendHostedLinqChatMessage.mock.calls[0]?.[0].message;
+    expect(deliveredInvite?.trim().length).toBeGreaterThan(
+      "https://join.example.test/join/code_first_text".length,
     );
     expect(mocks.incrementHostedLinqInboundDailyState).toHaveBeenCalledWith({
       memberId: "member_123",


### PR DESCRIPTION
## Why and outcome

The Linq dispatch suite repeated a Temporal failure scenario and pinned private preparation shapes, callback counts, diagnostic phases, and incidental read counts. Remove those assertions, use existing signed-webhook delivery proof for the redundant prewarm success case, and check signup copy at the webhook-to-send boundary. Three overlapping tests are removed; all 207 remaining cases pass.

## Product UX

- Effort: Not applicable; this is test maintenance with no product behavior change.
- Result: Not applicable; no member journey changes.
- Walkthrough: Existing admission, privacy, cancellation, deduplication, and recovery scenarios remain intact.

## Evidence

- Direct: `pnpm --dir apps/web test:prepared -- test/hosted-onboarding-linq-dispatch.test.ts` passed, 207 tests.
- Typecheck: `pnpm --dir apps/web typecheck:prepared` passed after `pnpm --dir packages/device-syncd build`. The initial full Web typecheck reported only an unresolved existing `@murphai/device-syncd/service` dist export in an untouched test; the normal package build supplied it.
- Coverage: The surviving Temporal failure case retains rejection, suppressed read receipts, and failure diagnostics. Existing signed-webhook scenarios in `apps/cloudflare/test/hosted-local-linq-webhook-e2e.test.ts` cover accepted input through runtime execution to the same-chat reply, including correlated message prewarm. Those E2Es were inspected, not rerun locally; broad exact-head CI remains pending.
- Coverage: The direct ingress-root race case retains prewarm ordering and bounded retry proof. Signup copy now has its URL and surrounding-text assertion at the actual mocked provider-send boundary. SMS/RCS classification still checks the accepted envelope and observable side effects. The edit dispatch case retains event routing, the mailbox pointer signal, and absence of another send/read receipt; real revision and lineage proof remains in `hosted-onboarding-linq-home-routing-postgres.test.ts`.
- Checks: `git diff --check` and the scoped identifier scan passed. Candidate review passed; final ReviewGPT is exempt for this narrow test-only cleanup.

## Non-obvious affected surfaces

None; the single changed file is the Linq dispatch suite.

## Architecture and reuse

- Existing systems reused: Existing dispatch fixtures, Postgres correction-lineage proof, and signed-webhook delivery scenarios own the retained guarantees.
- New logic: No production logic; the existing signup send scenario absorbs one helper-level copy assertion.
- New abstractions: None; existing test composition is sufficient.
- Complexity intentionally avoided: No new integration harness, shared fixture framework, production seam, or dependency.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base origin/main`; no authored production JavaScript or TypeScript source to analyze.
- Hotspots: The guard excludes test files, so it reports no production hotspots. The large existing dispatch fixture is unchanged.
- Agent judgment: Removing documented overlap is justified. Further bulk deletion would remove distinct admission and recovery guarantees, so it is outside this cleanup.

## Hot reply path impact

- Path status: Not applicable; only test code changes.
- Database calls: None added or moved in production.
- Network/provider calls: None added or moved in production.
- Other awaited latency: No runtime work changes.
- Before/after proof: Production files are identical; focused dispatch proof passes after consolidation.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no prompt, tool, schema, generated guidance, or provider-visible runtime input changes. No token measurement was needed.

## Deployment concerns

- Deployment: not applicable
- Reason: Test-only cleanup; no production code, configuration, schema, or runtime protocol changes.

## Change-shape breakdown

Classification rule: The sole changed test file is tests/fixtures. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 7 | 206 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **7** | **206** |

## Changelog

- Changelog: not applicable
- Reason: Internal test maintenance; no member-visible behavior changes.
