### PR TITLE
Bound persistent Webpack cache memory during CI builds

### DIFF
--- a/.github/workflows/host-support.yml
+++ b/.github/workflows/host-support.yml
@@ -388,6 +388,7 @@ jobs:
     timeout-minutes: 45
     env:
       MURPH_HOSTED_WEB_VERIFY_LANE: build
+      MURPH_HOSTED_WEB_WEBPACK_CACHE: "1"
       MURPH_HOSTED_WEB_VERIFY_SKIP_TYPECHECK: "1"
       MURPH_VERIFY_STEP_PARALLEL: "1"
     steps:

--- a/agent-docs/exec-plans/active/2026-09-04-temporal-ci-speed.md
+++ b/agent-docs/exec-plans/active/2026-09-04-temporal-ci-speed.md
@@ -35,3 +35,7 @@ Focused Web tests (53) and harness tests (52), Web/harness typechecks, and the c
 Private controller fixtures also passed unchanged assertions with two concurrent isolated subprocesses: 127 tests in 742 seconds versus the local serial baseline of 1674 seconds (56% less wall time). All 687 private Temporal coverage tests passed with two file workers. This is separate from the hosted E2E critical path and does not establish under-ten-minute release admission.
 
 Prepared candidates proceed through exact-head PR/CI review; public support must land before private consumption. The initial ReviewGPT consultation is design input, not a final PR gate. The complete admission performance target remains open until measured in private GitHub CI.
+
+## Cached compiler memory follow-up
+
+A real isolated Web CI build exhausted the existing 3 GB compiler heap with persistent caching enabled. Next configures an unlimited additional memory cache for production. The follow-up retains disk caching while setting `maxMemoryGenerations: 0`, and explicitly exercises that opt-in in hosted-Web CI under the existing memory guard and heap limits. Full private integration and cold/warm performance validation remain required; the ten-minute goal is still unproven.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -312,6 +312,15 @@ export function configureHostedWebWebpack(
     // Vercel keeps cold compilation. CI jobs that persist the compiler cache
     // explicitly opt in and let Webpack validate its source dependencies.
     config.cache = false;
+  } else if (
+    !context.dev
+    && config.cache
+    && typeof config.cache === "object"
+    && "type" in config.cache
+    && config.cache.type === "filesystem"
+  ) {
+    // Disk reuse must fit the same bounded compiler heap as cold compilation.
+    Object.assign(config.cache, { maxMemoryGenerations: 0 });
   }
 
   if (!hasOptionalModule("@farcaster/mini-app-solana")) {

--- a/apps/web/test/next-config.test.ts
+++ b/apps/web/test/next-config.test.ts
@@ -654,6 +654,7 @@ test("the Webpack callback retains Next compiler caching only for explicit CI op
   const cache = {
     type: "filesystem",
     version: "next-owned",
+    maxMemoryGenerations: Infinity,
     buildDependencies: { config: ["next.config.ts"] },
   };
   for (const value of [undefined, "0", "true", "1"]) {
@@ -665,11 +666,14 @@ test("the Webpack callback retains Next compiler caching only for explicit CI op
     assert(webpack);
     webpack(config, { dev: false } as Parameters<typeof webpack>[1]);
     assert.equal(config.cache, value === "1" ? cache : false);
+    assert.equal(cache.maxMemoryGenerations, value === "1" ? 0 : Infinity);
+    assert.equal(cache.version, "next-owned");
+    assert.deepEqual(cache.buildDependencies, { config: ["next.config.ts"] });
   }
 });
 
 test("configureHostedWebWebpack preserves development caching", () => {
-  const cache = { type: "filesystem" };
+  const cache = { type: "filesystem", maxMemoryGenerations: Infinity };
   const webpackConfig = {
     cache,
     resolve: {},
@@ -678,6 +682,7 @@ test("configureHostedWebWebpack preserves development caching", () => {
   configureHostedWebWebpack(webpackConfig, { dev: true });
 
   assert.equal(webpackConfig.cache, cache);
+  assert.equal(cache.maxMemoryGenerations, Infinity);
 });
 
 test("resolvePrivyBaseDomainOrigin normalizes base-domain inputs into a Privy origin", () => {

--- a/scripts/pull-request-ci-policy.test.mjs
+++ b/scripts/pull-request-ci-policy.test.mjs
@@ -248,6 +248,7 @@ function inspectHostSupportReleaseGraph(source) {
     "markdown-docs-scope",
   ]);
   assert.match(webBuild, /^      MURPH_HOSTED_WEB_VERIFY_LANE: build$/mu);
+  assert.match(webBuild, /^      MURPH_HOSTED_WEB_WEBPACK_CACHE: "1"$/mu);
   assert.match(webBuild, /^      MURPH_HOSTED_WEB_VERIFY_SKIP_TYPECHECK: "1"$/mu);
   assert.match(webBuild, /^      MURPH_VERIFY_STEP_PARALLEL: "1"$/mu);
   assert.match(webBuild, /^        run: pnpm --dir apps\/web verify$/mu);


### PR DESCRIPTION
## Why and outcome

A real standalone Web CI build exhausted the existing 3 GB compiler heap after opting into persistent Webpack caching. Next enables an unlimited additional memory cache in production. Set `maxMemoryGenerations: 0` on the opted-in filesystem cache to retain disk reuse without that extra memory layer. Hosted-Web CI now explicitly enables the cache so its real compilation and existing memory guard exercise this path. The under-ten-minute integration target remains unverified.

## Product UX

- Effort: Not applicable; internal build controls.
- Result: Not applicable; no member-facing UI change.
- Walkthrough: Maintainers keep the same cache opt-in and normal build command. Cached builds retain all preparation, typechecks, compilation, and artifact validation.

## Evidence

- Direct: 53 Web configuration/build-runner tests and 24 CI-policy tests passed. Web typecheck, complexity, and documentation checks passed.
- Coverage: The actual Next callback selects the bounded memory policy only for opted-in production filesystem caches, retains the same cache object/version/build dependencies, and preserves development caching. CI policy requires the real Web build owner to opt in.
- Commands: `pnpm exec vitest run --config apps/web/vitest.config.ts apps/web/test/next-config.test.ts apps/web/test/production-next-build-runner.test.ts --no-coverage`; `node --test scripts/pull-request-ci-policy.test.mjs`; `pnpm --dir apps/web typecheck:prepared`; `pnpm complexity:diff`; `pnpm docs:drift`.
- ReviewGPT: Final review passed on `075f25e31803f536313d82bb6bc97787285c10f9` with verified GPT-6 Pro and no qualifying findings. [Review](https://chatgpt.com/c/6a9b911a-d41c-83ea-93b5-7c6c5f795111).
- Full cached compilation: [exact-head CI job](https://github.com/cobuildwithus/murph/actions/runs/33942671809/job/101243576728) passed. Compilation took 3.0 minutes; build/lint/smoke took 7m09s. Peak cgroup memory was 11.10 GB and anonymous memory reached 8.28 GB, above the 7.20 GB advisory budget. Heap limits stayed unchanged. This establishes successful cached compilation; it does not establish the ten-minute integration target or a peak-memory reduction.
- Configuration semantics: [Webpack cache documentation](https://webpack.js.org/configuration/cache/#cachemaxmemorygenerations).

## Non-obvious affected surfaces

The 1024 MB parent, 3072 MB compiler worker, 3584 MB route-aware typecheck, compiler isolation, and memory guard remain unchanged. Default production caching stays disabled unless explicitly enabled. Development caching retains its existing policy. Next's cache version and build-dependency identity remain intact.

## Architecture and reuse

- Existing systems reused: the Next Webpack callback, Next's filesystem cache, hosted-Web CI, and its memory guard.
- New logic: disable the additional memory-cache layer for opted-in production filesystem caching.
- New abstractions: None are needed because the existing Next callback owns this cache configuration.
- Complexity intentionally avoided: no new cache owner, dependency, heap override, or runner provider.

## Complexity impact

- Guard: pass; `pnpm complexity:diff` found no new complexity debt.
- Hotspots: changed source remains below the threshold; file maximum remains 19.
- Agent judgment: keep the memory setting beside the existing cache opt-in.

## Hot reply path impact

- Path status: Not applicable; compiler configuration only.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None added to production.
- Before/after proof: runtime assertions and generated-input/typecheck gates remain required.

## Murph initial provider input impact

Not applicable for individual or group runtimes; no prompts, tools, schemas, or provider inputs change.

## Deployment concerns

- Deployment: applicable
- Supported skew: existing default production builds retain cold compilation.
- Safe order: merge this cache-memory correction before enabling the pending private CI cache consumer.
- Rollback floor: disable private cache opt-in before reverting this correction.
- Expected exposure: cached compilation must pass the same heap limits and Web validation.
- Reversibility: restore the previous cache setting and CI opt-in.
- Convergence proof: full cached Web compilation and private integration must pass before the private optimization merges.
- Post-deploy checks: measure cold/warm build memory and total integration duration; no production deployment is requested here.

ReviewGPT context sensitivity: sensitive
Classification reason: Production compiler cache and cross-repository verification dependency.

## Changelog

- Changelog: not applicable
- Reason: Internal CI and compiler performance correction.

## Change-shape breakdown

Classification rule: tests by test paths, Markdown as docs, workflow and Next configuration as tooling. No generated or binary changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 7 | 1 |
| Docs | 4 | 0 |
| Config / tooling | 10 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **21** | **1** |

ReviewGPT first-reviewed head: 075f25e31803f536313d82bb6bc97787285c10f9
