### PR TITLE
Serialize hosted member seed environments

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-05-frog-2647-member-seed-environment.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-frog-2647-member-seed-environment.md
@@ -1,0 +1,29 @@
+# Serialize hosted member seed environments
+
+## Outcome and owner
+
+Concurrent synthetic hosted member seeds must retain their own environment through routing and disconnect, then restore the caller environment. The existing test-only `withHostedMemberSeedEnvironment` owns environment and cached-global setup. Production owners and databases are unchanged.
+
+## Evidence and approach
+
+The helper currently applies process-wide environment values, awaits a seed operation, and restores values without coordinating another invocation. Two overlapping calls can observe or restore the peer environment. Serialize the existing environment scope with one module-local promise tail; evaluate ambient input only after the preceding scope restores, and release after both success and failure. No durable state, production queue, new dependency, or generic lock abstraction.
+
+The only composed seed call invokes `seedHostedActiveLinqMember` before entering a separate environment scope, so no nested scope waits on itself. Other public helpers enter the same scope directly.
+
+## Verification plan
+
+- Reproduce with the public Linq seed helper and synthetic mocked storage/crypto boundaries, pausing the first member creation and checking actual routing environment.
+- Cover successful and failing predecessors, disconnect, restoration, and queued default/explicit ambient environment.
+- Focused hosted-Web tests, relevant typecheck/lint, complexity diff, privacy/diff review.
+- Push scoped draft PR, user-requested exact-head ReviewGPT concurrently with required CI, and land only after all authorized low-risk gates pass.
+
+## Progress
+
+- Diagnosis and call-graph review complete. Four public-helper regressions failed on the original code: overlapping explicit input replaced the active fingerprint; ambient input restored an earlier temporary value.
+- Corrected existing scope with a promise tail. The same four regressions now pass, including failed predecessor recovery and both ambient-input forms. Frozen install and Frog intake passed.
+- Focused regression passed4/4 after final fixture edit; scoped ESLint and canonical Web prepared typecheck passed. The typecheck first needed the declared device-syncd build for an existing service export; that build passed without source changes.
+- Complexity guard passed (test tree excluded by its policy); manual review found one scoped promise tail, no nested lock acquisition, and no production owner change. Privacy and diff checks passed.
+- Implementation candidate complete; user-requested exact-head ReviewGPT and required CI are the remaining PR landing gates.
+Status: completed
+Updated: 2026-09-05
+Completed: 2026-09-05

--- a/apps/web/test/hosted-member-seeds.test.ts
+++ b/apps/web/test/hosted-member-seeds.test.ts
@@ -1,0 +1,141 @@
+import { setImmediate } from "node:timers/promises";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const seedMocks = vi.hoisted(() => ({
+  createMember: vi.fn(),
+  disconnect: vi.fn(),
+  routeMember: vi.fn(),
+}));
+
+vi.mock("../src/lib/prisma", () => ({
+  createPrismaClient: () => ({
+    $disconnect: seedMocks.disconnect,
+    $transaction: async (operation: (tx: object) => Promise<void>) => operation({}),
+  }),
+}));
+vi.mock("../src/lib/hosted-onboarding/contact-privacy", () => ({
+  createHostedPhoneLookupKey: () => "synthetic-phone-key",
+  createHostedPhoneLookupKeyReadCandidates: () => [],
+  readHostedPhoneHint: () => "0001",
+}));
+vi.mock("../src/lib/hosted-crypto/domain-root-store", () => ({
+  provisionHostedCryptoDomainRootsForUserTx: vi.fn(),
+}));
+vi.mock("../src/lib/hosted-onboarding/hosted-member-identity-store", () => ({
+  upsertHostedMemberIdentity: vi.fn(),
+}));
+vi.mock("../src/lib/hosted-onboarding/hosted-member-routing-store", () => ({
+  readHostedMemberRoutingState: vi.fn(),
+  upsertHostedMemberHomeLinqBindingTx: vi.fn(),
+  upsertHostedMemberHomeLinqRecipientPhoneTx: seedMocks.routeMember,
+  upsertHostedMemberTelegramRoutingBindingTx: vi.fn(),
+}));
+vi.mock("../src/lib/hosted-onboarding/hosted-member-store", () => ({
+  createHostedMember: seedMocks.createMember,
+}));
+vi.mock("../src/lib/hosted-onboarding/hosted-member-billing-store", () => ({
+  writeHostedMemberStripeBillingRefTx: vi.fn(),
+}));
+vi.mock("../src/lib/hosted-onboarding/starter-usage-grant", () => ({
+  ensureHostedStarterUsageGrantTx: vi.fn(),
+}));
+vi.mock("../src/lib/hosted-onboarding/linq-daily-state", () => ({
+  incrementHostedLinqInboundDailyState: vi.fn(),
+}));
+vi.mock("../src/lib/hosted-onboarding/linq-line-store", () => ({
+  projectHostedLinqLineForDeliveryReceiptTx: vi.fn(),
+  upsertHostedLinqLineForPhoneTx: vi.fn(),
+}));
+
+import { seedHostedActiveLinqMember } from "./support/hosted-member-seeds";
+
+function seed(memberId: string, environment?: NodeJS.ProcessEnv) {
+  return seedHostedActiveLinqMember({
+    environment,
+    homePhone: "+15559870002",
+    memberId,
+    memberPhone: "+15559870001",
+  });
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+describe("hosted member seed environment ownership", () => {
+  let originalEnvironment: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnvironment = { ...process.env };
+    process.env.HOSTED_MAILBOX_FINGERPRINT_KEY = "synthetic-original";
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnvironment;
+  });
+
+  it.each([false, true])("serializes routing and restores environment after first failure=%s", async (failFirst) => {
+    const firstEntered = deferred();
+    const releaseFirst = deferred();
+    const routes: Array<[string, string | undefined]> = [];
+    const failure = new Error("synthetic seed failure");
+    seedMocks.createMember.mockImplementation(async ({ memberId }: { memberId: string }) => {
+      if (memberId === "member_first") {
+        firstEntered.resolve();
+        await releaseFirst.promise;
+        if (failFirst) throw failure;
+      }
+    });
+    seedMocks.routeMember.mockImplementation(async ({ memberId }: { memberId: string }) => {
+      routes.push([memberId, process.env.HOSTED_MAILBOX_FINGERPRINT_KEY]);
+    });
+
+    const first = seed("member_first", { NODE_ENV: "test", HOSTED_MAILBOX_FINGERPRINT_KEY: "synthetic-first" });
+    const firstOutcome = first.catch((error: unknown) => error);
+    await Promise.race([firstEntered.promise, first]);
+    const second = seed("member_second", { NODE_ENV: "test", HOSTED_MAILBOX_FINGERPRINT_KEY: "synthetic-second" });
+    const secondOutcome = second.catch((error: unknown) => error);
+    try {
+      await setImmediate();
+      expect(seedMocks.createMember).toHaveBeenCalledTimes(1);
+      expect(process.env.HOSTED_MAILBOX_FINGERPRINT_KEY).toBe("synthetic-first");
+    } finally {
+      releaseFirst.resolve();
+      await Promise.all([firstOutcome, secondOutcome]);
+    }
+
+    expect(await firstOutcome).toBe(failFirst ? failure : undefined);
+    expect(await secondOutcome).toBeUndefined();
+    expect(routes).toEqual([
+      ...(failFirst ? [] : [["member_first", "synthetic-first"]]),
+      ["member_second", "synthetic-second"],
+    ]);
+    expect(seedMocks.disconnect).toHaveBeenCalledTimes(2);
+    expect(process.env.HOSTED_MAILBOX_FINGERPRINT_KEY).toBe("synthetic-original");
+  });
+
+  it.each([false, true])("resolves queued ambient environment after restoration, explicit process.env=%s", async (explicit) => {
+    const firstEntered = deferred();
+    const releaseFirst = deferred();
+    const observed: Array<string | undefined> = [];
+    seedMocks.createMember.mockImplementation(async ({ memberId }: { memberId: string }) => {
+      if (memberId === "member_first") {
+        firstEntered.resolve();
+        await releaseFirst.promise;
+      } else {
+        observed.push(process.env.HOSTED_MAILBOX_FINGERPRINT_KEY);
+      }
+    });
+    const first = seed("member_first", { NODE_ENV: "test", HOSTED_MAILBOX_FINGERPRINT_KEY: "synthetic-first" });
+    await Promise.race([firstEntered.promise, first]);
+    const second = seed("member_second", explicit ? process.env : undefined);
+    releaseFirst.resolve();
+    await Promise.all([first, second]);
+    expect(observed).toEqual(["synthetic-original"]);
+    expect(process.env.HOSTED_MAILBOX_FINGERPRINT_KEY).toBe("synthetic-original");
+  });
+});

--- a/apps/web/test/support/hosted-member-seeds.ts
+++ b/apps/web/test/support/hosted-member-seeds.ts
@@ -1275,16 +1275,24 @@ async function seedHostedJunctionDeviceSyncConnectionWithStore(input: {
   };
 }
 
+let hostedMemberSeedEnvironmentTail: Promise<void> = Promise.resolve();
+
 async function withHostedMemberSeedEnvironment<T>(
   source: NodeJS.ProcessEnv | undefined,
   operation: (environment: NodeJS.ProcessEnv) => Promise<T>,
 ): Promise<T> {
-  const scope = applyHostedMemberSeedEnvironment(source);
-  try {
-    return await operation(scope.environment);
-  } finally {
-    scope.restore();
-  }
+  const result = hostedMemberSeedEnvironmentTail.then(async () => {
+    // Read ambient inputs only after the preceding scope restores them.
+    const scope = applyHostedMemberSeedEnvironment(source);
+    try {
+      return await operation(scope.environment);
+    } finally {
+      scope.restore();
+    }
+  });
+  // A failed seed must release the environment for the next caller too.
+  hostedMemberSeedEnvironmentTail = result.then(() => {}, () => {});
+  return await result;
 }
 
 function applyHostedMemberSeedEnvironment(


### PR DESCRIPTION
## Why and outcome

Concurrent hosted-local member seeds replace each other's process-wide environment while awaiting storage work. Serialize the existing test-helper environment scope so each seed retains its settings through routing and disconnect, restores the caller's settings, and releases the next caller after success or failure.

Frog autofix issue: #2647

## Product UX

- Effort: Not applicable — synthetic test infrastructure only.
- Result: Ready
- Walkthrough: Concurrent Linq member seeds with distinct settings stay isolated; a failed predecessor releases its queued peer; omitted and explicit ambient settings are read after restoration.

## Evidence

- Direct: Four deterministic cases call the public Linq seed helper and pause actual member creation at mocked storage boundaries. All four failed on the original helper and passed after correction. They inspect the routing environment, error propagation, disconnect, and final restoration.
- Coverage: Existing environment setup/restore and public seed call paths run directly. No production database, provider request, or hosted deployment was used.
- Commands: Focused hosted-Web Vitest passed 4/4; scoped Web ESLint passed; canonical Web prepared typecheck passed after building the existing device-syncd service export. Frozen installation and the device-syncd build passed.
- Review: User-requested round-1 full-diff ReviewGPT passed on the exact candidate with no findings; requested and actual model matched. Exact capture/hash checks passed; capture occurred365.7 seconds after response waiting began.
- Pending: Required exact-head CI.

## Non-obvious affected surfaces

All test helper operations already using the member-seed environment scope share the same serialization. The family-member composite completes its inner Linq seed before entering its next scope, so it cannot wait on itself.

## Architecture and reuse

- Existing systems reused: The test-only member-seed environment setup, restore, and cached-global cleanup.
- New logic: A module-local promise tail holds that existing scope through asynchronous completion; a rejected seed does not reject the tail.
- New abstractions: None; no new exported helper or durable state.
- Complexity intentionally avoided: No production queue, locking dependency, timeout, or generic environment manager.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; its source policy excludes the test tree.
- Hotspots: No changed production function; manual inspection of the changed test-helper function found no hotspot above 20.
- Agent judgment: One short promise tail is the smallest correction at the existing environment owner. No further split or abstraction is justified.

## Hot reply path impact

Not applicable: only hosted-local test support changes; production database/network calls and foreground timing remain unchanged.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no provider-visible prompt, tool, or generated input changes.

## Deployment concerns

- Deployment: not applicable
- Reason: Synthetic test helper and regression coverage only.

## Change-shape breakdown

Test helper and regression:155 additions,6 deletions. Completed plan:29 additions,0 deletions. Source, config/tooling, generated/other:0. Total:184 additions,6 deletions. No binary files.

## Changelog

- Changelog: not applicable
- Reason: Internal synthetic fixture isolation has no member-visible change.

ReviewGPT context sensitivity: routine
Classification reason: Isolated test helper; no production behavior, auth, persistence, dependency, or external effect changes.
ReviewGPT first-reviewed head: ac495cfd4e3a3a2ad02b737185ee339cb1b16eb9
