### PR TITLE
Remove orphan Next route guards before source typecheck

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-05-stale-next-route-guards.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-stale-next-route-guards.md
@@ -1,0 +1,35 @@
+# Remove orphan Next route guards before source typecheck
+
+## Outcome and invariants
+
+Deleted routes must not leave generated guards that break ordinary Web source typecheck. Preserve generated guards for live page, layout, and route sources, unrelated files, and the separate production Next route-contract check. Keep cleanup within validated generated directories without following symlinks.
+
+## Cause and owner
+
+Frog autofix issue: #2790. Current Next 16.3 Webpack emits per-route guards under `.next/types/app`; `scripts/ensure-next-route-type-stubs.ts` removes only the aggregate validator. Direct synthetic Next generation and TypeScript 7 checks proved that an orphan guard survives preparation and still fails with TS2307. Removing only that guard restores the check while live guards remain.
+
+Extend the existing preparation owner. No package dependency, product runtime, deployment, or shared policy change is needed. Generated import paths identify the source; preserve unknown shapes and live source extensions.
+
+## Work and evidence
+
+- [x] Verify committed authority and exclusive sanctioned worktree ownership.
+- [x] Prove current Webpack failure and distinguish already-handled validator cleanup.
+- [x] Add focused executable regression and confirm failure before repair.
+- [x] Implement bounded orphan cleanup and prove live/unknown/symlink preservation.
+- [x] Run real generated-fixture TypeScript transition, focused tests, tools typecheck, complexity and privacy review.
+- [x] Freeze the implementation candidate for canonical review and required CI; delivery gates continue in the PR.
+
+## Changelog and deployment
+
+Internal developer tooling only; no member-visible changelog or deploy action.
+
+## Candidate verification
+
+The baseline regression failed three cases while ten existing cases passed. The repaired suite passes all fifteen cases, including both generated-directory symlink cases. Focused TypeScript 7 checking and documentation drift checks pass. Complexity debt remains zero; the changed source has no function above twenty.
+
+A current Next 16.3 Webpack build produced real route guards. Source removal fails TypeScript 7 before and after baseline preparation. Repaired preparation removes the orphan and passes; repeated preparation passes. Live page/layout guards are byte-identical, and an invalid live page still fails through its generated guard before restoring the valid page returns green.
+
+Parent review found no unresolved correctness, privacy, ownership, or unnecessary-scope issue. All data is synthetic. External review and required exact-head GitHub checks are pending at this candidate freeze and remain mandatory before landing.
+Status: completed
+Updated: 2026-09-05
+Completed: 2026-09-05

--- a/scripts/check-no-js.test.ts
+++ b/scripts/check-no-js.test.ts
@@ -158,6 +158,81 @@ describe("check-no-js hygiene guards", () => {
     }
   });
 
+  it.each([
+    [".next/types", "app"],
+    [".next/types", "src/app"],
+    [".next-smoke/dev/types", "src/app"],
+  ])("removes orphan route guards in %s while preserving live %s guards", async (typesDir, appDir) => {
+    const tempRoot = process.env.MURPH_VITEST_TEMP_ROOT;
+    if (!tempRoot) throw new Error("MURPH_VITEST_TEMP_ROOT is required.");
+    const root = await mkdtemp(path.join(tempRoot, "next-orphan-guards-"));
+    const nextEnvPath = path.join(root, "next-env.d.ts");
+    const makeGuard = async (relativePath: string, sourcePath: string) => {
+      const guardPath = path.join(root, relativePath);
+      const importedPath = path.relative(path.dirname(guardPath), path.join(root, sourcePath))
+        .replace(/\\/gu, "/");
+      const contents = `// File: synthetic route fixture\nimport * as entry from '${importedPath}'\n`;
+      await mkdir(path.dirname(guardPath), { recursive: true });
+      await writeFile(guardPath, contents);
+      return { guardPath, contents };
+    };
+    try {
+      await mkdir(path.join(root, appDir), { recursive: true });
+      await writeFile(path.join(root, appDir, "page.tsx"), "export default function Page() {}\n");
+      await writeFile(path.join(root, appDir, "layout.jsx"), "export default function Layout() {}\n");
+      await mkdir(path.join(root, appDir, "api/live"), { recursive: true });
+      await writeFile(path.join(root, appDir, "api/live/route.ts"), "export function GET() {}\n");
+      await writeFile(nextEnvPath, buildNextEnvDeclarationArtifact(`./${typesDir}/routes.d.ts`));
+      const orphan = await makeGuard(`${typesDir}/app/api/removed/route.ts`, `${appDir}/api/removed/route.js`);
+      const stableOrphan = await makeGuard(".next/types/app/api/old/route.ts", `${appDir}/api/old/route.js`);
+      const page = await makeGuard(`${typesDir}/app/page.ts`, `${appDir}/page.js`);
+      const layout = await makeGuard(`${typesDir}/app/layout.ts`, `${appDir}/layout.js`);
+      const route = await makeGuard(`${typesDir}/app/api/live/route.ts`, `${appDir}/api/live/route.js`);
+      const unknown = await makeGuard(`${typesDir}/app/custom.ts`, `${appDir}/missing.js`);
+      const unrecognized = await makeGuard(`${typesDir}/app/unrecognized/route.ts`, `${appDir}/unrecognized/route.js`);
+      unrecognized.contents = "export {}; // unrelated generated shape\n";
+      await writeFile(unrecognized.guardPath, unrecognized.contents);
+      const outside = await makeGuard(`${typesDir}/app/elsewhere/route.ts`, "other/route.js");
+      await writeFile(path.join(root, typesDir, "validator.ts"), "import './removed.js';\n");
+
+      await ensureNextRouteTypeStub(nextEnvPath);
+
+      await expect(access(orphan.guardPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(access(stableOrphan.guardPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(access(path.join(root, typesDir, "validator.ts"))).rejects.toMatchObject({ code: "ENOENT" });
+      for (const retained of [page, layout, route, unknown, unrecognized, outside]) {
+        await expect(readFile(retained.guardPath, "utf8")).resolves.toBe(retained.contents);
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each(["app", "app/nested"])("preserves route guards behind a generated %s symlink", async (linkedDirectory) => {
+    const tempRoot = process.env.MURPH_VITEST_TEMP_ROOT;
+    if (!tempRoot) throw new Error("MURPH_VITEST_TEMP_ROOT is required.");
+    const root = await mkdtemp(path.join(tempRoot, "next-linked-guards-"));
+    const outside = await mkdtemp(path.join(tempRoot, "next-retained-guards-"));
+    const nextEnvPath = path.join(root, "next-env.d.ts");
+    const linkPath = path.join(root, ".next/types", linkedDirectory);
+    const importedPath = path.relative(linkPath, path.join(root, "app/route.js"))
+      .replace(/\\/gu, "/");
+    const guard = `// File: synthetic route fixture\nimport * as entry from '${importedPath}'\n`;
+    try {
+      await mkdir(path.dirname(linkPath), { recursive: true });
+      await symlink(outside, linkPath, "dir");
+      await writeFile(path.join(outside, "route.ts"), guard);
+      await writeFile(nextEnvPath, buildNextEnvDeclarationArtifact("./.next/types/routes.d.ts"));
+
+      await ensureNextRouteTypeStub(nextEnvPath);
+
+      await expect(readFile(path.join(outside, "route.ts"), "utf8")).resolves.toBe(guard);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
   it("rejects a root-params import outside the accepted route-types directory", async () => {
     const testTempRoot = process.env.MURPH_VITEST_TEMP_ROOT;
     if (!testTempRoot) {

--- a/scripts/ensure-next-route-type-stubs.ts
+++ b/scripts/ensure-next-route-type-stubs.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, lstat, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -72,7 +72,7 @@ export async function ensureNextRouteTypeStub(nextEnvPath: string): Promise<stri
   );
 
   await ensureNextRouteTypesRuntimeStub(stubPath);
-  await removeStaleNextValidatorStub(stubPath);
+  await removeStaleNextRouteChecks(stubPath);
 
   return stubPath;
 }
@@ -161,7 +161,7 @@ async function ensureNextRouteTypesRuntimeStub(routeTypesStubPath: string): Prom
   }
 }
 
-async function removeStaleNextValidatorStub(routeTypesStubPath: string): Promise<void> {
+async function removeStaleNextRouteChecks(routeTypesStubPath: string): Promise<void> {
   if (!routeTypesStubPath.endsWith("/routes.d.ts")) {
     return;
   }
@@ -178,8 +178,62 @@ async function removeStaleNextValidatorStub(routeTypesStubPath: string): Promise
   await Promise.all(
     [...candidateValidatorPaths].map(async (validatorPath) => {
       await rm(validatorPath, { force: true });
+      if (workspaceRoot) {
+        await removeOrphanNextRouteGuards(path.dirname(validatorPath), workspaceRoot);
+      }
     }),
   );
+}
+
+async function removeOrphanNextRouteGuards(typesDirectory: string, workspaceRoot: string): Promise<void> {
+  const appTypesDirectory = path.join(typesDirectory, "app");
+  if (!(await isPlainGeneratedDirectory(workspaceRoot, appTypesDirectory))) return;
+
+  const entries = await readdir(appTypesDirectory, { recursive: true, withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isFile() || !/^(?:page|layout|route)\.ts$/u.test(entry.name)) continue;
+    const guardPath = path.join(entry.parentPath, entry.name);
+    const contents = await readFile(guardPath, "utf8");
+    // Next's Webpack guards import the source through its emitted .js path.
+    const sourceImport = contents.match(/^import \* as entry from ['"](\.\.?\/[^'"\r\n]+)\.js['"]/mu)?.[1];
+    if (!sourceImport) continue;
+    const sourceStem = path.resolve(path.dirname(guardPath), sourceImport);
+    if (path.basename(sourceStem) !== entry.name.replace(/\.ts$/u, "")) continue;
+    const isAppSource = ["app", "src/app"].some((appDirectory) =>
+      sourceStem.startsWith(path.join(workspaceRoot, appDirectory) + path.sep)
+    );
+    if (!isAppSource || await hasNextRouteSource(sourceStem)) continue;
+    await rm(guardPath, { force: true });
+  }
+}
+
+async function isPlainGeneratedDirectory(workspaceRoot: string, directory: string): Promise<boolean> {
+  let current = workspaceRoot;
+  for (const segment of path.relative(workspaceRoot, directory).split(path.sep)) {
+    current = path.join(current, segment);
+    try {
+      const info = await lstat(current);
+      if (!info.isDirectory() || info.isSymbolicLink()) return false;
+    } catch (error) {
+      if (isNodeErrorWithCode(error, "ENOENT")) return false;
+      throw error;
+    }
+  }
+  return true;
+}
+
+async function hasNextRouteSource(sourceStem: string): Promise<boolean> {
+  for (const extension of ["ts", "tsx", "js", "jsx", "mjs", "cjs"]) {
+    try {
+      await access(`${sourceStem}.${extension}`);
+      return true;
+    } catch (error) {
+      if (!isNodeErrorWithCode(error, "ENOENT") && !isNodeErrorWithCode(error, "ENOTDIR")) {
+        throw error;
+      }
+    }
+  }
+  return false;
 }
 
 function extractWorkspaceRootFromRouteTypesPath(routeTypesStubPath: string): string | null {


### PR DESCRIPTION
## Why and outcome

A removed Web route can leave a Webpack-generated guard that still imports the deleted module, so ordinary source typecheck fails after the existing validator cleanup. Preparation now removes orphan page, layout, and route guards from validated Next output while preserving live guards and unknown generated shapes.

Frog autofix issue: #2790

## Product UX

- Effort: Not applicable — internal developer verification tooling.
- Result: Not applicable
- Walkthrough: No member-facing journey or production behavior changes.

## Evidence

- Direct: A real Next 16.3 Webpack fixture passes initially, then fails TypeScript 7 after deleting its route both before and after baseline preparation. Repaired preparation passes, removes only the orphan, and preserves live page/layout guard bytes. Repeated preparation passes. A deliberately invalid live page still fails through its guard; restoring it passes.
- Coverage: `pnpm exec vitest run --config scripts/vitest.config.ts --no-coverage scripts/check-no-js.test.ts` passes 15 tests. Before the repair, the three new orphan cases failed while ten existing tests passed. Cases cover app/src-app roots, stable/suffixed output, live sources, unknown shapes, unrelated imports, and generated-directory symlinks.
- Focused TypeScript 7: `node scripts/run-typescript.mjs package -p audit-packages/tsconfig.focused.json --pretty false` passes for the changed preparation and test owner plus their imports. Broad repository checks are assigned to required CI.
- Documentation drift and diff hygiene pass. Parent correctness, privacy, scope, and complexity review has no unresolved findings. All fixtures are synthetic.

- Review: Canonical full round 1 PASS on `813ba668f65a272d888bdcf73bc92a71f10d01d3`, requested and verified model `gpt-6-pro`, no findings. Exact response/turn/ZIP metadata matched; conservative duration lower bounds were 444 seconds from send and 423 seconds from response wait.

## Non-obvious affected surfaces

Stable `.next/types` cleanup also runs when next-env points to a suffixed generated directory. The existing production Next generation and TypeScript 5 route-contract check are unchanged.

## Architecture and reuse

- Existing systems reused: The existing route-stub preparation, validated Next output paths, and Node filesystem APIs.
- New logic: Recognize generated guard entry imports, retain guards with existing source extensions, and remove only orphan guards within the app source boundary.
- New abstractions: Private owner-local directory and source-existence helpers; no new shared owner or persisted state.
- Complexity intentionally avoided: No output-tree reset, build regeneration, dependency, global cleanup, or changes to TypeScript's checks.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`; source debt 0 to 0, maximum 8 to 10.
- Hotspots: None above 20 in the changed source.
- Agent judgment: The directory check prevents symlink traversal, and the source check preserves supported live extensions. Further deletion would remove those protections.

## Hot reply path impact

Not applicable: repository-local typecheck preparation adds no runtime, provider, network, or database work.

## Murph initial provider input impact

Not applicable: individual and group runtime prompts, tools, and provider requests are unchanged.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal verification tooling only; no runtime or deployment configuration changes.

## Change-shape breakdown

Source: 57 additions / 3 deletions. Tests: 75 / 0. Documentation: 35 / 0. Config/tooling beyond source: 0 / 0. Generated/other: 0 / 0. Total: 167 additions / 3 deletions across 3 files; no binary files.

## Changelog

- Changelog: not applicable
- Reason: Internal source-typecheck repair with no member-visible change.

ReviewGPT first-reviewed head: 813ba668f65a272d888bdcf73bc92a71f10d01d3
ReviewGPT context sensitivity: routine
Context reason: Bounded repository-local generated-artifact maintenance without product runtime or external-state changes.
