### PR TITLE
fix(cli): reject misplaced workout exercise fields

### DIFF
--- a/apps/web/changelog/entries/2026-09-04/workout-setup-validates-exercise-details.json
+++ b/apps/web/changelog/entries/2026-09-04/workout-setup-validates-exercise-details.json
@@ -1,0 +1,17 @@
+{
+  "publishedOn": "2026-09-04",
+  "order": 100,
+  "item": {
+    "id": "workout-setup-validates-exercise-details",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Workout setup catches misplaced exercise details",
+    "summary": "Workout setup now rejects misplaced set counts and other exercise details before saving a plan.",
+    "details": "This catches cases where a set count became part of an exercise name and left the plan at one set. Valid exercise names, notes, and optional set defaults keep their existing behavior.",
+    "relevanceTags": [
+      "workouts",
+      "training"
+    ],
+    "sourcePullRequests": []
+  }
+}

--- a/apps/web/changelog/entries/2026-09-04/workout-setup-validates-exercise-details.json
+++ b/apps/web/changelog/entries/2026-09-04/workout-setup-validates-exercise-details.json
@@ -12,6 +12,8 @@
       "workouts",
       "training"
     ],
-    "sourcePullRequests": []
+    "sourcePullRequests": [
+      2893
+    ]
   }
 }

--- a/packages/cli/src/commands/workout-live.ts
+++ b/packages/cli/src/commands/workout-live.ts
@@ -54,6 +54,23 @@ function invalidInitialExercise(message: string): never {
   throw new VaultCliError('invalid_option', message)
 }
 
+function rejectEmbeddedExerciseFields(
+  fields: ReadonlyMap<string, string>,
+): void {
+  // Notes remain free text; other fields must not swallow supported assignments.
+  for (const [key, value] of fields) {
+    if (key === 'note') continue
+    for (const match of value.matchAll(/[,\s]([A-Za-z][A-Za-z0-9]*)\s*=/gu)) {
+      const embeddedField = match[1]
+      if (embeddedField !== undefined && initialExerciseFields.has(embeddedField)) {
+        invalidInitialExercise(
+          `--exercise field "${key}" contains "${embeddedField}=" without a semicolon separator. Use ";${embeddedField}=..." to start a separate field.`,
+        )
+      }
+    }
+  }
+}
+
 function parseInitialExercise(
   entry: string,
 ): StartLiveWorkoutExerciseInput {
@@ -68,6 +85,7 @@ function parseInitialExercise(
     initialExerciseFields,
     invalidInitialExercise,
   )
+  rejectEmbeddedExerciseFields(fields)
   const setCount = compactInteger(
     fields,
     'sets',

--- a/packages/cli/test/workout-live-command.test.ts
+++ b/packages/cli/test/workout-live-command.test.ts
@@ -349,6 +349,110 @@ test('ad-hoc workout start accepts canonical decimal planned loads', async () =>
   assert.equal(rejected.envelope.error.code, 'invalid_payload')
 })
 
+test('live workout starts reject misplaced compact exercise fields before writing', async () => {
+  const { parentRoot, vaultRoot } = await createTempVaultContext(
+    'murph-workout-compact-fields-',
+  )
+  cleanupPaths.push(parentRoot)
+  const cli = createWorkoutCli()
+  assert.equal(requireData((await run<{ created: boolean }>(cli, [
+    'init', '--vault', vaultRoot, '--timezone', 'UTC',
+  ])).envelope).created, true)
+
+  const persisted: HostedCanonicalWritePersistenceInput[] = []
+  await withHostedCanonicalWritePort(
+    {
+      async persistCanonicalWrite(input) {
+        persisted.push(input)
+      },
+    },
+    async () => {
+      for (const [exercise, embeddedField] of [
+        ['name=Step-up,sets=4;mode=bodyweight', 'sets'],
+        ['name=Step-up reps=6;sets=2;mode=bodyweight', 'reps'],
+        ['name=Step-up, sets = 4;mode=bodyweight', 'sets'],
+        ['name=Step-up,\tsets\t=\t4;mode=bodyweight', 'sets'],
+        ['name=Step-up, tempo=controlled, sets=4;mode=bodyweight', 'sets'],
+        ['name=Step-up,name=Push-up;mode=bodyweight', 'name'],
+        ['name=Step-up,targetWeight=20;mode=bodyweight', 'targetWeight'],
+        ['name=Step-up,targetWeightUnit=kg;mode=bodyweight', 'targetWeightUnit'],
+        ['name=Step-up,sourceExerciseId=EX_STEP;mode=bodyweight', 'sourceExerciseId'],
+        ['name=Step-up,groupId=circuit-a;mode=bodyweight', 'groupId'],
+        ['name=Step-up,mode=bodyweight', 'mode'],
+        ['name=Row,unitOverride=kg;mode=weight_reps', 'unitOverride'],
+        ['name=Step-up,note=Controlled;mode=bodyweight', 'note'],
+        ['name=Step-up;sourceExerciseId=EX_STEP,sets=4;mode=bodyweight', 'sets'],
+        ['name=Step-up;groupId=circuit-a reps=6;mode=bodyweight', 'reps'],
+        ['name=Step-up;sets=4,reps=6;mode=bodyweight', 'reps'],
+        ['name=Step-up;mode=bodyweight,sets=4', 'sets'],
+      ] as const) {
+        const result = await run<WorkoutResult>(cli, [
+          'workout', 'start', 'Compact field validation',
+          '--exercise', 'name=Push-up;sets=2;mode=bodyweight',
+          '--exercise', exercise,
+          '--vault', vaultRoot,
+        ])
+        assert.equal(result.envelope.ok, false)
+        if (result.envelope.ok) {
+          throw new Error('Expected misplaced compact exercise fields to fail.')
+        }
+        assert.equal(result.envelope.error.code, 'invalid_option')
+        assert.match(result.envelope.error.message ?? '', /semicolon/iu)
+        assert.ok(result.envelope.error.message?.includes(`;${embeddedField}=`))
+        assert.equal(persisted.length, 0)
+      }
+    },
+  )
+  assert.equal(persisted.length, 0)
+})
+
+test('live workout compact fields preserve punctuation, notes, and default sets', async () => {
+  const { parentRoot, vaultRoot } = await createTempVaultContext(
+    'murph-workout-compact-literals-',
+  )
+  cleanupPaths.push(parentRoot)
+  const cli = createWorkoutCli()
+  assert.equal(requireData((await run<{ created: boolean }>(cli, [
+    'init', '--vault', vaultRoot, '--timezone', 'UTC',
+  ])).envelope).created, true)
+
+  const started = requireData((await run<WorkoutResult>(cli, [
+    'workout', 'start', 'Compact exercise literals',
+    '--exercise', 'name=Step-up;sets=4;reps=6;mode=bodyweight;sourceExerciseId=EX_STEP;groupId=circuit-a',
+    '--exercise', 'name=Row, neutral grip;sets=3;mode=weight_reps;unitOverride=kg',
+    '--exercise', String.raw`name=Band\row (left/right);mode=bodyweight;note=Keep tempo=controlled, sets=optional`,
+    '--exercise', String.raw`name=Row, sets\=optional + press (left/right)!;mode=bodyweight`,
+    '--exercise', 'name=Step-up, tempo=controlled;mode=bodyweight',
+    '--exercise', 'name=Offsetsets=4;mode=bodyweight',
+    '--vault', vaultRoot,
+  ])).envelope)
+  const shown = requireData((await run<ShowResult>(cli, [
+    'workout', 'show', started.eventId, '--vault', vaultRoot,
+  ])).envelope)
+  const exercises = shown.entity.data.workout.exercises
+  assert.deepEqual(exercises.map((exercise) => exercise.name), [
+    'Step-up',
+    'Row, neutral grip',
+    String.raw`Band\row (left/right)`,
+    String.raw`Row, sets\=optional + press (left/right)!`,
+    'Step-up, tempo=controlled',
+    'Offsetsets=4',
+  ])
+  assert.deepEqual(
+    exercises.map((exercise) => exercise.sets.length),
+    [4, 3, 1, 1, 1, 1],
+  )
+  assert.deepEqual(
+    exercises.map((exercise) => exercise.setPlanIsFinite),
+    [true, true, false, false, false, false],
+  )
+  assert.equal(exercises[0]?.memberRepsPerSet, 6)
+  assert.equal(exercises[0]?.sourceExerciseId, 'EX_STEP')
+  assert.equal(exercises[0]?.groupId, 'circuit-a')
+  assert.equal(exercises[1]?.unitOverride, 'kg')
+  assert.equal(exercises[2]?.note, 'Keep tempo=controlled, sets=optional')
+})
+
 test('ad-hoc workout exercises require explicit editor modes and weight units', async () => {
   const { parentRoot, vaultRoot } = await createTempVaultContext(
     'murph-live-workout-editor-mode-',


### PR DESCRIPTION
## Why and outcome

A misplaced comma or space in compact workout exercise arguments could store a set count as part of an exercise name and leave the plan at the one-set default. Workout start now rejects supported field assignments missing their semicolon separator before invoking canonical persistence, with an actionable field-specific repair.

## Product UX

- Effort: Patch.
- Result: Ready.
- Walkthrough: Malformed exercise details fail before any workout write, including when an earlier exercise is valid. Properly separated set counts, literal punctuation and backslashes, free-text notes, and omitted set defaults retain their existing behavior.

## Evidence

- Direct: The new regression failed against the unchanged parser because malformed input succeeded. The final focused workout command suite passes 14 tests, including 17 malformed cases with zero canonical writes and persisted readback for six valid exercises.
- Coverage: CLI command parsing through the hosted canonical write boundary and canonical workout readback. CLI typecheck passes.
- ReviewGPT implementation: Managed GPT-6 Pro produced the source-and-test patch. Applied its downloaded patch and extracted the validator into a private helper after the complexity guard flagged added branching in the existing parser.
- Changelog: `pnpm --dir apps/web test -- changelog-page.test.tsx` passed (9 tests). `pnpm --dir apps/web typecheck` also passed. CLI typecheck covers the changed TypeScript.
- Built CLI: malformed second exercise returns `invalid_option`, `retryable: false`, semicolon repair guidance, no submitted name/path echo, and zero vault file changes; correctly separated input creates four sets.
- Final ReviewGPT: PASS on `4e8c5a28bcb3d932e56fe9290434689f0bccffec`; Phlebas captured GPT-6 Pro, exact turn/signature and response SHA256 verified, 627.214 seconds from send to completed capture. The full three-file snapshot and empty remediation deltas were verified. Independent source probes exercised a 900-case assignment matrix, malformed batches, canonical start ordering, valid/default targets and changelog loading; no qualifying Critical, High, or Complexity Collapse findings. [Accepted review](https://chatgpt.com/c/6a9ba41a-8300-83e9-95fa-3fab6d7dbebc). The earlier 325.49-second capture remains diagnostic only because it was below the repository minimum.
- Exact-head CI: [Release verification passed](https://github.com/cobuildwithus/murph/actions/runs/33946004688) on the reviewed head. All package coverage, Web tests, Cloudflare verification, runner bundle proof and the release aggregator passed. The first Web build worker exhausted its heap; its isolated same-head retry passed without source or configuration changes.

## Non-obvious affected surfaces

The shared compact parser and canonical one-set default remain unchanged. Valid workout metadata, editor modes, and notes are checked through canonical readback.

## Architecture and reuse

- Existing systems reused: Workout-owned allowed-field set, compact field parsing, typed CLI errors, and canonical workout use case.
- New logic: Reject known compact assignments embedded after commas or whitespace in non-note fields.
- New abstractions: One private workout validator keeps the existing parser's branching unchanged; no shared abstraction or state owner.
- Complexity intentionally avoided: No new parser protocol, dependencies, storage, or alternate persistence path.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff --base 18b498bc49435c49adb99588754a8a2bf72c4ce6`; maximum complexity remains 25 and debt remains 5.
- Hotspots: Existing `parseInitialExercise` remains at complexity 25. The added validation has its own narrow helper.
- Agent judgment: Further parser refactoring would expand this behavior fix without reducing its implementation risk.

## Hot reply path impact

- Path status: Not applicable — local synchronous workout argument validation adds no orchestration or awaited work.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved.
- Before/after proof: Malformed commands now stop before the canonical write port; successful command readback remains covered.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no prompts, tool descriptions, schemas, routing, or generated provider guidance changed. No provider-input measurement was needed.

## Design proof

- Design page: [Changelog archive](https://www.withmurph.ai/screenshots/ops#changelog-archive).
- Evidence: Authored changelog content only, following the documented no-preview route.
- Coverage: Existing archive representation applies; no renderer, layout, style, or interaction changed. Focused changelog validation passed all nine tests.

## Deployment concerns

- Deployment: not applicable
- Reason: Synchronous CLI validation with no schema, stored-state, protocol, or independently deployed consumer change.

## Change-shape breakdown

Classification rule: Production TypeScript is source; command tests are tests; the authored changelog JSON is product content under other. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 18 | 0 |
| Tests / fixtures | 104 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 19 | 0 |
| **Total** | **141** | **0** |

## Changelog

- Changelog: updated
- Items: 2026-09-04 · workout-setup-validates-exercise-details

ReviewGPT first-reviewed head: 4e8c5a28bcb3d932e56fe9290434689f0bccffec
ReviewGPT context sensitivity: sensitive
Reason: CLI input validation guards canonical workout writes.
