### PR TITLE
fix(web): resolve public device sync service from source

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-05-frog-autofix-2907.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-frog-autofix-2907.md
@@ -1,0 +1,33 @@
+# Resolve the public device sync service from Web source
+
+Status: completed
+Created: 2026-09-05
+Updated: 2026-09-05
+
+## Goal
+
+The documented Web typecheck must resolve its public device-sync service import in a fresh checkout without an undeclared package build prerequisite.
+
+## Owner and scope
+
+The established explicit paths in apps/web/tsconfig.json own Web source resolution. The package already declares its service export; retain that public boundary and all runtime behavior. Add one alias and one regression in the existing workspace source-resolution suite. No new dependency, runtime behavior, wildcard alias, or generated artifact owner.
+
+## Evidence and decisions
+
+- Admitted issue #2907 reports TS2307 in the hosted runtime authority test. Its current public service export points to dist, while neighboring Web entrypoints have source mappings.
+- A synthetic workspace copies the actual Web/base configs, package exports, and service source but contains no package dist. The canonical TypeScript 7 runner's resolved file graph omits the service before the alias and includes it afterward.
+- Keep that fixture a resolution-only proof; full canonical Web typecheck separately proves the actual dependency graph. No duplicate Frog entry for this existing issue; #2914 has the same cause and receives no separate repair.
+
+## Tasks
+
+1. Revalidate admitted authority and ownership, and reproduce the missing source resolution.
+2. Extend the existing source-alias owner and run focused resolution plus canonical Web typecheck.
+3. Complete candidate review, scoped commit, full ReviewGPT and required exact-head CI before guarded landing and issue closure.
+
+## Verification
+
+- Focused workspace source-resolution suite: baseline 1 failure / 7 passes; alias candidate 8 passes.
+- Canonical `pnpm --dir apps/web typecheck` passes in the fresh worktree after its own generated prerequisites; device-syncd/dist remains absent.
+- Focused TypeScript 7 check of the changed test passes. Complexity guard, docs drift and whitespace checks pass.
+- Full ReviewGPT and required exact-head CI remain landing gates.
+Completed: 2026-09-05

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -345,6 +345,9 @@
       "@murphai/device-syncd/public-provider-descriptors": [
         "../../packages/device-syncd/src/public-provider-descriptors.ts"
       ],
+      "@murphai/device-syncd/service": [
+        "../../packages/device-syncd/src/service.ts"
+      ],
       "@murphai/device-syncd/source-staleness": [
         "../../packages/device-syncd/src/source-staleness.ts"
       ],

--- a/scripts/workspace-source-resolution.test.ts
+++ b/scripts/workspace-source-resolution.test.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -13,6 +15,43 @@ import {
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 describe("workspace source resolution", () => {
+  it("resolves the Web device-sync service through source when package dist is absent", () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(tmpdir(), "murph-web-source-"));
+    const webDir = path.join(fixtureRoot, "apps/web");
+    const packageDir = path.join(fixtureRoot, "packages/device-syncd");
+    const servicePath = path.join(packageDir, "src/service.ts");
+
+    try {
+      fs.mkdirSync(webDir, { recursive: true });
+      fs.mkdirSync(path.dirname(servicePath), { recursive: true });
+      fs.mkdirSync(path.join(webDir, "node_modules/@murphai"), { recursive: true });
+      fs.symlinkSync(packageDir, path.join(webDir, "node_modules/@murphai/device-syncd"), "dir");
+      for (const relativePath of ["tsconfig.base.json", "packages/device-syncd/package.json", "packages/device-syncd/src/service.ts"]) {
+        fs.copyFileSync(path.join(repoRoot, relativePath), path.join(fixtureRoot, relativePath));
+      }
+      const config = JSON.parse(fs.readFileSync(path.join(repoRoot, "apps/web/tsconfig.json"), "utf8"));
+      config.include = ["probe.ts"];
+      config.exclude = [];
+      config.compilerOptions.incremental = false;
+      config.compilerOptions.types = [];
+      config.compilerOptions.plugins = [];
+      delete config.compilerOptions.tsBuildInfoFile;
+      fs.writeFileSync(path.join(webDir, "tsconfig.json"), JSON.stringify(config));
+      fs.writeFileSync(path.join(webDir, "probe.ts"), 'import { SqliteDeviceSyncStore } from "@murphai/device-syncd/service";\nvoid SqliteDeviceSyncStore;\n');
+
+      const output = execFileSync(process.execPath, [
+        path.join(repoRoot, "scripts/run-typescript.mjs"),
+        "web", "-p", path.join(webDir, "tsconfig.json"), "--listFilesOnly", "--pretty", "false",
+      ], { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+
+      // Resolution proof only: sibling source dependencies are deliberately absent.
+      expect(output.split(/\r?\n/u)).toContain(servicePath);
+      expect(fs.existsSync(path.join(packageDir, "dist"))).toBe(false);
+    } finally {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   it("keeps configured package source anchors on files that exist", () => {
     const entries = resolveHostedWebWorkspaceSourceEntries(path.join(repoRoot, "apps/web"));
 


### PR DESCRIPTION
## Why and outcome

The documented Web typecheck failed in a fresh checkout because its public `@murphai/device-syncd/service` import depended on an unbuilt declaration artifact. Add the missing exact source alias beside the existing device-sync mappings, so Web uses the already-declared public service entrypoint without an extra package build.

Frog autofix issue: #2907

## Product UX

- Effort: Not applicable — internal source resolution for the existing hosted runtime authority test.
- Result: Not applicable.
- Walkthrough: A fresh checkout can run the documented Web typecheck after its own generated prerequisites; no member-facing behavior changes.

## Evidence

- Direct: `pnpm --dir apps/web typecheck` passes after a frozen install in the fresh worktree. `packages/device-syncd/dist` remains absent.
- Coverage: The existing workspace source-resolution suite uses the canonical TypeScript 7 runner with actual Web/base configuration, public package exports, and current service source copied into a synthetic workspace containing no dist. Its resolved file graph omits the service before the alias and includes it afterward. This fixture proves resolution only; the full Web typecheck separately proves the current dependency graph.
- Tests: `pnpm exec vitest run --config scripts/vitest.config.ts scripts/workspace-source-resolution.test.ts --no-coverage` — baseline one failure/seven passes, candidate eight passes.
- Checks: Focused TypeScript 7 check of the changed test, docs drift, complexity guard, and whitespace checks pass. All four required exact-head checks passed. Canonical full ReviewGPT round 1 PASS on this head, gpt-6-pro, 365.7s conservative capture interval; zero findings. Two pre-send lane failures and one too-fast pass are retained as invalid diagnostic evidence.

## Non-obvious affected surfaces

The service subpath is already public. Its only current Web import is the hosted runtime authority test. Public package exports and production imports are unchanged.

## Architecture and reuse

- Existing systems reused: Exact Web TypeScript paths, declared device-sync service export, canonical TypeScript runner, and existing workspace-resolution suite.
- New logic: One explicit source alias.
- New abstractions: None; the existing source-resolution owner is sufficient.
- Complexity intentionally avoided: No wildcard mapping, custom bundler rewrite, dependency, or extra build prerequisite.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`; the test file is excluded from the production-source metric.
- Hotspots: No production functions changed; the guard reports no authored source to analyze.
- Agent judgment: The existing alias owner is the smallest correction; no additional runtime machinery is justified.

## Hot reply path impact

- Path status: Not applicable — no runtime caller or reply-path behavior changed.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None on the production reply path.
- Before/after proof: Compiler resolution and fresh Web typecheck, not a production latency measurement.

## Murph initial provider input impact

Not applicable to individual and group runtimes: prompts, tools, schemas, and provider input assembly are unchanged. Token measurement was not run.

ReviewGPT first-reviewed head: d7e51dae1f4f2adc675531857a32f0b84a541cc7
ReviewGPT context sensitivity: routine
Classification reason: Exact alias for an existing public entrypoint currently imported only by a Web test, plus isolated compiler proof and execution plan.

## Deployment concerns

- Deployment: not applicable
- Reason: No deployed runtime boundary or package export changes; the existing test resolves directly to source.

## Change-shape breakdown

Classification rule: Web tsconfig is config/tooling, the existing test is tests/fixtures, and the execution plan is docs. No binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 39 | 0 |
| Docs | 33 | 0 |
| Config / tooling | 3 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **75** | **0** |

## Changelog

- Changelog: not applicable
- Reason: Internal typecheck preparation fix with no member-visible product change.
