### PR TITLE
fix(assistant): preserve earlier accepted reply targets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,11 +19,21 @@ invocation-scoped root tools: the resident App Server may expose them to the
 active root turn, but descendant or foreign resident threads fail before the
 accepted-message resolver runs.
 
+Native replies may select any input admitted in the active turn through the
+exact tool or response ordinal, including earlier live-steering segments.
+Reactions remain segment-only. Native selection and pre-delivery revalidation
+use the same bounded prefix; invalid ordinals, including request-relative
+ordinals before group reconsideration rebasing, fail closed. Admission and
+checkpointing still precede target authority, and no-reply accounting is
+unchanged.
+
 `murph.select_reply_target` annotates a normal response segment;
 `murph.react_to_message` keeps the existing reaction effect and outbox
 operation. The delivery owner re-resolves the selected input immediately before
-each effect and clones its reply context instead of mutating shared input. Every
-`---` bubble from one response segment inherits the same selected target.
+each effect. Native replies clone the response ordinal's reply context and
+overlay only the canonical message target, without replacing the route or
+audience or mutating shared input. Every `---` bubble from one response segment
+inherits the same selected target.
 
 Intentional replies persist a true-only `nativeReplyRequested` marker on each
 normal message intent. The marker participates in strict parsing, persistence,

--- a/agent-docs/exec-plans/active/2026-09-04-earlier-message-reply.md
+++ b/agent-docs/exec-plans/active/2026-09-04-earlier-message-reply.md
@@ -2,7 +2,7 @@
 
 Status: active
 Created: 2026-09-04
-Updated: 2026-09-04
+Updated: 2026-09-05
 
 ## Goal
 
@@ -20,7 +20,7 @@ Updated: 2026-09-04
 
 ## Scope
 
-- In scope: accepted-message selection in local-service, preceding/final reply
+- In scope: accepted-message selection in local-service, progress/preceding/final reply
   revalidation, directly affected tests and current targeting documentation.
 - Out of scope: admission eligibility, reaction policy, new delivery owners,
   schemas, historical transcript targeting, production mutation and deployment.
@@ -78,15 +78,28 @@ Updated: 2026-09-04
 
 ## Verification
 
-- The selected Telegram group regression fails against unchanged production
-  source and passes with the patch. The initial narrower filter skipped all
-  tests and is not counted as evidence.
-- Focused native-prefix and canonical-target suites pass all 35 tests with one
-  worker. They cover both providers and audiences, checkpoint ordering,
-  preceding/final revalidation, invalid ordinals, reconsideration and reactions.
+- Selected Telegram group regression: failed against unchanged production and
+  passed with the patch. An initial filter skipped every test and is excluded
+  from evidence.
+- `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir packages/assistant-engine exec vitest run
+  --config vitest.config.ts --no-coverage
+  test/assistant-local-service-native-reply-prefix.test.ts
+  test/assistant-message-target-selection.test.ts`: 35 passed. Covers both
+  providers and audiences, admission checkpoint ordering, preceding/final
+  revalidation, invalid ordinals, reconsideration and unchanged reaction scope.
+- `pnpm --dir packages/assistant-engine typecheck`: passed again after the final fixture correction.
+- `pnpm complexity:diff --base 18b498bc49435c49adb99588754a8a2bf72c4ce6`:
+  passed. Existing local-service debt decreased 154 to 153 and maximum 131 to
+  130. Existing orchestration hotspots need no unrelated extraction for this fix.
+- `pnpm test:assistant:live -- --test 'real Codex live native reply prefix e2e'`:
+  passed with the local subscription and `gpt-5.6-terra`. The synthetic user
+  explicitly waits for a clarification: exactly one earlier-ref selection at
+  ordinal 1, no preceding answer, correct concise final answer, no internal ref
+  leakage. Reply review: Ready. The initial fixture allowed an answer before
+  clarification; it was corrected without weakening the no-duplicate assertion.
 - Parent inspected the production diff and requested no source remediation.
-- Focused assistant-engine live-input, delivery and message-target tests.
-- Assistant-engine package typecheck; complexity diff and documentation checks.
-- Focused opt-in real-assistant journey after deterministic boundaries pass.
-- Expected outcome: exact earlier provider target with unchanged audience and
-  message counts; no effect for invalid authority. Pending execution.
+- `MURPH_VITEST_MAX_WORKERS=1 MURPH_APP_VITEST_MAX_WORKERS=1 pnpm --dir
+  apps/web test -- changelog-page.test.tsx`: nine server-rendering tests passed.
+- Current-main merge-tree proof is clean; no base rebase was needed.
+- Remaining: Web typecheck, exact-head final ReviewGPT and required CI, then
+  parent completion review.

--- a/agent-docs/exec-plans/active/2026-09-04-earlier-message-reply.md
+++ b/agent-docs/exec-plans/active/2026-09-04-earlier-message-reply.md
@@ -1,0 +1,92 @@
+# Preserve earlier accepted native reply targets
+
+Status: active
+Created: 2026-09-04
+Updated: 2026-09-04
+
+## Goal
+
+- Keep native replies attached to the intended earlier message when several
+  authorized messages join one active assistant turn.
+
+## Success criteria
+
+- Native reply selection and dispatch accept an earlier same-conversation
+  message already admitted through the selecting delivery-context ordinal.
+- Future-ordinal, cross-turn, missing, unsupported and foreign-route references
+  fail closed; reactions retain their existing scope.
+- Focused deterministic and real-assistant proof, typecheck, parent review,
+  scoped commit and exact-head external review establish the candidate.
+
+## Scope
+
+- In scope: accepted-message selection in local-service, preceding/final reply
+  revalidation, directly affected tests and current targeting documentation.
+- Out of scope: admission eligibility, reaction policy, new delivery owners,
+  schemas, historical transcript targeting, production mutation and deployment.
+
+## Constraints
+
+- Reuse the existing bounded accepted-input prefix; retain canonical event
+  reloads and conversation, provider, audience, account and thread checks.
+- Obtain a concrete implementation patch through managed ReviewGPT, inspect it
+  locally, and coordinate one heavy test command at a time with the parent.
+- Use synthetic evidence only. Keep review artifacts ignored.
+
+## Risks and mitigations
+
+1. A stale response could target input admitted after its ordinal. Preserve
+   prefix ordering and cover concurrent live-steering admission explicitly.
+2. Selection could outlive target authority. Re-resolve the stored event at
+   dispatch and prove missing or changed targets cause no provider send.
+3. Group reconsideration offsets could widen or lose authority. Verify the
+   provider-request base ordinal and preserve selected-response accounting.
+
+## Tasks
+
+1. Trace membership, live-steering checkpoints, route checks and delivery owners.
+2. Obtain ReviewGPT implementation diff; apply and critique its narrow scope.
+3. Prove earlier targets, earlier/future ordering, dispatch revalidation and
+   unchanged reaction boundaries; run focused typecheck and assistant journey.
+4. Update current owner docs and member release note, inspect complete diff,
+   obtain parent candidate review, commit and open a draft PR.
+5. Run final ReviewGPT on the stable pushed head alongside required CI; hand
+   findings to the parent and retain the worktree without merging or deploying.
+
+## Decisions
+
+- Source trace: native-reply authorization and both preceding/final delivery
+  rechecks use segment-only IDs. The existing cumulative helper already serves
+  participant effects. The shared message-target resolver needs no weaker check.
+- ReviewGPT implementation uses a guarded snapshot whose affected source and
+  tests match the worktree base; final review will use the pushed candidate.
+- The verified configured ReviewGPT model returned an applicable unified diff,
+  14 deterministic scenarios and an opt-in model journey. Local review retains
+  its bounded native-reply helper: invalid ordinals cannot use the accounting
+  helper's out-of-range fallback or become valid through reconsideration rebasing.
+- Local proof also prints the synthetic model reply for the required UX review;
+  the external implementation environment could not run repository dependencies.
+
+## Product UX
+
+- Outcome: a reply can remain linked to an earlier request after a later message
+  arrives in the same active exchange.
+- Reaches: supported private and authenticated group iMessage/Telegram routes;
+  ordinary flat replies and reaction scope remain unchanged.
+- Proof: synthetic live admission through selected reply dispatch, denied
+  future/foreign/deleted targets, and a focused production-derived model turn.
+
+## Verification
+
+- The selected Telegram group regression fails against unchanged production
+  source and passes with the patch. The initial narrower filter skipped all
+  tests and is not counted as evidence.
+- Focused native-prefix and canonical-target suites pass all 35 tests with one
+  worker. They cover both providers and audiences, checkpoint ordering,
+  preceding/final revalidation, invalid ordinals, reconsideration and reactions.
+- Parent inspected the production diff and requested no source remediation.
+- Focused assistant-engine live-input, delivery and message-target tests.
+- Assistant-engine package typecheck; complexity diff and documentation checks.
+- Focused opt-in real-assistant journey after deterministic boundaries pass.
+- Expected outcome: exact earlier provider target with unchanged audience and
+  message counts; no effect for invalid authority. Pending execution.

--- a/agent-docs/exec-plans/completed/2026-09-04-earlier-message-reply.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-earlier-message-reply.md
@@ -1,6 +1,6 @@
 # Preserve earlier accepted native reply targets
 
-Status: active
+Status: completed
 Created: 2026-09-04
 Updated: 2026-09-05
 
@@ -101,5 +101,15 @@ Updated: 2026-09-05
 - `MURPH_VITEST_MAX_WORKERS=1 MURPH_APP_VITEST_MAX_WORKERS=1 pnpm --dir
   apps/web test -- changelog-page.test.tsx`: nine server-rendering tests passed.
 - Current-main merge-tree proof is clean; no base rebase was needed.
-- Remaining: Web typecheck, exact-head final ReviewGPT and required CI, then
-  parent completion review.
+- `pnpm --dir apps/web typecheck`: passed after the normal device-syncd build
+  prerequisite supplied its missing declaration. No source correction was needed.
+- Final ReviewGPT round 1: PASS on immutable candidate
+  `c7247d9b18c61e3fa30aed7fab2eae1579309878`. The configured model, response
+  hashes, committed-turn association, exact head and completion marker all
+  validate; recorded send-to-capture elapsed time was 637.346 seconds. The
+  reviewer found no qualifying issue and accurately separated synthetic route
+  proof from the real-model selection fixture and untested physical rendering.
+- Parent final review passed with zero findings. Implementation and review are
+  complete. Final documentation-head CI remains tracked on PR 2882 and must
+  pass before the overall PR handoff; merge and deployment remain out of scope.
+Completed: 2026-09-05

--- a/agent-docs/product-specs/shared-message-targeting.md
+++ b/agent-docs/product-specs/shared-message-targeting.md
@@ -1,6 +1,6 @@
 # Shared Message Targeting
 
-Last verified: 2026-08-05
+Last verified: 2026-09-04
 Status: Implemented
 
 ## Decision
@@ -57,12 +57,23 @@ foreign-thread calls are rejected before accepted-message authority is
 consulted. The resolver must then:
 
 1. bind the call to its current accepted-input delivery-context ordinal;
-2. require an exact accepted input id from that context;
+2. for a native reply, require an exact accepted input id from the cumulative
+   prefix admitted in this active turn through that ordinal; for a reaction,
+   require an id from that ordinal's own segment, unchanged;
 3. reload the stored `AssistantInputEvent`;
 4. recheck conversation, route, thread, direct/group audience, account, and
    group-actor authority, including an exact match between the event's provider
    reply thread and the current thread-kind binding; and
 5. apply the action-specific native-reply or reaction capability policy.
+
+Native reply membership is bounded by the exact tool or response ordinal, not
+by the latest input in the turn. Later live-steered input does not revoke an
+earlier admitted target, but an earlier ordinal can never target later input.
+Invalid ordinals fail closed, including negative request-relative ordinals
+before held group draft reconsideration rebases them. Request 1 uses its
+`providerRequestDeliveryContextBaseOrdinal` for this same bounded prefix; it
+creates no cross-turn authority. Live-steered input must finish admission and
+checkpointing before its ordinal becomes selectable.
 
 The thread binding is the provider-route authority. A one-off explicit-target
 override is not required for tool availability or resolution and does not
@@ -71,7 +82,11 @@ replace that binding.
 The resolver fails closed for an invented, stale, cross-turn, cross-thread, or
 unsupported ref. The tool result and provider-turn result carry only the
 opaque accepted input id. The local delivery owner resolves the corresponding
-provider message id again immediately before the effect.
+provider message id again immediately before the effect. Native progress,
+preceding response segments (including split bubbles), and final responses
+repeat the same prefix-bounded canonical-event check. Deleted targets or revoked
+route authority fail delivery rather than falling back to a newer target or a
+flat reply. Reaction scope and no-reply accounting are unchanged.
 
 Provider message ids never enter prompts, tool arguments, tool results, model
 history, or diagnostics. There is no second ref map, provider-id registry,
@@ -79,9 +94,10 @@ database projection, service, API, or feature flag.
 
 ## Delivery and persistence
 
-The delivery owner clones the selected input's existing reply-delivery context.
-It does not mutate the shared accepted input. This keeps response segments and
-reactions isolated even when several inputs joined one live turn.
+The native-reply delivery owner clones the response ordinal's existing
+reply-delivery context and overlays only the selected canonical message target.
+Selecting an earlier input does not replace the response's route or audience.
+It does not mutate shared accepted input or reaction state.
 Same-route inputs accepted during that turn may update their message anchor,
 reaction capability, and idempotency inputs, but do not replace the current
 thread binding or create an explicit-target override.

--- a/apps/web/changelog/entries/2026-09-04/replies-stay-with-earlier-messages.json
+++ b/apps/web/changelog/entries/2026-09-04/replies-stay-with-earlier-messages.json
@@ -9,6 +9,6 @@
     "summary": "Murph can keep a reply attached to an earlier question when another message arrives while it is answering.",
     "details": "This works in supported private and group iMessage and Telegram conversations for messages received during the same active exchange.",
     "relevanceTags": ["conversation"],
-    "sourcePullRequests": []
+    "sourcePullRequests": [2882]
   }
 }

--- a/apps/web/changelog/entries/2026-09-04/replies-stay-with-earlier-messages.json
+++ b/apps/web/changelog/entries/2026-09-04/replies-stay-with-earlier-messages.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-04",
+  "order": 100,
+  "item": {
+    "id": "replies-stay-with-earlier-messages",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Replies stay with the intended message",
+    "summary": "Murph can keep a reply attached to an earlier question when another message arrives while it is answering.",
+    "details": "This works in supported private and group iMessage and Telegram conversations for messages received during the same active exchange.",
+    "relevanceTags": ["conversation"],
+    "sourcePullRequests": []
+  }
+}

--- a/packages/assistant-engine/src/assistant/local-service.ts
+++ b/packages/assistant-engine/src/assistant/local-service.ts
@@ -260,6 +260,11 @@ function rebaseAssistantProviderResultDeliveryContexts(input: {
   if (input.baseOrdinal === 0) {
     return input.providerResult
   }
+  // A negative request-relative ordinal must not become valid after rebasing.
+  const rebaseReplyOrdinal = (ordinal: number): number =>
+    Number.isInteger(ordinal) && ordinal >= 0
+      ? ordinal + input.baseOrdinal
+      : -1
   return {
     ...input.providerResult,
     acceptedNoReplyDeliveryContextOrdinals:
@@ -270,7 +275,7 @@ function rebaseAssistantProviderResultDeliveryContexts(input: {
       input.providerResult.precedingResponseSegments?.map((segment) => ({
         ...segment,
         deliveryContextOrdinal:
-          segment.deliveryContextOrdinal + input.baseOrdinal,
+          rebaseReplyOrdinal(segment.deliveryContextOrdinal),
       })),
     reactions: input.providerResult.reactions?.map((reaction) => ({
       ...reaction,
@@ -278,7 +283,7 @@ function rebaseAssistantProviderResultDeliveryContexts(input: {
         reaction.deliveryContextOrdinal + input.baseOrdinal,
     })),
     responseDeliveryContextOrdinal:
-      input.providerResult.responseDeliveryContextOrdinal + input.baseOrdinal,
+      rebaseReplyOrdinal(input.providerResult.responseDeliveryContextOrdinal),
   }
 }
 
@@ -892,9 +897,6 @@ export async function sendAssistantMessageLocal(
               deliver: async (progressInput) => {
                 const deliveryContextOrdinal =
                   progressInput.deliveryContextOrdinal ?? 0
-                const absoluteDeliveryContextOrdinal =
-                  providerRequestDeliveryContextBaseOrdinal +
-                  deliveryContextOrdinal
                 const { targetInputId, ...untargetedProgressInput } = progressInput
                 if (targetInputId) {
                   await beforeHostedToolExecution(deliveryContextOrdinal)
@@ -905,8 +907,9 @@ export async function sendAssistantMessageLocal(
                       input:
                         await applyAssistantAcceptedMessageTargetToDeliveryInput({
                           acceptedInputIds:
-                            resolveAcceptedInputIdsThroughDeliveryContextOrdinal(
-                              absoluteDeliveryContextOrdinal,
+                            resolveNativeReplyAcceptedInputIds(
+                              deliveryContextOrdinal,
+                              providerRequestDeliveryContextBaseOrdinal,
                             ),
                           action: 'native-reply',
                           input: progressInput.input,
@@ -1369,6 +1372,24 @@ export async function sendAssistantMessageLocal(
             ),
           ]
         }
+        // Native authority must not use the shared helper's out-of-range
+        // accounting fallback, or rebase an invalid request-relative ordinal.
+        function resolveNativeReplyAcceptedInputIds(
+          deliveryContextOrdinal: number,
+          baseOrdinal = 0,
+        ): readonly string[] {
+          const absoluteOrdinal = baseOrdinal + deliveryContextOrdinal
+          if (
+            !Number.isInteger(deliveryContextOrdinal) ||
+            deliveryContextOrdinal < 0 ||
+            absoluteOrdinal >= acceptedInputIdsByDeliveryContextOrdinal.length
+          ) {
+            return []
+          }
+          return resolveAcceptedInputIdsThroughDeliveryContextOrdinal(
+            absoluteOrdinal,
+          )
+        }
         function resolveNoReplyAcceptedInputIds(
           deliveryContextOrdinal: number,
           precedingReplyDeliveryContextOrdinal: number | null,
@@ -1406,13 +1427,18 @@ export async function sendAssistantMessageLocal(
               providerRequestDeliveryContextBaseOrdinal +
               authorizationInput.deliveryContextOrdinal
             const acceptedInputIds =
-              authorizationInput.action === 'participant-effect'
-                ? resolveAcceptedInputIdsThroughDeliveryContextOrdinal(
-                    deliveryContextOrdinal,
+              authorizationInput.action === 'native-reply'
+                ? resolveNativeReplyAcceptedInputIds(
+                    authorizationInput.deliveryContextOrdinal,
+                    providerRequestDeliveryContextBaseOrdinal,
                   )
-                : acceptedInputIdsByDeliveryContextOrdinal[
-                    deliveryContextOrdinal
-                  ]
+                : authorizationInput.action === 'participant-effect'
+                  ? resolveAcceptedInputIdsThroughDeliveryContextOrdinal(
+                      deliveryContextOrdinal,
+                    )
+                  : acceptedInputIdsByDeliveryContextOrdinal[
+                      deliveryContextOrdinal
+                    ]
             const deliveryContext =
               replyDeliveryContexts[deliveryContextOrdinal]
             if (!acceptedInputIds || !deliveryContext) {
@@ -1459,9 +1485,9 @@ export async function sendAssistantMessageLocal(
               throw error
             }
           }
-        // Cumulative through the ordinal: the no-reply hook and participant
-        // effects may reference any input already admitted into the provider
-        // turn. Native replies and reactions remain exact to one ordinal.
+        // Cumulative through the ordinal: the no-reply hook, participant
+        // effects and native replies may reference any input already admitted
+        // through their ordinal. Reactions remain exact to one ordinal.
         const admissionMs = elapsedSince(admissionStartedAt)
         const providerStartAtPreProviderSetupDone =
           stampAssistantProviderStartCriticalPath(
@@ -2413,9 +2439,7 @@ export async function sendAssistantMessageLocal(
               }
               return await applyAssistantAcceptedMessageTargetToDeliveryInput({
                 acceptedInputIds:
-                  acceptedInputIdsByDeliveryContextOrdinal[
-                    deliveryContextOrdinal
-                  ] ?? [],
+                  resolveNativeReplyAcceptedInputIds(deliveryContextOrdinal),
                 action: 'native-reply',
                 input: segmentInput.input,
                 session: segmentInput.session,
@@ -2505,9 +2529,9 @@ export async function sendAssistantMessageLocal(
             finalDeliveryInput =
               await applyAssistantAcceptedMessageTargetToDeliveryInput({
                 acceptedInputIds:
-                  acceptedInputIdsByDeliveryContextOrdinal[
-                    providerResult.responseDeliveryContextOrdinal
-                  ] ?? [],
+                  resolveNativeReplyAcceptedInputIds(
+                    providerResult.responseDeliveryContextOrdinal,
+                  ),
                 action: 'native-reply',
                 input: finalReplyInput,
                 session: deliverySession,

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -117,6 +117,7 @@ import {
   MURPH_MEMBER_MEMORY_TOOL,
   MURPH_PERSONALIZATION_TOOL,
   MURPH_PLAN_USAGE_TOOL,
+  MURPH_SELECT_REPLY_TARGET_TOOL,
   MURPH_SEND_PROGRESS_UPDATE_TOOL,
   MURPH_SUBMIT_PRODUCT_FEEDBACK_TOOL,
   MURPH_SUBSCRIPTION_TOOL,
@@ -26134,6 +26135,80 @@ describeRealCodex('real Codex latest-context nutrition-card e2e', () => {
       )
     } finally {
       await removeRealCodexTemporaryPaths(config.temporaryPaths)
+    }
+  })
+})
+
+describeRealCodex('real Codex live native reply prefix e2e', () => {
+  it('selects an earlier accepted message after later live input', {
+    timeout: 480_000,
+  }, async () => {
+    const config = await resolveRealCodexE2eConfig()
+    const workingDirectory = await mkdtemp(
+      path.join(tmpdir(), 'murph-native-reply-prefix-real-e2e-'),
+    )
+    const earlierRef = 'ain_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    const laterRef = 'ain_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    const steerCompleted = createDeferred<void>()
+    const steerOutcome = steerCompleted.promise.then(
+      () => null,
+      (error: unknown) => error,
+    )
+    const selections: Array<{ deliveryContextOrdinal: number; messageRef: string }> = []
+
+    try {
+      // The local-service regression owns admission and canonical route checks.
+      // This opt-in journey checks real model selection across a live steer.
+      const result = await executeRealCodexAppServerTurn({
+        approvalPolicy: 'never',
+        authorizeAcceptedMessageTarget: async (selection) => {
+          if (selection.action !== 'native-reply' ||
+              selection.deliveryContextOrdinal !== 1 ||
+              selection.messageRef !== earlierRef) return null
+          selections.push({ deliveryContextOrdinal: 1, messageRef: earlierRef })
+          return { targetInputId: earlierRef }
+        },
+        baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+        codexCommand: normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+          ?? undefined,
+        codexHome: config.codexHome,
+        developerInstructions: buildGroupPointOfViewDeveloperInstructions(),
+        dynamicTools: [MURPH_SELECT_REPLY_TARGET_TOOL],
+        env: config.env,
+        excludeResumeTurns: true,
+        model: config.model,
+        modelProvider: config.modelProvider,
+        onLiveTurn: (turn) => {
+          void turn.steer({
+            prompt: [
+              `Message ref: ${laterRef}`,
+              'Another group participant: Please attach your answer to the earlier',
+              'arithmetic question, not this follow-up, so the group can follow it.',
+            ].join('\n'),
+          }).then(
+            () => steerCompleted.resolve(),
+            (error) => steerCompleted.reject(error),
+          )
+        },
+        prompt: [
+          `Message ref: ${earlierRef}`,
+          'A group participant: Murph, what is 13 plus 28?',
+        ].join('\n'),
+        reasoningEffort: 'low',
+        sandbox: 'read-only',
+        workingDirectory,
+      })
+      const steerError = await steerOutcome
+      if (steerError) throw steerError
+      process.stdout.write(`Synthetic earlier-message reply: ${result.finalMessage}\n`)
+      expect(selections).toEqual([{ deliveryContextOrdinal: 1, messageRef: earlierRef }])
+      expect(result.responseDeliveryContextOrdinal).toBe(1)
+      expect(result.targetInputId).toBe(earlierRef)
+      expect(result.precedingAgentMessageSegments).toEqual([])
+      expect(result.finalMessage).toContain('41')
+      expect(result.finalMessage).not.toContain('ain_')
+    } finally {
+      await removeRealCodexTemporaryPaths([workingDirectory, ...config.temporaryPaths])
     }
   })
 })

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -26193,6 +26193,7 @@ describeRealCodex('real Codex live native reply prefix e2e', () => {
         prompt: [
           `Message ref: ${earlierRef}`,
           'A group participant: Murph, what is 13 plus 28?',
+          'I am sending a clarification next; please wait for it before answering.',
         ].join('\n'),
         reasoningEffort: 'low',
         sandbox: 'read-only',

--- a/packages/assistant-engine/test/assistant-local-service-native-reply-prefix.test.ts
+++ b/packages/assistant-engine/test/assistant-local-service-native-reply-prefix.test.ts
@@ -1,0 +1,417 @@
+import { rm } from 'node:fs/promises'
+import { writeAssistantStateVersionedJson } from '@murphai/runtime-state/node'
+import { expect, test, vi } from 'vitest'
+import {
+  executeMurphDynamicToolRequest,
+} from '../src/assistant-codex/dynamic-tools.ts'
+import {
+  assistantInputCandidateFromStoredEvent,
+} from '../src/assistant/input-source.ts'
+import {
+  ASSISTANT_INPUT_EVENT_SCHEMA,
+  ASSISTANT_INPUT_EVENT_SCHEMA_VERSION,
+  resolveAssistantInputEventPath,
+  upsertAssistantInputEvent,
+} from '../src/assistant/input-store.ts'
+import {
+  applyAssistantReplyDeliveryContext,
+} from '../src/assistant/reply-delivery-context.ts'
+import type {
+  AssistantDeliveryOutcome,
+  AssistantMessageInput,
+} from '../src/assistant/service-contracts.ts'
+import { resolveAssistantStatePaths } from '../src/assistant/store/paths.ts'
+import type {
+  AssistantActiveTurnInputAdmissionHook,
+} from '../src/assistant/turn-input.ts'
+import { readAssistantAcceptedTurnInputJournal } from '../src/assistant/active-turn-input-journal.ts'
+import { createTempVaultContext } from './test-helpers.ts'
+import {
+  createAssistantSession,
+  createDeferred,
+  createHostedMailboxSourceRef,
+  createSharedPlan,
+  loadLocalServiceModule,
+  tempRoots,
+} from './assistant-local-service-runtime.harness.ts'
+
+test.each([
+  { channel: 'telegram', direct: true },
+  { channel: 'telegram', direct: false },
+  { channel: 'linq', direct: true },
+  { channel: 'linq', direct: false },
+] as const)(
+  'native reply prefix preserves $channel direct=$direct targeting after live admission',
+  async (route) => {
+    const result = await runLivePrefixScenario(route)
+    expect(result.outcome).toMatchObject({ kind: 'completed' })
+    expect(result.precedingInputs).toHaveLength(1)
+    expect(result.mocks.dispatchAssistantReply).toHaveBeenCalledOnce()
+    const final = result.mocks.dispatchAssistantReply.mock.calls[0]?.[0]
+    expect(final?.response).toBe('Final detail.')
+    for (const deliveryInput of [result.precedingInputs[0], final?.input]) {
+      expect(deliveryInput).toMatchObject({
+        deliveryNativeReplyRequested: true,
+        deliveryReplyToMessageId: '101',
+      })
+      expect(deliveryInput?.deliveryTarget).toBeUndefined()
+    }
+    expect(final?.session.binding).toEqual(result.session.binding)
+    expect(final?.sharedPlan.conversationPolicy.audience)
+      .toEqual(result.plan.conversationPolicy.audience)
+    expect(result.mocks.deliverAssistantReaction).not.toHaveBeenCalled()
+    expect(result.mocks.executeCodexTurnWithRecovery).toHaveBeenCalledOnce()
+  },
+  20_000,
+)
+
+test('native reply prefix rebases held group reconsideration without resending the draft', async () => {
+  const result = await runLivePrefixScenario({ held: true })
+  expect(result.outcome).toMatchObject({ kind: 'completed' })
+  expect(result.precedingInputs).toEqual([])
+  expect(result.mocks.dispatchAssistantReply).toHaveBeenCalledOnce()
+  expect(result.mocks.dispatchAssistantReply.mock.calls[0]?.[0]).toMatchObject({
+    input: { deliveryNativeReplyRequested: true, deliveryReplyToMessageId: '101' },
+    response: 'Final detail.',
+  })
+  expect(result.mocks.executeCodexTurnWithRecovery.mock.calls.map(
+    ([input]) => input.providerRequestOrdinal,
+  )).toEqual([0, 1])
+  expect(result.mocks.finalizeAssistantTurnArtifacts.mock.calls[0]?.[0]?.providerResult)
+    .toMatchObject({ responseDeliveryContextOrdinal: 1, precedingResponseSegments: [] })
+}, 20_000)
+
+test('native reply prefix validates targeted progress during group reconsideration', async () => {
+  const result = await runLivePrefixScenario({ held: true, targetedProgress: true })
+  expect(result.outcome).toMatchObject({ kind: 'completed' })
+  expect(result.mocks.deliverAssistantProgressUpdate).toHaveBeenCalledOnce()
+  expect(result.mocks.deliverAssistantProgressUpdate.mock.calls[0]?.[0]).toMatchObject({
+    input: { deliveryNativeReplyRequested: true, deliveryReplyToMessageId: '101' },
+  })
+  expect(result.precedingInputs).toEqual([])
+  expect(result.mocks.dispatchAssistantReply).toHaveBeenCalledOnce()
+}, 20_000)
+
+test.each(['deleted', 'revoked'] as const)(
+  'native reply prefix rechecks a %s earlier target before preceding and final delivery',
+  async (invalidation) => {
+    const result = await runLivePrefixScenario({ invalidation })
+    expect(result.outcome).toMatchObject({ kind: 'completed' })
+    expect(result.precedingInputs).toEqual([])
+    expect(result.mocks.dispatchAssistantReply).not.toHaveBeenCalled()
+    expect(result.mocks.finalizeDeliveredAssistantTurn.mock.calls[0]?.[0])
+      .toMatchObject({ outcome: { kind: 'failed' } })
+  },
+  20_000,
+)
+
+test('native reply prefix rejects a final reply aimed at a later ordinal', async () => {
+  const result = await runLivePrefixScenario({ futureFinal: true })
+  expect(result.precedingInputs).toHaveLength(1)
+  expect(result.mocks.dispatchAssistantReply).not.toHaveBeenCalled()
+}, 20_000)
+
+test.each([-1, 0.5, Number.NaN, Number.POSITIVE_INFINITY, 99])(
+  'native reply prefix rejects final ordinal %s after group rebasing',
+  async (responseOrdinal) => {
+    const result = await runLivePrefixScenario({ held: true, responseOrdinal })
+    expect(result.outcome).toMatchObject({
+      kind: 'failed',
+      error: { code: 'ASSISTANT_DELIVERY_CONTEXT_ORDINAL_INVALID' },
+    })
+    expect(result.precedingInputs).toEqual([])
+    expect(result.mocks.dispatchAssistantReply).not.toHaveBeenCalled()
+  },
+  20_000,
+)
+
+async function runLivePrefixScenario(options: {
+  channel?: 'linq' | 'telegram'
+  direct?: boolean
+  futureFinal?: boolean
+  held?: boolean
+  invalidation?: 'deleted' | 'revoked'
+  responseOrdinal?: number
+  targetedProgress?: boolean
+}) {
+  const channel = options.channel ?? 'telegram'
+  const direct = options.direct ?? false
+  const context = await createTempVaultContext('assistant-native-reply-prefix-')
+  tempRoots.push(context.parentRoot)
+  const session = createAssistantSession({
+    binding: {
+      actorId: direct ? 'actor-1' : null,
+      channel,
+      conversationKey: 'synthetic-prefix-conversation',
+      delivery: { kind: 'thread', target: 'thread-1' },
+      identityId: 'identity-1',
+      threadId: 'thread-1',
+      threadIsDirect: direct,
+    },
+  })
+  const plan = createSharedPlan()
+  Object.assign(plan.conversationPolicy.audience, {
+    actorId: session.binding.actorId,
+    channel,
+    effectiveThreadIsDirect: direct,
+    explicitTarget: null,
+    threadIsDirect: direct,
+  })
+  const events = await Promise.all([1, 2, 3].map((ordinal) =>
+    upsertAssistantInputEvent({
+      vault: context.vaultRoot,
+      event: {
+        content: { attachmentDescriptors: [], text: `Synthetic request ${ordinal}.` },
+        conversation: {
+          accountId: 'identity-1',
+          actorId: direct ? 'actor-1' : `actor-${ordinal}`,
+          actorIsSelf: false,
+          source: channel,
+          threadId: 'thread-1',
+          threadIsDirect: direct,
+        },
+        occurredAt: `2026-09-01T10:00:0${ordinal}.000Z`,
+        receivedAt: `2026-09-01T10:00:0${ordinal}.000Z`,
+        replyTarget: { channel, messageId: String(100 + ordinal), threadId: 'thread-1' },
+        sourceMetadata: channel === 'linq'
+          ? {
+              externalThreadRouteAuthorityPresent: true,
+              kind: 'linq',
+              partCount: 1,
+              reactionEligible: true,
+              replyToMessageId: null,
+              service: 'iMessage',
+            }
+          : {
+              externalThreadRouteAuthorityPresent: true,
+              kind: 'telegram',
+              mediaGroupId: null,
+              replyContext: null,
+            },
+        sourceRef: createHostedMailboxSourceRef({
+          eventId: `evt_native_prefix_${ordinal}`,
+          laneSeq: String(ordinal),
+        }),
+      },
+    }),
+  ))
+  const [earlier, later, unadmitted] = events
+  if (!earlier || !later || !unadmitted) throw new Error('Missing synthetic inputs.')
+  const earlierText = earlier.content.text
+  const laterText = later.content.text
+  if (!earlierText || !laterText) throw new Error('Missing synthetic text.')
+  const providerStarted = createDeferred<void>()
+  const steerAcknowledged = createDeferred<void>()
+  const executeTools = createDeferred<void>()
+  const checkpointStarted = createDeferred<void>()
+  const checkpointRelease = createDeferred<void>()
+  let toolSelectionCompleted = false
+  const activeTurnInput: AssistantActiveTurnInputAdmissionHook = async (input) => {
+    if (!input.availableInputIds?.includes(later.inputId) ||
+        input.knownInputIds?.includes(later.inputId)) return { kind: 'no-new-input' }
+    return {
+      acceptedInputs: [{
+        ...assistantInputCandidateFromStoredEvent(later).acceptedInput,
+        promptFallbackReason: 'missing-content-ref',
+        promptFallbackText: laterText,
+      }],
+      kind: 'accepted',
+      prompt: laterText,
+      transcriptText: laterText,
+    }
+  }
+  const { mocks, sendAssistantMessageLocal } = await loadLocalServiceModule({
+    adapter: { setMessageReaction: vi.fn() },
+    plan,
+    realAcceptedInputPersistence: true,
+    realMessageTargetSelection: true,
+    session,
+  })
+  const { notifyAssistantActiveTurnInputAvailable } = await import(
+    '../src/assistant/active-turn-input-controller.ts'
+  )
+  // Exercise the local owner's real pre-dispatch resolver; transport stays stubbed.
+  const precedingInputs: AssistantMessageInput[] = []
+  mocks.deliverAssistantPrecedingReplies.mockImplementation(async (input) => {
+    const outcomes: AssistantDeliveryOutcome[] = []
+    for (const segment of input.segments ?? []) {
+      try {
+        if (!input.resolveSegmentDeliveryInput) throw new Error('Missing recheck.')
+        const resolved = await input.resolveSegmentDeliveryInput({
+          input: applyAssistantReplyDeliveryContext({
+            context: segment.deliveryContext ?? null,
+            input: input.input,
+          }),
+          segment,
+          session: input.session,
+        })
+        precedingInputs.push(resolved)
+        expect(segment.response).toBe('Earlier detail.\n---\nAnother detail.')
+        outcomes.push({ kind: 'queued', error: null, intentId: 'synthetic-preceding', media: [], session })
+      } catch (error) {
+        // The forged earlier-ordinal segment must fail, never silently go flat.
+        expect(error).toMatchObject({ code: 'ASSISTANT_MESSAGE_TARGET_UNAVAILABLE' })
+        outcomes.push({
+          kind: 'failed', intentId: null, media: [], session,
+          error: { code: 'ASSISTANT_MESSAGE_TARGET_UNAVAILABLE', message: 'Unavailable.' },
+        })
+      }
+    }
+    return outcomes
+  })
+  if (options.invalidation) {
+    mocks.finalizeAssistantTurnArtifacts.mockImplementationOnce(async () => {
+      const eventPath = resolveAssistantInputEventPath({
+        inputId: earlier.inputId,
+        paths: resolveAssistantStatePaths(context.vaultRoot),
+      })
+      if (options.invalidation === 'deleted') await rm(eventPath)
+      else await writeAssistantStateVersionedJson({
+        filePath: eventPath,
+        schema: ASSISTANT_INPUT_EVENT_SCHEMA,
+        schemaVersion: ASSISTANT_INPUT_EVENT_SCHEMA_VERSION,
+        value: {
+          ...earlier,
+          sourceMetadata: { ...earlier.sourceMetadata, externalThreadRouteAuthorityPresent: false },
+        },
+      })
+      return session
+    })
+  }
+  mocks.executeCodexTurnWithRecovery.mockImplementation(async (providerInput) => {
+    await providerInput.onProviderRequestPlanned?.({
+      providerAttemptId: null,
+      codexContinuation: { kind: 'explicit-structured-history' },
+    })
+    const ordinal = providerInput.providerRequestOrdinal === 1 ? 0 : 1
+    const authorize = providerInput.authorizeAcceptedMessageTarget
+    if (!authorize) throw new Error('Missing real target authorizer.')
+    if (providerInput.providerRequestOrdinal === 0) {
+      const release = providerInput.activeTurnSteering?.registerLiveProviderTurn({
+        interrupt: async () => undefined,
+        codexThreadId: 'thread-prefix-provider',
+        providerTurnId: 'turn-prefix-provider',
+        sessionId: session.sessionId,
+        steer: async () => { steerAcknowledged.resolve() },
+        turnId: 'turn-1',
+      })
+      providerStarted.resolve()
+      await executeTools.promise
+      expect(await authorize({ action: 'native-reply', deliveryContextOrdinal: 1,
+        messageRef: later.inputId })).toBeNull()
+      await providerInput.hostedToolContext?.beforeToolExecution?.(1)
+      expect(await authorize({ action: 'native-reply', deliveryContextOrdinal: 0,
+        messageRef: later.inputId })).toBeNull()
+      release?.()
+    }
+    for (const invalid of [-1, 0.5, Number.NaN, Number.POSITIVE_INFINITY, 99]) {
+      expect(await authorize({ action: 'native-reply', deliveryContextOrdinal: invalid,
+        messageRef: earlier.inputId })).toBeNull()
+    }
+    for (const messageRef of [unadmitted.inputId, 'ain_ffffffffffffffffffffffffffffffff']) {
+      expect(await authorize({ action: 'native-reply', deliveryContextOrdinal: ordinal,
+        messageRef })).toBeNull()
+    }
+    expect(await authorize({ action: 'reaction', deliveryContextOrdinal: ordinal,
+      messageRef: earlier.inputId })).toBeNull()
+    expect(await authorize({ action: 'reaction', deliveryContextOrdinal: ordinal,
+      messageRef: later.inputId })).toEqual({ targetInputId: later.inputId })
+    const selected = await executeMurphDynamicToolRequest({
+      authorizeAcceptedMessageTarget: authorize,
+      deliveryContextOrdinal: ordinal,
+      env: {},
+      fetchImpl: vi.fn(async () => { throw new Error('Unexpected network request.') }),
+      nextUsageOrdinal: () => 0,
+      progressDelivery: null,
+      request: { kind: 'select-reply-target', messageRef: earlier.inputId },
+    })
+    expect(selected.rpcResult.success).toBe(true)
+    expect(selected.replyTargetPatch).toEqual({ targetInputId: earlier.inputId })
+    expect(JSON.stringify(selected)).not.toContain('"101"')
+    if (options.targetedProgress && providerInput.providerRequestOrdinal === 1) {
+      const progress = providerInput.progressDelivery
+      if (!progress) throw new Error('Missing progress delivery.')
+      for (const invalid of [-1, 0.5, 99]) {
+        expect(await progress.send('Synthetic progress.', {
+          deliveryContextOrdinal: invalid, required: true, targetInputId: earlier.inputId,
+        })).toMatchObject({ kind: 'failed' })
+      }
+      expect(await progress.send('Synthetic progress.', {
+        deliveryContextOrdinal: ordinal, required: true, targetInputId: earlier.inputId,
+      })).toMatchObject({ kind: 'sent' })
+    }
+    toolSelectionCompleted = true
+    providerInput.activeTurnSteering?.onFirstAssistantResponseCompleted()
+    return {
+      kind: 'succeeded',
+      providerTurn: {
+        onboardingGuidanceInjected: true,
+        codexContinuation: { kind: 'explicit-structured-history' },
+        codexThreadId: 'thread-prefix-provider',
+        route: { routeId: 'route-prefix' },
+        precedingResponseSegments: [
+          { deliveryContextOrdinal: ordinal, response: 'Earlier detail.\n---\nAnother detail.',
+            targetInputId: earlier.inputId },
+          { deliveryContextOrdinal: 0, response: 'Must not reach later input.',
+            targetInputId: later.inputId },
+        ],
+        response: options.held && providerInput.providerRequestOrdinal === 0
+          ? 'Unsent draft.' : 'Final detail.',
+        responseDeliveryContextOrdinal: options.futureFinal ? 0 : options.responseOrdinal ?? ordinal,
+        session,
+        targetInputId: options.futureFinal ? later.inputId : selected.replyTargetPatch?.targetInputId,
+        transcriptResponse: 'Final detail.',
+      },
+    }
+  })
+  const unexpectedProviderSend = vi.fn(async () => {
+    throw new Error('Unexpected provider transport call.')
+  })
+  const outcomePromise = sendAssistantMessageLocal({
+    acceptedTurnInput: { initialInputs: [assistantInputCandidateFromStoredEvent(earlier).acceptedInput] },
+    activeTurnInput,
+    activeTurnCheckpoint: async () => {
+      checkpointStarted.resolve()
+      await checkpointRelease.promise
+    },
+    deliverResponse: true,
+    executionContext: { hosted: {
+      memberId: 'member-synthetic',
+      progressDeliveryDependencies: {
+        sendLinq: unexpectedProviderSend,
+        sendTelegram: unexpectedProviderSend,
+      },
+      userEnvKeys: [],
+    } },
+    prompt: earlierText,
+    ...(options.held ? { turnTrigger: 'automation-auto-reply' as const } : {}),
+    vault: context.vaultRoot,
+  }).then(
+    (result) => ({ kind: 'completed' as const, result }),
+    (error: unknown) => ({ kind: 'failed' as const, error }),
+  )
+  await providerStarted.promise
+  await notifyAssistantActiveTurnInputAvailable({
+    conversation: { channel, identityId: 'identity-1', threadId: 'thread-1',
+      ...(direct ? { participantId: 'actor-1' } : {}), directness: direct ? 'direct' : 'group' },
+    inputIds: [later.inputId],
+    vault: context.vaultRoot,
+  })
+  await steerAcknowledged.promise
+  executeTools.resolve()
+  await checkpointStarted.promise
+  expect(toolSelectionCompleted).toBe(false)
+  expect(await mocks.executeCodexTurnWithRecovery.mock.calls[0]?.[0]
+    .authorizeAcceptedMessageTarget?.({
+      action: 'native-reply', deliveryContextOrdinal: 1, messageRef: later.inputId,
+    })).toBeNull()
+  checkpointRelease.resolve()
+  const outcome = await outcomePromise
+  if (outcome.kind === 'failed' && options.responseOrdinal === undefined) {
+    throw outcome.error
+  }
+  expect(unexpectedProviderSend).not.toHaveBeenCalled()
+  const journal = await readAssistantAcceptedTurnInputJournal(context.vaultRoot, 'turn-1')
+  expect(journal?.inputIds).toEqual([earlier.inputId, later.inputId])
+  return { mocks, outcome, plan, precedingInputs, session }
+}


### PR DESCRIPTION
## Why and outcome

When another message joins an active turn, Murph can lose permission to attach its answer to an earlier accepted question. Native reply selection and delivery now use the accepted-input prefix through the exact response ordinal, preserving conversation and route authority.

## Product UX

- Effort: Patch
- Result: Ready — deterministic authority proof, real-model reply review, all focused local checks, final ReviewGPT, and all 33 final-head CI checks pass.
- Walkthrough: Private and authenticated group iMessage/Telegram conversations can retain the earlier message anchor. No cross-turn targeting is introduced.

## Evidence

- Direct: 35 focused native-prefix and canonical-resolver tests pass; assistant-engine typecheck passes. The selected baseline regression fails before the patch.
- Coverage: Live admission checkpoint ordering; both channels and audiences; preceding/final and targeted progress revalidation; deleted, revoked, future and unadmitted targets; invalid ordinals; held group reconsideration; unchanged reaction scope.
- Managed ReviewGPT supplied the initial concrete patch and tests using the configured, verified model. Local review applied the patch and strengthened failure reporting and synthetic reply capture. Parent source review requested no remediation.
- Live: `pnpm test:assistant:live -- --test "real Codex live native reply prefix e2e"` passed with `gpt-5.6-terra`, local subscription. Exactly one earlier-ref selection at ordinal 1, no preceding/duplicate answer, correct concise reply, no internal ref leakage. Reply review: Ready. Canonical resolver and transport-boundary proof come from the deterministic tests; external delivery stays stubbed.
- Final review: ReviewGPT round 1 PASS at immutable baseline `c7247d9b18c61e3fa30aed7fab2eae1579309878`, configured `gpt-6-pro`, 637.346 seconds from recorded send to capture. Model, hash, turn association, head and completion marker validate. Parent final review passed; the final commit only archives the explanatory plan.
- CI retry: the reviewed-head Release build/typecheck job failed in unchanged `scripts/frog-workflow-guards.test.ts:449` because GitHub Markdown rendering returned HTTP 403. There was no TypeScript diagnostic. [Failed job](https://github.com/cobuildwithus/murph/actions/runs/33944142141/job/101247189439). Final-head CI passed this same guard; no validation was weakened.
- Changelog: nine server-rendering tests pass. Final assistant-engine typecheck passes after the fixture correction. Web typecheck passes after building the existing device-syncd declaration prerequisite; the initial missing-declaration failure required no source change.

- Final-head CI: 33 checks passed on `8e7b0cb3406ce9ce2c504b3205ddd67501c3ba37`. The Temporal compatibility job initially stopped because the private base changed during proof; retrying the unchanged candidate passed.

## Non-obvious affected surfaces

Held group draft reconsideration rebases request-relative reply ordinals. Invalid ordinals remain invalid before and after rebasing. Targeted progress uses the same bounded native authority. Reactions retain segment-only scope; no-reply accounting is unchanged.

## Architecture and reuse

- Existing systems reused: accepted-input journal, bounded prefix helper, canonical event resolver, reply delivery contexts and provider delivery owners.
- New logic: native-only prefix bounds reject future and invalid ordinals before event resolution.
- New abstractions: one local native-authority wrapper and a local ordinal rebasing function; no shared service or persistence.
- Complexity intentionally avoided: no new map, schema, registry, queue or provider-specific targeting layer.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base 18b498bc49435c49adb99588754a8a2bf72c4ce6`
- Hotspots: existing local-service `run` is 130, down from 131; `runCurrentProviderRequest` remains 63. Debt decreases from 154 to 153.
- Agent judgment: the small native-only wrapper keeps authority bounds explicit. Extracting unrelated orchestration would expand this fix without improving its boundary.

## Hot reply path impact

- Path status: Touched
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved; existing canonical-event reads remain at the same selection and dispatch points.
- Before/after proof: focused tests preserve provider request and delivery counts. The native path uses the existing accepted-input prefix, bounded by the active-turn input limit.

## Murph initial provider input impact

Not applicable for both individual and group Murph: no production instruction, tool schema, generated guidance or provider-visible input surface changed.

## Design proof

- Design page: [Existing changelog archive](https://www.withmurph.ai/screenshots/ops#changelog-archive)
- Evidence: Content-only changelog entry; authored copy reviewed directly. No rendering or interaction changes.
- Coverage: Nine changelog page tests pass through the production archive component.

## Deployment concerns

- Deployment: not applicable
- Reason: assistant-only authority correction with no schema, provider contract or cross-version data change; normal application rollout and rollback suffice.

## Change-shape breakdown

Classification rule: runtime TypeScript is source; assistant test files are tests; architecture/spec/plan are docs; the authored changelog fragment is product content. No generated output or binaries.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 46 | 22 |
| Tests / fixtures | 493 | 0 |
| Docs | 149 | 8 |
| Config / tooling | 0 | 0 |
| Generated / other | 14 | 0 |
| **Total** | **702** | **30** |

## Changelog

- Changelog: updated
- Items: 2026-09-04 · replies-stay-with-earlier-messages

ReviewGPT first-reviewed head: c7247d9b18c61e3fa30aed7fab2eae1579309878
ReviewGPT context sensitivity: sensitive
Classification reason: Native reply authority depends on active-turn admission, ordinal ordering and conversation/provider route ownership.
