### PR TITLE
fix(web): show latest dated experiment results

### DIFF
--- a/apps/web/app/design/experiment-repeated-results-study.tsx
+++ b/apps/web/app/design/experiment-repeated-results-study.tsx
@@ -2,6 +2,7 @@ import {
   ExperimentSchedule,
   ExperimentScheduleSidebar,
 } from "@/src/components/experiments/experiment-detail/experiment-schedule";
+import { ResultsSummary } from "@/src/components/experiments/experiment-detail/results-summary";
 import { ExperimentSummaryTiles } from "@/src/components/experiments/experiment-detail/experiment-summary-tiles";
 import type { ExperimentSchedule as ExperimentScheduleModel } from "@/src/types/experiments";
 
@@ -77,6 +78,27 @@ export function ExperimentRepeatedResultsStudy() {
             },
             schedule: DESIGN_REPEATED_RESULTS_SCHEDULE,
           }}
+        />
+
+        <ResultsSummary
+          signals={[
+            {
+              label: "Repetition benchmark", value: "12", unit: "reps", statistic: "max",
+              baseline: "10 reps", delta: "+2 reps", direction: "up", expected: "",
+              latestResult: { date: "2026-08-15", value: "9", unit: "reps" },
+            },
+            {
+              label: "Grip endurance", value: "41", unit: "sec", statistic: "mean",
+              delta: "", direction: "neutral", expected: "",
+              latestResult: { date: "2026-08-15", value: "38", unit: "sec" },
+            },
+          ]}
+          trends={[{
+            label: "Repetition benchmark", unit: "reps", startDate: "2026-08-09",
+            history: [], baseline: [{ day: 1, value: 8 }, { day: 2, value: 9 }, { day: 3, value: 10 }],
+            active: [{ day: 4, value: 12 }, { day: 5, value: 10 }, { day: 7, value: 9 }],
+            baselineAvg: 10, currentValue: 12, statistic: "max", delta: "+2 reps",
+          }]}
         />
 
         <div className="grid items-start gap-5 xl:grid-cols-[minmax(0,1fr)_18rem]">

--- a/apps/web/changelog/entries/2026-09-05/experiment-latest-dated-results.json
+++ b/apps/web/changelog/entries/2026-09-05/experiment-latest-dated-results.json
@@ -1,0 +1,19 @@
+{
+  "publishedOn": "2026-09-05",
+  "order": 100,
+  "item": {
+    "id": "experiment-latest-dated-results",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "See the latest result in your experiment",
+    "summary": "Experiment results now show the latest dated result alongside the statistic used to compare the experiment windows.",
+    "details": "Available results remain visible when a baseline is missing. Before-and-during changes still appear only when there is enough data to compare.",
+    "relevanceTags": [
+      "experiments",
+      "results"
+    ],
+    "sourcePullRequests": [
+      2889
+    ]
+  }
+}

--- a/apps/web/src/components/experiments/experiment-detail/results-summary.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/results-summary.tsx
@@ -1,5 +1,6 @@
 import { MetricCard } from "@/src/components/ui/metric-card";
 import { Skeleton } from "@/src/components/ui/skeleton";
+import { formatExperimentStatisticLabel } from "@/src/lib/experiments/experiment-detail";
 import type {
   ExperimentRunProjection,
   ExperimentSchedule,
@@ -38,7 +39,7 @@ export function ResultsSummary({
             Before and during the experiment
           </h3>
           <p className="text-sm/6 text-muted-foreground">
-            Daily measurements and declared window summaries, where available.
+            Dated results may summarize multiple measurements. Comparisons use each outcome’s declared statistic.
           </p>
         </div>
         {outcomeConfidence ? (
@@ -76,6 +77,8 @@ export function ResultsSummary({
                   label={signal.label}
                   value={signal.value}
                   unit={signal.unit}
+                  valueLabel={signal.statistic ? `Window ${formatExperimentStatisticLabel(signal.statistic)}` : undefined}
+                  latestResult={signal.latestResult}
                   delta={signal.delta}
                   direction={signal.direction}
                   sentiment={signal.sentiment}

--- a/apps/web/src/components/experiments/experiment-detail/trend-chart.tsx
+++ b/apps/web/src/components/experiments/experiment-detail/trend-chart.tsx
@@ -14,6 +14,8 @@ import {
   ChartTooltip,
   type ChartConfig,
 } from "@/src/components/ui/chart";
+import { LatestMetricResult } from "@/src/components/ui/metric-card";
+import { formatExperimentStatisticLabel } from "@/src/lib/experiments/experiment-detail";
 import type { ExperimentSignal, TrendData } from "@/src/types/experiments";
 import { cn } from "@/src/lib/utils";
 
@@ -74,13 +76,9 @@ export function TrendChart({ data, className, signal }: TrendChartProps) {
   const metricUnit = signal?.unit ?? data.unit;
   const delta = signal?.delta ?? data.delta;
   const statisticLabel = data.statistic
-    ? formatTrendStatisticLabel(data.statistic)
+    ? formatExperimentStatisticLabel(data.statistic)
     : null;
-  const accessibleLabel = statisticLabel
-    ? `${data.label}: baseline ${statisticLabel} ${formatValueWithUnit(data.baselineAvg, data.unit)}; experiment ${statisticLabel} ${formatValueWithUnit(data.currentValue, data.unit)}.`
-    : data.windowComparison
-      ? `${data.label}: baseline window average ${formatValueWithUnit(data.baselineAvg, data.unit)}; experiment window average ${formatValueWithUnit(data.currentValue, data.unit)}.`
-      : `${data.label}: daily baseline and experiment measurements${data.unit ? ` in ${data.unit}` : ""}.`;
+  const accessibleLabel = formatTrendAccessibleLabel(data, statisticLabel);
 
   return (
     <div
@@ -134,6 +132,8 @@ export function TrendChart({ data, className, signal }: TrendChartProps) {
           </div>
         )}
       </div>
+
+      {signal?.latestResult ? <LatestMetricResult result={signal.latestResult} /> : null}
 
       <ChartContainer
         aria-label={accessibleLabel}
@@ -300,14 +300,14 @@ function WindowComparisonFooter({ data }: { data: TrendData }) {
     <div className="grid grid-cols-2 gap-4 border-t border-border/70 pt-3">
       <WindowLabel
         coverage={baselineCoverage}
-        label={`Baseline ${data.statistic ? formatTrendStatisticLabel(data.statistic) : "average"}`}
+        label={`Baseline ${data.statistic ? formatExperimentStatisticLabel(data.statistic) : "average"}`}
         unit={data.unit}
         value={data.baselineAvg}
       />
       <WindowLabel
         align="right"
         coverage={interventionCoverage}
-        label={`Experiment ${data.statistic ? formatTrendStatisticLabel(data.statistic) : "average"}`}
+        label={`Experiment ${data.statistic ? formatExperimentStatisticLabel(data.statistic) : "average"}`}
         unit={data.unit}
         value={data.currentValue}
       />
@@ -388,29 +388,16 @@ function formatChartValue(value: number): string {
   }).format(value);
 }
 
-function formatValueWithUnit(value: number, unit: string): string {
-  return [formatChartValue(value), unit].filter(Boolean).join(" ");
+function formatTrendAccessibleLabel(data: TrendData, statisticLabel: string | null): string {
+  return statisticLabel
+    ? `${data.label}: baseline ${statisticLabel} ${formatValueWithUnit(data.baselineAvg, data.unit)}; experiment ${statisticLabel} ${formatValueWithUnit(data.currentValue, data.unit)}.`
+    : data.windowComparison
+      ? `${data.label}: baseline window average ${formatValueWithUnit(data.baselineAvg, data.unit)}; experiment window average ${formatValueWithUnit(data.currentValue, data.unit)}.`
+      : `${data.label}: daily baseline and experiment measurements${data.unit ? ` in ${data.unit}` : ""}.`;
 }
 
-function formatTrendStatisticLabel(
-  statistic: NonNullable<TrendData["statistic"]>,
-): string {
-  switch (statistic) {
-    case "count":
-      return "count";
-    case "latest":
-      return "latest";
-    case "max":
-      return "maximum";
-    case "mean":
-      return "average";
-    case "median":
-      return "median";
-    case "min":
-      return "minimum";
-    case "sum":
-      return "total";
-  }
+function formatValueWithUnit(value: number, unit: string): string {
+  return [formatChartValue(value), unit].filter(Boolean).join(" ");
 }
 
 export function buildTrendChartPoints(data: TrendData, showHistory: boolean): TrendChartPoint[] {

--- a/apps/web/src/components/ui/metric-card.tsx
+++ b/apps/web/src/components/ui/metric-card.tsx
@@ -16,6 +16,8 @@ interface MetricCardProps {
   label: string;
   value: string;
   unit?: string;
+  valueLabel?: string;
+  latestResult?: { date: string; value: string; unit?: string };
   delta?: string;
   direction?: "up" | "down" | "neutral" | null;
   deltaTone?: "directional" | "neutral";
@@ -29,6 +31,8 @@ export function MetricCard({
   label,
   value,
   unit,
+  valueLabel,
+  latestResult,
   delta,
   direction = "neutral",
   deltaTone = "directional",
@@ -51,6 +55,7 @@ export function MetricCard({
       <span className="font-mono text-[10px] uppercase tracking-widest text-foreground/50">
         {label}
       </span>
+      {valueLabel ? <span className="text-xs text-muted-foreground">{valueLabel}</span> : null}
       <div className="flex items-baseline gap-1.5">
         <span className="font-serif text-3xl font-semibold tabular-nums text-foreground">
           {value}
@@ -70,6 +75,24 @@ export function MetricCard({
           {footer}
         </span>
       ) : null}
+      {latestResult ? <LatestMetricResult result={latestResult} /> : null}
+    </div>
+  );
+}
+
+export function LatestMetricResult({
+  result,
+}: {
+  result: NonNullable<MetricCardProps["latestResult"]>;
+}) {
+  return (
+    <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 border-t border-border/70 pt-3 text-sm">
+      <span className="text-muted-foreground">
+        Latest dated result · <time dateTime={result.date}>{result.date}</time>
+      </span>
+      <span className="font-semibold tabular-nums text-foreground">
+        {result.value}{result.unit ? ` ${result.unit}` : ""}
+      </span>
     </div>
   );
 }

--- a/apps/web/src/lib/browser-vault/experiment-run.ts
+++ b/apps/web/src/lib/browser-vault/experiment-run.ts
@@ -351,24 +351,31 @@ function dedupeLookups(
 function buildSignals(results: BrowserVaultExperimentResultsView): ExperimentRunProjection["signals"] {
   return results.biomarkers
     .filter(isRenderableBiomarker)
-    .flatMap((biomarker) => {
-      if (biomarker.deltaAbs === null) {
-        return [];
-      }
-
+    .map((biomarker) => {
+      const { deltaAbs } = biomarker;
+      const latestPoint = biomarker.points.reduce(
+        (latest, point) => !latest || point.date > latest.date ? point : latest,
+        biomarker.points[0],
+      );
       const currentValue = readCurrentBiomarkerValue(biomarker);
       const unit = resolveOutcomeDisplayUnit(biomarker);
       // A day-one reading against a multi-day baseline is noise, not a change.
       // Only present the delta once the replica classifies both windows as
       // having enough days (`completeness === "good"`).
-      const showDelta = biomarker.completeness === "good";
-      const direction = showDelta ? resolveSignalDirection(biomarker.deltaAbs) : "neutral";
+      const showDelta = deltaAbs !== null && biomarker.completeness === "good";
+      const direction = showDelta ? resolveSignalDirection(deltaAbs) : "neutral";
 
-      return [{
+      return {
         label: biomarker.label,
         value: formatMetricValue(currentValue),
         unit,
-        delta: showDelta ? formatDelta(biomarker.deltaAbs, unit) : "",
+        statistic: biomarker.statistic,
+        latestResult: latestPoint ? {
+          date: latestPoint.date,
+          value: formatMetricValue(latestPoint.value),
+          unit: biomarker.statistic === "count" ? undefined : latestPoint.unit ?? undefined,
+        } : undefined,
+        delta: showDelta ? formatDelta(deltaAbs, unit) : "",
         direction,
         sentiment: showDelta
           ? resolveBiomarkerChangeSentiment(
@@ -381,7 +388,7 @@ function buildSignals(results: BrowserVaultExperimentResultsView): ExperimentRun
           : undefined,
         expected: formatExpectedSignalText(biomarker) ?? "",
         protocolProminence: "focus",
-      }];
+      };
     });
 }
 

--- a/apps/web/src/lib/experiments/experiment-detail.ts
+++ b/apps/web/src/lib/experiments/experiment-detail.ts
@@ -2,6 +2,7 @@ import type {
   Experiment,
   ExperimentProtocol,
   ExperimentRunProjection,
+  TrendData,
 } from "@/src/types/experiments";
 
 export const CURRENT_EXPERIMENT_PROTOCOL_CONTRACT_VERSION = 1;
@@ -40,4 +41,25 @@ export function composeExperimentDetail({
     summaryDetail: privateRun?.summaryDetail,
     conclusions: privateRun?.conclusions,
   };
+}
+
+export function formatExperimentStatisticLabel(
+  statistic: NonNullable<TrendData["statistic"]>,
+): string {
+  switch (statistic) {
+    case "count":
+      return "count";
+    case "latest":
+      return "latest";
+    case "max":
+      return "maximum";
+    case "mean":
+      return "average";
+    case "median":
+      return "median";
+    case "min":
+      return "minimum";
+    case "sum":
+      return "total";
+  }
 }

--- a/apps/web/src/types/experiments.ts
+++ b/apps/web/src/types/experiments.ts
@@ -126,6 +126,9 @@ export interface ExperimentSignal {
   label: string;
   value: string;
   unit?: string;
+  statistic?: ExperimentOutcomeStatistic;
+  /** Query-owned dated result; may summarize multiple measurements on that date. */
+  latestResult?: { date: string; value: string; unit?: string };
   delta: string;
   direction: "up" | "down" | "neutral";
   sentiment?: "positive" | "negative" | "neutral";

--- a/apps/web/test/experiment-detail-private-run.test.tsx
+++ b/apps/web/test/experiment-detail-private-run.test.tsx
@@ -156,6 +156,13 @@ describe("experiment detail private-run composition", () => {
       }),
     ]);
 
+    expect(privateRun?.signals[0]?.latestResult).toBeUndefined();
+    const savedMarkup = renderToStaticMarkup(
+      <ResultsSummary signals={privateRun!.signals} trends={privateRun!.trends} />,
+    );
+    expect(savedMarkup).toContain("Experiment average");
+    expect(savedMarkup).not.toContain("Latest dated result");
+
     const [homeCard] = buildExperimentLibraryCards({
       client,
       protocols: [],
@@ -935,12 +942,6 @@ describe("experiment detail private-run composition", () => {
           value: 62,
         },
         {
-          date: "2026-04-03",
-          phase: "baseline",
-          unit: "bpm",
-          value: 61,
-        },
-        {
           date: "2026-04-04",
           phase: "intervention",
           unit: "bpm",
@@ -957,6 +958,13 @@ describe("experiment detail private-run composition", () => {
           phase: "intervention",
           unit: "bpm",
           value: 57,
+        },
+        // Saved points need not be ordered by date.
+        {
+          date: "2026-04-03",
+          phase: "baseline",
+          unit: "bpm",
+          value: 61,
         },
       ],
       schemaVersion: "murph.experiment-outcome.v2",
@@ -1023,7 +1031,15 @@ describe("experiment detail private-run composition", () => {
     }));
     expect(privateRun?.summaryDetail).toBe(outcome.conclusion.plainLanguage);
     expect(privateRun?.outcomeConfidence).toBe("medium");
-    expect(privateRun?.signals).toEqual([]);
+    expect(privateRun?.signals).toEqual([
+      expect.objectContaining({
+        delta: "",
+        direction: "neutral",
+        value: "58",
+        latestResult: { date: "2026-04-06", value: "57", unit: "bpm" },
+      }),
+    ]);
+    expect(privateRun?.signals[0]?.sentiment).toBeUndefined();
     expect(privateRun?.trends).toEqual([
       expect.objectContaining({
         active: [
@@ -1063,6 +1079,8 @@ describe("experiment detail private-run composition", () => {
     expect(markup).toContain(outcome.confidence.reasons[0]);
     expect(markup).toContain(outcome.conclusion.caveats[0]);
     expect(markup).toContain("Saved result");
+    expect(markup).toMatch(/<time datetime="2026-04-06">2026-04-06<\/time>/iu);
+    expect(markup).toContain("57 bpm");
     expect(markup.match(/medium confidence/gu)).toHaveLength(1);
     expect(markup).toContain('data-slot="chart"');
     expect(markup).toContain("Baseline");
@@ -1129,7 +1147,7 @@ describe("experiment detail private-run composition", () => {
     expect(markup).toContain("flex min-w-0 flex-col gap-4");
     expect(markup).not.toContain("md:grid-cols-2");
     expect(markup).not.toContain("xl:grid-cols-2");
-    expect(markup).toContain("Daily measurements and declared window summaries, where available.");
+    expect(markup).toContain("Dated results may summarize multiple measurements.");
   });
 
   it("renders a saved structured review without a false empty-metrics state", async () => {
@@ -1445,7 +1463,12 @@ describe("experiment detail private-run composition", () => {
 
       expect(trend?.statistic).toBe(item.statistic);
       expect(trend?.unit).toBe(item.statistic === "count" ? "" : item.unit);
-      const markup = renderToStaticMarkup(<TrendChart data={trend!} />);
+      expect(privateRun?.signals[0]?.latestResult).toBeUndefined();
+      const markup = renderToStaticMarkup(
+        <ResultsSummary signals={privateRun!.signals} trends={privateRun!.trends} />,
+      );
+
+      expect(markup).not.toContain("Latest dated result");
 
       expect(markup).toContain(`Window statistic: ${item.expectedLabel}`);
       expect(markup).toContain(`Baseline ${item.expectedLabel}`);
@@ -1462,15 +1485,26 @@ describe("experiment detail private-run composition", () => {
     }
   });
 
-  it("keeps daily trend dates stable outside UTC", () => {
+  it.each(["America/New_York", "Pacific/Kiritimati"])("keeps result dates stable in %s", (timeZone) => {
     const previousTimeZone = process.env.TZ;
-    process.env.TZ = "America/New_York";
+    process.env.TZ = timeZone;
 
     try {
       expect(formatTrendDay("2026-05-29", 1)).toBe("May 29");
+      const markup = renderToStaticMarkup(
+        <ResultsSummary
+          signals={[{
+            label: "Secondary measurement", value: "7", delta: "", direction: "neutral", expected: "",
+            latestResult: { date: "2026-05-29", value: "7" },
+          }]}
+          trends={[]}
+        />,
+      );
+      expect(markup).toMatch(/<time datetime="2026-05-29">2026-05-29<\/time>/iu);
       expect(formatTrendDay("2026-05-29", 2)).toBe("May 30");
     } finally {
-      process.env.TZ = previousTimeZone;
+      if (previousTimeZone === undefined) delete process.env.TZ;
+      else process.env.TZ = previousTimeZone;
     }
   });
 
@@ -1511,7 +1545,15 @@ describe("experiment detail private-run composition", () => {
     expect(doneMarkup).toContain("does not have a canonical saved outcome to render");
   });
 
-  it("maps real browser-vault biomarker trends without inventing an expected range band", async () => {
+  it.each([
+    { statistic: "mean", label: "average", baseline: 62, current: 59, latest: 58, delta: "-3 bpm" },
+    { statistic: "max", label: "maximum", baseline: 63, current: 60, latest: 58, delta: "-3 bpm" },
+    { statistic: "min", label: "minimum", baseline: 61, current: 58, latest: 58, delta: "-3 bpm" },
+    { statistic: "median", label: "median", baseline: 62, current: 59, latest: 58, delta: "-3 bpm" },
+    { statistic: "sum", label: "total", baseline: 186, current: 177, latest: 58, delta: "-9 bpm" },
+    { statistic: "count", label: "count", baseline: 3, current: 3, latest: 1, delta: "0" },
+    { statistic: "latest", label: "latest", baseline: 61, current: 58, latest: 58, delta: "-3 bpm" },
+  ] as const)("separates the latest dated result from the $statistic comparison", async (item) => {
     const protocol = resolveHealthCommonsExperimentProtocol("finnish-sauna");
 
     expect(protocol).not.toBeNull();
@@ -1531,7 +1573,13 @@ describe("experiment detail private-run composition", () => {
           frontmatter: createExperimentFrontmatter({
             analysisPlan: {
               desiredDirection: "decrease",
-              primaryBiomarkerKey: "biomarker:resting-heart-rate",
+              primaryOutcome: {
+                capture: { kind: "measurement" },
+                key: "biomarker:resting-heart-rate",
+                kind: "metric",
+                label: "Resting Heart Rate",
+                statistic: item.statistic,
+              },
               secondaryBiomarkerKeys: ["biomarker:morning-blood-pressure"],
             },
             id: "exp_sauna_real_metrics",
@@ -1565,46 +1613,57 @@ describe("experiment detail private-run composition", () => {
       protocol: protocol!,
     });
 
+    const unit = item.statistic === "count" ? undefined : "bpm";
+    const suffix = unit ? ` ${unit}` : "";
     expect(privateRun?.signals).toEqual([
       expect.objectContaining({
-        baseline: "62 bpm",
-        delta: "-3 bpm",
+        baseline: `${item.baseline}${suffix}`,
+        delta: item.delta,
         expected: "",
         label: "Resting Heart Rate",
-        value: "59",
+        value: String(item.current),
+        latestResult: { date: "2026-04-10", value: String(item.latest), unit },
       }),
     ]);
     expect(privateRun?.trends).toEqual([
       expect.objectContaining({
         baseline: [
-          { day: 1, value: 63 },
-          { day: 2, value: 62 },
-          { day: 3, value: 61 },
+          { day: 1, value: item.statistic === "count" ? 1 : 63 },
+          { day: 2, value: item.statistic === "count" ? 1 : 62 },
+          { day: 3, value: item.statistic === "count" ? 1 : 61 },
         ],
         active: [
-          { day: 8, value: 60 },
-          { day: 9, value: 59 },
-          { day: 10, value: 58 },
+          { day: 8, value: item.statistic === "count" ? 1 : 60 },
+          { day: 9, value: item.statistic === "count" ? 1 : 59 },
+          { day: 10, value: item.statistic === "count" ? 1 : 58 },
         ],
         expectedRange: undefined,
-        statistic: "mean",
+        baselineAvg: item.baseline,
+        currentValue: item.current,
+        statistic: item.statistic,
       }),
     ]);
 
     const trendMarkup = renderToStaticMarkup(
-      <TrendChart data={privateRun!.trends[0]!} />,
+      <ResultsSummary signals={privateRun!.signals} trends={privateRun!.trends} />,
     );
 
     expect(trendMarkup).not.toContain("Expected");
-    expect(trendMarkup).toContain("experiment average");
-    expect(trendMarkup).not.toContain("latest");
+    expect(trendMarkup).toContain("Latest dated result");
+    expect(trendMarkup).toMatch(/<time datetime="2026-04-10">2026-04-10<\/time>/iu);
+    expect(trendMarkup).toContain(`>${item.latest}${suffix}</span>`);
     expect(trendMarkup).toContain('role="region"');
     expect(trendMarkup).toContain(
-      'aria-label="Resting Heart Rate: baseline average 62 bpm; experiment average 59 bpm."',
+      `aria-label="Resting Heart Rate: baseline ${item.label} ${item.baseline}${suffix}; experiment ${item.label} ${item.current}${suffix}."`,
     );
+    expect(buildExperimentRunCardSummary(privateRun!).metric).toEqual(expect.objectContaining({
+      current: `${item.current}${suffix}`,
+      delta: item.delta,
+    }));
+    if (item.statistic === "count") expect(trendMarkup).not.toContain("bpm");
   });
 
-  it("projects ordered comparable card metrics from production browser-vault signals", async () => {
+  it("keeps comparable card summaries while showing secondary results without a baseline", async () => {
     const protocol = resolveHealthCommonsExperimentProtocol("finnish-sauna");
 
     expect(protocol).not.toBeNull();
@@ -1638,10 +1697,8 @@ describe("experiment detail private-run composition", () => {
             ["2026-04-10", 90],
           ]),
           ...metricRows("rem-sleep-minutes", "min", [
-            ["2026-04-01", 80],
-            ["2026-04-02", 80],
-            ["2026-04-03", 80],
             ["2026-04-08", 82],
+            ["2026-04-10", 0],
           ]),
         ],
         trackedExperiments: [{
@@ -1688,7 +1745,23 @@ describe("experiment detail private-run composition", () => {
       { label: "Hrv Rmssd", sentiment: "negative" },
       { label: "Deep Sleep Minutes", sentiment: "neutral" },
     ]);
-    expect(privateRun?.signals.find((signal) => signal.label === "Rem Sleep Minutes")?.delta).toBe("");
+    const secondary = privateRun!.signals.find((signal) => signal.label === "Rem Sleep Minutes");
+    expect(secondary).toEqual(expect.objectContaining({
+      baseline: undefined,
+      delta: "",
+      direction: "neutral",
+      value: "41",
+      latestResult: { date: "2026-04-10", value: "0", unit: "min" },
+    }));
+    expect(secondary?.sentiment).toBeUndefined();
+    expect(privateRun!.trends.some((trend) => trend.label === secondary?.label)).toBe(false);
+    const markup = renderToStaticMarkup(
+      <ResultsSummary signals={privateRun!.signals} trends={privateRun!.trends} />,
+    );
+    expect(markup).toContain("Rem Sleep Minutes");
+    expect(markup).toContain("Window average");
+    expect(markup).toContain(">0 min</span>");
+    expect(markup.match(/Latest dated result/gu)).toHaveLength(4);
   });
 
   it("hides deltas until the intervention window has enough days to compare", async () => {
@@ -1742,11 +1815,17 @@ describe("experiment detail private-run composition", () => {
         direction: "neutral",
         label: "Resting Heart Rate",
         value: "60",
+        latestResult: { date: "2026-04-08", value: "60", unit: "bpm" },
       }),
     ]);
     expect(privateRun?.signals[0]?.sentiment).toBeUndefined();
     expect(privateRun?.trends[0]?.delta).toBe("");
     expect(privateRun?.summary).toBe("Protocol in progress");
+    const markup = renderToStaticMarkup(
+      <ResultsSummary signals={privateRun!.signals} trends={privateRun!.trends} />,
+    );
+    expect(markup).toContain("Latest dated result");
+    expect(markup).not.toContain("-2 bpm");
   });
 
   it("bridges shown history into the first baseline point", () => {
@@ -3041,6 +3120,7 @@ describe("experiment detail private-run composition", () => {
       expect.objectContaining({
         label: "Resting Heart Rate",
         value: "59",
+        latestResult: { date: "2026-04-05", value: "59", unit: "bpm" },
       }),
     ]);
     expect(stoppedRun?.trends[0]?.active).toEqual([{ day: 5, value: 59 }]);
@@ -3055,6 +3135,8 @@ describe("experiment detail private-run composition", () => {
     );
     expect(stoppedMarkup).toContain("Your experiment was stopped");
     expect(stoppedMarkup).toContain("Resting Heart Rate");
+    expect(stoppedMarkup).toMatch(/<time datetime="2026-04-05">2026-04-05<\/time>/iu);
+    expect(stoppedMarkup).not.toContain("2026-04-06");
   });
 
   it("projects stopped runs from live boundaries when they diverge from a suppressed outcome", async () => {


### PR DESCRIPTION
## Why and outcome

Experiment results showed a window statistic while the latest dated result was not identified separately, and available secondary results could disappear without a baseline comparison. Results now show the latest dated value and date alongside the declared window statistic, while retaining meaningful before-and-during comparisons.

## Product UX

- Effort: Patch.
- Result: Ready. Desktop and phone rendering passed with the real components and synthetic result props.
- Walkthrough: A member can distinguish a newer result from an average or maximum, see a secondary result without a baseline, and retain the saved experiment boundary. Aggregate-only saved outcomes do not gain an invented date.

## Evidence

- Direct: `pnpm --dir apps/web test:prepared test/experiment-detail-private-run.test.tsx` passed 56 tests; full `pnpm --dir apps/web typecheck:prepared` passed after the normal device-syncd build prepared its declared public entrypoint; `git diff --check` passed. Changelog SSR passed 9 tests on the final fragment.
- Coverage: Seven declared statistics, unordered saved points, absent baseline, zero value, incomplete comparisons, count units, aggregate-only outcomes, stopped-run bounds, time zones, and unchanged aggregate library cards.
- ReviewGPT implementation: The managed guarded source snapshot produced a concrete unified patch using verified `gpt-6-pro`. The patch was applied and locally checked; local refinement preserves the existing accessibility labels while reducing chart complexity. Final ReviewGPT is not applicable under the frontend-only eligibility exemption: this patch changes only browser presentation and its query-derived view model; no backend, persistence, authentication, or runtime boundary changes.

## Non-obvious affected surfaces

Experiment library cards continue using aggregate values and comparable deltas. Chart headlines, axes, and baseline/experiment statistics retain their existing meaning; the focused regression fixtures cover those paths.

## Architecture and reuse

- Existing systems reused: Browser Vault query-owned result points, experiment signal/trend contracts, ResultsSummary, MetricCard, and TrendChart.
- New logic: Select the greatest supplied ISO date without sorting or mutating points; keep available results visible independently of whether a comparable delta exists.
- New abstractions: One shared latest-result renderer in the existing metric card module; the statistic formatter lives in the existing experiment presentation module, and existing accessibility-label formatting is named separately.
- Complexity intentionally avoided: No new query, persistence, network request, cache, dependency, or alternate outcome owner.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff --base 18b498bc49435c49adb99588754a8a2bf72c4ce6`.
- Hotspots: TrendChart decreases from 34 to 33. Existing mapExperimentResultsProjection (47), buildRunNextStep (24), and composeExperimentDetail (21) are unchanged.
- Agent judgment: The scoped extraction separates accessibility text formatting from chart rendering. Broader restructuring of unchanged projection owners would add unrelated risk.

## Hot reply path impact

- Path status: Not applicable — browser result presentation only.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Existing query results feed the presentation; no foreground runtime code changed.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no prompts, tools, generated provider guidance, or provider input builders changed.

## Design proof

- Design page: [Protected current-branch results study](https://murph-dzks5gxp9-cobuildwithus.vercel.app/screenshots/health#experiment-repeated-results). The preview records candidate commit `1218e881704c9cb40601eea0b0999a78f0636f35`; authenticated HTTP proof returned 200 and verified the changed result markup.
- Evidence: Two Chromium captures passed at 390px and 1440px viewport widths, asserting latest values/dates, declared maxima/averages, no horizontal overflow, and no browser errors. Native-resolution image review passed. Capture-only CSS hid unrelated forced-open synthetic catalog dialogs; the production result components are unchanged. The final capture waits for the chart entry animation.

![Desktop latest dated result and declared window statistics](https://github.com/user-attachments/assets/234d77f2-b277-42fd-bec6-cdaedff964c6)

![Phone latest dated result and secondary result without a baseline](https://github.com/user-attachments/assets/1d6a4a35-6b53-4edf-bae1-626e84d86fdb)

- Coverage: Maximum comparison of 12 versus 10 reps with latest result 9 reps; secondary latest result 38 sec alongside its 41 sec average.

## Deployment concerns

- Deployment: not applicable
- Reason: Presentation-only change; no schema, migration, runtime protocol, or deployment-order dependency.

## Change-shape breakdown

Source: +85/-40. Tests and synthetic fixtures: +137/-33. Docs: +0/-0. Config/tooling: +0/-0. Generated/other (changelog content): +19/-0. Total: +241/-73. The design study is classified as a synthetic fixture. No binary files.

## Changelog

- Changelog: updated
- Items: 2026-09-05 · experiment-latest-dated-results
