### PR TITLE
Preserve fixture PATH in real-Codex login shells

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-05-real-codex-fixture-path.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-real-codex-fixture-path.md
@@ -1,0 +1,31 @@
+# Preserve fixture PATH through login shells
+
+## Outcome and invariants
+
+Explicit real-Codex fixture tools must remain first in PATH when a synthetic journey executes a login shell. Keep this inside the existing test harness; retain provider-key exclusion, explicit config precedence, caller environment/profile ownership, and caller-owned temporary cleanup. No runtime or global profile change.
+
+## Owner and evidence
+
+Frog #2729 is bound to `.agents/friction-log/20260829231539-real-codex-harness/friction.md`. The suite currently duplicates private `.zprofile` setup in two Personal Patterns journeys. Prior synthetic proof established that a login profile can displace the injected PATH. Extend the existing turn wrapper with explicit fixture intent and reuse one profile-preparation helper rather than general PATH interception.
+
+## Plan
+
+1. Reproduce actual `/bin/zsh -lc` selection through an injected test executor; assert the unmodified baseline and provider-key filtering.
+2. Move both duplicated journey profiles into an explicit fixture-bin option. Preserve caller-owned ZDOTDIR; conflicting automatic-profile intent must fail before invocation without touching caller files.
+3. Run the deterministic harness group, relevant typecheck, docs checks, and complexity inspection. Close this plan with focused evidence.
+4. Push a draft, establish exact readiness, run requested full ReviewGPT with validated model/timing concurrently with required CI, then land and verify the actual merged tree before closing the issue and retiring the worktree.
+
+## Verification
+
+- Before implementation, both new focused tests failed: actual login-shell selection returned the ambient marker, and conflicting caller-profile intent reached the executor.
+- After implementation, the complete deterministic harness group passes 12 tests. Controls prove non-login injected selection, login ambient displacement, helper-prepared login selection, shell-policy provider-key exclusion, explicit override precedence, unchanged caller env/profile, and early rejection of conflicting profile ownership.
+- `pnpm --dir packages/assistant-engine typecheck` passed including the changed test file. `pnpm complexity:diff` passed and correctly excludes test-only code from its source metric; the small helper introduces no complex branch. `pnpm docs:drift` and `pnpm docs:gardening` passed. Usage is documented in the package README; the generic testing index remains unchanged.
+- Two duplicate Personal Patterns profile blocks now use the shared explicit option. Other unrelated PATH customizations remain unchanged.
+- No live model or nested Codex invocation occurred. Required external review and exact-head CI remain the PR completion gates.
+
+## Completion decisions
+
+Internal test tooling only: Product UX and public changelog are not applicable. Preserve existing shell permissions and production configuration. Use the existing Frog entry; no duplicate report.
+Status: completed
+Updated: 2026-09-05
+Completed: 2026-09-05

--- a/packages/assistant-engine/README.md
+++ b/packages/assistant-engine/README.md
@@ -267,5 +267,7 @@ that directory to PATH and creates a private login profile beneath the journey's
 working directory, whose existing cleanup owns it. Ordinary calls retain their
 supplied environment. An explicit caller `ZDOTDIR` remains caller-owned and
 cannot be combined with automatic fixture-profile preparation. Deterministic
-harness tests exercise actual `zsh -lc` selection and retain provider-key
-exclusion without starting Codex or making a model request.
+harness tests exercise actual `zsh -lc` selection when zsh is installed; that
+integration case explicitly skips when the executable is absent. Portable
+profile quoting, provider-key exclusion, and caller-profile ownership remain
+covered without zsh. These tests do not start Codex or make a model request.

--- a/packages/assistant-engine/README.md
+++ b/packages/assistant-engine/README.md
@@ -258,3 +258,14 @@ mechanics live in the co-packaged `references/session-support.md`, which must be
 read before support questions or effects. Normal recursive skill packaging and
 filesystem reads remain the owners. Keep that reference in focused real-Codex
 fixtures when changing support policy.
+
+## Real-Codex test fixtures
+
+Synthetic real-Codex journeys that need fixture executables can opt into
+`executeRealCodexAppServerTurn`'s `fixtureBinDirectory`. The test harness adds
+that directory to PATH and creates a private login profile beneath the journey's
+working directory, whose existing cleanup owns it. Ordinary calls retain their
+supplied environment. An explicit caller `ZDOTDIR` remains caller-owned and
+cannot be combined with automatic fixture-profile preparation. Deterministic
+harness tests exercise actual `zsh -lc` selection and retain provider-key
+exclusion without starting Codex or making a model request.

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -1,6 +1,7 @@
 import { WORKFLOW_SKILL_REFERENCES } from './support/workflow-skill-policy.js'
 import { execFile } from 'node:child_process'
 import { createHash } from 'node:crypto'
+import { existsSync } from 'node:fs'
 import { chmod, cp, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { homedir, tmpdir } from 'node:os'
 import path from 'node:path'
@@ -24498,7 +24499,7 @@ describe('real Codex app-server cache usage e2e harness', () => {
     ])
   })
 
-  it('preserves explicit fixture PATH through the login-shell launch pipeline', async () => {
+  it.skipIf(!existsSync('/bin/zsh'))('preserves explicit fixture PATH through the login-shell launch pipeline', async () => {
     const directory = await mkdtemp(path.join(tmpdir(), 'murph-fixture-path-'))
     const home = path.join(directory, 'home')
     const ambientBin = path.join(directory, 'ambient-bin')
@@ -24555,6 +24556,49 @@ describe('real Codex app-server cache usage e2e harness', () => {
       expect(observedOverrides?.at(-1)).toBe('features.shell_tool=false')
       if (!observedProfile) throw new Error('Expected an owned fixture profile.')
       expect(path.dirname(observedProfile)).toBe(directory)
+      expect(env).toEqual(originalEnv)
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
+  it('preserves fixture profile quoting and provider-key exclusion without zsh', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'murph-portable-profile-'))
+    try {
+      const fixtureBin = path.join(directory, "fixture bin ' $literal")
+      await mkdir(fixtureBin)
+      await writeFile(path.join(fixtureBin, 'fixture-tool'),
+        '#!/bin/sh\nprintf fixture\n', { mode: 0o755 })
+      const env = buildRealCodexE2eEnv({
+        apiKeyEnv: 'PROVIDER_AUTH',
+        sourceEnv: { PATH: '/usr/bin:/bin', PROVIDER_AUTH: 'synthetic-provider-value' },
+      })
+      const originalEnv = { ...env }
+      let shellOutput: string | undefined
+      let observedOverrides: readonly string[] | undefined
+      await expect(executeRealCodexAppServerTurn({
+        configOverrides: ['features.shell_tool=false'],
+        dynamicTools: [],
+        env,
+        fixtureBinDirectory: fixtureBin,
+        prompt: 'Exercise the generated fixture profile.',
+        workingDirectory: directory,
+      }, async (input) => {
+        observedOverrides = input.configOverrides
+        const includeOnly = input.configOverrides?.find((value) =>
+          value.startsWith('shell_environment_policy.include_only='))
+        if (!includeOnly) throw new Error('Expected an explicit shell environment policy.')
+        const keys: string[] = JSON.parse(includeOnly.slice(includeOnly.indexOf('=') + 1))
+        const shellEnv = Object.fromEntries(
+          Object.entries(input.env ?? {}).filter(([key]) => keys.includes(key)),
+        )
+        shellOutput = (await execFileAsync('/bin/sh', ['-c',
+          'PATH=/usr/bin:/bin; . "$ZDOTDIR/.zprofile"; fixture-tool; printf ":%s" "${PROVIDER_AUTH-unset}"',
+        ], { env: shellEnv })).stdout
+        throw new Error('Stop after the portable profile proof.')
+      })).rejects.toThrow('Real Codex turn failed')
+      expect(shellOutput).toBe('fixture:unset')
+      expect(observedOverrides?.at(-1)).toBe('features.shell_tool=false')
       expect(env).toEqual(originalEnv)
     } finally {
       await rm(directory, { force: true, recursive: true })

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -12016,11 +12016,6 @@ describeRealCodex('real Codex Personal Patterns first complete digest e2e', () =
         ledgerCapturePath,
         vocabularyCapturePath,
       })
-      await writeFile(
-        path.join(workingDirectory, '.zprofile'),
-        `export PATH=${JSON.stringify(binDirectory)}:$PATH\n`,
-        'utf8',
-      )
       const result = await executeRealCodexAppServerTurn({
         allowFinishWithoutReply: true,
         approvalPolicy: 'never',
@@ -12030,11 +12025,8 @@ describeRealCodex('real Codex Personal Patterns first complete digest e2e', () =
         codexHome: config.codexHome,
         developerInstructions: buildWeeklyHealthInsightDeveloperInstructions(),
         dynamicTools: [MURPH_FINISH_WITHOUT_REPLY_TOOL],
-        env: {
-          ...config.env,
-          PATH: `${binDirectory}:${config.env.PATH ?? ''}`,
-          ZDOTDIR: workingDirectory,
-        },
+        env: config.env,
+        fixtureBinDirectory: binDirectory,
         excludeResumeTurns: true,
         model: config.model,
         modelProvider: config.modelProvider,
@@ -12147,11 +12139,6 @@ describeRealCodex('real Codex Personal Patterns vocabulary normalization e2e', (
         ledgerCapturePath,
         vocabularyCapturePath,
       })
-      await writeFile(
-        path.join(workingDirectory, '.zprofile'),
-        `export PATH=${JSON.stringify(binDirectory)}:$PATH\n`,
-        'utf8',
-      )
       const result = await executeRealCodexAppServerTurn({
         allowFinishWithoutReply: true,
         approvalPolicy: 'never',
@@ -12161,11 +12148,8 @@ describeRealCodex('real Codex Personal Patterns vocabulary normalization e2e', (
         codexHome: config.codexHome,
         developerInstructions: buildWeeklyHealthInsightDeveloperInstructions(),
         dynamicTools: [MURPH_FINISH_WITHOUT_REPLY_TOOL],
-        env: {
-          ...config.env,
-          PATH: `${binDirectory}:${config.env.PATH ?? ''}`,
-          ZDOTDIR: workingDirectory,
-        },
+        env: config.env,
+        fixtureBinDirectory: binDirectory,
         excludeResumeTurns: true,
         model: config.model,
         modelProvider: config.modelProvider,
@@ -24514,6 +24498,102 @@ describe('real Codex app-server cache usage e2e harness', () => {
     ])
   })
 
+  it('preserves explicit fixture PATH through the login-shell launch pipeline', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'murph-fixture-path-'))
+    const home = path.join(directory, 'home')
+    const ambientBin = path.join(directory, 'ambient-bin')
+    const fixtureBin = path.join(directory, "fixture bin ' $literal")
+    try {
+      await Promise.all([home, ambientBin, fixtureBin].map((entry) => mkdir(entry)))
+      await writeFile(
+        path.join(home, '.zprofile'),
+        `export PATH=${quoteNutritionShellLiteral(ambientBin)}:/usr/bin:/bin\n`,
+      )
+      await writeFile(path.join(ambientBin, 'fixture-tool'),
+        '#!/bin/sh\nprintf ambient\n', { mode: 0o755 })
+      await writeFile(path.join(fixtureBin, 'fixture-tool'),
+        '#!/bin/sh\nprintf fixture\n', { mode: 0o755 })
+      const env = buildRealCodexE2eEnv({
+        apiKeyEnv: 'PROVIDER_AUTH',
+        sourceEnv: {
+          PATH: `${fixtureBin}:/usr/bin:/bin`,
+          PROVIDER_AUTH: 'synthetic-provider-value',
+        },
+      })
+      env.HOME = home
+      const originalEnv = { ...env }
+      expect((await execFileAsync('/bin/zsh', ['-c', 'fixture-tool'], { env })).stdout).toBe('fixture')
+      expect((await execFileAsync('/bin/zsh', ['-lc', 'fixture-tool'], { env })).stdout).toBe('ambient')
+      let selectedTool: string | undefined
+      let shellProviderValue: string | undefined
+      let observedProfile: string | undefined
+      let observedOverrides: readonly string[] | undefined
+      await expect(executeRealCodexAppServerTurn({
+        configOverrides: ['features.shell_tool=false'],
+        dynamicTools: [],
+        env,
+        fixtureBinDirectory: fixtureBin,
+        prompt: 'Exercise the synthetic fixture shell.',
+        workingDirectory: directory,
+      }, async (input) => {
+        observedOverrides = input.configOverrides
+        observedProfile = input.env?.ZDOTDIR
+        const includeOnly = input.configOverrides?.find((value) =>
+          value.startsWith('shell_environment_policy.include_only='))
+        if (!includeOnly) throw new Error('Expected an explicit shell environment policy.')
+        const keys: string[] = JSON.parse(includeOnly.slice(includeOnly.indexOf('=') + 1))
+        const shellEnv = Object.fromEntries(
+          Object.entries(input.env ?? {}).filter(([key]) => keys.includes(key)),
+        )
+        selectedTool = (await execFileAsync('/bin/zsh', ['-lc', 'fixture-tool'], { env: shellEnv })).stdout
+        shellProviderValue = (await execFileAsync('/bin/zsh',
+          ['-lc', 'printf "%s" "${PROVIDER_AUTH-unset}"'], { env: shellEnv })).stdout
+        throw new Error('Stop after the synthetic shell proof.')
+      })).rejects.toThrow('Real Codex turn failed')
+      expect(selectedTool).toBe('fixture')
+      expect(shellProviderValue).toBe('unset')
+      expect(observedOverrides?.at(-1)).toBe('features.shell_tool=false')
+      if (!observedProfile) throw new Error('Expected an owned fixture profile.')
+      expect(path.dirname(observedProfile)).toBe(directory)
+      expect(env).toEqual(originalEnv)
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
+  it('preserves a caller-owned login profile and rejects conflicting fixture intent', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'murph-caller-profile-'))
+    try {
+      const profile = path.join(directory, '.zprofile')
+      const contents = 'export CALLER_PROFILE=preserved\n'
+      await writeFile(profile, contents)
+      const env = { PATH: '/usr/bin:/bin', ZDOTDIR: directory }
+      const originalEnv = { ...env }
+      let calls = 0
+      const executeTurn: typeof executeCodexAppServerTurn = async (input) => {
+        calls += 1
+        expect(input.env).toBe(env)
+        throw new Error('Stop after observing caller-owned input.')
+      }
+      const input = {
+        dynamicTools: [],
+        env,
+        prompt: 'Preserve the caller profile.',
+        workingDirectory: directory,
+      }
+      await expect(executeRealCodexAppServerTurn(input, executeTurn)).rejects.toThrow('Real Codex turn failed')
+      await expect(executeRealCodexAppServerTurn(
+        { ...input, fixtureBinDirectory: directory }, executeTurn,
+      )).rejects.toThrow('explicit ZDOTDIR')
+      expect(calls).toBe(1)
+      expect(env).toEqual(originalEnv)
+      expect(await readFile(profile, 'utf8')).toBe(contents)
+      expect(await readdir(directory)).toEqual(['.zprofile'])
+    } finally {
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
   it('pins live turns to the hosted shell and plugin boundaries', async () => {
     let observedConfigOverrides: readonly string[] | undefined
 
@@ -30399,15 +30479,25 @@ async function executeRealCodexOnboardingProbe(
 async function executeRealCodexAppServerTurn(
   input: Omit<CodexAppServerTurnInput, 'dynamicTools'> & {
     dynamicTools?: CodexAppServerTurnInput['dynamicTools']
+    fixtureBinDirectory?: string
   },
   executeTurn: typeof executeCodexAppServerTurn = executeCodexAppServerTurn,
 ): ReturnType<typeof executeCodexAppServerTurn> {
+  const { fixtureBinDirectory, ...turnInput } = input
+  const env = fixtureBinDirectory === undefined
+    ? input.env
+    : await prepareRealCodexFixtureShellEnvironment({
+      binDirectory: fixtureBinDirectory,
+      env: input.env,
+      workingDirectory: input.workingDirectory,
+    })
   try {
     const result = await executeTurn({
-      ...input,
+      ...turnInput,
+      env,
       configOverrides: [
         ...REAL_CODEX_HOSTED_CONFIG_OVERRIDES,
-        ...buildRealCodexShellEnvironmentConfigOverrides(input.env),
+        ...buildRealCodexShellEnvironmentConfigOverrides(env),
         ...(input.configOverrides ?? []),
       ],
       dynamicTools: input.dynamicTools ?? resolveMurphDynamicTools({
@@ -30484,6 +30574,40 @@ function recordRealCodexProviderUsage(usage: AssistantProviderUsage): void {
   realCodexSuiteUsage.outputTokens += usage.outputTokens ?? 0
   realCodexSuiteUsage.reasoningTokens += usage.reasoningTokens ?? 0
   realCodexSuiteUsage.totalTokens += usage.totalTokens ?? 0
+}
+
+async function prepareRealCodexFixtureShellEnvironment(input: {
+  binDirectory: string
+  env: NodeJS.ProcessEnv | undefined
+  workingDirectory: string
+}): Promise<NodeJS.ProcessEnv> {
+  if (input.env?.ZDOTDIR !== undefined) {
+    throw new Error(
+      'An explicit ZDOTDIR already owns login profiles; omit fixtureBinDirectory and prepare the caller profile.',
+    )
+  }
+  const binDirectory = path.resolve(input.workingDirectory, input.binDirectory)
+  // The journey's existing working-directory cleanup owns this private profile.
+  const profileDirectory = await mkdtemp(
+    path.join(input.workingDirectory, '.codex-fixture-shell-'),
+  )
+  await writeFile(
+    path.join(profileDirectory, '.zprofile'),
+    `export PATH=${quoteNutritionShellLiteral(binDirectory)}:$PATH\n`,
+    { mode: 0o600 },
+  )
+  const env = {
+    ...input.env,
+    PATH: [binDirectory, input.env?.PATH].filter(Boolean).join(path.delimiter),
+    ZDOTDIR: profileDirectory,
+  }
+  const providerApiKeyEnv = input.env
+    ? realCodexProviderApiKeyEnvByEnvironment.get(input.env)
+    : undefined
+  if (providerApiKeyEnv !== undefined) {
+    realCodexProviderApiKeyEnvByEnvironment.set(env, providerApiKeyEnv)
+  }
+  return env
 }
 
 function buildRealCodexShellEnvironmentConfigOverrides(


### PR DESCRIPTION
## Why and outcome

Real-Codex test journeys can inject a fixture directory into PATH, but a login profile can replace it and select an unrelated ambient executable. The test-only turn wrapper now accepts explicit `fixtureBinDirectory`, prepares an owned private login profile beneath the journey working directory, and preserves fixture selection through `zsh -lc`.

Two Personal Patterns journeys now reuse this option instead of duplicating profile writes. Ordinary calls retain their supplied environment; an explicit caller ZDOTDIR remains caller-owned and conflicting automatic preparation fails before execution.

Frog autofix issue: #2729

## Product UX

Not applicable: this is synthetic test-harness setup. Member journeys and production behavior are unchanged.

## Evidence

- Regression reproduced before the fix: the actual login shell selected the ambient marker instead of the injected fixture; conflicting caller-profile intent reached the executor.
- `pnpm --dir packages/assistant-engine test test/assistant-codex-real-e2e.test.ts -t 'real Codex app-server cache usage e2e harness'` — 13 passed locally. The injected executor runs actual `/bin/zsh -c` and `-lc` against synthetic profiles and tools, including a fixture directory containing shell metacharacters. No Codex process or model request is started.
- The composed launch proof preserves provider-key exclusion from the shell, caller override precedence, and the original environment. Explicit caller profiles stay untouched, and conflicting opt-in fails before execution.
- `pnpm --dir packages/assistant-engine typecheck` — passed, including the changed tests.
- `pnpm complexity:diff`, `pnpm docs:drift`, `pnpm docs:gardening`, and `git diff --check` — passed.
- Full requested ReviewGPT passed on `56173ce12e7aab08806225921cfc0fdafc2acbac`; all four required exact-head CI contexts passed on `dd072197d4cf1e15ff85463e603b4b108a0a8abf`. Ubuntu assistant-engine coverage passed 272 test files and 4,429 tests (231 skipped); the harness file passed 38 tests with 202 skipped. Run: https://github.com/cobuildwithus/murph/actions/runs/33956222866.
- Initial Ubuntu CI lacked `/bin/zsh` and failed the new integration case. The isolated proof correction explicitly skips only that case when the executable is absent. Portable `/bin/sh` profile quoting, provider-key exclusion, and caller-profile ownership remain active. Actual macOS zsh red/green proof is retained; Ubuntu zsh execution is unavailable. No workflow or dependency changes.

## Non-obvious affected surfaces

The new derived environment retains the original provider-key exclusion metadata before shell-policy construction. The existing hosted configuration and caller override ordering remain intact. Unrelated PATH customizations in other journeys are unchanged.

## Architecture and reuse

- Existing systems reused: the test-only turn wrapper, shell-policy builder, provider-key environment metadata, existing shell quoting helper, and journey working-directory cleanup.
- New logic: explicit fixture intent creates one private profile and prepends its tool directory after login initialization.
- New abstractions: one test-local environment preparation helper replaces two duplicate profile blocks; no production export, state owner, or service is added.
- Complexity intentionally avoided: no global profile edit, PATH interception for ordinary calls, runtime flag, retry loop, or alternate Codex process owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` found no authored runtime JS/TS source changes; the changed file is test-only.
- Hotspots: the added helper has only the explicit-profile rejection and metadata-preservation branches; no added function approaches complexity 20.
- Agent judgment: explicit fixture selection and existing cleanup ownership keep the correction bounded. Broader journey migration is unnecessary for the two reproduced workarounds.

## Hot reply path impact

Not applicable: no production source, database call, provider call, or foreground execution path changes.

## Murph initial provider input impact

Not applicable for individual and group runtimes: production prompts, tool definitions, schemas, and provider-visible context are unchanged. Only explicitly opted-in synthetic test environments change.

## Review

- Parent candidate and final review: complete; source, profile ownership, environment provenance, cleanup, and the exact proof-only portability delta were inspected without unresolved findings.
- Requested full-patch ReviewGPT: valid round 1 PASS on `56173ce12e7aab08806225921cfc0fdafc2acbac`, actual model `gpt-6-pro`, exact turn identity, 378.205 seconds Send-to-capture and 365.717 seconds response-wait-to-capture. Response SHA-256: `a8aa0bc28e11145962de99301fefd8a63785d9cb0dccfd95df60795fa5f3bfbe`. The complete snapshot and empty deltas were verified.
- The subsequent proof-only portability correction leaves the reviewed helper and journey behavior unchanged and is covered by the current test/documentation exemption; new-head CI passed as recorded above.
- Invalid attempt history: the first capture was invalid because response-wait-to-capture was 245.650 seconds, below the required 270 seconds, despite matching model/turn identity and 281.175 seconds from Send. Diagnostic SHA-256: `ddcd789159a18375a3f70cf12a9f51fa873a847b56f9443ad48edd4e77d32522`. No round was credited for that capture; the same head and round were retried successfully as recorded above.

ReviewGPT first-reviewed head: 56173ce12e7aab08806225921cfc0fdafc2acbac
ReviewGPT context sensitivity: routine
Classification reason: Test-only fixture preparation with synthetic shell proof; production configuration, state, deployment, and provider boundaries are unchanged.

## Deployment concerns

- Deployment: not applicable
- Reason: Test-harness and package documentation changes require no runtime deployment.

## Change-shape breakdown

Classification follows file ownership: harness implementation/regressions are tests; README and completed plan are documentation. No binary or generated artifacts.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests/fixtures | 190 | 22 |
| Docs | 44 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 234 | 22 |

## Changelog

- Changelog: not applicable
- Reason: Internal test fixture reliability is not member-visible.
