### PR TITLE
test(web): replace experiment UI wiring checks with rendered outcomes

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-04-test-ui-composition.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-test-ui-composition.md
@@ -1,0 +1,42 @@
+# Simplify experiment UI test contracts
+
+Status: completed
+Created: 2026-09-04
+Updated: 2026-09-04
+
+## Goal
+
+Remove tests that freeze implementation spelling or replay mocks, while retaining experiment route, stale-contract, start-action and private-run protection.
+
+## Scope and ownership
+
+Only experiment UI tests change. Production components, query owners, persistence and authorization remain unchanged. Existing layout/header composition and Browser Vault core fixtures provide proof without new harnesses, dependencies or abstractions.
+
+## Evidence and decisions
+
+- The client suite mocks tabs, protocol/results components and a run resolver that its tested components no longer consume.
+- Two contact-context tests call a direct export alias and compare mocked return values; the contact-context owner retains its behavior tests.
+- The greenfield version assertion pins a constant; the retained stale-version render test protects refresh behavior.
+- Route projection tests assert exact resolver spellings and an absent substring. Keep executable metadata, canonical alias, draft rejection and projection parity tests; the separate route-bundle boundary suite remains responsible for dependency constraints.
+- Render the real header in layout tests, asserting a visible start action on the protocol route and its absence on results routes. Construct the server layout to prove it does not await contact reads before returning its deferred tree.
+
+## Tasks
+
+1. Remove dead doubles, alias tests and source-string assertions.
+2. Replace mocked header prop checks with rendered layout/header assertions.
+3. Run focused tests, web typecheck and complexity check; inspect privacy and full diff.
+4. Parent candidate review approved; scoped commit and PR handoff.
+
+## Risks and proof
+
+Real components may expose assumptions in the existing DOM harness. Use existing facilities only. Retain the active/paused run tests backed by the real Browser Vault core client, disabled start fallback, stale payload refresh, canonical route selection, route metadata and draft rejection.
+
+## Verification
+
+- Focused Vitest: 29 companion tests passed in the page-projection, contact-context and route-bundle suites; the updated client-contract suite passed all 8 tests after platform setup corrections.
+- Real header rendering reuses the existing Linkedom harness with its native Element global; Next Image is a plain image adapter alongside the existing Next Link/navigation adapters.
+- Web typecheck: initial clean-worktree attempt found an absent device-syncd service declaration. The existing package build passed; the full web typecheck rerun passed. Shared setup friction is tracked by the sibling cleanup lane.
+- Complexity guard passed with no production JS/TS to analyze. Final diff removes 152 test lines and adds 20; no production code or dependency changes.
+- Parent candidate review approved the retained proof. The page-projection suite still renders the actual server/client/header composition and asserts its deferred start slot renders; the client suite now checks visible heading/start action and results-route suppression.
+- Test-only change: no product behavior, deployment contract or changelog outcome changes.
+Completed: 2026-09-04

--- a/apps/web/test/experiment-detail-client-contract.test.tsx
+++ b/apps/web/test/experiment-detail-client-contract.test.tsx
@@ -23,23 +23,15 @@ import type {
   ExperimentShellProjection,
 } from "@/src/lib/health-commons/experiment-projections";
 import type { BrowserVaultContextValue } from "@/src/lib/browser-vault/context";
-import type {
-  ExperimentProtocol,
-  ExperimentRunProjection,
-} from "@/src/types/experiments";
+import type { ExperimentProtocol } from "@/src/types/experiments";
 
 const mocks = vi.hoisted(() => ({
-  experimentHeader: vi.fn(() => createElement("div", null, "header")),
-  experimentHero: vi.fn(() => createElement("div", null, "hero")),
   notFound: vi.fn(() => {
     throw new Error("not found");
   }),
   pathname: "/experiments/finnish-sauna",
-  protocolTab: vi.fn(() => createElement("div", null, "protocol tab")),
   readHostedMurphContactContext: vi.fn(),
   refresh: vi.fn(),
-  resolveBrowserVaultExperimentRun: vi.fn<() => ExperimentRunProjection | null>(() => null),
-  resultsTab: vi.fn(() => createElement("div", null, "results tab")),
   useBrowserVault: vi.fn<() => BrowserVaultContextValue>(() => ({
     client: null,
     dataVersion: null,
@@ -79,35 +71,8 @@ vi.mock("next/link", () => ({
   }) => createElement("a", { ...props, href }, children),
 }));
 
-vi.mock("@/src/components/ui/tabs", () => ({
-  Tabs({ children }: { children: ReactNode }) {
-    return createElement("div", { "data-testid": "tabs" }, children);
-  },
-  TabsContent({ children }: { children: ReactNode }) {
-    return createElement("div", null, children);
-  },
-  TabsList({ children }: { children: ReactNode }) {
-    return createElement("div", null, children);
-  },
-  TabsTrigger({ children }: { children: ReactNode }) {
-    return createElement("button", { type: "button" }, children);
-  },
-}));
-
-vi.mock("@/src/components/experiments/experiment-detail/experiment-hero", () => ({
-  ExperimentHero: mocks.experimentHero,
-}));
-
-vi.mock("@/src/components/experiments/experiment-detail/experiment-header", () => ({
-  ExperimentHeader: mocks.experimentHeader,
-}));
-
-vi.mock("@/src/components/experiments/experiment-detail/protocol-tab", () => ({
-  ProtocolTab: mocks.protocolTab,
-}));
-
-vi.mock("@/src/components/experiments/experiment-detail/results-tab", () => ({
-  ResultsTab: mocks.resultsTab,
+vi.mock("next/image", () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => createElement("img", { alt, src }),
 }));
 
 vi.mock("@/src/lib/browser-vault/context", () => ({
@@ -115,11 +80,6 @@ vi.mock("@/src/lib/browser-vault/context", () => ({
     return createElement("div", null, children);
   },
   useBrowserVault: mocks.useBrowserVault,
-}));
-
-vi.mock("@/src/lib/browser-vault/experiment-run", () => ({
-  buildBrowserVaultExperimentResultLookups: (protocol: { id: string }) => [protocol.id],
-  resolveBrowserVaultExperimentRun: mocks.resolveBrowserVaultExperimentRun,
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/hosted-contact-context", () => ({
@@ -168,10 +128,6 @@ afterEach(async () => {
   activeCleanups.clear();
 });
 
-test("pins the experiment protocol contract to greenfield v1", () => {
-  expect(CURRENT_EXPERIMENT_PROTOCOL_CONTRACT_VERSION).toBe(1);
-});
-
 test("refreshes instead of hydrating the new protocol UI against a stale contract payload", async () => {
   const view = await renderClient(
     createElement(
@@ -186,13 +142,14 @@ test("refreshes instead of hydrating the new protocol UI against a stale contrac
   );
 
   expect(mocks.refresh).toHaveBeenCalledTimes(1);
-  expect(mocks.protocolTab).not.toHaveBeenCalled();
+  expect(view.container.textContent).not.toContain("child content");
+  expect(view.container.querySelector("h1")).toBeNull();
   assert.match(view.container.textContent ?? "", /Refreshing experiment/);
 
   await view.cleanup();
 });
 
-test("passes the hosted start action slot into the experiment header", async () => {
+test("renders the hosted start action with the experiment heading", async () => {
   const startAction = createElement("button", { type: "button" }, "server start action");
   const view = await renderClient(
     createElement(
@@ -205,13 +162,9 @@ test("passes the hosted start action slot into the experiment header", async () 
     ),
   );
 
-  expect(mocks.experimentHeader).toHaveBeenCalledTimes(1);
-  const headerProps = (mocks.experimentHeader.mock.calls.at(-1) as
-    | [{
-        startAction?: ReactNode;
-      }]
-    | undefined)?.[0];
-  expect(headerProps?.startAction).toBe(startAction);
+  expect(view.container.querySelector("h1")?.textContent).toBe("Finnish Dry Sauna");
+  expect(view.container.textContent).toContain("server start action");
+  expect(view.container.textContent).toContain("child content");
 
   await view.cleanup();
 });
@@ -248,54 +201,13 @@ test.each([
   expect(resultsLink?.textContent).toBe("Your results");
   expect(resultsLink?.getAttribute("aria-current")).toBe("page");
   expect(resultsLink?.hasAttribute("role")).toBe(false);
-  const headerProps = (mocks.experimentHeader.mock.calls.at(-1) as
-    | [{ showStartAction?: boolean }]
-    | undefined)?.[0];
-  expect(headerProps?.showStartAction).toBe(false);
+  expect(view.container.querySelector("h1")?.textContent).toBe("Finnish Dry Sauna");
+  expect([...view.container.querySelectorAll("button")].some(
+    (button) => button.textContent === "start",
+  )).toBe(false);
   expect(view.container.textContent).toContain("completed results");
 
   await view.cleanup();
-});
-
-test("hosted experiment start context resolves the assigned member phone", async () => {
-  mocks.readHostedMurphContactContext.mockResolvedValue({
-    initialContactChannels: {
-      email: true,
-      telegram: false,
-      text: true,
-    },
-    murphEmailAddress: "murph+alias123@mail.withmurph.ai",
-    murphPhoneNumber: "+15550100001",
-  });
-
-  const { readHostedExperimentStartContactContext } = await import(
-    "../app/(dashboard)/experiments/[experimentId]/experiment-start-button-server"
-  );
-  const context = await readHostedExperimentStartContactContext();
-
-  expect(mocks.readHostedMurphContactContext).toHaveBeenCalledTimes(1);
-  expect(context.initialContactChannels).toEqual({
-    email: true,
-    telegram: false,
-    text: true,
-  });
-  expect(context.murphEmailAddress).toBe("murph+alias123@mail.withmurph.ai");
-  expect(context.murphPhoneNumber).toBe("+15550100001");
-});
-
-test("hosted experiment start context preserves anonymous contact defaults", async () => {
-  const { readHostedExperimentStartContactContext } = await import(
-    "../app/(dashboard)/experiments/[experimentId]/experiment-start-button-server"
-  );
-  const context = await readHostedExperimentStartContactContext();
-
-  expect(mocks.readHostedMurphContactContext).toHaveBeenCalledTimes(1);
-  expect(context.initialContactChannels).toEqual({
-    email: false,
-    telegram: false,
-    text: false,
-  });
-  expect(context.murphPhoneNumber).toBeNull();
 });
 
 test("experiment start fallback is not a live contact route", async () => {
@@ -432,26 +344,17 @@ function createExperimentRunCardClient(status: BrowserVaultExperimentRunCardStat
   return createBrowserVaultCoreQueryClient(core);
 }
 
-test("server layout keeps contact reads inside the deferred start action slot", async () => {
+test("constructs the public server layout without waiting for member contact reads", async () => {
   const { default: ExperimentDetailLayout } = await import(
     "../app/(dashboard)/experiments/[experimentId]/layout"
   );
-  const view = await renderClient(
-    await ExperimentDetailLayout({
-      children: createElement("div", null, "child content"),
-      params: Promise.resolve({ experimentId: "finnish-sauna" }),
-    }),
-  );
+  const layout = await ExperimentDetailLayout({
+    children: createElement("div", null, "child content"),
+    params: Promise.resolve({ experimentId: "finnish-sauna" }),
+  });
 
+  expect(layout).toBeTruthy();
   expect(mocks.readHostedMurphContactContext).not.toHaveBeenCalled();
-  const headerProps = (mocks.experimentHeader.mock.calls.at(-1) as
-    | [{
-        startAction?: ReactNode;
-      }]
-    | undefined)?.[0];
-  expect(headerProps?.startAction).toBeTruthy();
-
-  await view.cleanup();
 });
 
 async function renderClient(element: ReactNode) {
@@ -489,6 +392,7 @@ function installGlobals(
     setGlobal("self", window),
     setGlobal("document", document),
     setGlobal("navigator", window.navigator),
+    setGlobal("Element", window.Element),
     setGlobal("HTMLElement", window.HTMLElement),
     setGlobal("Node", window.Node),
     setGlobal("Event", window.Event),

--- a/apps/web/test/experiment-page-projections.test.tsx
+++ b/apps/web/test/experiment-page-projections.test.tsx
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import { createElement, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -120,35 +119,6 @@ describe("experiment page projections", () => {
     mocks.resultsTabClient.mockClear();
   });
 
-  it("keeps experiment route entrypoints on generated projections instead of the full resolver", () => {
-    const pageSource = readFileSync(
-      new URL("../app/(dashboard)/experiments/[experimentId]/page.tsx", import.meta.url),
-      "utf8",
-    );
-    const layoutSource = readFileSync(
-      new URL("../app/(dashboard)/experiments/[experimentId]/layout.tsx", import.meta.url),
-      "utf8",
-    );
-    const layoutClientSource = readFileSync(
-      new URL("../app/(dashboard)/experiments/[experimentId]/experiment-layout-client.tsx", import.meta.url),
-      "utf8",
-    );
-    const resultsSource = readFileSync(
-      new URL("../app/(dashboard)/experiments/[experimentId]/results/page.tsx", import.meta.url),
-      "utf8",
-    );
-
-    expect(pageSource).toContain("resolveHealthCommonsExperimentProtocolTab");
-    expect(pageSource).not.toContain("resolveHealthCommonsExperimentProtocol(");
-    expect(pageSource).not.toContain("ExperimentDetailClient");
-    expect(layoutSource).toContain("resolveHealthCommonsExperimentShell");
-    expect(layoutSource).not.toContain("resolveHealthCommonsExperimentProtocol");
-    expect(resultsSource).toContain("resolveHealthCommonsExperimentResultsPublic");
-    expect(resultsSource).not.toContain("resolveHealthCommonsExperimentProtocol");
-    expect(layoutClientSource).not.toContain("BrowserVaultProvider");
-    expect(layoutClientSource).not.toContain("resolveBrowserVaultExperimentRun");
-  });
-
   it("renders the authenticated results route from the narrow public projection", async () => {
     await expect(generateResultsMetadata({
       params: Promise.resolve({
@@ -198,12 +168,6 @@ describe("experiment page projections", () => {
       experimentId: "exp:private-run",
     });
     expect(markup).toContain('data-private-run-id="exp:private-run"');
-
-    const privatePageSource = readFileSync(
-      new URL("../app/(dashboard)/experiments/runs/[experimentId]/page.tsx", import.meta.url),
-      "utf8",
-    );
-    expect(privatePageSource).not.toContain("HealthCommons");
   });
 
   it("uses the shell projection for metadata and shared layout props", async () => {


### PR DESCRIPTION
## Why and outcome

Experiment UI tests should fail when a heading, start action, route selection or stale-payload boundary breaks. This removes dead component mocks, a hardcoded version assertion, contact-context alias echo tests and source-substring assertions. The layout tests now render the real Header and Hero and assert the start action is visible on the protocol route and absent on results routes.

## Product UX

- Effort: Not applicable — test maintenance only; no production UI or behavior changes.
- Result: Ready
- Walkthrough: Existing stale-payload refresh, canonical results links, active/paused run status, disabled start fallback, route metadata and draft rejection remain covered.

## Evidence

- Direct: `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/experiment-detail-client-contract.test.tsx apps/web/test/experiment-page-projections.test.tsx apps/web/test/hosted-contact-context.test.ts apps/web/test/health-commons-route-bundle-boundary.test.ts` — 29 companion tests passed; the final affected client suite was rerun with the same command and its single path, passing 8/8.
- Coverage: Real layout/header rendering replaces prop-spy assertions. The existing page-projection suite still renders the server layout through its deferred start slot, while the contact-context owner retains anonymous/member/default behavior proof. Real Browser Vault core query fixtures still protect active/paused status.
- Typecheck: `pnpm --dir apps/web typecheck` — passed. The clean checkout first needed `pnpm --dir packages/device-syncd build` for its public service declarations; that existing package build passed.
- Review: Parent candidate review passed. Required CI remains pending on the PR head. This small test-only change qualifies for the low-risk test exemption from final ReviewGPT.

## Non-obvious affected surfaces

None. Next Image remains a platform adapter and the existing DOM setup now installs Linkedom's native Element global so the real header tooltip can mount.

## Architecture and reuse

- Existing systems reused: Production experiment layout/header/hero, route projections, Browser Vault core query client and existing DOM harness.
- New logic: None in production; test assertions inspect rendered outcomes.
- New abstractions: None; existing component and query owners provide the proof.
- Complexity intentionally avoided: No additional E2E framework, fixture store, dependency or production test hook.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base origin/main`; test-only files are excluded by the existing guard, with no production JS/TS to analyze.
- Hotspots: No production functions changed. Removed unused mocks and repetitive alias/source checks after reviewing the full test diff.
- Agent judgment: The remaining tests protect observable behavior or projection contracts. Broader experiment journey work can use the existing browser/integration owners independently.

## Hot reply path impact

- Path status: Not applicable — only experiment UI tests change.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved.
- Before/after proof: Production files are unchanged.

## Murph initial provider input impact

Not applicable to individual or group Murph: no prompts, schemas, tools, runtime composition or provider-input fixtures change.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Test-only changes do not alter a runtime deployment boundary.

## Change-shape breakdown

Classification rule: `apps/web/test` is tests/fixtures; the completed execution plan is documentation. No source, generated or binary files change.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 20 | 152 |
| Docs | 42 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **62** | **152** |

## Changelog

- Changelog: not applicable
- Reason: Internal test maintenance with unchanged member-visible behavior.
