### PR TITLE
Preserve bounded ECG binding reasons in failure telemetry

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1446,6 +1446,12 @@ Last verified: 2026-09-04
   `device-sync.maintenance_failed`, and activity scheduling uses
   `assistant.device_activity_automation_failed`; none increments the
   failed-attempt metric.
+  For `JUNCTION_ECG_RECORDING_BINDING_INCOMPLETE`, the existing failed-attempt
+  event may also carry `junctionEcgBindingReason`, checked against the same
+  finite service-owned reason set before generic log sanitization. Missing,
+  malformed, and unknown reasons are omitted. ECG recording/sample counts,
+  identifiers, raw errors, URLs, paths, and payloads remain excluded. This reason
+  describes local binding validation, not proof of an upstream HTTP response.
   Junction sync-result metadata preserves the existing historical progress and
   coverage keys before optional diagnostics when the 16-entry envelope fills.
   The provider owner supplies that priority to the shared sanitized merge for

--- a/agent-docs/exec-plans/completed/2026-09-05-device-sync-failure-telemetry.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-device-sync-failure-telemetry.md
@@ -1,0 +1,61 @@
+# Preserve bounded ECG failure reasons in hosted telemetry
+
+Status: completed
+Created: 2026-09-05
+Updated: 2026-09-05
+
+## Goal
+
+Expose the existing closed-vocabulary ECG binding rejection reason in hosted device-sync failure telemetry so operators can distinguish incomplete collections from identity conflicts without reading health payloads.
+
+## Success criteria
+
+- Synthetic hosted failure proof fails on the base and passes with the accepted ReviewGPT patch.
+- Existing log sanitization, foreground priority, canonical ownership, retries, and import behavior are unchanged.
+- Focused tests, affected typecheck, parent review, final ReviewGPT and required exact-head CI pass.
+- Any telemetry deployment follows the existing reviewed production path; record the observation query and retention decision.
+
+## Scope
+
+- In scope: existing hosted failure projection, closed reason metadata, focused proof, owner documentation; read-only wake and failure investigation.
+- Out of scope: provider payloads or health/sample values, recovery operations, new state or schedulers, changes to identity validation, retries, credentials, and existing PR-owned checkpoint behavior.
+
+## Constraints
+
+- ReviewGPT authors production implementation and substantive revisions. Local work owns investigation, test-only reproduction, patch application, verification, and Git.
+- The device service owns sanitized ECG diagnostics; hosted logging projects that existing fact. No new persistence owner, event stream, provider I/O, or log volume.
+- Existing observability retention and event limits apply. Only a finite reason vocabulary is needed; sample/recording counts are excluded.
+
+## Risks and mitigations
+
+- A generic code formatter is not a semantic privacy allowlist: prove unknown/freeform reasons cannot escape.
+- Old runners omit the field; absence must remain unknown, not successful recovery.
+- A passed sync job or consumed wake alone does not prove each resource imported; keep aggregate and outcome evidence distinct.
+
+## Tasks
+
+1. Reverify current production aggregates and branch ownership; classify aged wakes and failures.
+2. Ask ReviewGPT for the smallest diagnostic projection patch plus composed positive/privacy regression proof.
+3. Apply accepted patch exactly; prove the base failure and head pass, typecheck and inspect diff.
+4. Commit, push, open PR, final ReviewGPT concurrently with required CI; remediate through ReviewGPT if needed.
+5. If telemetry deployment is needed and gates permit, deploy exact reviewed change and verify read-only. Preserve bug-fix merge/deployment prohibitions.
+
+## Decisions
+
+- Preserve only the binding reason; no health-related sample counts, values, identifiers, or raw errors.
+- Existing idle checkpoint PR retains its owner; this task does not edit that branch.
+
+## Verification
+
+- Baseline: existing maintenance suite 100 tests passed; mailbox-state suite 24 tests passed; assistant-runtime typecheck passed.
+- ReviewGPT authored the accepted four-file patch. Its test-only application produced exactly two expected failures for allowed queued/exhausted reasons; the other 109 maintenance cases passed.
+- The exact accepted source patch passes 168 maintenance and assistant-phase scheduling tests. Both assistant-runtime and device-syncd typechecks pass.
+- Complexity guard passes with unchanged file debt/maxima. Existing orchestration and diagnostic hotspots are unchanged and outside this bounded projection correction. Documentation index updated mechanically to satisfy owner-doc drift validation.
+- Parent review: one existing finite set is exported through an existing package entrypoint, with no dependency or owner added. The projection preserves the reason before the shared key cap. Synthetic proof covers normal, exhausted, malformed and wrong-code cases through the existing event parser and shared sanitizer.
+- No new developer-friction entry: existing worktree-helper issue remains owned separately.
+- Final external review, exact-head CI, merge and any deployment evidence will be recorded in the PR. Deployment observation remains dependent on naturally occurring failures; no replay is authorized.
+
+- Existing hosted-runtime maintenance tests with synthetic failures, assistant-runtime typecheck, complexity guard, documentation drift, diff checks.
+- Before: the hosted event omits the service-owned allowed reason. After: an allowed reason survives, and unknown/private fields remain absent.
+- Post-deploy: aggregate device-sync.job_failed by the bounded ECG reason over the next 24 hours, with no active replay; retain this low-cardinality field under the existing log retention policy if diagnostically useful.
+Completed: 2026-09-05

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -10,7 +10,8 @@ are specified by `ARCHITECTURE.md`, `agent-docs/RELIABILITY.md`, and
 `agent-docs/references/testing-ci-map.md`.
 
 Device-sync metadata priority within the existing bounded envelope is specified
-by `agent-docs/RELIABILITY.md`; Junction's progress keys remain provider-owned.
+by `agent-docs/RELIABILITY.md`, including the service-owned finite ECG binding
+reason in hosted failure events; Junction's progress keys remain provider-owned.
 
 This is a directory, not a second copy of the system contracts. Start with
 `AGENTS.md` and `agent-docs/operations/agent-workflow-routing.md`; open the

--- a/packages/assistant-runtime/src/hosted-runtime/device-sync-maintenance.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/device-sync-maintenance.ts
@@ -22,6 +22,7 @@ import type {
   DeviceSyncJobTimingDiagnostic,
 } from "@murphai/device-syncd/types";
 import {
+  JUNCTION_ECG_BINDING_REASONS,
   resolveDeviceSyncStoreNextJobWakeAt,
   resolveDeviceSyncStoreNextWakeAt,
   type DeviceSyncService,
@@ -2031,6 +2032,16 @@ function buildHostedDeviceSyncFailureDiagnosticRedactedJson(
   const redacted: Record<string, boolean | number | string | null> = {
     failureRetryable: diagnostic.retryable,
   };
+
+  // Keep this finite reason ahead of optional details for bounded log sanitizers.
+  const ecgBindingReason = diagnostic.details.junctionEcgBindingReason;
+  if (
+    diagnostic.code === "JUNCTION_ECG_RECORDING_BINDING_INCOMPLETE"
+    && typeof ecgBindingReason === "string"
+    && JUNCTION_ECG_BINDING_REASONS.has(ecgBindingReason)
+  ) {
+    redacted.junctionEcgBindingReason = ecgBindingReason;
+  }
 
   if (diagnostic.accountStatus) {
     redacted.providerAccountStatus = toHostedRuntimeLogCode(diagnostic.accountStatus);

--- a/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@murphai/hosted-execution/runtime-control";
 import { parseHostedRuntimeLogRequest } from "@murphai/hosted-execution/parsers";
 import { SqliteDeviceSyncStore } from "@murphai/device-syncd/service";
+import { sanitizeHostedExecutionStructuredLogDetails } from "@murphai/hosted-execution";
 import {
   restoreHostedExecutionContext,
   snapshotHostedExecutionContext,
@@ -4092,7 +4093,44 @@ describe("runHostedDeviceSyncPass", () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
-  it("emits exactly one sanitized job-failed event for a failed device-sync attempt", async () => {
+  it.each<{
+    code: string;
+    expectedReason?: string;
+    exhausted?: boolean;
+    label: string;
+    reason?: unknown;
+  }>([
+    { label: "ordinary failure", code: "SYNC_JOB_FAILED" },
+    ...[
+      { label: "valid queued reason", reason: "sample_count_mismatch", expectedReason: "sample_count_mismatch" },
+      { label: "valid exhausted reason", reason: "summary_identity_incomplete", expectedReason: "summary_identity_incomplete", exhausted: true },
+      { label: "missing reason" },
+      { label: "unknown token", reason: "unknown_binding_reason" },
+      { label: "freeform reason", reason: "synthetic-private-ecg detail" },
+      { label: "padded reason", reason: " sample_count_mismatch " },
+      { label: "null reason", reason: null },
+      { label: "numeric reason", reason: 123 },
+      { label: "array reason", reason: ["sample_count_mismatch"] },
+      { label: "object reason", reason: { reason: "sample_count_mismatch" } },
+    ].map((entry) => ({ ...entry, code: "JUNCTION_ECG_RECORDING_BINDING_INCOMPLETE" })),
+    { label: "reason on another failure", code: "SYNC_JOB_FAILED", reason: "sample_count_mismatch" },
+  ])("emits exactly one sanitized job-failed event: $label", async ({ code, expectedReason, exhausted = false, reason }) => {
+    const ecgFailure = code === "JUNCTION_ECG_RECORDING_BINDING_INCOMPLETE";
+    const provider = ecgFailure ? "junction" : "whoop";
+    const sensitiveEcgDetails = {
+      junctionEcgActualRecordingCount: 987_001,
+      junctionEcgActualSampleCount: 987_002,
+      junctionEcgExpectedRecordingCount: 987_003,
+      junctionEcgExpectedSampleCount: 987_004,
+      junctionEcgMaxRecordingCount: 987_005,
+      junctionEcgMaxSampleCount: 987_006,
+      recordingId: "synthetic-private-ecg-recording",
+      sampleId: "synthetic-private-ecg-sample",
+      rawError: "synthetic-private-ecg-error",
+      url: "https://example.test/synthetic-private-ecg",
+      path: "/tmp/synthetic-private-ecg",
+      payload: { voltage: "synthetic-private-ecg-payload" },
+    };
     const close = vi.fn();
     const drainWorker = vi.fn(async () => 1);
     const runSchedulerOnce = vi.fn(async () => undefined);
@@ -4107,9 +4145,11 @@ describe("runHostedDeviceSyncPass", () => {
         {
           accountId: "local_account_sensitive",
           accountStatus: null,
-          attempts: 1,
-          code: "SYNC_JOB_FAILED",
+          attempts: exhausted ? 5 : 1,
+          code,
           details: {
+            ...sensitiveEcgDetails,
+            ...(reason === undefined ? {} : { junctionEcgBindingReason: reason }),
             failureCauseCode: "UND_ERR_CONNECT_TIMEOUT",
             failureErrorCause: "Connect Timeout Error",
             failureErrorName: "TypeError",
@@ -4144,24 +4184,24 @@ describe("runHostedDeviceSyncPass", () => {
             providerOAuthResponseErrorFieldPresent: true,
             providerOAuthResponseShapeKind: "json_object",
           },
-          jobDisposition: "queued",
+          jobDisposition: exhausted ? "dead" : "queued",
           jobKind: "reconcile",
           maxAttempts: 5,
-          remainingAttempts: 4,
+          remainingAttempts: exhausted ? 0 : 4,
           retryable: true,
         },
       ]),
       listAccounts: vi.fn(() => [
         {
           id: "local_account_sensitive",
-          lastErrorCode: "SYNC_JOB_FAILED",
+          lastErrorCode: code,
           lastErrorMessage:
             "Importer failed reading file://<fixture-path> for owner@example.test with access_token=<fixture-secret>.",
           lastSyncCompletedAt: null,
           lastSyncErrorAt: "2026-04-08T00:00:03.000Z",
           lastSyncStartedAt: "2026-04-08T00:00:01.000Z",
           nextReconcileAt: "2026-04-08T02:00:00.000Z",
-          provider: "whoop",
+          provider,
           setupPhase: null,
           status: "active",
         },
@@ -4213,7 +4253,7 @@ describe("runHostedDeviceSyncPass", () => {
         runtimeLogPlatform: {
           logPort: {
             async write(request) {
-              logRequests.push(request);
+              logRequests.push(parseHostedRuntimeLogRequest(request));
               return {
                 loggedCount: request.entries.length,
               };
@@ -4236,18 +4276,18 @@ describe("runHostedDeviceSyncPass", () => {
     const entry = jobFailureEntries[0];
     assert.ok(entry);
     assert.equal(entry.component, "device-sync");
-    assert.equal(entry.errorCode, "SYNC_JOB_FAILED");
+    assert.equal(entry.errorCode, code);
     assert.equal(entry.eventCode, "device-sync.job_failed");
     assert.equal(entry.level, "warn");
     assert.equal(entry.phase, "invoke");
     assert.deepEqual(entry.redactedJson, {
-      failureCode: "SYNC_JOB_FAILED",
-      failureDisposition: "queued",
+      failureCode: code,
+      failureDisposition: exhausted ? "dead" : "queued",
       failureEventOrigin: "worker_attempt",
-      failureJobAttempts: 1,
+      failureJobAttempts: exhausted ? 5 : 1,
       failureJobKind: "reconcile",
       failureJobMaxAttempts: 5,
-      failureJobRemainingAttempts: 4,
+      failureJobRemainingAttempts: exhausted ? 0 : 4,
       failureSummary:
         "Importer failed reading <redacted-path> for <redacted-email> with",
       failureCauseCode: "UND_ERR_CONNECT_TIMEOUT",
@@ -4262,6 +4302,7 @@ describe("runHostedDeviceSyncPass", () => {
       normalizationTimestampKind: "invalid",
       normalizationTimestampSemantics: "unknown",
       failureRetryable: true,
+      ...(expectedReason ? { junctionEcgBindingReason: expectedReason } : {}),
       hadPriorFailure: false,
       hadPriorSuccess: false,
       hostedConnectionKnown: true,
@@ -4289,7 +4330,7 @@ describe("runHostedDeviceSyncPass", () => {
       providerOAuthResponseErrorDescriptionFieldPresent: true,
       providerOAuthResponseErrorFieldPresent: true,
       providerOAuthResponseShapeKind: "json_object",
-      provider: "whoop",
+      provider,
       setupPhase: null,
       status: "active",
       syncCompletedAt: null,
@@ -4298,7 +4339,17 @@ describe("runHostedDeviceSyncPass", () => {
       wakeKind: "device-sync.wake",
       wakeReason: "webhook_hint",
     });
+    assert.ok(entry.redactedJson);
+    // Exercise the shared 32-key sanitizer with the fully populated diagnostic.
+    expect(Object.keys(entry.redactedJson).length).toBeGreaterThan(32);
+    const sharedDetails = sanitizeHostedExecutionStructuredLogDetails(entry.redactedJson);
+    expect(sharedDetails?.junctionEcgBindingReason).toBe(expectedReason);
+    for (const field of Object.keys(sensitiveEcgDetails)) {
+      expect(entry.redactedJson).not.toHaveProperty(field);
+      expect(sharedDetails).not.toHaveProperty(field);
+    }
     const serialized = JSON.stringify(logRequests);
+    expect(serialized).not.toContain("synthetic-private-ecg");
     expect(serialized).not.toContain("local_account_sensitive");
     expect(serialized).not.toContain("hosted_connection_sensitive");
     expect(serialized).not.toContain("file://");

--- a/packages/device-syncd/src/service.ts
+++ b/packages/device-syncd/src/service.ts
@@ -151,7 +151,7 @@ const JUNCTION_WORKOUT_STREAM_CANDIDATE_DIAGNOSTIC_LIMIT =
   resolveJunctionTimeseriesResourcePolicy("workout_stream")?.maxRecordsPerWindow ?? 0;
 const JUNCTION_ECG_DIAGNOSTIC_COUNT_LIMIT =
   (resolveJunctionTimeseriesResourcePolicy("electrocardiogram_voltage")?.maxSamplesPerWindow ?? 0) + 1;
-const JUNCTION_ECG_BINDING_REASONS = new Set([
+export const JUNCTION_ECG_BINDING_REASONS: ReadonlySet<string> = new Set([
   "collection_source_ambiguous",
   "feature_cardinality_mismatch",
   "group_ambiguous",


### PR DESCRIPTION
## Why and outcome

Hosted device-sync failure logs drop the service's existing ECG binding reason, leaving distinct local validation failures under one umbrella code. Preserve `junctionEcgBindingReason` only for `JUNCTION_ECG_RECORDING_BINDING_INCOMPLETE` and only when it belongs to the existing 19-value service allowlist.

The field survives the existing shared key limit. Missing, malformed, unknown and wrong-code values remain absent; recording/sample counts, identifiers and payloads remain excluded. This changes telemetry only. The synthetic status associated with binding rejection is not evidence of an upstream HTTP response.

## Product UX

- Effort: Not applicable — internal failure diagnostics only.
- Result: Not applicable.
- Walkthrough: Import validation, retry disposition, scheduling, foreground priority and member-facing behavior are unchanged.

## Evidence

- Direct: Applied the ReviewGPT-authored tests alone to the unchanged implementation: exactly the two valid queued/exhausted reason cases failed; the other 109 maintenance cases passed. Applied the accepted source patch exactly, then all 168 maintenance and assistant-phase scheduling tests passed.
- Coverage: Composed failure emission uses the real hosted log parser and shared 32-key sanitizer. Tests cover valid queued/exhausted, absent, unknown, padded, freeform, null, numeric, array, object and wrong-code reasons, and exclude sensitive fields.
- Commands: `pnpm --dir packages/assistant-runtime test test/hosted-runtime-maintenance.test.ts test/hosted-runtime-workspace-assistant-phase-scheduling.test.ts`; `pnpm --dir packages/assistant-runtime typecheck`; `pnpm --dir packages/device-syncd typecheck` — all pass. Baseline mailbox-state suite: 24 pass. `git diff --check` and `bash scripts/check-agent-docs-drift.sh` pass.
- Authorship: ReviewGPT authored the production patch and regression proof; parent inspected and applied it exactly. Final independent ReviewGPT: PASS on the unchanged head, Hercules / gpt-6-pro; 426s after response wait started, verified exact-turn/model/hash evidence. The earlier subminimum capture was excluded and round 1 repeated. No accepted or unresolved findings. All four required exact-head checks passed: Linux and macOS host matrix, Release checks, and hosted Stripe billing boundary. [Release CI](https://github.com/cobuildwithus/murph/actions/runs/33946862167). [Review](https://chatgpt.com/c/6a9ba7c1-51ec-83ea-bb6e-811d1f2c6a7d).
- External proof: No production replay or payload inspection. Natural failures after runner rollout are needed to classify the underlying ECG issue; this patch does not claim to repair that issue.

## Non-obvious affected surfaces

The service exports its existing readonly reason set through the already-used package entrypoint. No package edge is added. Shared parser/sanitizer proof covers the optional field and existing key cap.

## Architecture and reuse

- Existing systems reused: Device service diagnostic owner, hosted failure-event projection, existing log parser and sanitizer, existing retention.
- New logic: Exact failure-code, string-type and finite-membership check before projecting one field.
- New abstractions: None; the service's existing reason set is reused.
- Complexity intentionally avoided: No new event stream, persistence owner, scheduler, retry policy, provider request or generic diagnostic passthrough.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`; file debt and maxima unchanged.
- Hotspots: Existing `runHostedDeviceSyncPass` 88, `writeHostedDeviceSyncPassLifecycleLog` 46, `buildHostedDeviceSyncFailureLogRedactedJson` 31, `runWorkerPassOnce` 81, and `buildDeviceSyncErrorFailureDiagnostics` 46. Their control flow is unchanged.
- Agent judgment: Further orchestration refactoring is outside the reason-projection boundary; the small exact membership check is the simplest sufficient correction.

## Hot reply path impact

- Path status: Not applicable — background device-sync diagnostic projection only.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved.
- Before/after proof: Source diff adds only a synchronous set lookup; assistant-phase scheduling regression suite passes.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no prompt, tool, schema, routing or provider-input surface changes.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

ReviewGPT first-reviewed head: b128ea459ca736ab0236d0124ad68c2f5867b860
ReviewGPT context sensitivity: sensitive
Classification reason: Hosted runtime telemetry crosses the existing privacy boundary, despite the bounded additive scope.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing readers accept an optional string in redacted JSON; old runners omit it, which remains unknown. No schema migration or new required field.
- Safe order: Existing compatible log readers already deployed; roll out the new runner through the protected hosted deployment workflow.
- Rollback floor: Pre-change readers and runners remain compatible; no state-format transition. No rollback is requested.
- Expected exposure: At most the existing failed-attempt events carry one field from 19 values; no added event volume or retention period. Old warm runners may omit the field until they converge.
- Reversibility: Reverting the projection removes future reason telemetry without altering canonical data.
- Convergence proof: Synthetic old/missing and new/present log shapes pass current parser/sanitizer tests. Live runner version convergence is not yet established: telemetry PR merged as `aeaf8dfc1ad6829a62b60c380fa84582d2512ff2`; deployment held because the protected workflow selects current main without a source-SHA input, and current main also contains undeployed runtime releases #2892 and #2895. The narrow telemetry deployment authority does not cover that broader release.
- Post-deploy checks: Verify immutable public source and fleet rollout read-only, then aggregate natural ECG failed attempts by bounded reason/disposition over a closed 24-hour window. Missing reason remains unknown. Retain the field under existing 14-day log retention; no replay or health values needed.

## Change-shape breakdown

Classification rule: Package source is source, package test is proof, and owner/index/completed-plan Markdown is docs. No binaries or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 12 | 1 |
| Tests / fixtures | 65 | 14 |
| Docs | 69 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **146** | **16** |

## Changelog

- Changelog: not applicable
- Reason: Internal diagnostic metadata only; no member-facing product behavior changes.


## Approved production rollout

The user approved the protected current-main rollout after merge. [Deployment 33952612888](https://github.com/cobuildwithus/murph-cloud/actions/runs/33952612888) passed all predeployment gates and managed-container smoke, deploying public source `67d41c24b9ab0e64921710ef7be7917029e08d18` with immediate container replacement and no secret synchronization. This source includes this telemetry and the independently merged mailbox-ownership fix #2844; the compatible Web reader was confirmed first.

Read-only verification matched the receipt to Worker `adac7be3-eab9-4dde-920f-9f74fd71dfbe` at 100% traffic and container application versions runner 804, standby 42, deploy-smoke 560. All three image digests matched; no old image references or active rollouts remained in the complete bounded inventory. A transient startup health event cleared. Smoke passed at 07:56:34 UTC on September 5.

Natural ECG failure observation begins after 07:56:35 UTC for up to 24 hours, grouped only by finite binding reason and failure disposition. No natural ECG failure had occurred at the initial postdeploy check, so the underlying ECG cause remains unclassified; no forced failure or replay was performed. This rollout supersedes the earlier deployment hold recorded above.
