### PR TITLE
perf(web): avoid payload hydration in control reads

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1828,6 +1828,10 @@ Last verified: 2026-09-04
   `whoop`, but admission uses the Junction `whoop_v2` lifecycle source. Resume,
   omitted intent, stale
   events, and background work never clear the source fence.
+  SDK sign-in chooses its provider connection from a limit-plus-one metadata
+  projection of id, lifecycle status, and setup phase. Selection never opens
+  credential ciphertext; connect and resume mutation owners still revalidate
+  the exact selected connection and source authority.
 - Personal Patterns operator email is terminal-state only. A failed cron
   attempt remains silent while the finalized job has a scheduled retry. Web
   treats an absent retry disposition from an older runner as non-terminal, so
@@ -1872,7 +1876,10 @@ Last verified: 2026-09-04
   error-code-independent stalls. Conversation rows with a non-null
   `consumed_at` are terminal and are excluded before both head selection and the
   lane's `COUNT(*) OVER()`; system-lane selection remains unchanged. A system
-  head ages from its accepted mailbox creation time. Import and unrelated
+  head ages from its accepted mailbox creation time.
+  Lane high-water reads select only sequence and update time; they never fetch
+  inline or externalized mailbox ciphertext.
+  Import and unrelated
   checkpoint or wake changes cannot reset that clock. The independent device
   and assistant wake projections remain scheduler inputs, not per-item progress
   evidence. Advancing the canonical handling frontier exposes the next live

--- a/agent-docs/exec-plans/completed/2026-09-04-metadata-only-control-plane-reads.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-metadata-only-control-plane-reads.md
@@ -1,0 +1,93 @@
+# Bound metadata-only control-plane reads
+
+Status: completed
+Created: 2026-09-04
+Updated: 2026-09-04
+
+## Goal
+
+- Stop mailbox high-water and companion SDK sign-in selection from loading
+  encrypted payload or credential fields that those decisions do not use.
+
+## Success criteria
+
+- Mailbox high-water queries select only lane sequence and update time.
+- Companion SDK sign-in selects bounded connection lifecycle metadata without
+  opening any connection credential ciphertext.
+- Connect, resume, legacy omitted-intent, terminal-state, and ambiguous-state
+  behavior remains unchanged.
+- Focused tests, hosted-Web typecheck, exact-head CI, and the required
+  cross-cutting review gate pass.
+
+## Scope
+
+- In scope: the mailbox high-water projection, the existing bounded
+  device-connection metadata projection, companion SDK sign-in selection,
+  focused tests, and the directly affected reliability documentation.
+- Out of scope: provider token writes, lifecycle mutation protocols, mailbox
+  payload delivery, schemas, member-visible copy, and new runtime state.
+
+## Constraints
+
+- Keep reads bounded at the existing companion connection cap.
+- Preserve the server-owned lifecycle rule: omitted intent may establish only
+  when no provider row exists, and terminal or ambiguous state must fail.
+- Reuse the existing connection-status projection rather than adding another
+  query or lifecycle owner.
+
+### Product UX Patch
+
+- Outcome: Companion sign-in and hosted runtime wake decisions retain the same
+  member-visible results with less database and encryption-key work.
+- Reaches: native companion connect/resume/legacy sign-in, terminal reconnect
+  recovery, ambiguous account recovery, and hosted mailbox wake snapshots.
+- Proof: exact query-projection assertions, no-decryption assertions, and the
+  existing lifecycle matrix exercised through the public ingress service.
+
+## Risks and mitigations
+
+1. Risk: A metadata projection omits setup phase and treats an incomplete
+   connection as established.
+   Mitigation: project setup phase explicitly and keep the shared
+   `isEstablishedDeviceSyncConnection` predicate.
+2. Risk: Filtering out disconnected rows permits an old client to recreate a
+   terminal connection.
+   Mitigation: request every provider row and apply lifecycle filtering only
+   after the bounded metadata snapshot is complete.
+3. Risk: The query replaces unbounded decryption with an unbounded metadata
+   scan.
+   Mitigation: preserve the existing limit-plus-one saturation check.
+
+## Tasks
+
+1. Characterize both existing read paths and their lifecycle/query contracts.
+2. Narrow mailbox high-water fields and prove ciphertext is absent from the
+   query projection.
+3. Extend the existing bounded connection-status projection with setup phase
+   and an all-status mode, then use it for SDK sign-in selection.
+4. Exercise every sign-in lifecycle branch and prove credential decryption is
+   not called.
+5. Run focused tests, typecheck, complexity and diff/privacy checks; archive the
+   plan, commit, and open the draft PR.
+6. Push the exact candidate, run ReviewGPT concurrently with required CI, and
+   resolve all required gates before handoff.
+
+## Decisions
+
+- Combine these two narrowly related reductions in one PR because both replace
+  payload-bearing control-plane reads with metadata-only projections and share
+  the same hosted-Web verification surface.
+- Reuse the existing companion connection cap of 32 rather than introducing a
+  second threshold.
+- Do not change lifecycle semantics or decrypt a selected connection after the
+  decision; subsequent mutation owners already revalidate exact authority.
+
+## Verification
+
+- Commands to run: focused mailbox-store, Prisma connection-store, and hosted
+  public-ingress tests; hosted-Web typecheck; `pnpm complexity:diff`; scoped
+  lint and privacy/diff review; exact PR-head CI; ReviewGPT.
+- Expected outcomes: selected Prisma fields contain no mailbox ciphertext or
+  device credentials, all existing companion outcomes remain unchanged, and a
+  33rd connection fails closed before selection.
+Completed: 2026-09-04

--- a/apps/web/src/lib/device-sync/prisma-store.ts
+++ b/apps/web/src/lib/device-sync/prisma-store.ts
@@ -359,7 +359,7 @@ export class PrismaDeviceSyncControlPlaneStore
   async listMemberConnectionStatuses(input: {
     limit: number;
     provider: string;
-    status: "active" | "not_disconnected";
+    status: "active" | "all" | "not_disconnected";
     userId: string;
   }): Promise<HostedMemberDeviceConnectionStatus[]> {
     return this.connections.listMemberConnectionStatuses(input);

--- a/apps/web/src/lib/device-sync/prisma-store/connections.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/connections.ts
@@ -161,6 +161,7 @@ async function requireExactOAuthClaimResolutionTx(
 
 export interface HostedMemberDeviceConnectionStatus {
   id: string;
+  setupPhase: HostedDeviceConnectionSetupPhase | null;
   status: HostedStaticDeviceSyncConnectionRecord["status"];
 }
 
@@ -876,7 +877,7 @@ export class PrismaHostedConnectionStore {
   async listMemberConnectionStatuses(input: {
     limit: number;
     provider: string;
-    status: "active" | "not_disconnected";
+    status: "active" | "all" | "not_disconnected";
     userId: string;
   }): Promise<HostedMemberDeviceConnectionStatus[]> {
     const provider = normalizeNullableString(input.provider);
@@ -891,15 +892,20 @@ export class PrismaHostedConnectionStore {
     const records = await this.prisma.deviceConnection.findMany({
       where: {
         provider,
-        status: input.status === "active"
-          ? "active"
-          : { not: "disconnected" },
+        ...(input.status === "all"
+          ? {}
+          : {
+              status: input.status === "active"
+                ? "active"
+                : { not: "disconnected" },
+            }),
         userId,
       },
       orderBy: [{ updatedAt: "desc" }, { id: "desc" }],
       take: input.limit + 1,
       select: {
         id: true,
+        setupPhase: true,
         status: true,
       },
     });
@@ -915,6 +921,7 @@ export class PrismaHostedConnectionStore {
 
     return records.map((record) => ({
       id: record.id,
+      setupPhase: normalizeHostedDeviceSyncSetupPhase(record.setupPhase),
       status: normalizeHostedDeviceSyncLifecycleStatus(record.status),
     }));
   }

--- a/apps/web/src/lib/device-sync/public-ingress-service.ts
+++ b/apps/web/src/lib/device-sync/public-ingress-service.ts
@@ -38,6 +38,7 @@ import { createHostedDeviceSyncControlPlaneContext } from "./control-plane-conte
 import {
   assertCompanionHrvRmssdObservationFresh,
   COMPANION_APPLE_HEALTH_SOURCE_PROVIDER,
+  COMPANION_DEVICE_SYNC_STATUS_CONNECTION_LIMIT,
   resolveCompanionHrvRmssdConnection,
   type CompanionConnectionIntent,
 } from "./companion";
@@ -369,13 +370,18 @@ export class HostedDeviceSyncPublicIngressService {
     provider: string,
     connectionIntent: CompanionConnectionIntent | null,
   ): Promise<SdkSignInSessionResult> {
+    const providerConnections = await this.context.store.listMemberConnectionStatuses({
+      limit: COMPANION_DEVICE_SYNC_STATUS_CONNECTION_LIMIT,
+      provider,
+      status: "all",
+      userId,
+    });
+    const establishedConnections = providerConnections.filter(
+      isEstablishedDeviceSyncConnection,
+    );
+
     if (connectionIntent === "connect") {
-      const providerConnections = (await this.context.store.listConnectionsForUser(userId))
-        .filter((connection) =>
-          connection.provider === provider
-          && isEstablishedDeviceSyncConnection(connection)
-        );
-      if (providerConnections.length > 1) {
+      if (establishedConnections.length > 1) {
         throw deviceSyncError({
           code: "SDK_SIGN_IN_CONNECTION_AMBIGUOUS",
           message: "The companion could not identify one active device-sync connection.",
@@ -383,7 +389,7 @@ export class HostedDeviceSyncPublicIngressService {
           httpStatus: 409,
         });
       }
-      const establishedConnection = providerConnections[0] ?? null;
+      const establishedConnection = establishedConnections[0] ?? null;
       const capturedReconnectProof = establishedConnection
         ? await captureHostedDeviceSyncConnectionSourceReconnect({
             connectionId: establishedConnection.id,
@@ -421,12 +427,6 @@ export class HostedDeviceSyncPublicIngressService {
       });
       return session;
     }
-
-    const providerConnections = (await this.context.store.listConnectionsForUser(userId))
-      .filter((connection) => connection.provider === provider);
-    const establishedConnections = providerConnections.filter(
-      isEstablishedDeviceSyncConnection,
-    );
 
     if (establishedConnections.length > 1) {
       throw deviceSyncError({

--- a/apps/web/src/lib/hosted-mailbox/store.ts
+++ b/apps/web/src/lib/hosted-mailbox/store.ts
@@ -1820,6 +1820,10 @@ export async function readHostedMailboxMaxSeqByLane(input: {
       orderBy: {
         laneSeq: "desc",
       },
+      select: {
+        laneSeq: true,
+        updatedAt: true,
+      },
       where: {
         ...buildHostedMailboxLiveItemWhere(now),
         lane,

--- a/apps/web/test/device-sync-hosted-wake.test.ts
+++ b/apps/web/test/device-sync-hosted-wake.test.ts
@@ -47,6 +47,7 @@ const mocks = vi.hoisted(() => {
     listBoundedConnectionSourcesForConnections: vi.fn(),
     listConnectionSources: vi.fn(),
     listConnectionsForUser: vi.fn(),
+    listMemberConnectionStatuses: vi.fn(),
     listConnectionsRequiringCleanupForUser: vi.fn(),
     markConnectionSourcesDisconnected: vi.fn(),
     markDirtyConnectionProcessed: vi.fn(),
@@ -350,6 +351,14 @@ function buildHostedConnection(
   };
 }
 
+function toHostedConnectionStatus(connection: ReturnType<typeof buildHostedConnection>) {
+  return {
+    id: connection.id,
+    setupPhase: connection.setupPhase,
+    status: connection.status,
+  };
+}
+
 function buildWebhookAdmissionRecord(
   overrides: Parameters<typeof buildHostedConnection>[0] = {},
 ) {
@@ -614,6 +623,7 @@ vi.mock("@/src/lib/device-sync/prisma-store", () => ({
       mocks.listBoundedConnectionSourcesForConnections;
     listConnectionSources = mocks.listConnectionSources;
     listConnectionsForUser = mocks.listConnectionsForUser;
+    listMemberConnectionStatuses = mocks.listMemberConnectionStatuses;
     listConnectionsRequiringCleanupForUser = mocks.listConnectionsRequiringCleanupForUser;
     markConnectionSourcesDisconnected = mocks.markConnectionSourcesDisconnected;
     markDirtyConnectionProcessed = mocks.markDirtyConnectionProcessed;
@@ -725,6 +735,8 @@ describe("hosted device-sync wakes", () => {
     mocks.getConnectionForUser.mockReset();
     mocks.getConnectionRecordForUser.mockReset();
     mocks.getStoredConnectionAccountForUser.mockReset();
+    mocks.listMemberConnectionStatuses.mockReset();
+    mocks.listMemberConnectionStatuses.mockResolvedValue([]);
     mocks.materializeStoredConnectionAccount.mockReset();
     mocks.readOAuthStateProviderApplicationBinding.mockReset();
     mocks.resolveDeviceProviderApplication.mockReset();
@@ -1130,7 +1142,9 @@ describe("hosted device-sync wakes", () => {
     mocks.getStoredConnectionAccountForUser.mockImplementation(
       async () => buildProviderConfigStoredConnection(currentConnection),
     );
-    mocks.listConnectionsForUser.mockResolvedValue([currentConnection]);
+    mocks.listMemberConnectionStatuses.mockResolvedValue([
+      toHostedConnectionStatus(currentConnection),
+    ]);
     mocks.listConnectionSources.mockImplementation(async () => [currentSource]);
     mocks.resolveConnectionSourceAdmissionCandidate.mockImplementation(async () =>
       buildHostedConnectionSourceAdmissionCandidate(currentSource)
@@ -1165,7 +1179,13 @@ describe("hosted device-sync wakes", () => {
       provider: "junction",
     });
     expect(mocks.resumeSdkSignInSession).not.toHaveBeenCalled();
-    expect(mocks.listConnectionsForUser).toHaveBeenCalledWith("user-123");
+    expect(mocks.listMemberConnectionStatuses).toHaveBeenCalledWith({
+      limit: 32,
+      provider: "junction",
+      status: "all",
+      userId: "user-123",
+    });
+    expect(mocks.listConnectionsForUser).not.toHaveBeenCalled();
     expect(mocks.upsertConnectionSource).toHaveBeenCalledWith(expect.objectContaining({
       connectionId: currentConnection.id,
       firstSeenAt: "2026-03-26T12:00:00.000Z",
@@ -1311,7 +1331,9 @@ describe("hosted device-sync wakes", () => {
       setupPhase: "source_confirmed",
     });
     mockConnectionForAdmission(connection);
-    mocks.listConnectionsForUser.mockResolvedValue([connection]);
+    mocks.listMemberConnectionStatuses.mockResolvedValue([
+      toHostedConnectionStatus(connection),
+    ]);
     mocks.listConnectionSources.mockResolvedValue([
       buildHostedConnectionSource(connection.id, "apple_health_kit", {
         lastErrorCode: "SOURCE_USER_DISCONNECTED",
@@ -1349,7 +1371,9 @@ describe("hosted device-sync wakes", () => {
     });
     const source = buildHostedConnectionSource(connection.id, "apple_health_kit");
     mocks.getConnectionForUser.mockResolvedValue(connection);
-    mocks.listConnectionsForUser.mockResolvedValue([connection]);
+    mocks.listMemberConnectionStatuses.mockResolvedValue([
+      toHostedConnectionStatus(connection),
+    ]);
     mocks.listConnectionSources.mockResolvedValue([source]);
     const ingress = createHostedDeviceSyncPublicIngressService(
       new Request("https://control.example.test/api/device-sync/companion/sign-in-token"),
@@ -1407,7 +1431,9 @@ describe("hosted device-sync wakes", () => {
       canonicalSource,
     ];
     const canonicalSnapshot = { ...canonicalSource };
-    mocks.listConnectionsForUser.mockResolvedValue([connection]);
+    mocks.listMemberConnectionStatuses.mockResolvedValue([
+      toHostedConnectionStatus(connection),
+    ]);
     mocks.getConnectionForUser.mockResolvedValue(connection);
     mocks.listConnectionSources.mockImplementation(async () => sources);
     mocks.upsertConnectionSource.mockImplementation(async (input) => {
@@ -1527,7 +1553,9 @@ describe("hosted device-sync wakes", () => {
     };
     const deferredSession = createDeferred<typeof session>();
     mocks.createSdkSignInSession.mockReturnValue(deferredSession.promise);
-    mocks.listConnectionsForUser.mockResolvedValue([connection]);
+    mocks.listMemberConnectionStatuses.mockResolvedValue([
+      toHostedConnectionStatus(connection),
+    ]);
     mockConnectionForAdmission(connection);
     mocks.listConnectionSources.mockImplementation(async () => [source]);
     const ingress = createHostedDeviceSyncPublicIngressService(
@@ -1569,7 +1597,9 @@ describe("hosted device-sync wakes", () => {
     };
     const deferredSession = createDeferred<typeof session>();
     mocks.createSdkSignInSession.mockReturnValue(deferredSession.promise);
-    mocks.listConnectionsForUser.mockResolvedValue([establishedConnection]);
+    mocks.listMemberConnectionStatuses.mockResolvedValue([
+      toHostedConnectionStatus(establishedConnection),
+    ]);
     mocks.getConnectionForUser.mockImplementation(async () => currentConnection);
     mocks.listConnectionSources.mockResolvedValue([source]);
     const ingress = createHostedDeviceSyncPublicIngressService(
@@ -1598,12 +1628,12 @@ describe("hosted device-sync wakes", () => {
   it.each(["resume", null] as const)(
     "resumes the one active companion SDK connection for intent %s without ensuring it",
     async (connectionIntent) => {
-      mocks.listConnectionsForUser.mockResolvedValueOnce([
-        buildHostedConnection({
+      mocks.listMemberConnectionStatuses.mockResolvedValueOnce([
+        toHostedConnectionStatus(buildHostedConnection({
           id: "dsc_junction_active",
           provider: "junction",
           setupPhase: "source_confirmed",
-        }),
+        })),
       ]);
       const ingress = createHostedDeviceSyncPublicIngressService(
         new Request("https://control.example.test/api/device-sync/companion/sign-in-token"),
@@ -1625,7 +1655,7 @@ describe("hosted device-sync wakes", () => {
   );
 
   it("preserves legacy first-connect behavior only when no provider row exists", async () => {
-    mocks.listConnectionsForUser.mockResolvedValueOnce([]);
+    mocks.listMemberConnectionStatuses.mockResolvedValueOnce([]);
     const ingress = createHostedDeviceSyncPublicIngressService(
       new Request("https://control.example.test/api/device-sync/companion/sign-in-token"),
     );
@@ -1642,7 +1672,7 @@ describe("hosted device-sync wakes", () => {
   });
 
   it("rejects explicit resume when no provider row exists without ensuring one", async () => {
-    mocks.listConnectionsForUser.mockResolvedValueOnce([]);
+    mocks.listMemberConnectionStatuses.mockResolvedValueOnce([]);
     const ingress = createHostedDeviceSyncPublicIngressService(
       new Request("https://control.example.test/api/device-sync/companion/sign-in-token"),
     );
@@ -1661,13 +1691,13 @@ describe("hosted device-sync wakes", () => {
   it.each(["resume", null] as const)(
     "requires an explicit reconnect for terminal companion state with intent %s",
     async (connectionIntent) => {
-      mocks.listConnectionsForUser.mockResolvedValueOnce([
-        buildHostedConnection({
+      mocks.listMemberConnectionStatuses.mockResolvedValueOnce([
+        toHostedConnectionStatus(buildHostedConnection({
           id: "dsc_junction_terminal",
           provider: "junction",
           setupPhase: "source_confirmed",
           status: "disconnected",
-        }),
+        })),
       ]);
       const ingress = createHostedDeviceSyncPublicIngressService(
         new Request("https://control.example.test/api/device-sync/companion/sign-in-token"),
@@ -1686,17 +1716,17 @@ describe("hosted device-sync wakes", () => {
   );
 
   it("rejects ambiguous active companion SDK connections without minting or ensuring", async () => {
-    mocks.listConnectionsForUser.mockResolvedValueOnce([
-      buildHostedConnection({
+    mocks.listMemberConnectionStatuses.mockResolvedValueOnce([
+      toHostedConnectionStatus(buildHostedConnection({
         id: "dsc_junction_active_1",
         provider: "junction",
         setupPhase: "source_confirmed",
-      }),
-      buildHostedConnection({
+      })),
+      toHostedConnectionStatus(buildHostedConnection({
         id: "dsc_junction_active_2",
         provider: "junction",
         setupPhase: "source_confirmed",
-      }),
+      })),
     ]);
     const ingress = createHostedDeviceSyncPublicIngressService(
       new Request("https://control.example.test/api/device-sync/companion/sign-in-token"),

--- a/apps/web/test/hosted-mailbox-store.test.ts
+++ b/apps/web/test/hosted-mailbox-store.test.ts
@@ -2498,6 +2498,10 @@ describe("fetchHostedMailboxItemsAfterLaneCursors", () => {
       orderBy: {
         laneSeq: "desc",
       },
+      select: {
+        laneSeq: true,
+        updatedAt: true,
+      },
       where: expectLiveHostedMailboxWhere({
         lane: "conversation",
         userId: "member_mailbox_1",

--- a/apps/web/test/prisma-store-connection-sources.test.ts
+++ b/apps/web/test/prisma-store-connection-sources.test.ts
@@ -1384,6 +1384,7 @@ describe("PrismaDeviceSyncControlPlaneStore connection source projection", () =>
     };
     vi.spyOn(store, "listMemberConnectionStatuses").mockResolvedValue([{
       id: connection.id,
+      setupPhase: "source_confirmed",
       status: "active",
     }]);
 

--- a/apps/web/test/prisma-store-oauth-connection.test.ts
+++ b/apps/web/test/prisma-store-oauth-connection.test.ts
@@ -2205,9 +2205,10 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     expect(findMany).toHaveBeenCalledTimes(1);
   });
 
-  it("uses an id-and-status-only member projection for companion status", async () => {
+  it("uses bounded lifecycle metadata without credential ciphertext for companion selection", async () => {
     const findMany = vi.fn(async () => [{
       id: "dsc_123",
+      setupPhase: "source_confirmed",
       status: "active",
     }]);
     const store = new PrismaDeviceSyncControlPlaneStore({
@@ -2219,10 +2220,11 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     await expect(store.listMemberConnectionStatuses({
       limit: 32,
       provider: "junction",
-      status: "not_disconnected",
+      status: "all",
       userId: "user-123",
     })).resolves.toEqual([{
       id: "dsc_123",
+      setupPhase: "source_confirmed",
       status: "active",
     }]);
     expect(findMany).toHaveBeenCalledWith({
@@ -2230,11 +2232,11 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       take: 33,
       select: {
         id: true,
+        setupPhase: true,
         status: true,
       },
       where: {
         provider: "junction",
-        status: { not: "disconnected" },
         userId: "user-123",
       },
     });


### PR DESCRIPTION
## Why and outcome

Mailbox high-water reads fetched complete encrypted mailbox rows while using only sequence and update time. Companion SDK sign-in likewise hydrated and decrypted every connection before using only provider, lifecycle status, setup phase, and id. This change makes both decisions metadata-only and keeps companion selection bounded at 32 rows plus one saturation probe.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Replayed explicit companion connect, resume, legacy omitted-intent first connect, disconnected recovery, concurrent disconnect, and ambiguous-connection journeys. Every existing result and recovery boundary is unchanged; the work removes unused database and KMS work only.

## Evidence

- Direct: `pnpm --dir apps/web test -- hosted-mailbox-store.test.ts prisma-store-oauth-connection.test.ts prisma-store-connection-sources.test.ts device-sync-hosted-wake.test.ts` — 346/346 passed. The suites assert exact two-field mailbox selection, exact three-field connection metadata selection, no credential decryption, all SDK lifecycle outcomes, and the existing limit-plus-one failure.
- Coverage: `pnpm --dir packages/device-syncd build && pnpm --dir apps/web typecheck` passed; scoped ESLint passed; `pnpm complexity:diff` passed; `git diff --check` passed.

## Non-obvious affected surfaces

Legacy companion clients omit lifecycle intent. Their no-row first-connect behavior remains distinct from disconnected or incomplete durable rows because the new query requests every provider-row status, then applies the shared establishment predicate in memory. Connection/source mutation owners continue to revalidate exact authority after selection.

## Architecture and reuse

- Existing systems reused: the bounded member-connection status projection, shared setup-confirmation predicate, existing companion connection cap, Prisma field selection, and mailbox live-row owner.
- New logic: one all-status option on the existing metadata projection and setup phase in its three-field result.
- New abstractions: No new abstraction is needed because the existing bounded status projection already owns validation, ordering, and saturation.
- Complexity intentionally avoided: no new query owner, cache, stored state, schema migration, credential materialization, pool change, or lifecycle protocol.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; debt and maximum complexity are unchanged in all four source files.
- Hotspots: Existing connection-store hotspots remain at 32 and the existing mailbox assertion hotspot remains at 24; this patch does not change their complexity.
- Agent judgment: The existing metadata reader is the narrowest owner for both companion status and sign-in selection; a second selection API would duplicate its validation, ordering, and saturation contract.

## Hot reply path impact

- Path status: Not applicable — companion sign-in and orchestration high-water snapshots are outside current-message acceptance and reply handoff.
- Database calls: Companion sign-in replaces an unbounded full-row read with one bounded three-column read; mailbox high-water keeps the same one-row-per-lane queries with two selected columns.
- Network/provider calls: Unchanged.
- Other awaited latency: Connection secret decryption/KMS work is removed from sign-in selection.
- Before/after proof: Focused tests assert the full connection reader is not called and the secure-box opener remains unused.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no model/provider input surface changed.

ReviewGPT first-reviewed head: 542a20092a84ea886541f8251a24d39587ceaf75
ReviewGPT context sensitivity: sensitive
Classification reason: Production database projections and companion authorization selection changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Web-only query implementation with no schema, configuration, cross-service protocol, or mixed-version dependency.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source, focused Vitest is tests, and the reliability contract plus completed plan are docs/process. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 29 | 18 |
| Tests / fixtures | 60 | 23 |
| Docs | 101 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **190** | **42** |

## Changelog

- Changelog: not applicable
- Reason: Internal database/KMS efficiency only; no member-visible capability, interaction, or supportable performance claim changed.

