### PR TITLE
Normalize Frog metadata and refresh build assertion

### DIFF
--- a/.agents/friction-log/20260829231539-real-codex-harness/friction.md
+++ b/.agents/friction-log/20260829231539-real-codex-harness/friction.md
@@ -1,6 +1,6 @@
 ---
-title: "Real-Codex harness login shell discards injected fixture PATH"
-severity: "minor"
+title: 'Real-Codex harness login shell discards injected fixture PATH'
+severity: 'minor'
 ---
 
 ## Expected Behavior

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -2031,7 +2031,7 @@ describe("hosted web production migration guard", () => {
     assert.match(productionNextBuildScript, /^#!\/usr\/bin\/env bash\nset -euo pipefail$/mu);
     assert.match(productionNextBuildScript, /parent_old_space_mb=1024/u);
     assert.match(productionNextBuildScript, /build_worker_old_space_mb=3072/u);
-    assert.match(productionNextBuildScript, /typecheck_old_space_mb=3584/u);
+    assert.match(productionNextBuildScript, /typecheck_old_space_mb=6144/u);
     assert.match(
       productionNextBuildScript,
       /build_cache_epoch=webpack-next-16\.3-v6-isolated-worker-no-webpack-cache/u,


### PR DESCRIPTION
## Why and outcome

Normalize two YAML scalar delimiters to Frog's existing single-quoted format. The pending reconciliation can then add its issue binding without also rewriting the report's title and severity formatting.

This is a formatting prerequisite for #2718, not a repair or closure of the underlying harness report. Required CI also exposed an existing stale build-proof assertion: the current runner uses a 6 GiB typecheck heap, while the migration guard still expected 3.5 GiB. Align that assertion with the existing runner setting.

## Product UX

- Effort: Not applicable — internal report formatting only.
- Result: Not applicable.
- Walkthrough: The existing report parses identically and remains readable.

## Evidence

- Direct: Parsed before and after with the pinned Frog 1.1.0 public `Entry.parse` API and asserted deep equality. Asserted the report body is byte-identical and the final file exactly equals `Entry.serialize` output.
- Coverage: Documentation drift, documentation gardening, diff hygiene and parent privacy inspection passed. The shared one-line assertion correction is byte-identical to the published correction in #2719; all 71 migration/build-runner tests pass. No runtime logic changed. The separate final ReviewGPT gate is exempt for meaning-preserving report formatting and an isolated test expectation.

## Non-obvious affected surfaces

The static Web build-proof assertion reflects the already-shipped typecheck heap setting; it does not change the runner. The existing Frog Action remains the issue and reconciliation owner.

## Architecture and reuse

- Existing systems reused: The pinned Frog entry parser and serializer.
- New logic: None; two YAML quoting delimiters and one static test expectation change.
- New abstractions: None; canonical serialization already exists.
- Complexity intentionally avoided: No serializer patch, reconciliation exception, workflow modification, or second synchronization owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; no authored production JavaScript or TypeScript changes.
- Hotspots: None; report formatting only.
- Agent judgment: The two-line normalization is sufficient; additional machinery would not improve the invariant.

## Hot reply path impact

- Path status: Not applicable — internal friction report only.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Parsed data and complete report body are unchanged.

## Murph initial provider input impact

- Individual Murph: Not applicable — no provider-input changes.
- Group Murph: Not applicable — no provider-input changes.
- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: A friction report's YAML delimiters do not change a deployed runtime.

## Change-shape breakdown

Classification rule: The Markdown report is documentation; the static test expectation is tests/fixtures; no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 1 | 1 |
| Docs | 2 | 2 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **3** | **3** |

## Changelog

- Changelog: not applicable
- Reason: Meaning-preserving internal report formatting only.

## CI recovery

The initial CI run reproduced the stale heap assertion (1 failure among 3,060 exercised Web tests) and a one-vCPU timing comparison failure on identical runtime source and matching bundle sizes. The confirmed stale assertion is corrected without changing runtime settings or weakening either gate. A fresh required CI run must pass on the final head.
