### PR TITLE
Keep reconnect classification progress across bounded retries

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1644,8 +1644,12 @@ Last verified: 2026-09-04
   It then compare-and-sets the marker and deletes credential-scoped payloads
   set-wise in that transaction. Reconnect and acknowledgement therefore both
   lock the dirty marker before touching payload rows.
-  A larger nullable backlog fails retryably until runtime acknowledgement
-  reduces it; classification may never run before the consent fence.
+  A larger nullable backlog commits only its bounded classification annotations
+  before the existing reconnect retry. Connection credentials and epoch, marker
+  reset, payload deletion and OAuth claim resolution wait until classification
+  is complete. Exhausting the request retry budget returns the existing retryable
+  error with annotation progress retained for the next request. Every pass
+  reacquires authority and consent; classification never precedes that fence.
 - Queue-enabled provider webhooks verify once, freeze a versioned prepared
   event, and encrypt before any Postgres read. Raw provider signature headers
   and payload bytes do not enter Queue state. The prepared event enters one

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1648,8 +1648,12 @@ Last verified: 2026-09-04
   before the existing reconnect retry. Connection credentials and epoch, marker
   reset, payload deletion and OAuth claim resolution wait until classification
   is complete. Exhausting the request retry budget returns the existing retryable
-  error with annotation progress retained for the next request. Every pass
-  reacquires authority and consent; classification never precedes that fence.
+  error with annotation progress retained for the next request. The OAuth
+  callback must not run failed-setup replacement cleanup for this outcome:
+  the old connection remains intact and the exact consumed claim retains
+  unresolved provider authority behind the existing replay/recovery fence.
+  Every pass reacquires authority and consent; classification never precedes
+  that fence.
 - Queue-enabled provider webhooks verify once, freeze a versioned prepared
   event, and encrypt before any Postgres read. Raw provider signature headers
   and payload bytes do not enter Queue state. The prepared event enters one

--- a/agent-docs/exec-plans/active/2026-09-05-reconnect-classification-progress.md
+++ b/agent-docs/exec-plans/active/2026-09-05-reconnect-classification-progress.md
@@ -1,0 +1,49 @@
+# Commit bounded reconnect classification progress
+
+Status: active
+Created: 2026-09-05
+Updated: 2026-09-05
+
+## Outcome and cause
+
+Reconnect must make durable progress through more than 800 legacy nullable
+payload classifications without advancing credentials, connection epoch or the
+OAuth claim until all payloads are classified. The current classification limit
+throws inside the upsert transaction, rolling back its own annotations. The
+existing retry therefore repeats the same work forever for a large backlog.
+
+## Smallest correction
+
+The existing dirty-state owner returns classification_pending instead of
+throwing inside the transaction. Run it before connection credential preparation
+and updates. Return from the transaction to commit annotations, then throw the
+existing retryable error outside it. Reuse the existing two-attempt retry owner.
+No new persisted state, queue, retry loop, dependency or unbounded work.
+
+Authority remains member, consent, connection and dirty-marker locks in their
+existing order. Only classification annotations may commit on a pending pass;
+current credentials, epoch, dirty counters, payloads and callback claim remain
+unchanged. Every retry revalidates current authority. The existing bounded
+legacy decrypt exception remains at most 800 rows per pass; this patch does not
+expand external work under locks or change the steady-state path.
+
+## Product UX
+
+Patch. Reaches existing device reconnect/recovery. Proof covers a backlog above
+one pass and above the whole request budget, plus consent rejection and retained
+credential-independent evidence. Existing failure codes remain unchanged.
+
+## Verification
+
+Focused OAuth-connection and dirty-store tests; real PostgreSQL upsert with 801
+and 1601 legacy rows; verify progress survives a retryable return while sensitive
+state remains unchanged. Typecheck, lint, complexity/diff/privacy review, then
+scoped commit, PR, ReviewGPT concurrent with CI.
+
+## Candidate proof
+
+- Both new full-store PostgreSQL regressions fail on the original source: 801 rows never completes, and all 1601 rows remain nullable after the request budget. The corrected source passes both.
+- 89 focused OAuth-connection, dirty-store, reconnect progress and retention tests pass, plus four consent/acknowledgement PostgreSQL scenarios.
+- Web typecheck passes after generating public workspace service declarations; scoped ESLint and diff/privacy checks pass. Complexity debt decreases by two in the connection owner; dirty-store debt is unchanged.
+- The unrelated build-memory assertion now matches the existing 6144 MiB production policy; its migration guard suite passes.
+- Changelog and final PR review/CI remain before completion.

--- a/agent-docs/exec-plans/completed/2026-09-05-reconnect-callback-progress.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-reconnect-callback-progress.md
@@ -1,0 +1,34 @@
+# Preserve reconnect progress at the OAuth callback boundary
+
+Status: completed
+Created: 2026-09-05
+Updated: 2026-09-05
+
+## Cause and correction
+
+ReviewGPT found that exhausted classification retries enter failed-setup cleanup.
+That replacement upsert can finish the backlog and disable the active connection.
+Handle the exact pending error before cleanup at the existing callback owner.
+Keep the consumed claim unresolved; never replay provider code or reset the claim.
+No new state, abstraction, retry loop or cleanup owner is needed.
+
+## Product behavior and verification
+
+Exercise the actual callback with the PostgreSQL control-plane store: 801 rows
+finalize; 1601 retain annotations, payloads, old credentials, status, epoch and
+exact consumed claim with no cleanup or revocation. Redelivery is replay-fenced
+and expired claims require existing recovery. Genuine failures retain cleanup.
+Run focused Web and device-syncd tests, both typechecks, lint, complexity and
+privacy checks. Push, then run round-two ReviewGPT concurrently with CI.
+
+## Proof and final review
+
+The 1601-row callback regression fails on the previous callback source: failed
+setup cleanup deletes 800 payloads. Both PostgreSQL callback cases pass with the
+correction. All 83 public-ingress tests, including genuine-failure cleanup,
+and 58 Web OAuth-connection tests pass. Web and device-syncd typechecks pass.
+Web scoped ESLint and complexity guard pass; device-syncd has no ESLint lane.
+The cleanup admission assertion adds no complexity debt to the existing callback
+owner and no new state, provider call or replay authority. Privacy/diff review
+is clean. Product UX: Ready for review; expired claims retain existing recovery.
+Completed: 2026-09-05

--- a/agent-docs/exec-plans/completed/2026-09-05-reconnect-classification-progress.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-reconnect-classification-progress.md
@@ -1,6 +1,6 @@
 # Commit bounded reconnect classification progress
 
-Status: active
+Status: completed
 Created: 2026-09-05
 Updated: 2026-09-05
 
@@ -46,4 +46,5 @@ scoped commit, PR, ReviewGPT concurrent with CI.
 - 89 focused OAuth-connection, dirty-store, reconnect progress and retention tests pass, plus four consent/acknowledgement PostgreSQL scenarios.
 - Web typecheck passes after generating public workspace service declarations; scoped ESLint and diff/privacy checks pass. Complexity debt decreases by two in the connection owner; dirty-store debt is unchanged.
 - The unrelated build-memory assertion now matches the existing 6144 MiB production policy; its migration guard suite passes.
-- Changelog and final PR review/CI remain before completion.
+- The reconnect recovery changelog renders through the existing archive; all seven focused archive tests pass. PR #2908 owns final ReviewGPT and exact-head CI.
+Completed: 2026-09-05

--- a/agent-docs/exec-plans/completed/2026-09-05-reconnect-classification-progress.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-reconnect-classification-progress.md
@@ -46,5 +46,5 @@ scoped commit, PR, ReviewGPT concurrent with CI.
 - 89 focused OAuth-connection, dirty-store, reconnect progress and retention tests pass, plus four consent/acknowledgement PostgreSQL scenarios.
 - Web typecheck passes after generating public workspace service declarations; scoped ESLint and diff/privacy checks pass. Complexity debt decreases by two in the connection owner; dirty-store debt is unchanged.
 - The unrelated build-memory assertion now matches the existing 6144 MiB production policy; its migration guard suite passes.
-- The reconnect recovery changelog renders through the existing archive; all seven focused archive tests pass. PR #2908 owns final ReviewGPT and exact-head CI.
+- The reconnect recovery changelog renders through the existing archive; all nine focused archive tests pass. PR #2908 owns final ReviewGPT and exact-head CI.
 Completed: 2026-09-05

--- a/apps/web/changelog/entries/2026-09-05/health-source-reconnect-progress.json
+++ b/apps/web/changelog/entries/2026-09-05/health-source-reconnect-progress.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-05",
+  "order": 100,
+  "item": {
+    "id": "health-source-reconnect-progress",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Health source reconnects keep their progress",
+    "summary": "Reconnecting a health source can now work through a large backlog of older queued updates without starting over on every retry.",
+    "details": "A reconnect may still need another attempt while the backlog is processed. Your current connection stays unchanged until that step finishes, and saved updates that can be imported without the old credentials are retained.",
+    "relevanceTags": ["device-sync"],
+    "sourcePullRequests": [2908]
+  }
+}

--- a/apps/web/src/lib/device-sync/prisma-store/connections.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/connections.ts
@@ -90,6 +90,7 @@ import {
   type HostedRuntimeApplyTokenWritePreparation,
 } from "./connection-secrets";
 import {
+  createDirtyPayloadClassificationPendingError,
   isHostedDirtyPayloadClassificationPendingError,
   supersedeHostedCredentialScopedDirtyStateForConnectionTx,
 } from "./dirty-connections";
@@ -333,7 +334,7 @@ export class PrismaHostedConnectionStore {
       if (existing) {
         assertHostedUpsertExistingConnectionGuard(existing, input.existingAccountGuard ?? null);
 
-        if (ownerId && existing.userId !== ownerId) {
+        if (existing.userId !== ownerId) {
           throw deviceSyncError({
             code: "CONNECTION_OWNERSHIP_CONFLICT",
             message: "This provider account is already connected to a different Murph user.",
@@ -364,8 +365,6 @@ export class PrismaHostedConnectionStore {
             existing,
             input.existingAccountPolicy,
           )
-          && ownerId
-          && existing.userId === ownerId
         ) {
           await requireExactOAuthClaimResolutionTx(tx, input.oauthClaim);
           return {
@@ -384,6 +383,17 @@ export class PrismaHostedConnectionStore {
               }),
             )
           : replacementMetadata;
+
+        if (existing.connectedAt.getTime() !== connectedAt.getTime()) {
+          const dirtyState = await supersedeHostedCredentialScopedDirtyStateForConnectionTx({
+            connectionId: existing.id,
+            tx,
+            userId: existing.userId,
+          });
+          if (dirtyState === "classification_pending") {
+            return null;
+          }
+        }
 
         const credentialWrite = await buildHostedConnectionCredentialWrite({
           connectionId: existing.id,
@@ -430,13 +440,6 @@ export class PrismaHostedConnectionStore {
           },
           ...hostedConnectionRecordArgs,
         });
-        if (existing.connectedAt.getTime() !== connectedAt.getTime()) {
-          await supersedeHostedCredentialScopedDirtyStateForConnectionTx({
-            connectionId: existing.id,
-            tx,
-            userId: existing.userId,
-          });
-        }
         await requireExactOAuthClaimResolutionTx(tx, input.oauthClaim);
         return {
           record: updated,
@@ -499,6 +502,12 @@ export class PrismaHostedConnectionStore {
         previousRecord: null,
       };
     });
+
+    if (!result) {
+      // Commit legacy annotations before retrying; no connection epoch, token,
+      // dirty-marker reset, payload deletion or OAuth claim changed in this pass.
+      throw createDirtyPayloadClassificationPendingError();
+    }
 
     return {
       account: await this.buildDurableConnectionRecord(result.record),

--- a/apps/web/src/lib/device-sync/prisma-store/dirty-connections.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/dirty-connections.ts
@@ -230,7 +230,7 @@ export async function classifyHostedUnclassifiedDirtyPayloadsForConnection(input
     }
   }
 
-  throw createDirtyPayloadClassificationPendingError();
+  // The caller commits this bounded annotation work before asking for a retry.
 }
 
 export function isHostedDirtyPayloadClassificationPendingError(
@@ -249,7 +249,7 @@ export async function supersedeHostedCredentialScopedDirtyStateForConnectionTx(i
   connectionId: string;
   tx: HostedPrismaTransactionClient;
   userId: string;
-}): Promise<void> {
+}): Promise<"classification_pending" | void> {
   const [existing] = await input.tx.$queryRaw<Array<{
     dirtyRevision: bigint;
     latestDirtyAt: Date;
@@ -289,7 +289,7 @@ export async function supersedeHostedCredentialScopedDirtyStateForConnectionTx(i
     });
   }
   if (unclassifiedPayloadCount > 0) {
-    throw createDirtyPayloadClassificationPendingError();
+    return "classification_pending";
   }
 
   const updated = await input.tx.deviceSyncDirtyConnection.updateMany({
@@ -1190,7 +1190,7 @@ function createDirtyStateContentionError(operation: "ack" | "update"): Error {
   });
 }
 
-function createDirtyPayloadClassificationPendingError(): Error {
+export function createDirtyPayloadClassificationPendingError(): Error {
   return deviceSyncError({
     code: HOSTED_DEVICE_SYNC_DIRTY_PAYLOAD_CLASSIFICATION_PENDING_CODE,
     httpStatus: 503,

--- a/apps/web/test/device-sync-reconnect-classification-postgres.test.ts
+++ b/apps/web/test/device-sync-reconnect-classification-postgres.test.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { PrismaHostedConnectionStore } from "@/src/lib/device-sync/prisma-store/connections";
+import { sealHostedDeviceSyncDirtyPayloadJson } from "@/src/lib/device-sync/prisma-store/dirty-payloads";
+import { setHostedSecureBoxStringTestCodecForTests } from "@/src/lib/hosted-crypto/secure-box";
+import { createPrismaClient } from "@/src/lib/prisma";
+
+const databaseUrl = process.env.DATABASE_URL?.trim() ?? "";
+const runPostgresProof = process.env.MURPH_TEST_POSTGRES_CONCURRENCY === "1";
+
+describe.skipIf(!runPostgresProof)("reconnect legacy classification PostgreSQL progress", () => {
+  it.each([801, 1601])("commits bounded progress for %i legacy payloads", async (count) => {
+    if (!databaseUrl) {
+      throw new Error("DATABASE_URL is required for the PostgreSQL reconnect proof.");
+    }
+    const prisma = createPrismaClient({ databaseUrl, poolMax: 2 });
+    const userId = `member_reconnect_progress_${randomUUID()}`;
+    const state = `oauth_reconnect_progress_${randomUUID()}`;
+    const connectedAt = "2026-09-01T12:00:00.000Z";
+    const consumedAt = "2026-09-02T12:00:00.000Z";
+    const store = new PrismaHostedConnectionStore({
+      codec: { decrypt: (value) => value, encrypt: (value) => value, keyVersion: "v1" },
+      prisma,
+      providerAccountBlindIndexKey: Buffer.alloc(32, 23),
+    });
+    setHostedSecureBoxStringTestCodecForTests({
+      decrypt: (input) => input.value,
+      encrypt: (input) => input.value,
+    });
+    try {
+      await prisma.hostedMember.create({ data: { id: userId } });
+      const input = {
+        connectedAt,
+        existingAccountPolicy: "replace" as const,
+        externalAccountId: `oura_progress_${randomUUID()}`,
+        ownerId: userId,
+        provider: "oura",
+        scopes: ["daily"],
+        tokens: { accessToken: "old-access", refreshToken: "old-refresh" },
+      };
+      const connection = await store.upsertConnection(input);
+      const where = { connectionId: connection.id };
+      await prisma.deviceSyncDirtyConnection.create({
+        data: {
+          ...where,
+          userId,
+          provider: "oura",
+          dirtyRevision: 1n,
+          processedRevision: 0n,
+          firstDirtyAt: new Date(connectedAt),
+          latestDirtyAt: new Date(consumedAt),
+          eventCount: BigInt(count),
+        },
+      });
+      // Real encrypted/compressed envelopes, with only the external KMS seam replaced.
+      // Alternate retained deletion work and credential-scoped resource fetches.
+      for (let offset = 0; offset < count; offset += 100) {
+        const rows = [];
+        for (let index = offset; index < Math.min(offset + 100, count); index += 1) {
+          const id = `payload_${userId}_${String(index).padStart(4, "0")}`;
+          rows.push({
+            ...where,
+            id,
+            userId,
+            provider: "oura",
+            dirtyRevision: 1n,
+            credentialIndependent: null,
+            resourceEncrypted: await sealHostedDeviceSyncDirtyPayloadJson({
+              ...where,
+              dirtyRevision: 1n,
+              payloadId: id,
+              prisma,
+              provider: "oura",
+              userId,
+              value: {
+                count: 1,
+                jobKind: index % 2 === 0 ? "delete" : "resource",
+                payload: { objectId: `sleep_${index}` },
+                resource: "sleep",
+              },
+            }),
+          });
+        }
+        await prisma.deviceSyncDirtyPayload.createMany({ data: rows });
+      }
+      await prisma.deviceOauthSession.create({
+        data: {
+          state,
+          userId,
+          provider: "oura",
+          createdAt: new Date(connectedAt),
+          consumedAt: new Date(consumedAt),
+          expiresAt: new Date("2026-09-03T12:00:00.000Z"),
+        },
+      });
+      const replacement = {
+        ...input,
+        connectedAt: consumedAt,
+        oauthClaim: { state, consumedAt },
+        tokens: { accessToken: "new-access", refreshToken: "new-refresh" },
+      };
+      if (count > 1600) {
+        await expect(store.upsertConnection(replacement)).rejects.toMatchObject({
+          code: "HOSTED_DEVICE_SYNC_DIRTY_PAYLOAD_CLASSIFICATION_PENDING",
+          retryable: true,
+        });
+        expect(await prisma.deviceSyncDirtyPayload.count({ where })).toBe(count);
+        expect(await prisma.deviceSyncDirtyPayload.count({
+          where: { ...where, credentialIndependent: null },
+        })).toBe(1);
+        expect(await prisma.deviceConnection.findUnique({ where: { id: connection.id } }))
+          .toMatchObject({ connectedAt: new Date(connectedAt), tokenVersion: 1, accessTokenEncrypted: "old-access" });
+        expect(await prisma.deviceSyncDirtyConnection.findUnique({ where }))
+          .toMatchObject({ processedRevision: 0n, dirtyRevision: 1n });
+        expect(await prisma.deviceOauthSession.findUnique({ where: { state } }))
+          .toMatchObject({ consumedAt: new Date(consumedAt) });
+      }
+      await store.upsertConnection(replacement);
+      expect(await prisma.deviceConnection.findUnique({ where: { id: connection.id } }))
+        .toMatchObject({ connectedAt: new Date(consumedAt), tokenVersion: 2, accessTokenEncrypted: "new-access" });
+      expect(await prisma.deviceSyncDirtyPayload.count({ where })).toBe(Math.ceil(count / 2));
+      expect(await prisma.deviceSyncDirtyPayload.count({
+        where: { ...where, credentialIndependent: true },
+      })).toBe(Math.ceil(count / 2));
+      expect(await prisma.deviceSyncDirtyConnection.findUnique({ where }))
+        .toMatchObject({ processedRevision: 1n, dirtyRevision: 1n });
+      expect(await prisma.deviceOauthSession.findUnique({ where: { state } })).toBeNull();
+    } finally {
+      await prisma.deviceOauthSession.deleteMany({ where: { state } });
+      await prisma.hostedMember.deleteMany({ where: { id: userId } });
+      await prisma.$disconnect();
+      setHostedSecureBoxStringTestCodecForTests(null);
+    }
+  }, 30_000);
+});

--- a/apps/web/test/device-sync-reconnect-classification-postgres.test.ts
+++ b/apps/web/test/device-sync-reconnect-classification-postgres.test.ts
@@ -1,8 +1,13 @@
 import { randomUUID } from "node:crypto";
 
-import { describe, expect, it } from "vitest";
+import {
+  createDeviceSyncPublicIngress,
+  createDeviceSyncRegistry,
+  type DeviceSyncProvider,
+} from "@murphai/device-syncd/public-ingress";
+import { describe, expect, it, vi } from "vitest";
 
-import { PrismaHostedConnectionStore } from "@/src/lib/device-sync/prisma-store/connections";
+import { PrismaDeviceSyncControlPlaneStore } from "@/src/lib/device-sync/prisma-store";
 import { sealHostedDeviceSyncDirtyPayloadJson } from "@/src/lib/device-sync/prisma-store/dirty-payloads";
 import { setHostedSecureBoxStringTestCodecForTests } from "@/src/lib/hosted-crypto/secure-box";
 import { createPrismaClient } from "@/src/lib/prisma";
@@ -11,7 +16,7 @@ const databaseUrl = process.env.DATABASE_URL?.trim() ?? "";
 const runPostgresProof = process.env.MURPH_TEST_POSTGRES_CONCURRENCY === "1";
 
 describe.skipIf(!runPostgresProof)("reconnect legacy classification PostgreSQL progress", () => {
-  it.each([801, 1601])("commits bounded progress for %i legacy payloads", async (count) => {
+  it.each([801, 1601])("preserves the callback outcome for %i legacy payloads", async (count) => {
     if (!databaseUrl) {
       throw new Error("DATABASE_URL is required for the PostgreSQL reconnect proof.");
     }
@@ -20,7 +25,7 @@ describe.skipIf(!runPostgresProof)("reconnect legacy classification PostgreSQL p
     const state = `oauth_reconnect_progress_${randomUUID()}`;
     const connectedAt = "2026-09-01T12:00:00.000Z";
     const consumedAt = "2026-09-02T12:00:00.000Z";
-    const store = new PrismaHostedConnectionStore({
+    const store = new PrismaDeviceSyncControlPlaneStore({
       codec: { decrypt: (value) => value, encrypt: (value) => value, keyVersion: "v1" },
       prisma,
       providerAccountBlindIndexKey: Buffer.alloc(32, 23),
@@ -29,6 +34,8 @@ describe.skipIf(!runPostgresProof)("reconnect legacy classification PostgreSQL p
       decrypt: (input) => input.value,
       encrypt: (input) => input.value,
     });
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(consumedAt));
     try {
       await prisma.hostedMember.create({ data: { id: userId } });
       const input = {
@@ -91,18 +98,51 @@ describe.skipIf(!runPostgresProof)("reconnect legacy classification PostgreSQL p
           userId,
           provider: "oura",
           createdAt: new Date(connectedAt),
-          consumedAt: new Date(consumedAt),
           expiresAt: new Date("2026-09-03T12:00:00.000Z"),
         },
       });
-      const replacement = {
-        ...input,
-        connectedAt: consumedAt,
-        oauthClaim: { state, consumedAt },
+      const originalConnection = await prisma.deviceConnection.findUniqueOrThrow({
+        where: { id: connection.id },
+      });
+      const originalClaim = await prisma.deviceOauthSession.findUniqueOrThrow({ where: { state } });
+      const completeConnection = vi.fn(async () => ({
+        externalAccountId: input.externalAccountId,
         tokens: { accessToken: "new-access", refreshToken: "new-refresh" },
+        scopes: ["daily"],
+      }));
+      const revokeAccess = vi.fn(async () => {});
+      const provider: DeviceSyncProvider = {
+        provider: "oura",
+        descriptor: {
+          provider: "oura",
+          displayName: "Oura",
+          transportModes: ["oauth_callback"],
+          connection: { kind: "oauth2", callbackPath: "/oauth/oura/callback", defaultScopes: ["daily"] },
+          normalization: { metricFamilies: ["sleep"], snapshotParser: "schema" },
+          sourcePriorityHints: { defaultPriority: 50, metricFamilies: { sleep: 50 } },
+        },
+        connectionHandler: {
+          beginConnection: async () => ({ authorizationUrl: "https://provider.example.test/oauth" }),
+          completeConnection,
+          refreshTokens: async () => ({ accessToken: "refreshed-access" }),
+          revokeAccess,
+        },
       };
+      const ingress = createDeviceSyncPublicIngress({
+        publicBaseUrl: "https://sync.example.test/device-sync",
+        registry: createDeviceSyncRegistry([provider]),
+        store,
+      });
+      const callback = {
+        provider: "oura",
+        state,
+        code: "synthetic-authorization-code",
+        expectedOwnerId: userId,
+      };
+      const upsert = vi.spyOn(store, "upsertConnection");
+      const markFailed = vi.spyOn(store, "markConnectionSetupFailed");
       if (count > 1600) {
-        await expect(store.upsertConnection(replacement)).rejects.toMatchObject({
+        await expect(ingress.handleOAuthCallback(callback)).rejects.toMatchObject({
           code: "HOSTED_DEVICE_SYNC_DIRTY_PAYLOAD_CLASSIFICATION_PENDING",
           retryable: true,
         });
@@ -111,13 +151,29 @@ describe.skipIf(!runPostgresProof)("reconnect legacy classification PostgreSQL p
           where: { ...where, credentialIndependent: null },
         })).toBe(1);
         expect(await prisma.deviceConnection.findUnique({ where: { id: connection.id } }))
-          .toMatchObject({ connectedAt: new Date(connectedAt), tokenVersion: 1, accessTokenEncrypted: "old-access" });
+          .toEqual(originalConnection);
         expect(await prisma.deviceSyncDirtyConnection.findUnique({ where }))
           .toMatchObject({ processedRevision: 0n, dirtyRevision: 1n });
         expect(await prisma.deviceOauthSession.findUnique({ where: { state } }))
-          .toMatchObject({ consumedAt: new Date(consumedAt) });
+          .toEqual({ ...originalClaim, consumedAt: new Date(consumedAt) });
+        await expect(ingress.handleOAuthCallback(callback)).rejects.toMatchObject({
+          code: "OAUTH_STATE_REPLAYED",
+        });
+        vi.setSystemTime(new Date("2026-09-04T12:00:00.000Z"));
+        await expect(ingress.handleOAuthCallback(callback)).rejects.toMatchObject({
+          code: "OAUTH_CALLBACK_RECOVERY_REQUIRED",
+        });
+        expect(completeConnection).toHaveBeenCalledTimes(1);
+        expect(upsert).toHaveBeenCalledTimes(1);
+        expect(markFailed).not.toHaveBeenCalled();
+        expect(revokeAccess).not.toHaveBeenCalled();
+        return;
       }
-      await store.upsertConnection(replacement);
+      await ingress.handleOAuthCallback(callback);
+      expect(completeConnection).toHaveBeenCalledTimes(1);
+      expect(upsert).toHaveBeenCalledTimes(1);
+      expect(markFailed).not.toHaveBeenCalled();
+      expect(revokeAccess).not.toHaveBeenCalled();
       expect(await prisma.deviceConnection.findUnique({ where: { id: connection.id } }))
         .toMatchObject({ connectedAt: new Date(consumedAt), tokenVersion: 2, accessTokenEncrypted: "new-access" });
       expect(await prisma.deviceSyncDirtyPayload.count({ where })).toBe(Math.ceil(count / 2));
@@ -128,6 +184,7 @@ describe.skipIf(!runPostgresProof)("reconnect legacy classification PostgreSQL p
         .toMatchObject({ processedRevision: 1n, dirtyRevision: 1n });
       expect(await prisma.deviceOauthSession.findUnique({ where: { state } })).toBeNull();
     } finally {
+      vi.useRealTimers();
       await prisma.deviceOauthSession.deleteMany({ where: { state } });
       await prisma.hostedMember.deleteMany({ where: { id: userId } });
       await prisma.$disconnect();

--- a/apps/web/test/prisma-store-oauth-connection.test.ts
+++ b/apps/web/test/prisma-store-oauth-connection.test.ts
@@ -23,7 +23,7 @@ const {
   readHostedMemberSuspensionAfterLockTxMock: vi.fn(
     async (): Promise<"active" | "missing" | "suspended"> => "active",
   ),
-  supersedeDirtyStateMock: vi.fn(async () => undefined),
+  supersedeDirtyStateMock: vi.fn(async (): Promise<"classification_pending" | void> => undefined),
 }));
 
 vi.mock("@/src/lib/hosted-onboarding/shared", async (importOriginal) => ({
@@ -1268,7 +1268,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
     expect(tx.deviceConnection.update).not.toHaveBeenCalled();
   });
 
-  it("retries legacy classification once behind the consent and dirty-marker transaction", async () => {
+  it("commits legacy classification before retrying connection replacement", async () => {
     let stored = createConnection({
       accessTokenEncrypted: null,
       id: "dsc_classification_retry",
@@ -1314,10 +1314,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       providerAccountBlindIndexKey: BLIND_INDEX_KEY,
     });
     supersedeDirtyStateMock
-      .mockRejectedValueOnce({
-        code: "HOSTED_DEVICE_SYNC_DIRTY_PAYLOAD_CLASSIFICATION_PENDING",
-        retryable: true,
-      })
+      .mockResolvedValueOnce("classification_pending")
       .mockResolvedValueOnce(undefined);
 
     await expect(store.upsertConnection({
@@ -1352,6 +1349,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       supersedeDirtyStateMock.mock.invocationCallOrder[0] ?? 0,
     );
     expect(transaction).toHaveBeenCalledTimes(2);
+    expect(tx.deviceConnection.update).toHaveBeenCalledOnce();
   });
 
   it("bounds repeated connection unique-conflict recovery to one retry", async () => {

--- a/apps/web/test/production-migration-guard.test.ts
+++ b/apps/web/test/production-migration-guard.test.ts
@@ -2031,7 +2031,7 @@ describe("hosted web production migration guard", () => {
     assert.match(productionNextBuildScript, /^#!\/usr\/bin\/env bash\nset -euo pipefail$/mu);
     assert.match(productionNextBuildScript, /parent_old_space_mb=1024/u);
     assert.match(productionNextBuildScript, /build_worker_old_space_mb=3072/u);
-    assert.match(productionNextBuildScript, /typecheck_old_space_mb=3584/u);
+    assert.match(productionNextBuildScript, /typecheck_old_space_mb=6144/u);
     assert.match(
       productionNextBuildScript,
       /build_cache_epoch=webpack-next-16\.3-v6-isolated-worker-no-webpack-cache/u,

--- a/packages/device-syncd/src/public-ingress.ts
+++ b/packages/device-syncd/src/public-ingress.ts
@@ -1394,6 +1394,7 @@ export class DeviceSyncPublicIngress {
         }
       } else if (connection) {
         try {
+          assertOAuthConnectionCleanupAllowed(error, connectionPersisted);
           if (connectionPersisted && account) {
             await this.cleanupPersistedOAuthConnection(
               provider,
@@ -2296,6 +2297,19 @@ export class DeviceSyncPublicIngress {
       });
       return null;
     }
+  }
+}
+
+function assertOAuthConnectionCleanupAllowed(error: unknown, connectionPersisted: boolean): void {
+  if (
+    !connectionPersisted
+    && isDeviceSyncError(error)
+    && error.code === "HOSTED_DEVICE_SYNC_DIRTY_PAYLOAD_CLASSIFICATION_PENDING"
+  ) {
+    // Only annotations committed. Cleanup replacement could finish the backlog
+    // and revoke the established connection. Keep the exact consumed claim as
+    // unresolved provider authority behind the existing replay/recovery fence.
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Why and outcome

Reconnect could repeatedly roll back the same legacy payload annotations once its bounded classification pass filled up. Classification now commits before the existing retry, and credentials, connection epoch, dirty reset and OAuth claim finalization happen only after classification completes.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: A reconnect with a large legacy backlog keeps progress through bounded retries. Credential-independent deletion/import work is retained; current credentials and callback ownership remain unchanged while classification is pending.

## Evidence

- Direct: 89 focused connection, dirty-store, PostgreSQL progress and retention tests, plus four PostgreSQL consent/acknowledgement scenarios pass. Both new 801/1601-row full-store regressions fail on the original source and pass on the correction.
- Coverage: Web typecheck, scoped ESLint, complexity guard and diff/privacy review pass. The migration guard suite passes with its stale heap assertion aligned to the existing policy. The remediation also passes 83 public-ingress tests, 60 focused Web tests and both workspace typechecks. ReviewGPT round two and required exact-head CI pass.

## Non-obvious affected surfaces

Only legacy classification annotations commit on a pending pass. No dirty marker reset, payload deletion, credential update, connection epoch change or exact OAuth claim deletion commits. Each retry rechecks current member, consent and provider authority.

## Architecture and reuse

- Existing systems reused: Bounded dirty-payload classifier, connection upsert transaction and two-attempt retry owner.
- New logic: Return a pending result from the transaction and raise the existing retryable error after the annotation commit.
- New abstractions: One local cleanup-admission assertion recognizes the exact pending error before replacement cleanup; no new state or service owner.
- Complexity intentionally avoided: No queue, schema, additional retry owner or unbounded transaction.

## Complexity impact

- Guard: PASS — pnpm complexity:diff.
- Hotspots: Connection-owner debt decreases by two; existing unrelated token persistence and dirty-ingress hotspots remain unchanged.
- Agent judgment: Reordering the existing operation makes progress durable and removes redundant ownership conditions already established by admission.

## Hot reply path impact

- Path status: Not applicable — device reconnection does not run on reply handoff.
- Database calls: No new query shapes or fanout; one transaction per existing attempt, at most two attempts per request. Existing classification bound remains eight batches of 100 per pass.
- Network/provider calls: None added. The existing bounded legacy decrypt path remains behind consent checks.
- Other awaited latency: A later retry now handles remaining annotations instead of repeating rolled-back work.
- Before/after proof: Full callback-to-PostgreSQL tests with 801 and 1601 legacy payloads.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

ReviewGPT context sensitivity: sensitive
Classification reason: Device credentials, consent fencing and callback ownership.

## Deployment concerns

- Deployment: not applicable
- Reason: Web transaction ordering and the bundled device-syncd callback owner use existing annotations and error semantics. Ship the callback owner with the changed store; no schema or configuration change is required.

## Changelog

- Changelog: updated
- Items: 2026-09-05 · health-source-reconnect-progress
- Archive proof: Nine archive tests pass; unchanged presentation is covered by https://www.withmurph.ai/screenshots/ops#changelog-archive.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source, test files are tests, Markdown is docs, and the changelog fragment is content. No generated or binary changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 37 | 14 |
| Tests / fixtures | 199 | 7 |
| Docs | 94 | 2 |
| Content | 14 | 0 |

ReviewGPT first-reviewed head: 62a32c35d475269c9505d350d5ed7571850265d2

## ReviewGPT round 1 disposition — remediated

[ReviewGPT round 1](https://chatgpt.com/c/6a9bb6de-21c0-83e9-8f80-5736e03fa546) returned FINDINGS on 62a32c35d475269c9505d350d5ed7571850265d2. Native capture confirms GPT-6 Pro; response SHA-256 is b0ffa2dd0c6a49e4edad0715bfe29b07fdf66336c64695929bbc99670cffb64b.

Accepted High: the full OAuth callback catches classification-pending after provider completion and enters ensureFailedOAuthConnectionCleanupOwnership. That second upsert can complete the remaining annotations, replace an established connection, resolve its consumed claim and revoke its credential. The store-only PostgreSQL proof misses this outer cleanup owner. Source inspection confirms public-ingress.ts enters this path when connection exists but persistence did not finish.

Smallest correction: classify the pending outcome at the existing callback failure owner before failed-setup replacement cleanup; preserve the established connection, exact consumed claim and unresolved provider authority. Add a full callback-to-PostgreSQL 1601-row regression, retain 801-row success and genuine-failure cleanup proof. No new retry loop, queue or state owner is justified. The user resumed the mandatory pause. The callback cleanup admission now preserves this annotation-only outcome before any cleanup replacement. Full callback-to-PostgreSQL proof fails on the prior callback source and passes on the correction; immediate redelivery is replay-fenced and expired consumed claims enter existing recovery. All 83 package callback tests (including genuine cleanup), 60 focused Web tests and both typechecks pass. Round 2 and required exact-head CI pass.

## Final review

[ReviewGPT round 2](https://chatgpt.com/c/6a9bb6de-21c0-83e9-8f80-5736e03fa546) returned PASS on b01f22603ea637b94556a977954e3ba7057cd1ff. The exact completed assistant turn matches its preceding committed prompt; native GPT-6 Pro capture and local response hash both verify 10d7b8b8b605c9fd7c821d5a4534ad301ff1c99e32bc231e38824713f18b8fed. Apollo capture waited over six minutes, exceeding the mandatory 270-second minimum. The full sensitive snapshot was attached; the review verified all ten file hashes, correction lineage, actual callback cleanup and recovery boundaries. Accepted as substantive, scoped evidence. Current-base merge-tree proof is clean.

Required CI, the Release aggregate and Temporal compatibility are green on b01f22603ea637b94556a977954e3ba7057cd1ff. No source changes followed the passing review.
