### PR TITLE
Prepare device connection keys before member locks

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1654,6 +1654,15 @@ Last verified: 2026-09-04
   unresolved provider authority behind the existing replay/recovery fence.
   Every pass reacquires authority and consent; classification never precedes
   that fence.
+- Connection upsert prepares its device-domain encryption root outside the
+  member transaction, after advisory member and health-consent admission. The
+  transaction repeats admission under the member lock and retains exact
+  provider-application, connection ownership and refresh-lease checks. At the
+  credential-write boundary it commits/revalidates the exact prepared root and
+  seals tokens and account identity locally; KMS never participates in those
+  credential writes while locks are held. A competing root winner retries via
+  the existing bounded upsert owner with a fresh attempt-scoped cache. No
+  caller-supplied ciphertext, new key owner or cross-request cache is added.
 - Queue-enabled provider webhooks verify once, freeze a versioned prepared
   event, and encrypt before any Postgres read. Raw provider signature headers
   and payload bytes do not enter Queue state. The prepared event enters one

--- a/agent-docs/exec-plans/active/2026-09-05-connection-key-preparation.md
+++ b/agent-docs/exec-plans/active/2026-09-05-connection-key-preparation.md
@@ -1,0 +1,46 @@
+# Prepare device connection keys before member locks
+
+Status: active
+Created: 2026-09-05
+Updated: 2026-09-05
+
+## Cause and correction
+
+Connection creation and replacement seal access tokens, refresh tokens and the
+external account ID inside the member/advisory transaction. Cold device-root
+unwrapping therefore waits on KMS while holding
+member locks. The canonical prepared-root API already separates external key
+preparation from database-only root revalidation and local sealing.
+
+Prepare that root in an attempt-scoped cache after advisory member/consent
+admission. Repeat the same admission under the member lock, retain all existing
+connection/application/refresh authority checks, revalidate the already-provisioned root at the
+existing credential-write boundary, and seal through its exact local reference.
+Reuse the existing bounded retry owner for a root-winner race. Keep connection
+IDs, token versions and all writes derived under their current transaction.
+No schema, new key owner, cross-request cache or additional transaction.
+
+## Scope and proof
+
+Only connection upsert credential writes change. Existing runtime prepared-token
+writes and legacy dirty-payload classification retain their own owners.
+Prove remote preparation precedes the transaction, local sealing is used under
+locks, current consent/member/root authority is rechecked, and root drift never
+persists ciphertext. Cover create, replace, preserved connection, OAuth claim
+and revoked/suspended cases. Run focused tests, typecheck, lint and complexity
+checks; then ReviewGPT concurrent with exact-head CI.
+
+## Candidate proof
+
+The real-crypto full-store tests cover create, replace, consent withdrawal,
+suspension and a competing root winner. No KMS operation occurs inside their
+transactions. The existing prepared-root tests prove exact identity and local
+cache ownership. Web typecheck passes. Complexity debt drops by three in the
+connection owner without adding secret-helper debt. This PR will stack on
+reconnect #2908 so the two changes compose at the same credential boundary.
+
+113 focused crypto/connection tests, Web typecheck and scoped ESLint pass.
+The create and replacement tests fail on the original source with the explicit
+assertion that kms.decrypt ran inside the transaction. The same tests pass on
+the correction. Missing-root behavior remains fail-closed; preparation never
+creates an absent device root.

--- a/agent-docs/exec-plans/completed/2026-09-05-connection-key-preparation.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-connection-key-preparation.md
@@ -1,6 +1,6 @@
 # Prepare device connection keys before member locks
 
-Status: active
+Status: completed
 Created: 2026-09-05
 Updated: 2026-09-05
 
@@ -44,3 +44,9 @@ The create and replacement tests fail on the original source with the explicit
 assertion that kms.decrypt ran inside the transaction. The same tests pass on
 the correction. Missing-root behavior remains fail-closed; preparation never
 creates an absent device root.
+
+After stacking on #2908, 115 focused crypto/connection and PostgreSQL reconnect
+progress tests pass, together with Web typecheck. The resolved write boundary
+commits pending annotations first, then revalidates the prepared root only when
+credentials are ready to persist. The PR owns final ReviewGPT and exact-head CI.
+Completed: 2026-09-05

--- a/apps/web/src/lib/device-sync/prisma-store/connection-secrets.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/connection-secrets.ts
@@ -1,12 +1,19 @@
 import { parseSerializedHostedSecureBoxEnvelope } from "@murphai/runtime-state";
 
 import {
+  isHostedSecureBoxStringTestCodecConfiguredForTests,
   openHostedUserSecureBoxString,
   openHostedUserSecureBoxStrings,
   sealHostedUserSecureBoxString,
+  sealHostedUserSecureBoxStringFromPreparedRoot,
   sealHostedUserSecureBoxStrings,
   type HostedSecureBoxPrismaClient,
 } from "../../hosted-crypto/secure-box";
+import {
+  prepareHostedDomainRootForWeb,
+  readPreparedHostedDomainRootForWebLocal,
+  type PreparedHostedDomainRootForWeb,
+} from "../../hosted-crypto/domain-root-store";
 import { runWithHostedDomainRootUnwrapCache } from "../../hosted-crypto/domain-root-unwrap-cache";
 import { maybeIsoTimestamp, normalizeNullableString } from "../shared";
 import {
@@ -61,8 +68,27 @@ export interface HostedRuntimeApplyTokenWritePreparation {
   tokenBundle: HostedStoredConnectionTokenBundle | null;
 }
 
+export async function prepareHostedConnectionSecretRoot(input: {
+  prisma: HostedSecureBoxPrismaClient;
+  testCodec: HostedDeviceSyncSecretTestCodec | null;
+  userId: string;
+}): Promise<PreparedHostedDomainRootForWeb | null> {
+  if (normalizeHostedDeviceSyncSecretTestCodec(input.testCodec)
+    || isHostedSecureBoxStringTestCodecConfiguredForTests()) {
+    return null;
+  }
+  return prepareHostedDomainRootForWeb({
+    domain: "device",
+    prepareMissing: false,
+    prisma: input.prisma,
+    reason: "device-sync.connection",
+    userId: input.userId,
+  });
+}
+
 export async function encryptHostedConnectionSecret(input: {
   connectionId: string;
+  preparedRoot?: PreparedHostedDomainRootForWeb | null;
   provider: string;
   prisma?: HostedSecureBoxPrismaClient;
   purpose: HostedDeviceSyncSecretPurpose;
@@ -77,7 +103,7 @@ export async function encryptHostedConnectionSecret(input: {
   }
 
   const descriptor = resolveHostedDeviceSyncSecretDescriptor(input.purpose, input.connectionId);
-  const encrypted = await sealHostedUserSecureBoxString({
+  const sealInput = {
     aad: buildHostedDeviceSyncSecretAad({
       connectionId: input.connectionId,
       field: descriptor.field,
@@ -90,7 +116,17 @@ export async function encryptHostedConnectionSecret(input: {
     scope: descriptor.scope,
     userId: input.userId,
     value: input.value,
-  });
+  };
+  const local = input.preparedRoot
+    ? readPreparedHostedDomainRootForWebLocal(input.preparedRoot)
+    : null;
+  const encrypted = local
+    ? await sealHostedUserSecureBoxStringFromPreparedRoot({
+        ...sealInput,
+        preparedRoot: local.root,
+        preparedRootKeyId: local.rootKeyId,
+      })
+    : await sealHostedUserSecureBoxString(sealInput);
 
   if (!encrypted) {
     throw new TypeError("Hosted device-sync secure-box encryption returned an empty ciphertext.");

--- a/apps/web/src/lib/device-sync/prisma-store/connections.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/connections.ts
@@ -29,6 +29,12 @@ import type {
   DeviceAccountCredentialKind,
 } from "@murphai/device-syncd/types";
 
+import {
+  HostedDomainRootPreparationMismatchError,
+  revalidatePreparedHostedDomainRootForWebTx,
+  type PreparedHostedDomainRootForWeb,
+} from "../../hosted-crypto/domain-root-store";
+import { runWithFreshHostedDomainRootUnwrapCache } from "../../hosted-crypto/domain-root-unwrap-cache";
 import type { HostedSecureBoxPrismaClient } from "../../hosted-crypto/secure-box";
 import {
   HOSTED_HEALTH_DATA_CONSENT_SCOPE,
@@ -80,6 +86,7 @@ export { sanitizeHostedDeviceSyncConnectionMetadata } from "./connection-records
 import {
   HOSTED_DEVICE_SYNC_SECURE_BOX_KEY_VERSION,
   encryptHostedConnectionSecret,
+  prepareHostedConnectionSecretRoot,
   prepareHostedRuntimeApplyTokenWrites,
   readHostedRuntimeConnectionSecretMaterial,
   readHostedStoredExternalAccountId,
@@ -210,10 +217,13 @@ export class PrismaHostedConnectionStore {
       attempt += 1
     ) {
       try {
-        return await this.upsertConnectionWithPreviousOnce(input, binding);
+        return await runWithFreshHostedDomainRootUnwrapCache(
+          () => this.upsertConnectionWithPreviousOnce(input, binding),
+        );
       } catch (error) {
         if (
-          isHostedDirtyPayloadClassificationPendingError(error)
+          (isHostedDirtyPayloadClassificationPendingError(error)
+            || error instanceof HostedDomainRootPreparationMismatchError)
           && attempt < HOSTED_CONNECTION_UPSERT_MAX_ATTEMPTS - 1
         ) {
           continue;
@@ -274,39 +284,26 @@ export class PrismaHostedConnectionStore {
       });
     }
 
+    // This read is admission for key preparation only; the transaction repeats it
+    // under the member lock before granting authority to persist credentials.
+    await assertHostedConnectionOwnerAdmission({
+      ownerId,
+      ownsFailedOauthProviderCleanup,
+      prisma: this.prisma,
+    });
+    const preparedRoot = await prepareHostedConnectionSecretRoot({
+      prisma: this.prisma,
+      testCodec: this.testCodec,
+      userId: ownerId,
+    });
+
     const result = await this.prisma.$transaction(async (tx) => {
       await lockHostedMemberRow(tx, ownerId);
-      const ownerStatus = await readHostedMemberSuspensionAfterLockTx(
-        tx,
+      await assertHostedConnectionOwnerAdmission({
         ownerId,
-      );
-      if (ownerStatus === "missing") {
-        throw deviceSyncError({
-          code: "CONNECTION_OWNER_REQUIRED",
-          message: "Hosted device-sync connection owner no longer exists.",
-          retryable: false,
-          httpStatus: 404,
-        });
-      }
-      if (ownerStatus === "suspended" && !ownsFailedOauthProviderCleanup) {
-        throw deviceSyncError({
-          code: "CONNECTION_OWNER_SUSPENDED",
-          message: "Device connections cannot be completed while account deletion is active.",
-          retryable: false,
-          httpStatus: 409,
-        });
-      }
-      if (!ownsFailedOauthProviderCleanup && await readHostedHealthDataConsentState({
-        memberId: ownerId,
+        ownsFailedOauthProviderCleanup,
         prisma: tx,
-      }) === "revoked") {
-        throw deviceSyncError({
-          code: "HEALTH_DATA_CONSENT_REQUIRED",
-          httpStatus: 403,
-          message: "Use Murph again before connecting a health source.",
-          retryable: false,
-        });
-      }
+      });
 
       let existing = await tx.deviceConnection.findUnique({
         where: {
@@ -395,7 +392,11 @@ export class PrismaHostedConnectionStore {
           }
         }
 
+        if (preparedRoot) {
+          await revalidatePreparedHostedDomainRootForWebTx({ prepared: preparedRoot, tx });
+        }
         const credentialWrite = await buildHostedConnectionCredentialWrite({
+          preparedRoot,
           connectionId: existing.id,
           credential,
           prisma: tx,
@@ -419,6 +420,7 @@ export class PrismaHostedConnectionStore {
             providerApplicationId: binding?.applicationId ?? null,
             providerApplicationRevision: binding?.revision ?? null,
             externalAccountIdEncrypted: await encryptHostedConnectionSecret({
+              preparedRoot,
               connectionId: existing.id,
               provider: input.provider,
               prisma: tx,
@@ -458,7 +460,11 @@ export class PrismaHostedConnectionStore {
       });
 
       const connectionId = generateHostedRandomPrefixedId("dsc");
+      if (preparedRoot) {
+        await revalidatePreparedHostedDomainRootForWebTx({ prepared: preparedRoot, tx });
+      }
       const credentialWrite = await buildHostedConnectionCredentialWrite({
+        preparedRoot,
         connectionId,
         credential,
         prisma: tx,
@@ -475,6 +481,7 @@ export class PrismaHostedConnectionStore {
           connectedAt,
           displayName,
           externalAccountIdEncrypted: await encryptHostedConnectionSecret({
+            preparedRoot,
             connectionId,
             provider: input.provider,
             prisma: tx,
@@ -1839,6 +1846,7 @@ function resolveHostedDeviceSyncSetupExpiresAt(input: {
 }
 
 async function buildHostedConnectionCredentialWrite(input: {
+  preparedRoot: PreparedHostedDomainRootForWeb | null;
   connectionId: string;
   credential: DeviceAccountCredential;
   prisma: HostedPrismaTransactionClient;
@@ -1852,6 +1860,7 @@ async function buildHostedConnectionCredentialWrite(input: {
   switch (input.credential.kind) {
     case "oauth_tokens":
       return await buildHostedOAuthCredentialWrite({
+        preparedRoot: input.preparedRoot,
         connectionId: input.connectionId,
         prisma: input.prisma,
         provider: input.provider,
@@ -1950,6 +1959,7 @@ function normalizeDefaultProviderProfileKey(provider: string): string | null {
 }
 
 async function buildHostedOAuthCredentialWrite(input: {
+  preparedRoot: PreparedHostedDomainRootForWeb | null;
   connectionId: string;
   prisma: HostedPrismaTransactionClient;
   provider: string;
@@ -1969,6 +1979,7 @@ async function buildHostedOAuthCredentialWrite(input: {
 
   return {
     accessTokenEncrypted: await encryptHostedConnectionSecret({
+        preparedRoot: input.preparedRoot,
       connectionId: input.connectionId,
       provider: input.provider,
       prisma: input.prisma,
@@ -1985,6 +1996,7 @@ async function buildHostedOAuthCredentialWrite(input: {
     providerConfigKey: null,
     refreshTokenEncrypted: input.tokens.refreshToken
       ? await encryptHostedConnectionSecret({
+        preparedRoot: input.preparedRoot,
         connectionId: input.connectionId,
         provider: input.provider,
         prisma: input.prisma,
@@ -2047,4 +2059,43 @@ function buildHostedLocalHeartbeatUpdateData(
       ? { lastErrorMessage: sanitizeHostedConnectionLastErrorMessage(localState.lastErrorMessage ?? null) }
       : {}),
   };
+}
+
+// The preflight is advisory. Call again after the member lock before mutation.
+async function assertHostedConnectionOwnerAdmission(input: {
+  ownerId: string;
+  ownsFailedOauthProviderCleanup: boolean;
+  prisma: HostedPrismaTransactionClient;
+}): Promise<void> {
+  const ownerStatus = await readHostedMemberSuspensionAfterLockTx(
+    input.prisma,
+    input.ownerId,
+  );
+  if (ownerStatus === "missing") {
+    throw deviceSyncError({
+      code: "CONNECTION_OWNER_REQUIRED",
+      message: "Hosted device-sync connection owner no longer exists.",
+      retryable: false,
+      httpStatus: 404,
+    });
+  }
+  if (ownerStatus === "suspended" && !input.ownsFailedOauthProviderCleanup) {
+    throw deviceSyncError({
+      code: "CONNECTION_OWNER_SUSPENDED",
+      message: "Device connections cannot be completed while account deletion is active.",
+      retryable: false,
+      httpStatus: 409,
+    });
+  }
+  if (!input.ownsFailedOauthProviderCleanup && await readHostedHealthDataConsentState({
+    memberId: input.ownerId,
+    prisma: input.prisma,
+  }) === "revoked") {
+    throw deviceSyncError({
+      code: "HEALTH_DATA_CONSENT_REQUIRED",
+      httpStatus: 403,
+      message: "Use Murph again before connecting a health source.",
+      retryable: false,
+    });
+  }
 }

--- a/apps/web/test/hosted-crypto-domain-root-store.test.ts
+++ b/apps/web/test/hosted-crypto-domain-root-store.test.ts
@@ -2258,6 +2258,155 @@ test("a prepared domain root warms the scoped active key before its row exists",
   assert.equal(tx.persistedEnvelopes.length, 0);
 });
 
+test.each(["create", "replace", "consent_revoked", "suspended", "root_race"] as const)(
+  "connection %s prepares KMS before its transaction and rechecks authority",
+  async (scenario) => {
+    const { tx } = await createHostedWebCryptoTransactionFixture();
+    const { PrismaHostedConnectionStore } = await import(
+      "../src/lib/device-sync/prisma-store/connections"
+    );
+    const steps: string[] = [];
+    assert.ok(gcpKmsMock.client);
+    gcpKmsMock.client = createStepRecordingKmsClient({ client: gcpKmsMock.client, steps });
+    const userId = "member-connection-prepared-root";
+    let insideTransaction = false;
+    const state: { stored: HostedConnectionRecord | null } = { stored: null };
+    let attempts = 0;
+    const { prepareHostedCryptoDomainRootCandidates } = await import("../src/lib/hosted-crypto/domain-root-store");
+    const winner = scenario === "root_race"
+      ? (await prepareHostedCryptoDomainRootCandidates({ domains: ["device"], prisma: tx.prisma, userId })).get("device")
+      : null;
+    const active = (await prepareHostedCryptoDomainRootCandidates({
+      domains: ["device"], prisma: tx.prisma, userId,
+    })).get("device");
+    assert.ok(active);
+    tx.persistedEnvelopes.push(active);
+    const baseQuery = tx.prisma.$queryRaw.bind(tx.prisma);
+    const client = Object.assign(tx.prisma, {
+      async $queryRaw<T = unknown>(...args: Parameters<Prisma.TransactionClient["$queryRaw"]>): Promise<T> {
+        const query = args[0] as TemplateStringsArray | Prisma.Sql;
+        const sql = !Array.isArray(query) && "sql" in query ? query.sql : query.join("?");
+        if (sql.includes('from "hosted_member"')) {
+          steps.push("member.lock");
+          return [] as T;
+        }
+        if (sql.includes("suspended_at")) {
+          return [{ suspendedAt: insideTransaction && scenario === "suspended" ? new Date() : null }] as T;
+        }
+        if (sql.includes("device_sync_dirty_connection")) {
+          return [] as T;
+        }
+        return baseQuery<T>(...args);
+      },
+      async $transaction<T>(run: (transaction: Prisma.TransactionClient) => Promise<T>): Promise<T> {
+        attempts += 1;
+        if (winner && attempts === 1) tx.persistedEnvelopes.splice(0, 1, winner);
+        steps.push("transaction.begin");
+        insideTransaction = true;
+        try {
+          return await run(client);
+        } finally {
+          insideTransaction = false;
+          steps.push("transaction.end");
+        }
+      },
+      hostedConsentGrant: {
+        async findUnique() {
+          return {
+            scope: "launch.health-data",
+            status: insideTransaction && scenario === "consent_revoked" ? "revoked" : "granted",
+          };
+        },
+      },
+      deviceConnection: {
+        async findUnique() { return state.stored; },
+        async findFirst() { return null; },
+        async create({ data }: { data: Record<string, unknown> }) {
+          steps.push("connection.write");
+          state.stored = Object.assign(createHostedRuntimeDeviceSecretRecord({
+            accessTokenEncrypted: "",
+            connectionId: "dsc_prepared",
+            externalAccountIdEncrypted: "",
+            refreshTokenEncrypted: "",
+            tokenVersion: 1,
+            userId,
+          }), data);
+          return state.stored;
+        },
+        async update({ data }: { data: Record<string, unknown> }) {
+          steps.push("connection.write");
+          assert.ok(state.stored);
+          state.stored = Object.assign({}, state.stored, data);
+          return state.stored;
+        },
+      },
+    });
+    // The full store uses the real crypto implementation and only this narrow
+    // in-memory database boundary; KMS performs real local envelope cryptography.
+    const { createPrismaClient } = await import("../src/lib/prisma");
+    const backingClient = createPrismaClient({
+      databaseUrl: "postgresql://postgres:postgres@127.0.0.1:5432/murph_test",
+      poolMax: 1,
+    });
+    const prisma = new Proxy(backingClient, {
+      get(target, property) {
+        const owner = Reflect.has(client, property) ? client : target;
+        const value = Reflect.get(owner, property, owner);
+        return typeof value === "function" ? value.bind(owner) : value;
+      },
+    });
+    const store = new PrismaHostedConnectionStore({
+      prisma,
+      providerAccountBlindIndexKey: Buffer.alloc(32, 17),
+    });
+    const input = {
+      connectedAt: "2026-09-01T12:00:00.000Z",
+      existingAccountPolicy: "replace" as const,
+      externalAccountId: "account-prepared-root",
+      ownerId: userId,
+      provider: "oura",
+      tokens: { accessToken: "access-old", refreshToken: "refresh-old" },
+    };
+    if (scenario === "consent_revoked" || scenario === "suspended") {
+      await expect(store.upsertConnection(input)).rejects.toMatchObject({
+        code: scenario === "suspended" ? "CONNECTION_OWNER_SUSPENDED" : "HEALTH_DATA_CONSENT_REQUIRED",
+      });
+      expect(steps).not.toContain("connection.write");
+      expect(tx.persistedEnvelopes).toEqual([active]);
+    } else {
+      const { runWithHostedDomainRootUnwrapCache } = await import(
+        "../src/lib/hosted-crypto/domain-root-unwrap-cache"
+      );
+      const created = await runWithHostedDomainRootUnwrapCache(() => store.upsertConnection(input));
+      expect(created.externalAccountId).toBe(input.externalAccountId);
+      if (scenario === "replace") {
+        await store.upsertConnection({
+          ...input,
+          connectedAt: "2026-09-02T12:00:00.000Z",
+          tokens: { accessToken: "access-new", refreshToken: "refresh-new" },
+        });
+      }
+      assert.ok(state.stored);
+      expect(state.stored.tokenVersion).toBe(scenario === "replace" ? 2 : 1);
+      expect(parseSerializedHostedSecureBoxEnvelope(state.stored.accessTokenEncrypted ?? "").rootKeyId)
+        .toBe(tx.persistedEnvelopes[0]?.rootKeyId);
+    }
+    if (scenario === "root_race") {
+      expect(attempts).toBe(2);
+      expect(steps.filter((step) => step === "connection.write")).toHaveLength(1);
+    }
+    await backingClient.$disconnect();
+    let locked = false;
+    for (const step of steps) {
+      if (step === "transaction.begin") locked = true;
+      if (step === "transaction.end") locked = false;
+      if (step.startsWith("kms.")) expect(locked, step).toBe(false);
+    }
+    expect(steps).toContain("kms.decrypt");
+    expect(steps.indexOf("kms.decrypt")).toBeLessThan(steps.indexOf("member.lock"));
+  },
+);
+
 test("the prepared Web root token commits and reuses only its exact scoped root", async () => {
   const { tx } = await createHostedWebCryptoTransactionFixture();
   const {

--- a/apps/web/test/prisma-store-oauth-connection.test.ts
+++ b/apps/web/test/prisma-store-oauth-connection.test.ts
@@ -410,7 +410,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       prisma: tx,
     });
     expect(lockHostedMemberRowMock.mock.invocationCallOrder[0]).toBeLessThan(
-      readHostedHealthDataConsentStateMock.mock.invocationCallOrder[0] ?? 0,
+      readHostedHealthDataConsentStateMock.mock.invocationCallOrder[1] ?? 0,
     );
 
     expect(created.id).toMatch(/^dsc_[A-Za-z0-9_-]+$/u);
@@ -1343,7 +1343,7 @@ describe("PrismaDeviceSyncControlPlaneStore hosted connection access", () => {
       userId: "user-123",
     });
     expect(lockHostedMemberRowMock.mock.invocationCallOrder[0]).toBeLessThan(
-      readHostedHealthDataConsentStateMock.mock.invocationCallOrder[0] ?? 0,
+      readHostedHealthDataConsentStateMock.mock.invocationCallOrder[1] ?? 0,
     );
     expect(readHostedHealthDataConsentStateMock.mock.invocationCallOrder[0]).toBeLessThan(
       supersedeDirtyStateMock.mock.invocationCallOrder[0] ?? 0,


### PR DESCRIPTION
## Why and outcome

Connection creation and replacement decrypted their encryption root while holding member and connection locks. They now prepare the already-provisioned root before the transaction, repeat member/consent admission under the lock, revalidate the exact root and seal credentials locally.

Stacked on #2908. The upstream reconnect pending pass completes before this credential-write boundary.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Connection credentials and token versions retain their existing owner. Consent withdrawal or suspension during key preparation rejects persistence; a competing root winner triggers one bounded fresh preparation attempt.

## Evidence

- Direct: 115 focused crypto/connection and PostgreSQL reconnect tests pass. Full-store tests use real local envelope cryptography and record every KMS operation, covering create, replace, consent withdrawal, suspension and root drift. The create/replace regressions fail on original source because kms.decrypt occurs inside a transaction.
- Coverage: Web typecheck, scoped ESLint and complexity guard pass. Diff/privacy inspection passed. Required CI and ReviewGPT pending.

## Non-obvious affected surfaces

Missing device roots still fail closed. Each attempt owns a fresh cache, including beneath a broader request scope. Only exact prepared roots enter credential writes; connection/application/refresh authority remains locked. Legacy dirty-payload classification retains its separate bounded owner.

## Architecture and reuse

- Existing systems reused: Canonical prepared domain-root token, database root revalidation, local secure-box sealing, attempt-scoped cache and bounded upsert retry owner.
- New logic: Advisory admission before preparation, repeated locked admission, and exact prepared-root input to credential sealing.
- New abstractions: One small preparation helper reuses the existing root type and owner; no additional capability type or key cache.
- Complexity intentionally avoided: No optimistic token-version snapshot, additional transaction, schema, queue or separate retry mechanism.

## Complexity impact

- Guard: PASS — pnpm complexity:diff.
- Hotspots: Secret-helper debt stays zero; connection-owner debt decreases. Existing token persistence remains outside this scoped change.
- Agent judgment: Keep dependent connection identity and token-version derivation inside the transaction; move only external key preparation.

## Hot reply path impact

- Path status: Not applicable — device connection upsert does not run on reply handoff.
- Database calls: Two advisory admission reads before preparation and exact root revalidation at persistence. One database transaction per existing upsert attempt, bounded at two attempts. No collection fanout added.
- Network/provider calls: Device-root KMS unwrap occurs before member locks; local credential encryption under locks performs no KMS calls.
- Other awaited latency: Remote key-service latency no longer extends credential-write member locks.
- Before/after proof: Full-store real-crypto tests assert every KMS operation is outside its transaction and reject stale authority.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

ReviewGPT context sensitivity: sensitive
Classification reason: Encryption-root authority, device credentials and consent checks.

## Deployment concerns

- Deployment: not applicable
- Reason: Web-local encryption execution ordering with no schema, configuration or cross-service contract change. Existing envelopes and provisioned roots retain their format and owner.

## Changelog

- Changelog: not applicable
- Reason: Internal encryption execution ordering with unchanged connection behavior and no new member-facing interaction; reconnect recovery is documented in the upstream PR.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source, test paths are tests, and Markdown is docs. No generated or binary changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 120 | 33 |
| Tests / fixtures | 151 | 2 |
| Docs | 61 | 0 |

ReviewGPT first-reviewed head: 9d6cd15e470e4b9553222fa753ab0bf9fa206594

## Review result and stack dependency

[ReviewGPT round 1](https://chatgpt.com/c/6a9bb828-c1ec-83ea-874e-c4ba75b5e12f) returned PASS on 9d6cd15e470e4b9553222fa753ab0bf9fa206594. Native capture confirms GPT-6 Pro with response SHA-256 bd63070a3d1cf0ddc73d78f5d3173a91b018376ec23902db66e43949d2545e22.

The upstream #2908 callback correction is now included at base b01f22603ea637b94556a977954e3ba7057cd1ff. This base-only rebase mechanically combined adjacent reliability paragraphs; range-diff confirms identical runtime/test changes for this PR. The documented base-update-only exception applies. All 115 combined crypto, connection and full callback-to-PostgreSQL tests and Web typecheck pass on 72b70b36a645016ae42b52db44be45be3e40715d. Upstream #2908 round two has now passed on its corrected head; no accepted findings remain in either scoped patch. Current-base merge-tree proof is clean. Exact-head CI is green on 72b70b36a645016ae42b52db44be45be3e40715d, including all release coverage, build/typecheck, host matrix and billing boundary checks.
