### PR TITLE
fix hosted-local Buildx plugin discovery

### DIFF
--- a/packages/hosted-local-harness/README.md
+++ b/packages/hosted-local-harness/README.md
@@ -25,6 +25,11 @@ pnpm hosted-local run -- pnpm --dir apps/cloudflare test:workers
 
 Root `pnpm dev` is a thin alias for `pnpm hosted-local up`.
 
+`doctor` reports Docker daemon and Buildx prerequisites separately. Isolated
+Docker configuration selects the first candidate plugin directory containing an
+executable `docker-buildx`, so an empty or unusable earlier directory cannot hide
+a later installed Buildx plugin.
+
 ## External Temporal worker package
 
 Hosted-local keeps Web and Cloudflare in this checkout, but it can start the

--- a/packages/hosted-local-harness/src/cli.ts
+++ b/packages/hosted-local-harness/src/cli.ts
@@ -545,6 +545,7 @@ async function runDoctor(
     runDoctorCommand("node", ["--version"]),
     runDoctorCommand("pnpm", ["--version"]),
     runDoctorCommand("docker", ["info"]),
+    runDoctorCommand("docker", ["buildx", "version"]),
     runDoctorCommand("createdb", ["--version"]),
   ];
   const result = {

--- a/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { constants, existsSync, readdirSync, readFileSync } from "node:fs";
 import { access, chmod, copyFile, cp, mkdir, mkdtemp, readFile, rename, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -2319,7 +2319,7 @@ async function findDockerCliPluginSourceDir(input: {
     }
 
     try {
-      await access(candidate);
+      await access(path.join(candidate, "docker-buildx"), constants.X_OK);
       return candidate;
     } catch {
       continue;

--- a/packages/hosted-local-harness/test/cli.test.ts
+++ b/packages/hosted-local-harness/test/cli.test.ts
@@ -297,7 +297,27 @@ describe("hosted-local run CLI", () => {
       stdout: createBufferedStdout().stdout,
     });
 
-    expect(runDoctorCommand).toHaveBeenCalledTimes(4);
+    expect(runDoctorCommand).toHaveBeenCalledTimes(5);
+  });
+
+  test("reports unavailable Buildx as a doctor prerequisite failure", async () => {
+    const output = createBufferedStdout();
+    resolveHostedLocalDevConfig.mockReturnValueOnce({
+      ...resolveHostedLocalDevConfig(),
+      temporal: { ...resolveHostedLocalDevConfig().temporal, mode: "disabled" },
+    });
+    runDoctorCommand.mockImplementation((command, args) => ({
+      command: [command, ...args].join(" "),
+      ok: args[0] !== "buildx",
+      stderr: args[0] === "buildx" ? "Docker Buildx is unavailable" : "",
+      stdout: "",
+    }));
+
+    await runHostedLocalCli(["doctor"], { env: {}, stdout: output.stdout });
+
+    expect(output.text()).toContain("[fail] docker buildx version");
+    expect(output.text()).toContain("Docker Buildx is unavailable");
+    expect(startHostedLocalDevStack).not.toHaveBeenCalled();
   });
 
   test("prepares worktree resources before delegating worktree up to the normal stack", async () => {

--- a/packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { constants } from "node:fs";
 import { access, copyFile, cp, readFile, rename, rm, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { Writable } from "node:stream";
@@ -1816,7 +1817,10 @@ describe("hosted local dev stack", () => {
       `/tmp/murph-dev-env-test/docker-config/contexts/tls/${dockerContextId}`,
       { recursive: true },
     );
-    expect(access).toHaveBeenCalledWith(expect.stringContaining(".docker/cli-plugins"));
+    expect(access).toHaveBeenCalledWith(
+      expect.stringContaining(".docker/cli-plugins/docker-buildx"),
+      constants.X_OK,
+    );
     expect(rm).toHaveBeenCalledWith(
       "/tmp/murph-dev-env-test/docker-config/cli-plugins",
       { force: true, recursive: true },
@@ -1827,6 +1831,71 @@ describe("hosted local dev stack", () => {
       "dir",
     );
   });
+
+  it.each(["missing", "not executable"])(
+    "skips a Docker plugin directory whose Buildx is %s",
+    async (buildxState) => {
+      vi.stubEnv("OPENAI_API_KEY", "local-openai-key");
+      const configModule = await import("../../src/dev-hosted-local/config.ts");
+      vi.mocked(configModule.resolveHostedLocalDevConfig).mockReturnValueOnce({
+        ...defaultConfig,
+        skipLinqWebhookRegister: true,
+        webPort: 31001,
+        workerPersistDir: ".tmp/e2e/wrangler",
+        workerPort: 32001,
+      });
+      const firstDirectory = "/tmp/host-docker-config/cli-plugins";
+      const originalAccess = vi.mocked(access).getMockImplementation();
+      vi.mocked(access).mockImplementation(async (filePath, mode) => {
+        const value = String(filePath);
+        if (value === firstDirectory) {
+          return;
+        }
+        if (value === path.join(firstDirectory, "docker-buildx")) {
+          if (buildxState === "not executable" && mode !== constants.X_OK) {
+            return;
+          }
+          const error = createMissingFileError();
+          error.code = buildxState === "not executable" ? "EACCES" : "ENOENT";
+          throw error;
+        }
+        if (value.endsWith(path.join(".docker", "cli-plugins", "docker-buildx"))) {
+          return;
+        }
+        throw createMissingFileError();
+      });
+      try {
+        const { startHostedLocalDevStack } = await import("../../src/dev-hosted-local/stack.ts");
+        const stack = await startHostedLocalDevStack({
+          env: {
+            ...process.env,
+            DOCKER_CONFIG: "/tmp/host-docker-config",
+            MURPH_HOSTED_LOCAL_E2E_ISOLATION_REQUIRED: "1",
+            MURPH_DEV_SKIP_LINQ_WEBHOOK_REGISTER: "1",
+            MURPH_DEV_SKIP_STRIPE_LISTEN: "1",
+            NEXT_DIST_DIR_MODE: "smoke",
+            NEXT_DIST_DIR_SUFFIX: "e2e-fixture",
+          },
+        });
+        await stack.ready;
+        await stack.stop();
+        expect(symlink).toHaveBeenCalledWith(
+          expect.stringContaining(path.join(".docker", "cli-plugins")),
+          "/tmp/murph-dev-env-test/docker-config/cli-plugins",
+          "dir",
+        );
+        expect(symlink).not.toHaveBeenCalledWith(
+          firstDirectory,
+          expect.any(String),
+          "dir",
+        );
+      } finally {
+        if (originalAccess) {
+          vi.mocked(access).mockImplementation(originalAccess);
+        }
+      }
+    },
+  );
 
   it("discovers the Apple Silicon Homebrew Docker CLI plugin directory on macOS", async () => {
     const stackModule = await import("../../src/dev-hosted-local/stack.ts");


### PR DESCRIPTION
## Why and outcome

Hosted-local Docker plugin discovery accepted the first existing plugin directory even when it contained no usable Buildx executable. An empty or non-executable earlier candidate could hide a working later installation and break container image preparation.

The existing selector now checks execute permission on `docker-buildx` before selecting a directory. Doctor also reports `docker buildx version` as a separate prerequisite, so a working Docker daemon no longer conceals missing Buildx.

## Product UX

- Effort: Not applicable — repository-local developer tooling only.
- Result: Not applicable.
- Walkthrough: Existing candidate ordering and Docker configuration isolation are preserved; missing or non-executable Buildx candidates fall through to later candidates. Doctor reports a failed Buildx probe before any stack startup.

## Evidence

- Direct: Three new regressions failed against the original source: missing Buildx and non-executable Buildx selected the wrong directory; doctor omitted the Buildx failure.
- Coverage: `pnpm --dir packages/hosted-local-harness exec vitest run --config vitest.config.ts test/dev-hosted-local/stack.test.ts test/cli.test.ts --testTimeout 120000 --no-coverage` passed all 103 tests, including existing isolated Docker context and plugin behavior.
- `pnpm --dir packages/hosted-local-harness typecheck` passed.
- `pnpm complexity:diff`, `pnpm docs:drift`, `pnpm docs:gardening`, `git diff --check`, and scoped privacy inspection passed.
- The regressions exercise the actual stack and doctor owners with synthetic filesystem and process boundaries. They do not start Docker or contact production services.

- Final full-patch ReviewGPT passed on `54a1b762e4a82e4815fa60090fefa366a7bd85c0` with no qualifying findings; exact model, attachment, turn identity, and minimum-duration evidence verified.

## Non-obvious affected surfaces

None. Plugin selection and prerequisite reporting stay within the existing local harness.

## Architecture and reuse

- Existing systems reused: Ordered Docker plugin candidates, isolated configuration symlinking, native filesystem access checks, and doctor command reporting.
- New logic: Require execute permission on each candidate's Buildx path and run one additional existing-style doctor probe.
- New abstractions: None; no new owner, persisted state, or dependency.
- Complexity intentionally avoided: No subprocess-based discovery, installation workaround, plugin registry, or process-cleanup changes.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; CLI debt 14 → 14 and stack debt 119 → 119.
- Hotspots: Existing `runWorktree` complexity 34 and `startHostedLocalDevStack` complexity 139 are unchanged; neither function gained conditional logic.
- Agent judgment: The repair adds one native permission check at the existing selector and one doctor command entry. Further abstraction would add unnecessary machinery.

## Hot reply path impact

Not applicable. Repository-local Docker prerequisites and plugin selection do not execute on the hosted foreground reply path.

## Murph initial provider input impact

Not applicable for individual and group runtimes. No assembled prompt, tool schema, generated guidance, or provider-visible input changed.

## Change-shape breakdown

Classification uses authored file role; no binary files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 3 | 2 |
| Tests/fixtures | 91 | 2 |
| Docs | 5 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 99 | 4 |

## Deployment concerns

- Deployment: not applicable
- Reason: Local harness tooling, its tests, and package documentation only; no deployed artifact, dependency, or configuration changes.

## Changelog

- Changelog: not applicable
- Reason: Internal developer tooling only; no member-visible outcome.

ReviewGPT context sensitivity: routine
Classification reason: Narrow local tooling change preserves existing process, isolation, authentication, and deployment boundaries.

Frog autofix issue: #2677

ReviewGPT first-reviewed head: 54a1b762e4a82e4815fa60090fefa366a7bd85c0
