### PR TITLE
fix(web): align Family usage-credit lock order

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -2125,7 +2125,10 @@ Last verified: 2026-09-04
   an active purchase and map a different target to status/cancel-only recovery.
   The server projects a departed Family beneficiary as status/cancel-only and
   does not decrypt or serialize its Checkout URL, including when membership
-  changes while a Stripe request is in flight.
+  changes while a Stripe request is in flight. Family admission and terminal
+  reservation release acquire the owner member before a distinct beneficiary,
+  matching subscription reconciliation's owner-then-roster order; the separate
+  hosted-group sponsorship ledger keeps beneficiary-first ordering.
 - Usage-credit fulfillment reuses the Stripe event receipt as its retry owner.
   It verifies live one-time payment state, then appends the unique grant and
   updates the beneficiary balance/version projection in one locked

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -2125,8 +2125,14 @@ Last verified: 2026-09-04
   an active purchase and map a different target to status/cancel-only recovery.
   The server projects a departed Family beneficiary as status/cancel-only and
   does not decrypt or serialize its Checkout URL, including when membership
-  changes while a Stripe request is in flight. Family admission and terminal
-  reservation release acquire the owner member before a distinct beneficiary,
+  changes while a Stripe request is in flight. Stripe Checkout expiry chooses
+  the frozen Family owner at its outer transaction boundary before locking a
+  distinct beneficiary, then revalidates purchase ownership and reconciliation
+  version under those locks. Choosing owner-first only inside a nested release
+  helper cannot reorder a beneficiary lock already acquired by its caller.
+  Detached-payer replay and financial events retain beneficiary ownership.
+  Family admission and terminal reservation release acquire the owner member
+  before a distinct beneficiary,
   matching subscription reconciliation's owner-then-roster order; the separate
   hosted-group sponsorship ledger keeps beneficiary-first ordering.
 - Usage-credit fulfillment reuses the Stripe event receipt as its retry owner.

--- a/agent-docs/SECURITY.md
+++ b/agent-docs/SECURITY.md
@@ -467,8 +467,10 @@ Last verified: 2026-08-31
   after Stripe returns and before decrypting a Checkout URL or projecting retry
   permission, so membership removal during provider I/O degrades to
   status/cancel-only recovery; fulfillment remains bound to the frozen purchase.
-  Family admission first binds the
-  opaque selector to the owner's roster before locking the beneficiary. A
+  Family admission locks the owner before a distinct beneficiary, matching
+  Family subscription reconciliation. It binds the opaque selector to that
+  owner's roster before taking the beneficiary lock. Hosted-group sponsorship
+  remains on its separate beneficiary-first ledger protocol. A
   payer-wide conflict with another frozen target may be inspected or canceled
   but must never return a payable URL or retry permission, regardless of the
   requested or frozen target kind. Active-purchase projection releases a

--- a/agent-docs/exec-plans/completed/2026-09-04-family-usage-credit-lock-order.md
+++ b/agent-docs/exec-plans/completed/2026-09-04-family-usage-credit-lock-order.md
@@ -1,0 +1,54 @@
+# Family usage-credit lock ordering
+
+## Outcome
+
+Make every Family usage-credit checkout path acquire the Family owner member
+before a distinct beneficiary, matching Family subscription reconciliation, so
+the two protocols cannot form a PostgreSQL member-row deadlock.
+
+## Root cause
+
+Family subscription reconciliation locks the owner and then the active roster.
+Usage-credit checkout admission and terminal reservation release currently use
+the generic beneficiary-first purchase protocol. A checkout for a distinct
+Family member can therefore hold the beneficiary while waiting for the owner as
+reconciliation holds the owner while waiting for that beneficiary.
+
+## Scope
+
+- Preserve beneficiary-first ordering for hosted-group sponsorship purchases.
+- Use owner-first ordering for Family purchase admission and every reservation
+  release path that locks both Family member rows.
+- Derive terminal-path ordering from the immutable server-built Family target
+  marker without adding a database field or a new state owner.
+- Add unit order assertions and a real-PostgreSQL opposing-writer regression.
+- Update the durable Family billing lock-order contract.
+
+## Load and complexity
+
+The change adds no query fanout, persisted state, retry loop, or dependency.
+Each affected transaction still locks at most the same two member rows; only
+their acquisition order changes. Family subscription reconciliation remains
+bounded by the existing maximum roster size.
+
+## Risks
+
+1. Applying owner-first order to hosted-group sponsorship could create a new
+   inversion with its beneficiary-owned ledger protocol. Keep target-kind
+   selection explicit and test both branches.
+2. A terminal release path could infer a different target than admission.
+   Derive the order from the frozen Family return marker and keep malformed or
+   legacy non-Family rows on their existing ordering.
+3. A mock-only test could miss a real lock cycle. Interleave both transactions
+   against PostgreSQL with bounded lock and statement timeouts.
+
+## Verification
+
+- [x] Focused usage-credit and Family unit tests (524 passed).
+- [x] Real-PostgreSQL opposing lock-order regression (1 passed).
+- [x] Web typecheck and scoped lint.
+- [x] Complexity/diff/privacy checks.
+- [ ] Exact-head GitHub checks and final ReviewGPT pass.
+Status: completed
+Updated: 2026-09-04
+Completed: 2026-09-04

--- a/agent-docs/exec-plans/completed/2026-09-05-stripe-family-reconciliation-lock-order.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-stripe-family-reconciliation-lock-order.md
@@ -1,0 +1,49 @@
+# Stripe Family reconciliation lock order
+
+Status: completed
+Created: 2026-09-05
+Updated: 2026-09-05
+
+## Outcome and owner
+
+Remove the reachable owner/beneficiary deadlock between Stripe Checkout expiry
+and Family cancellation or account-deletion closure. The existing Stripe
+reconciliation transaction boundary selects the first member from the frozen
+purchase before acquiring locks. Canonical purchase state stays in PostgreSQL.
+
+## Evidence and correction
+
+PR #2883 round 1 correctly found that the outer Stripe wrapper locks the
+beneficiary before the nested Family helper runs. Foreground closure locks the
+owner then beneficiary, forming an opposing cycle. The user resumed remediation.
+Derive the first lock from the existing frozen Family selector, then revalidate
+that selection and the reconciliation version under the member locks. Preserve
+beneficiary-first group sponsorship and financial reconciliation. Detached-payer
+expiry replay retains its beneficiary owner.
+
+No schema, dependency, queue, retry loop, or new transaction abstraction is
+needed. Provider preparation remains outside the transaction; at most two
+existing member rows are locked on one connection. Mixed versions retain the
+same persisted contract; the deadlock fix takes effect when Web is updated.
+
+## Proof and completion
+
+- Add PostgreSQL proof composing the actual Stripe entrypoint and Family closure
+  with independent clients and controlled database lock barriers.
+- Assert provider-final release converges once and deletion readiness succeeds.
+- Run focused unit tests, PostgreSQL regression, Web typecheck, scoped lint,
+  complexity and privacy checks.
+- Update the reliability owner, commit the scoped correction, push PR #2883,
+  start ReviewGPT round 2 concurrently with required CI, and disposition results.
+
+## Local results
+
+- The two full Stripe/closure PostgreSQL races fail on the paused head with
+  PostgreSQL 40P01 deadlock errors and pass with the boundary correction.
+- Focused verification: 58 Stripe unit tests and three PostgreSQL concurrency
+  scenarios passed. Tests include retryable payer detachment, unchanged release
+  on event replay, and deletion readiness plus member/cleanup receipt commit.
+- Web typecheck, scoped ESLint, diff/privacy inspection and complexity guard
+  passed. The reconciliation owner remains below the complexity threshold.
+- Exact-head ReviewGPT round 2 and required CI remain external PR gates.
+Completed: 2026-09-05

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-account-deletion.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-account-deletion.ts
@@ -37,6 +37,7 @@ import {
 } from "./usage-credit-purchase-stripe";
 import {
   lockHostedUsageCreditPurchaseReservationOwnersTx,
+  readHostedUsageCreditPurchaseMemberLockOrder,
 } from "./usage-credit-purchase-reservation-lock";
 import { logHostedStripeFailure } from "./stripe-error-log";
 import {
@@ -97,7 +98,15 @@ export async function closeHostedUsageCreditPurchasesForAccountDeletion(input: {
       const reconciledDirectPayment =
         await cancelHostedUsageCreditDirectPayment({
           ...(purchase.beneficiaryMemberId !== purchase.payerMemberId
-            ? { groupBeneficiaryMemberId: purchase.beneficiaryMemberId }
+            ? {
+                memberLockOrder:
+                  readHostedUsageCreditPurchaseMemberLockOrder({
+                    beneficiaryMemberId: purchase.beneficiaryMemberId,
+                    checkoutSuccessUrl: purchase.checkoutSuccessUrl,
+                    payerMemberId:
+                      requireHostedUsageCreditPurchasePayerMemberId(purchase),
+                  }),
+              }
             : {}),
           now,
           prisma,
@@ -485,6 +494,12 @@ async function persistHostedUsageCreditAccountDeletionSessionState(input: {
     if (providerState === "expired") {
       await lockHostedUsageCreditPurchaseReservationOwnersTx({
         beneficiaryMemberId: input.purchase.beneficiaryMemberId,
+        memberLockOrder:
+          readHostedUsageCreditPurchaseMemberLockOrder({
+            beneficiaryMemberId: input.purchase.beneficiaryMemberId,
+            checkoutSuccessUrl: input.purchase.checkoutSuccessUrl,
+            payerMemberId,
+          }),
         payerMemberId,
         tx,
       });
@@ -607,6 +622,12 @@ async function persistHostedUsageCreditAccountDeletionNoSessionProof(input: {
     );
     await lockHostedUsageCreditPurchaseReservationOwnersTx({
       beneficiaryMemberId: input.purchase.beneficiaryMemberId,
+      memberLockOrder:
+        readHostedUsageCreditPurchaseMemberLockOrder({
+          beneficiaryMemberId: input.purchase.beneficiaryMemberId,
+          checkoutSuccessUrl: input.purchase.checkoutSuccessUrl,
+          payerMemberId,
+        }),
       payerMemberId,
       tx,
     });

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-reservation-lock.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-reservation-lock.ts
@@ -1,18 +1,62 @@
 import type { Prisma } from "@prisma/client";
 
-import { lockHostedUsageCreditBeneficiaryTx } from "../hosted-execution/usage-credit-ledger";
+import {
+  lockHostedUsageCreditBeneficiaryTx,
+  type LockedHostedUsageCreditBeneficiary,
+} from "../hosted-execution/usage-credit-ledger";
 import { lockHostedMemberRow } from "./shared";
+
+export type HostedUsageCreditMemberLockOrder =
+  | "beneficiary_first"
+  | "payer_first";
+
+export function readHostedUsageCreditTargetMemberLockOrder(
+  targetKind: "family" | "group" | "personal",
+): HostedUsageCreditMemberLockOrder {
+  return targetKind === "family" ? "payer_first" : "beneficiary_first";
+}
+
+export function readHostedUsageCreditPurchaseMemberLockOrder(input: {
+  beneficiaryMemberId: string;
+  checkoutSuccessUrl: string;
+  payerMemberId: string;
+}): HostedUsageCreditMemberLockOrder {
+  if (input.beneficiaryMemberId === input.payerMemberId) {
+    return "beneficiary_first";
+  }
+  try {
+    const successUrl = new URL(input.checkoutSuccessUrl);
+    return successUrl.pathname === "/settings"
+        && successUrl.searchParams.has("usageFamily")
+        && successUrl.searchParams.get("usageMember") === input.beneficiaryMemberId
+      ? "payer_first"
+      : "beneficiary_first";
+  } catch {
+    return "beneficiary_first";
+  }
+}
 
 export async function lockHostedUsageCreditPurchaseReservationOwnersTx(input: {
   beneficiaryMemberId: string;
+  memberLockOrder: HostedUsageCreditMemberLockOrder;
   payerMemberId: string;
   tx: Prisma.TransactionClient;
-}): Promise<void> {
-  await lockHostedUsageCreditBeneficiaryTx({
+}): Promise<LockedHostedUsageCreditBeneficiary> {
+  if (
+    input.memberLockOrder === "payer_first"
+    && input.payerMemberId !== input.beneficiaryMemberId
+  ) {
+    await lockHostedMemberRow(input.tx, input.payerMemberId);
+  }
+  const beneficiary = await lockHostedUsageCreditBeneficiaryTx({
     beneficiaryMemberId: input.beneficiaryMemberId,
     tx: input.tx,
   });
-  if (input.payerMemberId !== input.beneficiaryMemberId) {
+  if (
+    input.memberLockOrder === "beneficiary_first"
+    && input.payerMemberId !== input.beneficiaryMemberId
+  ) {
     await lockHostedMemberRow(input.tx, input.payerMemberId);
   }
+  return beneficiary;
 }

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-service.ts
@@ -65,6 +65,7 @@ import {
 } from "./usage-credit-purchase-status-service";
 import {
   lockHostedUsageCreditPurchaseReservationOwnersTx,
+  readHostedUsageCreditTargetMemberLockOrder,
 } from "./usage-credit-purchase-reservation-lock";
 import {
   assertHostedUsageCreditStripePriceMatchesPurchase,
@@ -524,8 +525,11 @@ async function createHostedUsageCreditCheckoutForTarget(input: {
         : null;
     let lockedBeneficiary: LockedHostedUsageCreditBeneficiary;
     try {
-      lockedBeneficiary = await lockHostedUsageCreditBeneficiaryTx({
+      lockedBeneficiary = await lockHostedUsageCreditPurchaseReservationOwnersTx({
         beneficiaryMemberId: input.target.beneficiaryMemberId,
+        memberLockOrder:
+          readHostedUsageCreditTargetMemberLockOrder(input.target.kind),
+        payerMemberId: input.target.payerMemberId,
         tx,
       });
     } catch (error) {
@@ -537,12 +541,6 @@ async function createHostedUsageCreditCheckoutForTarget(input: {
         throw buildHostedUsageCreditNotEligibleError(input.target.kind);
       }
       throw error;
-    }
-    if (
-      input.target.payerMemberId
-        !== lockedBeneficiary.beneficiaryMemberId
-    ) {
-      await lockHostedMemberRow(tx, input.target.payerMemberId);
     }
     const payer = await tx.hostedMember.findUnique({
       select: {
@@ -1613,6 +1611,7 @@ async function bindHostedUsageCreditCheckoutSession(input: {
     if (providerFinalNoPayment) {
       await lockHostedUsageCreditPurchaseReservationOwnersTx({
         beneficiaryMemberId: input.purchase.beneficiaryMemberId,
+        memberLockOrder: readHostedUsageCreditTargetMemberLockOrder(target.kind),
         payerMemberId,
         tx,
       });

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-status-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-purchase-status-service.ts
@@ -34,6 +34,8 @@ import {
 } from "./usage-credit-purchase-stripe";
 import {
   lockHostedUsageCreditPurchaseReservationOwnersTx,
+  readHostedUsageCreditPurchaseMemberLockOrder,
+  readHostedUsageCreditTargetMemberLockOrder,
 } from "./usage-credit-purchase-reservation-lock";
 import { normalizeHostedGroupUsageFundingLocator } from "../hosted-groups/group-usage-funding";
 import { getPrisma } from "../prisma";
@@ -399,8 +401,11 @@ export async function expireHostedUsageCreditCheckout(input: {
   if (canCancelHostedUsageCreditDirectPayment(purchase)) {
     const target = projectHostedUsageCreditPurchaseTarget(purchase);
     const reconciled = await cancelHostedUsageCreditDirectPayment({
-      ...(target.kind === "group"
-        ? { groupBeneficiaryMemberId: target.beneficiaryMemberId }
+      ...(target.kind !== "personal"
+        ? {
+            memberLockOrder:
+              readHostedUsageCreditTargetMemberLockOrder(target.kind),
+          }
         : {}),
       now,
       prisma,
@@ -438,6 +443,11 @@ export async function expireHostedUsageCreditCheckout(input: {
     if (providerState === "expired") {
       await lockHostedUsageCreditPurchaseReservationOwnersTx({
         beneficiaryMemberId: purchase.beneficiaryMemberId,
+        memberLockOrder: readHostedUsageCreditPurchaseMemberLockOrder({
+          beneficiaryMemberId: purchase.beneficiaryMemberId,
+          checkoutSuccessUrl: purchase.checkoutSuccessUrl,
+          payerMemberId: input.payerMemberId,
+        }),
         payerMemberId: input.payerMemberId,
         tx,
       });

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-saved-card-payment.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-saved-card-payment.ts
@@ -38,6 +38,7 @@ import {
 } from "./usage-credit-purchase-stripe";
 import {
   lockHostedUsageCreditPurchaseReservationOwnersTx,
+  type HostedUsageCreditMemberLockOrder,
 } from "./usage-credit-purchase-reservation-lock";
 import {
   HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE,
@@ -992,7 +993,7 @@ export function canCancelHostedUsageCreditDirectPayment(
 }
 
 export async function cancelHostedUsageCreditDirectPayment(input: {
-  groupBeneficiaryMemberId?: string;
+  memberLockOrder?: HostedUsageCreditMemberLockOrder;
   now: Date;
   prisma: PrismaClient;
   purchase: HostedUsageCreditPurchase;
@@ -1016,7 +1017,9 @@ export async function cancelHostedUsageCreditDirectPayment(input: {
   ) {
     return requireHostedUsageCreditDirectPaymentBinding(
       await bindHostedUsageCreditDirectPaymentIntent({
-        groupBeneficiaryMemberId: input.groupBeneficiaryMemberId,
+        ...(input.memberLockOrder
+          ? { memberLockOrder: input.memberLockOrder }
+          : {}),
         now: input.now,
         payerMemberId,
         paymentIntent,
@@ -1038,7 +1041,9 @@ export async function cancelHostedUsageCreditDirectPayment(input: {
   if (canceled.status === "succeeded" || canceled.status === "processing") {
     return requireHostedUsageCreditDirectPaymentBinding(
       await bindHostedUsageCreditDirectPaymentIntent({
-        groupBeneficiaryMemberId: input.groupBeneficiaryMemberId,
+        ...(input.memberLockOrder
+          ? { memberLockOrder: input.memberLockOrder }
+          : {}),
         now: input.now,
         payerMemberId,
         paymentIntent: canceled,
@@ -1054,7 +1059,9 @@ export async function cancelHostedUsageCreditDirectPayment(input: {
     );
   }
   const expired = await transitionCanceledHostedUsageCreditDirectPaymentIntent({
-    groupBeneficiaryMemberId: input.groupBeneficiaryMemberId,
+    ...(input.memberLockOrder
+      ? { memberLockOrder: input.memberLockOrder }
+      : {}),
     now: input.now,
     paymentIntent: canceled,
     prisma: input.prisma,
@@ -1071,7 +1078,7 @@ export async function cancelHostedUsageCreditDirectPayment(input: {
 
 async function transitionCanceledHostedUsageCreditDirectPaymentIntent(input: {
   billingAuthority?: HostedUsageCreditSavedCardBillingAuthority;
-  groupBeneficiaryMemberId?: string;
+  memberLockOrder?: HostedUsageCreditMemberLockOrder;
   now: Date;
   paymentIntent: Stripe.PaymentIntent;
   prisma: PrismaClient;
@@ -1086,22 +1093,20 @@ async function transitionCanceledHostedUsageCreditDirectPaymentIntent(input: {
   const payerMemberId = requireHostedUsageCreditPurchasePayerMemberId(
     input.purchase,
   );
-  const groupBeneficiaryMemberId =
-    input.billingAuthority?.kind === "group"
-      ? input.purchase.beneficiaryMemberId
-      : input.groupBeneficiaryMemberId ??
-        (input.purchase.groupSponsorshipAuthorizationId
-          ? input.purchase.beneficiaryMemberId
-          : null);
+  const memberLockOrder = input.billingAuthority
+    ? input.billingAuthority.kind === "family"
+      ? "payer_first"
+      : input.billingAuthority.kind === "group"
+        ? "beneficiary_first"
+        : undefined
+    : input.memberLockOrder;
   return input.prisma.$transaction(async (tx) => {
-    if (input.transition === "release") {
-      if (groupBeneficiaryMemberId) {
-        await lockHostedMemberRow(tx, groupBeneficiaryMemberId);
-      }
+    if (!memberLockOrder) {
       await lockHostedMemberRow(tx, payerMemberId);
     } else {
       await lockHostedUsageCreditPurchaseReservationOwnersTx({
         beneficiaryMemberId: input.purchase.beneficiaryMemberId,
+        memberLockOrder,
         payerMemberId,
         tx,
       });
@@ -1221,7 +1226,7 @@ async function transitionCanceledHostedUsageCreditDirectPaymentIntent(input: {
 async function bindHostedUsageCreditDirectPaymentIntent(input: {
   billingAuthority?: HostedUsageCreditSavedCardBillingAuthority;
   customerId?: string;
-  groupBeneficiaryMemberId?: string;
+  memberLockOrder?: HostedUsageCreditMemberLockOrder;
   now: Date;
   payerMemberId: string;
   paymentIntent: Stripe.PaymentIntent;
@@ -1240,18 +1245,24 @@ async function bindHostedUsageCreditDirectPaymentIntent(input: {
         "charge",
       )
     : null;
-  const groupBeneficiaryMemberId =
-    input.billingAuthority?.kind === "group"
-      ? input.purchase.beneficiaryMemberId
-      : input.groupBeneficiaryMemberId ??
-        (input.purchase.groupSponsorshipAuthorizationId
-          ? input.purchase.beneficiaryMemberId
-          : null);
+  const memberLockOrder = input.billingAuthority
+    ? input.billingAuthority.kind === "family"
+      ? "payer_first"
+      : input.billingAuthority.kind === "group"
+        ? "beneficiary_first"
+        : undefined
+    : input.memberLockOrder;
   return input.prisma.$transaction(async (tx) => {
-    if (groupBeneficiaryMemberId) {
-      await lockHostedMemberRow(tx, groupBeneficiaryMemberId);
+    if (memberLockOrder) {
+      await lockHostedUsageCreditPurchaseReservationOwnersTx({
+        beneficiaryMemberId: input.purchase.beneficiaryMemberId,
+        memberLockOrder,
+        payerMemberId,
+        tx,
+      });
+    } else {
+      await lockHostedMemberRow(tx, payerMemberId);
     }
-    await lockHostedMemberRow(tx, payerMemberId);
     const current = await tx.hostedUsageCreditPurchase.findUnique({
       where: { id: input.purchase.id },
     });

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-stripe-checkout-reconciliation.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-stripe-checkout-reconciliation.ts
@@ -31,6 +31,7 @@ import {
 } from "./usage-credit-stripe-reconciliation-context";
 import {
   lockHostedUsageCreditPurchaseReservationOwnersTx,
+  readHostedUsageCreditPurchaseMemberLockOrder,
 } from "./usage-credit-purchase-reservation-lock";
 import { requireHostedUsageCreditPurchasePayerMemberId } from "./usage-credit-purchase-stripe";
 
@@ -277,6 +278,13 @@ export async function reconcileHostedUsageCreditCheckoutEventTx(input: {
     }
     await lockHostedUsageCreditPurchaseReservationOwnersTx({
       beneficiaryMemberId: input.purchase.beneficiaryMemberId,
+      memberLockOrder: readHostedUsageCreditPurchaseMemberLockOrder({
+        beneficiaryMemberId: input.purchase.beneficiaryMemberId,
+        checkoutSuccessUrl: input.purchase.checkoutSuccessUrl,
+        payerMemberId: requireHostedUsageCreditPurchasePayerMemberId(
+          input.purchase,
+        ),
+      }),
       payerMemberId: requireHostedUsageCreditPurchasePayerMemberId(
         input.purchase,
       ),

--- a/apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation.ts
+++ b/apps/web/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation.ts
@@ -4,7 +4,8 @@ import type Stripe from "stripe";
 import { coerceStripeObjectId } from "./billing";
 import { withHostedMemberStripeMutationLock } from "./hosted-member-billing-store";
 import { requireHostedStripeApiMode } from "./runtime";
-import { normalizeNullableString } from "./shared";
+import { lockHostedMemberRow, normalizeNullableString } from "./shared";
+import { readHostedUsageCreditPurchaseMemberLockOrder } from "./usage-credit-purchase-reservation-lock";
 import {
   HOSTED_USAGE_CREDIT_CHECKOUT_PURPOSE,
   HOSTED_USAGE_CREDIT_SAVED_CARD_PURPOSE,
@@ -114,6 +115,7 @@ type HostedUsageCreditPreparedReconciliation =
   | {
       candidate: HostedUsageCreditStripeEventCandidate;
       kind: "prepared";
+      firstMemberId: string;
       prepared: HostedUsageCreditPreparedStripeEvent;
     };
 
@@ -144,16 +146,19 @@ export async function reconcileHostedUsageCreditStripeEvent(input: {
   if (preparation.kind === "unhandled") {
     return { handled: false };
   }
-  const { candidate, prepared } = preparation;
+  const { candidate, firstMemberId, prepared } = preparation;
 
   let reconciliation: Awaited<
     ReturnType<typeof reconcileHostedUsageCreditCheckoutEventTx>
   >;
   try {
     reconciliation = await withHostedMemberStripeMutationLock({
-      memberId: candidate.beneficiaryMemberId,
+      memberId: firstMemberId,
       prisma: input.prisma,
       run: async (tx) => {
+        if (firstMemberId !== candidate.beneficiaryMemberId) {
+          await lockHostedMemberRow(tx, candidate.beneficiaryMemberId);
+        }
         const purchase = await runHostedUsageCreditDatabaseOperation({
           read: () => tx.hostedUsageCreditPurchase.findUnique({
             select: HOSTED_USAGE_CREDIT_PURCHASE_SELECT,
@@ -171,7 +176,8 @@ export async function reconcileHostedUsageCreditStripeEvent(input: {
           );
         }
         if (
-          purchase.reconciliationVersion !== prepared.reconciliationVersion
+          purchase.reconciliationVersion !== prepared.reconciliationVersion ||
+          readStripeReconciliationFirstMemberId(input.event, purchase) !== firstMemberId
         ) {
           throw buildHostedUsageCreditStripeRetryableError(
             new Error(
@@ -224,6 +230,26 @@ export async function reconcileHostedUsageCreditStripeEvent(input: {
   };
 }
 
+// Choose before the transaction wrapper takes its first member lock. A nested
+// reservation helper cannot reorder a beneficiary lock already held by Stripe.
+function readStripeReconciliationFirstMemberId(
+  event: Stripe.Event,
+  purchase: HostedUsageCreditPurchaseForReconciliation,
+): string {
+  if (
+    event.type === "checkout.session.expired" &&
+    purchase.payerMemberId &&
+    readHostedUsageCreditPurchaseMemberLockOrder({
+      beneficiaryMemberId: purchase.beneficiaryMemberId,
+      checkoutSuccessUrl: purchase.checkoutSuccessUrl,
+      payerMemberId: purchase.payerMemberId,
+    }) === "payer_first"
+  ) {
+    return purchase.payerMemberId;
+  }
+  return purchase.beneficiaryMemberId;
+}
+
 async function prepareHostedUsageCreditStripeReconciliation(input: {
   context: HostedUsageCreditStripePreparationContext;
   event: Stripe.Event;
@@ -267,6 +293,7 @@ async function prepareHostedUsageCreditStripeReconciliation(input: {
     return {
       candidate,
       kind: "prepared",
+      firstMemberId: readStripeReconciliationFirstMemberId(input.event, purchase),
       prepared,
     };
   }

--- a/apps/web/test/hosted-family-plan.test.ts
+++ b/apps/web/test/hosted-family-plan.test.ts
@@ -5793,6 +5793,17 @@ describe("hosted Family plan", () => {
       groupId: "hbag_family",
     });
 
+    expect(tx.$queryRaw).toHaveBeenNthCalledWith(
+      1,
+      expect.arrayContaining([expect.stringContaining('from "hosted_member"')]),
+      "member_owner",
+    );
+    expect(tx.$queryRaw).toHaveBeenNthCalledWith(
+      2,
+      expect.arrayContaining([expect.stringContaining('from "hosted_member"')]),
+      "member_mom",
+    );
+
     expect(tx.hostedAccountGroupBillingRef.upsert).toHaveBeenCalledWith(expect.objectContaining({
       create: expect.objectContaining({
         billedSeatCount: 4,

--- a/apps/web/test/hosted-usage-credit-postgres-concurrency.test.ts
+++ b/apps/web/test/hosted-usage-credit-postgres-concurrency.test.ts
@@ -13,6 +13,12 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const usageCreditFinancialStripeMocks = vi.hoisted(() => ({
   stripe: {
+    checkout: {
+      sessions: {
+        retrieve: vi.fn(),
+        listLineItems: vi.fn(),
+      },
+    },
     charges: {
       retrieve: vi.fn(),
     },
@@ -83,6 +89,7 @@ import {
   createHostedPhoneLookupKey,
   createHostedStripeBillingEventLookupKey,
   createHostedStripeCustomerLookupKey,
+  createHostedStripeCheckoutSessionLookupKey,
   createHostedStripePriceLookupKey,
 } from "@/src/lib/hosted-onboarding/contact-privacy";
 import {
@@ -91,10 +98,13 @@ import {
 import {
   upsertHostedMemberHomeLinqBindingTx,
 } from "@/src/lib/hosted-onboarding/hosted-member-routing-store";
-import { assertHostedUsageCreditPurchasesReadyForAccountDeletionTx } from "@/src/lib/hosted-onboarding/usage-credit-purchase-account-deletion";
+import { assertHostedUsageCreditPurchasesReadyForAccountDeletionTx, closeHostedUsageCreditPurchasesForAccountDeletion } from "@/src/lib/hosted-onboarding/usage-credit-purchase-account-deletion";
 import {
   lockHostedUsageCreditPurchaseReservationOwnersTx,
 } from "@/src/lib/hosted-onboarding/usage-credit-purchase-reservation-lock";
+import { requireHostedUsageCreditLookupKey } from "@/src/lib/hosted-onboarding/usage-credit-purchase-stripe";
+import { expireHostedUsageCreditCheckout } from "@/src/lib/hosted-onboarding/usage-credit-purchase-status-service";
+import { persistHostedAccountDeletionCleanupTx } from "@/src/lib/hosted-privacy/account-deletion-cleanup";
 import { bindHostedUsageCreditStripeReferencesTx } from "@/src/lib/hosted-onboarding/usage-credit-stripe-reconciliation-context";
 import {
   isHostedUsageCreditStripeRetryableError,
@@ -5336,6 +5346,213 @@ describe.skipIf(!runPostgresConcurrencyProof)(
         await observer.$disconnect();
       }
     });
+
+    it.each(["cancellation", "account deletion"] as const)(
+      "serializes full Stripe expiry with Family %s and releases once",
+      async (closureKind) => {
+        const fixture = await createUsageCreditFixture({ crossOwner: true });
+        const closurePrepared = createDeferred();
+        const allowClosureProvider = createDeferred();
+        const stripeLocked = createDeferred();
+        const allowStripe = createDeferred();
+        const now = new Date("2026-07-16T12:31:00.000Z");
+        const sessionId = `cs_family_${randomUUID()}`;
+        const customerId = `cus_family_${randomUUID()}`;
+        const priceId = `price_family_${randomUUID()}`;
+        const cleanupId = `hbadc_family_${randomUUID()}`;
+        const successUrl = new URL("https://example.test/settings");
+        successUrl.searchParams.set("usageFamily", "return");
+        successUrl.searchParams.set("usageMember", fixture.beneficiaryMemberId);
+        let operations: Promise<PromiseSettledResult<unknown>[]> | undefined;
+        setHostedSecureBoxStringTestCodecForTests({
+          decrypt: (input) => input.value,
+          encrypt: (input) => input.value,
+        });
+        try {
+          const purchase = await fixture.observer.hostedUsageCreditPurchase.update({
+            data: {
+              id: `hucp_${randomUUID().replaceAll("-", "").slice(0, 16)}`,
+              checkoutSuccessUrl: successUrl.href,
+              status: "checkout_open",
+              stripeCheckoutSessionIdEncrypted: sessionId,
+              stripeCheckoutSessionLookupKey:
+                createHostedStripeCheckoutSessionLookupKey(sessionId),
+              stripeCustomerIdEncrypted: customerId,
+              stripeCustomerLookupKey: requireHostedUsageCreditLookupKey(
+                createHostedStripeCustomerLookupKey(customerId), "customer",
+              ),
+              stripePriceIdEncrypted: priceId,
+              stripePriceLookupKey: requireHostedUsageCreditLookupKey(
+                createHostedStripePriceLookupKey(priceId), "price",
+              ),
+            },
+            where: { id: fixture.purchaseId },
+          });
+          fixture.purchaseId = purchase.id;
+          const session = defineStripeFixture<Stripe.Checkout.Session>({
+            adaptive_pricing: { enabled: false },
+            amount_subtotal: 500,
+            amount_total: 500,
+            cancel_url: purchase.checkoutCancelUrl,
+            client_reference_id: purchase.id,
+            currency: "usd",
+            customer: customerId,
+            expires_at: Math.floor(purchase.checkoutExpiresAt.getTime() / 1000),
+            id: sessionId,
+            livemode: false,
+            metadata: {
+              policyVersion: purchase.checkoutRequestPolicyVersion,
+              purchaseId: purchase.id,
+              purpose: "hosted_usage_credit",
+            },
+            mode: "payment",
+            object: "checkout.session",
+            payment_intent: null,
+            payment_status: "unpaid",
+            status: "expired",
+            success_url: purchase.checkoutSuccessUrl,
+          });
+          usageCreditFinancialStripeMocks.stripe.checkout.sessions.retrieve
+            .mockReset()
+            .mockResolvedValue(session)
+            .mockImplementationOnce(async () => {
+              closurePrepared.resolve();
+              await allowClosureProvider.promise;
+              return session;
+            });
+          usageCreditFinancialStripeMocks.stripe.checkout.sessions.listLineItems
+            .mockResolvedValue({
+              data: [{ quantity: 1, price: { id: priceId } }],
+              has_more: false,
+              object: "list",
+              url: "/v1/checkout/sessions/line_items",
+            });
+          const event = defineStripeFixture<Stripe.Event>({
+            created: Math.floor(now.getTime() / 1000),
+            data: { object: session },
+            id: `evt_family_${randomUUID()}`,
+            livemode: false,
+            object: "event",
+            type: "checkout.session.expired",
+          });
+          // Pause after the real wrapper's first lock, without substituting any
+          // SQL or lock owner. The old wrapper holds the beneficiary here.
+          const stripeClient = new Proxy(fixture.secondClient, {
+            get(target, property) {
+              if (property === "$transaction") {
+                return (run: (tx: Prisma.TransactionClient) => Promise<unknown>) =>
+                  target.$transaction(async (tx) => {
+                    let firstQuery = true;
+                    return run(new Proxy(tx, {
+                      get(transaction, key) {
+                        if (key === "$queryRaw") {
+                          return async (...args: Parameters<typeof tx.$queryRaw>) => {
+                            const rows = await transaction.$queryRaw(...args);
+                            if (firstQuery) {
+                              firstQuery = false;
+                              stripeLocked.resolve();
+                              await allowStripe.promise;
+                            }
+                            return rows;
+                          };
+                        }
+                        const value = Reflect.get(transaction, key, transaction);
+                        return typeof value === "function" ? value.bind(transaction) : value;
+                      },
+                    }));
+                  }, transactionOptions);
+              }
+              const value = Reflect.get(target, property, target);
+              return typeof value === "function" ? value.bind(target) : value;
+            },
+          });
+          if (closureKind === "account deletion") {
+            await fixture.observer.hostedMember.update({
+              data: { suspendedAt: now },
+              where: { id: fixture.payerMemberId },
+            });
+          }
+          const closurePid = await readBackendPid(fixture.firstClient);
+          const closure = closureKind === "account deletion"
+            ? closeHostedUsageCreditPurchasesForAccountDeletion({
+                memberIds: [fixture.payerMemberId], now, prisma: fixture.firstClient,
+              })
+            : expireHostedUsageCreditCheckout({
+                now, payerMemberId: fixture.payerMemberId,
+                prisma: fixture.firstClient, purchaseId: fixture.purchaseId,
+              });
+          operations = Promise.allSettled([closure]);
+          await Promise.race([closurePrepared.promise, closure]);
+          const reconciliation = reconcileHostedUsageCreditStripeEvent({
+            event, prisma: stripeClient,
+          });
+          operations = Promise.allSettled([closure, reconciliation]);
+          await Promise.race([stripeLocked.promise, reconciliation]);
+          allowClosureProvider.resolve();
+          await waitForBlockedBackend({ observer: fixture.observer, pid: closurePid });
+          allowStripe.resolve();
+          const results = await operations;
+          expect(results).toEqual([
+            expect.objectContaining({ status: "fulfilled" }),
+            expect.objectContaining({ status: "fulfilled" }),
+          ]);
+          const released = await fixture.observer.hostedUsageCreditPurchase.findUniqueOrThrow({
+            where: { id: purchase.id },
+          });
+          expect(released.status).toBe("expired");
+          expect(released.grantSlotReleasedAt).toBeInstanceOf(Date);
+          expect(released.reconciliationVersion).toBe(1n);
+          await reconcileHostedUsageCreditStripeEvent({ event, prisma: fixture.secondClient });
+          expect(await fixture.observer.hostedUsageCreditPurchase.findUniqueOrThrow({
+            select: { grantSlotReleasedAt: true, reconciliationVersion: true },
+            where: { id: purchase.id },
+          })).toEqual({ grantSlotReleasedAt: released.grantSlotReleasedAt, reconciliationVersion: 1n });
+
+          if (closureKind === "account deletion") {
+            // Exercise the production deletion guard and receipt persistence in
+            // the same final commit as member deletion; only KMS output is synthetic.
+            await fixture.firstClient.$transaction(async (tx) => {
+              await assertHostedUsageCreditPurchasesReadyForAccountDeletionTx({
+                memberIds: [fixture.payerMemberId], now, prisma: tx,
+              });
+              await persistHostedAccountDeletionCleanupTx({
+                cleanup: {
+                  cloudflareCompletedAt: null, environment: "test", id: cleanupId,
+                  kmsKeyName: "projects/test/locations/global/keyRings/test/cryptoKeys/test",
+                  nextAttemptAt: now, payloadCiphertext: "synthetic-kms-ciphertext",
+                  privyCompletedAt: now, privyUserLookupKey: null,
+                  runtimeLogsCompletedAt: null, runtimeMemberIds: [fixture.payerMemberId],
+                  stripeCustomerIds: [customerId], stripeCompletedAt: null,
+                  stripeSubscriptionIds: [], temporalCompletedAt: null, temporalNextRuntimeIndex: 0,
+                },
+                prisma: tx,
+              });
+              await tx.hostedMember.delete({ where: { id: fixture.payerMemberId } });
+            }, transactionOptions);
+            expect(await fixture.observer.hostedMember.findUnique({
+              where: { id: fixture.payerMemberId },
+            })).toBeNull();
+            expect(await fixture.observer.hostedAccountDeletionCleanup.findUnique({
+              select: { id: true }, where: { id: cleanupId },
+            })).toEqual({ id: cleanupId });
+            await expect(reconcileHostedUsageCreditStripeEvent({
+              event, prisma: fixture.secondClient,
+            })).resolves.toMatchObject({ handled: true, granted: false });
+          }
+        } finally {
+          allowClosureProvider.resolve();
+          allowStripe.resolve();
+          await operations;
+          setHostedSecureBoxStringTestCodecForTests(null);
+          await fixture.observer.hostedAccountDeletionCleanup.updateMany({
+            data: { runtimeLogsCompletedAt: now, temporalCompletedAt: now },
+            where: { id: cleanupId },
+          });
+          await fixture.observer.hostedAccountDeletionCleanup.deleteMany({ where: { id: cleanupId } });
+          await cleanupUsageCreditFixture(fixture);
+        }
+      },
+    );
 
     it("serializes Family reservation release behind owner-first subscription locking", async () => {
       const fixtureId = randomUUID();

--- a/apps/web/test/hosted-usage-credit-postgres-concurrency.test.ts
+++ b/apps/web/test/hosted-usage-credit-postgres-concurrency.test.ts
@@ -3095,6 +3095,7 @@ describe.skipIf(!runPostgresConcurrencyProof)(
           releasePid.resolve(await readBackendPid(tx));
           await lockHostedUsageCreditPurchaseReservationOwnersTx({
             beneficiaryMemberId: fixture.beneficiaryMemberId,
+            memberLockOrder: "beneficiary_first",
             payerMemberId: fixture.payerMemberId,
             tx,
           });
@@ -3198,6 +3199,7 @@ describe.skipIf(!runPostgresConcurrencyProof)(
         await expect(fixture.firstClient.$transaction(async (tx) => {
           await lockHostedUsageCreditPurchaseReservationOwnersTx({
             beneficiaryMemberId: fixture.beneficiaryMemberId,
+            memberLockOrder: "beneficiary_first",
             payerMemberId: fixture.payerMemberId,
             tx,
           });
@@ -3333,6 +3335,7 @@ describe.skipIf(!runPostgresConcurrencyProof)(
         await fixture.secondClient.$transaction(async (tx) => {
           await lockHostedUsageCreditPurchaseReservationOwnersTx({
             beneficiaryMemberId: fixture.beneficiaryMemberId,
+            memberLockOrder: "beneficiary_first",
             payerMemberId: fixture.payerMemberId,
             tx,
           });
@@ -5331,6 +5334,80 @@ describe.skipIf(!runPostgresConcurrencyProof)(
           where: { id: { in: [beneficiaryMemberId, payerMemberId] } },
         }).catch(() => undefined);
         await observer.$disconnect();
+      }
+    });
+
+    it("serializes Family reservation release behind owner-first subscription locking", async () => {
+      const fixtureId = randomUUID();
+      const beneficiaryMemberId = `member_family_credit_beneficiary_${fixtureId}`;
+      const ownerMemberId = `member_family_credit_owner_${fixtureId}`;
+      const observer = createPrismaClient({ databaseUrl, poolMax: 1 });
+      const subscriptionClient = createPrismaClient({ databaseUrl, poolMax: 1 });
+      const releaseClient = createPrismaClient({ databaseUrl, poolMax: 1 });
+      const ownerLocked = createDeferred();
+      const releaseSubscription = createDeferred();
+      const reservationReleaseStarted = createDeferred<number>();
+
+      try {
+        await observer.hostedMember.createMany({
+          data: [
+            { billingStatus: "active", id: beneficiaryMemberId },
+            { billingStatus: "active", id: ownerMemberId },
+          ],
+        });
+
+        const subscriptionReconciliation = subscriptionClient.$transaction(
+          async (tx) => {
+            await tx.$queryRaw`
+              SELECT id
+              FROM hosted_member
+              WHERE id = ${ownerMemberId}
+              FOR UPDATE
+            `;
+            ownerLocked.resolve();
+            await releaseSubscription.promise;
+            await tx.$queryRaw`
+              SELECT id
+              FROM hosted_member
+              WHERE id = ${beneficiaryMemberId}
+              FOR UPDATE
+            `;
+            return "subscription" as const;
+          },
+          transactionOptions,
+        );
+        await ownerLocked.promise;
+
+        const reservationRelease = releaseClient.$transaction(async (tx) => {
+          reservationReleaseStarted.resolve(await readBackendPid(tx));
+          await lockHostedUsageCreditPurchaseReservationOwnersTx({
+            beneficiaryMemberId,
+            memberLockOrder: "payer_first",
+            payerMemberId: ownerMemberId,
+            tx,
+          });
+          return "release" as const;
+        }, transactionOptions);
+        await waitForBlockedBackend({
+          observer,
+          pid: await reservationReleaseStarted.promise,
+        });
+
+        releaseSubscription.resolve();
+        await expect(Promise.all([
+          subscriptionReconciliation,
+          reservationRelease,
+        ])).resolves.toEqual(["subscription", "release"]);
+      } finally {
+        releaseSubscription.resolve();
+        await observer.hostedMember.deleteMany({
+          where: { id: { in: [beneficiaryMemberId, ownerMemberId] } },
+        }).catch(() => undefined);
+        await Promise.all([
+          observer.$disconnect(),
+          releaseClient.$disconnect(),
+          subscriptionClient.$disconnect(),
+        ]);
       }
     });
 

--- a/apps/web/test/hosted-usage-credit-purchase-service.test.ts
+++ b/apps/web/test/hosted-usage-credit-purchase-service.test.ts
@@ -206,6 +206,9 @@ import {
   hostedUsageCreditPolicySupportsSavedCardTarget,
 } from "@/src/lib/hosted-onboarding/usage-credit-offers";
 import {
+  readHostedUsageCreditPurchaseMemberLockOrder,
+} from "@/src/lib/hosted-onboarding/usage-credit-purchase-reservation-lock";
+import {
   HOSTED_USAGE_CREDIT_CAPACITY_CONFLICT_CODE,
   HOSTED_USAGE_CREDIT_CAPACITY_CONFLICT_MESSAGE,
 } from "@/src/lib/hosted-onboarding/usage-credit-capacity-conflict";
@@ -215,6 +218,29 @@ const GROUP_REFILL_RECOVERY_NOW = new Date("2026-08-01T12:00:00.000Z");
 const LAST_STRIPE_EVENT_AT = new Date("2026-07-16T16:59:00.000Z");
 const MEMBER_ID = "hbm_member123";
 const CLIENT_REQUEST_KEY = "request_key_123456";
+
+describe("usage-credit purchase member lock order", () => {
+  it("recognizes only a distinct Family return marker as owner-first", () => {
+    expect(readHostedUsageCreditPurchaseMemberLockOrder({
+      beneficiaryMemberId: "hbm_familymember1",
+      checkoutSuccessUrl:
+        "https://example.test/settings?usageCheckout=success&usageFamily=hbag_abcdefghijklmnop&usageMember=hbm_familymember1&usagePurchase=hucp_abcdefghijklmnop#family",
+      payerMemberId: MEMBER_ID,
+    })).toBe("payer_first");
+    expect(readHostedUsageCreditPurchaseMemberLockOrder({
+      beneficiaryMemberId: "member_group_runtime",
+      checkoutSuccessUrl:
+        "https://example.test/groups/fund/group_join_code_1234?usageCheckout=success&usagePurchase=hucp_abcdefghijklmnop",
+      payerMemberId: MEMBER_ID,
+    })).toBe("beneficiary_first");
+    expect(readHostedUsageCreditPurchaseMemberLockOrder({
+      beneficiaryMemberId: MEMBER_ID,
+      checkoutSuccessUrl:
+        "https://example.test/settings?usageCheckout=success&usageFamily=hbag_abcdefghijklmnop&usageMember=hbm_familymember1&usagePurchase=hucp_abcdefghijklmnop#family",
+      payerMemberId: MEMBER_ID,
+    })).toBe("beneficiary_first");
+  });
+});
 
 function buildPersonalSavedCardBillingSnapshot(input?: {
   billingStatus?: "active" | "canceled";
@@ -565,7 +591,7 @@ describe("parseHostedGroupSponsorshipCheckoutRequest", () => {
 });
 
 describe("createHostedUsageCreditCheckout", () => {
-  it("admits a new Family checkout with 31 combined occupied slots under beneficiary-first locking", async () => {
+  it("admits a new Family checkout with 31 combined occupied slots under owner-first locking", async () => {
     const usageCreditEvents: string[] = [];
     const fake = createFakePrisma({
       occupiedUsageCreditSlotCount: 31,
@@ -588,8 +614,8 @@ describe("createHostedUsageCreditCheckout", () => {
     })).resolves.toMatchObject({ status: "checkout_open" });
 
     expect(usageCreditEvents).toEqual([
-      "beneficiary-lock",
       "payer-lock",
+      "beneficiary-lock",
       "capacity-read",
       "purchase-create",
     ]);
@@ -649,8 +675,8 @@ describe("createHostedUsageCreditCheckout", () => {
 
     expect(released).toMatchObject({ status: "expired" });
     expect(usageCreditEvents).toEqual([
-      "beneficiary-lock",
       `payer-lock:${MEMBER_ID}`,
+      "beneficiary-lock",
       `payer-lock:${MEMBER_ID}`,
     ]);
     expect(fake.purchases.get(released.purchaseId)).toMatchObject({

--- a/apps/web/test/hosted-usage-credit-stripe-reconciliation.test.ts
+++ b/apps/web/test/hosted-usage-credit-stripe-reconciliation.test.ts
@@ -85,10 +85,16 @@ vi.mock("@/src/lib/hosted-onboarding/hosted-member-billing-store", () => ({
 
 vi.mock(
   "@/src/lib/hosted-onboarding/usage-credit-purchase-reservation-lock",
-  () => ({
-    lockHostedUsageCreditPurchaseReservationOwnersTx:
-      mocks.lockPurchaseReservationOwners,
-  }),
+  async (importOriginal) => {
+    const original = await importOriginal<typeof import(
+      "../src/lib/hosted-onboarding/usage-credit-purchase-reservation-lock"
+    )>();
+    return {
+      ...original,
+      lockHostedUsageCreditPurchaseReservationOwnersTx:
+        mocks.lockPurchaseReservationOwners,
+    };
+  },
 );
 
 vi.mock("@/src/lib/hosted-onboarding/runtime", () => ({
@@ -789,6 +795,7 @@ describe("hosted usage-credit Stripe reconciliation", () => {
     }));
     expect(mocks.lockPurchaseReservationOwners).toHaveBeenLastCalledWith({
       beneficiaryMemberId: "member_beneficiary",
+      memberLockOrder: "beneficiary_first",
       payerMemberId: "member_payer",
       tx: harness.client,
     });

--- a/apps/web/test/hosted-usage-credit-stripe-reconciliation.test.ts
+++ b/apps/web/test/hosted-usage-credit-stripe-reconciliation.test.ts
@@ -143,6 +143,7 @@ type MutableUsageCreditPurchase = ReturnType<typeof makeUsageCreditPurchase>;
 type UsageCreditStripeLookupFilter = string | { in: string[] };
 
 type UsageCreditStripePrismaHarnessClient = {
+  $queryRaw: () => Promise<unknown[]>;
   $transaction: <T>(
     callback: (tx: UsageCreditStripePrismaHarnessClient) => Promise<T>,
   ) => Promise<T>;
@@ -815,6 +816,31 @@ describe("hosted usage-credit Stripe reconciliation", () => {
       harness.client.hostedUsageCreditPurchase.updateMany,
     );
     expect(updateMany).toHaveBeenCalledOnce();
+    expect(mocks.grantUsageCredit).not.toHaveBeenCalled();
+  });
+
+  it("retries when Family payer detachment changes the prepared lock owner", async () => {
+    const successUrl = "https://murph.example/settings?usageFamily=return&usageMember=member_beneficiary";
+    const harness = createUsageCreditStripePrismaHarness({
+      checkoutSuccessUrl: successUrl,
+    }, {
+      beforeTransaction: () => {
+        harness.purchase.payerMemberId = null;
+      },
+    });
+    mocks.stripe.checkout.sessions.retrieve.mockResolvedValue({
+      ...makeCheckoutSession({
+        paymentIntentId: null, paymentStatus: "unpaid", status: "expired",
+      }),
+      success_url: successUrl,
+    });
+
+    await expect(reconcileHostedUsageCreditStripeEvent({
+      event: makeCheckoutEvent("checkout.session.expired"),
+      prisma: harness.client,
+    })).rejects.toSatisfy(isHostedUsageCreditStripeRetryableError);
+    expect(harness.client.hostedUsageCreditPurchase.updateMany).not.toHaveBeenCalled();
+    expect(mocks.lockPurchaseReservationOwners).not.toHaveBeenCalled();
     expect(mocks.grantUsageCredit).not.toHaveBeenCalled();
   });
 
@@ -1903,6 +1929,7 @@ function createUsageCreditStripePrismaHarness(
   const purchaseExists = options?.purchaseExists ?? true;
   let transactionCall = 0;
   const client: UsageCreditStripePrismaHarnessClient = {
+    $queryRaw: vi.fn(async () => []),
     $transaction: vi.fn(async (callback) => {
       transactionCall += 1;
       await options?.beforeTransaction?.(transactionCall);

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -2031,7 +2031,7 @@ describe("hosted web production migration guard", () => {
     assert.match(productionNextBuildScript, /^#!\/usr\/bin\/env bash\nset -euo pipefail$/mu);
     assert.match(productionNextBuildScript, /parent_old_space_mb=1024/u);
     assert.match(productionNextBuildScript, /build_worker_old_space_mb=3072/u);
-    assert.match(productionNextBuildScript, /typecheck_old_space_mb=3584/u);
+    assert.match(productionNextBuildScript, /typecheck_old_space_mb=6144/u);
     assert.match(
       productionNextBuildScript,
       /build_cache_epoch=webpack-next-16\.3-v6-isolated-worker-no-webpack-cache/u,


### PR DESCRIPTION
## Why and outcome

Family usage-credit checkout could lock a beneficiary member and then the Family owner while subscription reconciliation locked the same rows owner-first. This change makes distinct Family purchase paths owner-first, including the outer Stripe expiry transaction before it can lock the beneficiary. Hosted-group sponsorship retains its beneficiary-first protocol.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Family owners and members keep the same top-up, recovery, cancellation, and fulfillment behavior. The only observable difference is removal of a latent deadlock under concurrent Family billing reconciliation.

## Evidence

- Direct: The original focused usage-credit/Family suite passed 524 tests. Remediation passed 58 Stripe unit tests and three PostgreSQL concurrency scenarios. The actual Stripe entrypoint races Family cancellation and account-deletion closure; both new tests reproduce PostgreSQL 40P01 deadlocks on the previous head and pass after the fix. Release replay is unchanged, and the deletion guard plus member deletion and durable cleanup receipt commit succeed. Provider and KMS edges use synthetic fixtures.
- Coverage: Web typecheck passed; scoped ESLint passed; complexity diff passed with source debt reduced; diff and privacy checks passed.

## Non-obvious affected surfaces

Terminal Checkout expiry, saved-card cancellation/binding, account-deletion convergence, and Stripe reconciliation all share the purchase member-row lock helper. Frozen legacy and non-Family return shapes retain beneficiary-first behavior; exact Family return markers select owner-first behavior.

## Architecture and reuse

- Existing systems reused: Family subscription owner-then-roster protocol, hosted member row lock, usage-credit beneficiary ledger lock, frozen checkout return target, and existing transaction owner.
- New logic: Explicit acquisition order in the existing purchase helper and first-member selection at the outer Stripe expiry boundary, derived from the frozen Family marker and revalidated with the purchase version under locks.
- New abstractions: The existing owner-local purchase lock helper now owns the explicit two-protocol order; no persisted state, service, or shared lifecycle owner was added.
- Complexity intentionally avoided: No deadlock retry, lease, queue, schema migration, provider change, or pool-size change.

## Complexity impact

- Guard: pass — pnpm complexity:diff; changed source complexity debt decreased by two overall and no file increased debt above the threshold.
- Hotspots: Existing purchase and saved-card hotspots remain; both decreased or held steady.
- Agent judgment: The purchase lock helper defines Family ordering; Stripe selects the first lock at its existing outer transaction boundary. No new transaction wrapper or lock manager is needed.

## Hot reply path impact

- Path status: Not applicable — Family billing and usage-credit management are authenticated billing paths, not current-message reply handoff.
- Database calls: Family Stripe expiry adds one member-lock statement at the outer boundary; it uses one transaction/connection and the same two distinct member rows. No collection fanout is added.
- Network/provider calls: None added or moved.
- Other awaited latency: Contended Family operations serialize instead of deadlocking.
- Before/after proof: The full Stripe/closure PostgreSQL races fail on the previous head with 40P01 and pass with the fix, including stable release replay and the account-deletion receipt commit.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

ReviewGPT first-reviewed head: 2b4d1b92e1f13dae6f24fd214c388b9db668bc12
ReviewGPT context sensitivity: sensitive
Classification reason: Production billing transaction lock order changed across Family, Stripe, and account-deletion paths.

## Deployment concerns

- Deployment: not applicable
- Reason: Web-only transaction ordering change with no schema, configuration, cross-service protocol, or mixed-version dependency.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source, focused Vitest is tests, and reliability/security contracts plus the completed plan are docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 165 | 45 |
| Tests / fixtures | 373 | 8 |
| Docs | 117 | 3 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **655** | **56** |

## Changelog

- Changelog: not applicable
- Reason: Internal concurrency reliability with no new member-visible capability, interaction, or supportable performance claim.
## Review and CI follow-up

ReviewGPT round 2 PASS on 0f9bcff77e4f61df7b7d8620adfac883e0fefb01: the accepted outer Stripe lock-order finding is resolved. Native capture verifies GPT-6 Pro and response hash 4ec4913c7afc0d2b41f7242c7b4cd19bd01cb8d8573cda1bbe5a0bf179d843cf. The full snapshot was attached and the completed review inspected the cumulative lock paths and concurrency proof. Approximately seven minutes of review falls within the documented discretionary timing band; accepted based on the verified identity, full attachment and substantive path-specific analysis. [Review conversation](https://chatgpt.com/c/6a9baf31-9094-83e9-89db-7547cc3e3b00).

The subsequent isolated test correction aligns the build-memory assertion with the already-existing 6144 MiB policy. Production behavior is unchanged, so the documented nonproduction follow-up exception applies. The migration guard suite and Web typecheck pass; all required CI, including the Release aggregate and Temporal compatibility, is green on e99abfad4e061d8f83ae9d3420d100a0ca100ba6. Current-base merge-tree proof is clean.
