### PR TITLE
perf(web): bound mailbox retention blocker lookup

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -904,6 +904,13 @@ Last verified: 2026-09-04
   sensitive-action lane has a partial expiry-and-token index so durable
   approval history cannot enlarge its transient claim scan. Approval-backed
   rows remain with their approval owner.
+- Mailbox content retirement keeps ciphertext retirement, policy non-reply
+  recording, and contiguous conversation-floor advancement in one bounded
+  statement. For each member touched by the at-most-5,000-row retired set, the
+  floor owner uses the existing member/lane/sequence index to read only the
+  first unconsumed blocker above the current floor. It excludes exact rows
+  retired by the same statement and never aggregates the member's remaining
+  pending backlog.
 - Account deletion must not discard its only external-cleanup owner. The
   canonical account transaction persists the KMS-encrypted, foreign-key-free
   receipt before deleting the member. The existing hourly retention sweep

--- a/agent-docs/exec-plans/completed/2026-09-04-retention-first-blocker.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-retention-first-blocker.md
@@ -1,0 +1,77 @@
+# Bound mailbox retention blocker lookup
+
+Status: completed
+Created: 2026-09-04
+Updated: 2026-09-04
+
+## Goal
+
+- Keep the 5,000-row mailbox retirement batch from aggregating every pending
+  conversation row when it advances each affected lane's contiguous floor.
+
+## Success criteria
+
+- Each affected conversation member resolves only the first unconsumed
+  non-retired blocker after the current floor.
+- The query uses the existing member/lane/sequence index and performs no
+  backlog-wide blocker aggregation.
+- Policy non-reply retirement and contiguous-floor semantics remain unchanged
+  under real PostgreSQL.
+- Focused tests, hosted-Web typecheck, exact-head CI, and ReviewGPT pass.
+
+## Scope
+
+- In scope: the mailbox retirement CTE, its SQL-shape proof, PostgreSQL
+  retention semantics, and the directly affected reliability contract.
+- Out of scope: retention windows, batch sizes, mailbox schema/index changes,
+  additional schedulers, and other retention categories.
+
+## Constraints
+
+- Preserve the one-statement transactional owner for ciphertext retirement,
+  explicit policy non-reply recording, and lane-floor advancement.
+- Reuse the existing user, lane, and lane-sequence index and the existing
+  bounded retired-row set.
+- Keep hourly work bounded by the current four batches of 5,000 rows.
+
+## Risks and mitigations
+
+1. Risk: The lookup advances past a younger unconsumed gap.
+   Mitigation: order blockers by lane sequence, take exactly one, and retain the
+   existing real-PostgreSQL younger-gap test.
+2. Risk: A row retired by the same data-modifying CTE still appears unconsumed
+   under the statement snapshot and blocks itself.
+   Mitigation: exclude exact ids returned by the bounded retired CTE.
+3. Risk: Historical rows below the already consumed floor enlarge the lookup.
+   Mitigation: start the indexed search strictly above the counter's current
+   consumed sequence.
+
+## Tasks
+
+1. Replace the blocker-wide join and grouped minimum with one ordered lateral
+   lookup per bounded affected member.
+2. Assert the indexed first-blocker SQL shape and absence of the aggregate.
+3. Run focused unit and local PostgreSQL retention proofs, typecheck, lint,
+   complexity, and diff/privacy review.
+4. Update the reliability contract, archive the plan, commit, and open a draft
+   PR.
+5. Push the exact candidate, run ReviewGPT concurrently with required CI, and
+   resolve all required gates before handoff.
+
+## Decisions
+
+- Keep this separate from unrelated retention categories so the PR proves one
+  query-plan correction without widening cleanup behavior.
+- Use a lateral ordered lookup rather than a new partial index because the
+  existing sequence index already matches the exact member/lane prefix and
+  ordering needed by the first-blocker decision.
+
+## Verification
+
+- Commands to run: focused retention Vitest, the existing local PostgreSQL
+  younger-gap and concurrency proofs, hosted-Web typecheck, scoped ESLint,
+  pnpm complexity:diff, exact PR-head CI, and ReviewGPT.
+- Expected outcomes: SQL contains one ordered lane-sequence lookup with a
+  one-row limit above the current floor, contains no blocker-wide minimum, and
+  PostgreSQL preserves the current contiguous-floor result.
+Completed: 2026-09-04

--- a/apps/web/src/lib/hosted-retention/cleanup.ts
+++ b/apps/web/src/lib/hosted-retention/cleanup.ts
@@ -498,27 +498,30 @@ export async function retireExpiredMailboxContent(input: {
         SELECT
           conversation_users."user_id",
           COALESCE(
-            MIN(blocker."lane_seq") - 1,
+            blocker."lane_seq" - 1,
             counter."next_seq" - 1
           ) AS "lane_seq"
         FROM conversation_users
         JOIN "hosted_mailbox_lane_counter" AS counter
           ON counter."user_id" = conversation_users."user_id"
           AND counter."lane" = 'conversation'
-        LEFT JOIN "hosted_mailbox_item" AS blocker
-          ON blocker."user_id" = conversation_users."user_id"
-          AND blocker."lane" = 'conversation'
-          AND blocker."consumed_at" IS NULL
-          AND NOT EXISTS (
-            SELECT 1
-            FROM retired AS policy_non_reply
-            WHERE policy_non_reply."id" = blocker."id"
-              AND policy_non_reply."retention_disposition"
-                = 'policy_non_reply.content_expired'
-          )
-        GROUP BY
-          conversation_users."user_id",
-          counter."next_seq"
+        LEFT JOIN LATERAL (
+          SELECT blocker."lane_seq"
+          FROM "hosted_mailbox_item" AS blocker
+          WHERE blocker."user_id" = conversation_users."user_id"
+            AND blocker."lane" = 'conversation'
+            AND blocker."lane_seq" > counter."consumed_seq"
+            AND blocker."consumed_at" IS NULL
+            AND NOT EXISTS (
+              SELECT 1
+              FROM retired AS policy_non_reply
+              WHERE policy_non_reply."id" = blocker."id"
+                AND policy_non_reply."retention_disposition"
+                  = 'policy_non_reply.content_expired'
+            )
+          ORDER BY blocker."lane_seq" ASC
+          LIMIT 1
+        ) AS blocker ON TRUE
       ),
       advanced AS (
         UPDATE "hosted_mailbox_lane_counter" AS counter

--- a/apps/web/test/hosted-retention-cleanup.test.ts
+++ b/apps/web/test/hosted-retention-cleanup.test.ts
@@ -195,7 +195,13 @@ describe("hosted retention cleanup", () => {
     );
     expect(mailboxDeleteSql).toContain('UPDATE "hosted_mailbox_lane_counter"');
     expect(mailboxDeleteSql).toContain('"consumed_seq" = GREATEST');
-    expect(mailboxDeleteSql).toContain('MIN(blocker."lane_seq") - 1');
+    expect(mailboxDeleteSql).toContain("LEFT JOIN LATERAL");
+    expect(mailboxDeleteSql).toContain(
+      'blocker."lane_seq" > counter."consumed_seq"',
+    );
+    expect(mailboxDeleteSql).toContain('ORDER BY blocker."lane_seq" ASC');
+    expect(mailboxDeleteSql).toContain("LIMIT 1");
+    expect(mailboxDeleteSql).not.toContain('MIN(blocker."lane_seq")');
     expect(mailboxDeleteSql.match(/FOR UPDATE SKIP LOCKED/g)).toHaveLength(2);
     expect(queryRaw.mock.calls[0]?.slice(1)).toEqual([
       now,


### PR DESCRIPTION
## Why and outcome

The 5,000-row mailbox retirement batch used a grouped join to compute the minimum blocker across every remaining unconsumed conversation row for each affected member. This change uses one ordered lateral lookup above the current consumed floor, returning only the first blocker through the existing member/lane/sequence index.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Replayed expired unhandled conversation messages, a younger unconsumed gap, already-consumed history, and concurrent locked cleanup rows. Policy non-replies, ciphertext retirement, and contiguous frontier results are unchanged.

## Evidence

- Direct: With an isolated local PostgreSQL database, `MURPH_TEST_POSTGRES_CONCURRENCY=1 pnpm --dir apps/web test -- hosted-retention-cleanup.test.ts hosted-assistant-ask-retention-postgres.test.ts hosted-retention-control-artifacts-postgres-concurrency.test.ts` — 21/21 passed. The tests prove the indexed first-blocker SQL shape, younger-gap preservation, same-statement retirement behavior, and lock skipping.
- Coverage: `pnpm --dir packages/device-syncd build && pnpm --dir apps/web typecheck` passed; scoped ESLint passed; `pnpm complexity:diff` passed; `git diff --check` passed.

## Non-obvious affected surfaces

PostgreSQL data-modifying CTEs share one statement snapshot, so a row retired by the same statement can still look unconsumed to another CTE. The ordered lookup preserves the existing exact-id exclusion through the bounded retired result before selecting the next blocker.

## Architecture and reuse

- Existing systems reused: the single mailbox-retention statement, lane counter, bounded retired CTE, existing user/lane/lane-sequence index, hourly scheduler, and four-by-5,000 work ceiling.
- New logic: one lateral ordered first-blocker lookup per member in the bounded retired set.
- New abstractions: No new abstraction is needed because blocker selection remains inside the existing SQL owner.
- Complexity intentionally avoided: no new index, schema migration, query owner, queue, cursor, cache, or secondary transaction.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; debt remains 0 and the source-file maximum remains 7.
- Hotspots: The changed retention owner has no function above the configured complexity threshold.
- Agent judgment: Keeping the lookup in the existing CTE is smaller and safer than introducing a second read or persisted progress owner, and it preserves atomic retirement/frontier advancement.

## Hot reply path impact

- Path status: Not applicable — this is hourly retention maintenance, outside current-message acceptance and reply handoff.
- Database calls: The same bounded statement remains; its blocker subplan changes from backlog-wide aggregation to ordered one-row lookup per bounded affected member.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: SQL-shape assertions reject the previous minimum aggregate, while real PostgreSQL tests preserve the exact frontier outcome.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no model/provider input surface changed.

ReviewGPT first-reviewed head: 67b31c51f47728c758041d5d1de5ac52783a3463
ReviewGPT context sensitivity: sensitive
Classification reason: Production mailbox-retention SQL and lane-frontier advancement changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Web-only query implementation with no schema, configuration, cross-service protocol, or mixed-version dependency.

## Change-shape breakdown

Classification rule: Runtime TypeScript/SQL is source, focused Vitest is tests, and the reliability contract plus completed plan are docs/process. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 18 | 15 |
| Tests / fixtures | 7 | 1 |
| Docs | 84 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **109** | **16** |

## Changelog

- Changelog: not applicable
- Reason: Internal retention-query efficiency only; member-visible retention semantics and privacy deadlines are unchanged.
