### PR TITLE
Prepare Worker dependencies for no-bundle E2E suites

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-05-frog-2717-worker-artifacts.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-frog-2717-worker-artifacts.md
@@ -1,0 +1,44 @@
+# Prepare Worker workspace artifacts before hosted-local snapshots
+
+Status: completed
+Created: 2026-09-05
+Updated: 2026-09-05
+
+## Goal
+
+Hosted-local Worker snapshots must not silently copy stale public workspace artifacts when runner-bundle preparation is skipped.
+
+## Success criteria
+
+- Prove the actual snapshot owner copies a stale synthetic module before correction.
+- Reuse existing declared package builds or an existing artifact owner to prepare the bounded Worker dependency closure before copying, with build failure/cancellation preventing Worker launch.
+- Preserve no-bundle runner reuse, production deployment validation and local process ownership.
+- Focused red/green proof, proportional typecheck/audits, full exact-head ReviewGPT and required CI before landing.
+
+## Scope
+
+Local Worker snapshot preparation and focused tests/owner documentation only. No production validators, new fingerprint/cache state, dependencies, real credentials, Docker, or unrelated lifecycle edits.
+
+## Evidence and decisions
+
+- Committed issue2717 authority is unique on main; static trace proves the existing materializer checks only dist-directory existence before copying. Current standalone owner is private inside stack.ts.
+- Actual public stack diagnostic reproduced copying a stale synthetic dist module. The initial per-stack build prototype fixed that diagnostic but would repeat work across scenario groups; it was removed before the intended candidate.
+- Public --no-bundle exists only on e2e CLI and maps to prepareRunnerBundle=false. The final correction uses existing suite preparation once before scenarios, with native pnpm --filter-prod dependency selection and existing foreground process/cancellation owners. Normal standalone up still builds the bundle; raw internal skip-bundle callers continue to supply prepared artifacts.
+- The final actual-suite regression independently fails at HEAD when stale source reaches scenario admission, and passes after declared synthetic pnpm builds. It proves transitive ordering, excludes Worker/dev-only/unrelated packages, and invokes preparation only once for multiple scenario batches.
+- The current Worker production dependency closure has 20 packages. Native declared builds avoid a second timestamp/hash freshness mechanism, exclude unrelated packages and reuse the existing concurrency setting. No production manifest/validator or snapshot/lifecycle source changes remain.
+
+## Tasks
+
+1. Establish dynamic stale-copy regression with actual materialization.
+2. Choose and implement the smallest existing-owner correction; cover build failure and cancellation.
+3. Run focused proof, typecheck and audits; update owner docs.
+4. Commit scoped candidate, launch full review concurrent CI, disposition findings and finish exact-head gates.
+
+## Verification
+
+- Actual stack diagnostic: one stale-copy regression failed before correction; no stack prototype remains in the final patch.
+- Final suite regression: failed against unchanged HEAD (stale export before scenario admission), then passed with native declared synthetic builds, transitive order and exclusion controls.
+- E2E suite and CLI: 56 passed. Actual foreground/process integration: 2 passed isolated; one cold parallel run hit the unchanged MinIO readiness bound before the isolated pass. No timeout or cleanup behavior changed.
+- Harness typecheck passed. Complexity guard passed: debt 0 to 0, maximum 13 unchanged, no hotspot above 20. Documentation drift and whitespace passed.
+- External full ReviewGPT, exact-head CI, and actual merge/closure proof remain completion gates tracked in the PR and automation evidence.
+Completed: 2026-09-05

--- a/packages/hosted-local-harness/README.md
+++ b/packages/hosted-local-harness/README.md
@@ -25,6 +25,19 @@ pnpm hosted-local run -- pnpm --dir apps/cloudflare test:workers
 
 Root `pnpm dev` is a thin alias for `pnpm hosted-local up`.
 
+`e2e --no-bundle` reuses the existing runner bundle, then builds the Worker's
+production workspace dependency closure once before launching any scenarios.
+This refreshes copied Worker imports without assembling the runner bundle again or
+repeating package preparation for each scenario. Builds use the existing
+`MURPH_RUNNER_BUNDLE_BUILD_CONCURRENCY` setting (default `1`); failure or
+interruption stops scenario admission. Dev-only dependencies and unrelated
+workspace packages are excluded.
+
+Standalone `up` keeps its normal runner-bundle preparation. Direct callers
+setting the internal `MURPH_DEV_SKIP_RUNNER_BUNDLE=1` flag supply both an existing
+runner bundle and prepared workspace artifacts; the public `--no-bundle` E2E
+command owns the workspace preparation described above.
+
 `doctor` reports Docker daemon and Buildx prerequisites separately. Isolated
 Docker configuration selects the first candidate plugin directory containing an
 executable `docker-buildx`, so an empty or unusable earlier directory cannot hide

--- a/packages/hosted-local-harness/src/e2e.ts
+++ b/packages/hosted-local-harness/src/e2e.ts
@@ -631,6 +631,23 @@ export async function runHostedLocalE2eSuite(
         await runAdmittedStep(async () => {
           await prepareHostedLocalRunnerBundle({ env: suiteEnv, scenarios });
         });
+      } else {
+        await runAdmittedStep(async () => {
+          await runForegroundCommand({
+            args: [
+              `--workspace-concurrency=${suiteEnv.MURPH_RUNNER_BUNDLE_BUILD_CONCURRENCY ?? "1"}`,
+              "--fail-if-no-match",
+              "--filter-prod",
+              "@murphai/cloudflare-runner^...",
+              "run",
+              "build",
+            ],
+            command: "pnpm",
+            cwd: hostedLocalHarnessRepoRoot,
+            env: suiteEnv,
+            label: "Hosted local Worker workspace preparation",
+          });
+        });
       }
       assertWorkAdmission();
       prepareHostedLocalRunnerSmokeEnv(suiteEnv);

--- a/packages/hosted-local-harness/test/e2e-suite.test.ts
+++ b/packages/hosted-local-harness/test/e2e-suite.test.ts
@@ -1,3 +1,7 @@
+import * as fs from "node:fs/promises";
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { tmpdir } from "node:os";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   ForegroundCommandSignalError,
@@ -98,6 +102,77 @@ function emitCapturedSignal(
 }
 
 describe("hosted-local E2E suite preparation", () => {
+  test("prepares stale Worker imports once before every no-bundle scenario", async () => {
+    const fixture = await fs.mkdtemp(path.join(tmpdir(), "hosted-local-workspace-artifacts-"));
+    const packageDir = path.join(fixture, "packages", "hosted-execution");
+    const scenarioArtifacts: string[] = [];
+    try {
+      await fs.mkdir(path.join(packageDir, "src"), { recursive: true });
+      await fs.mkdir(path.join(packageDir, "dist"), { recursive: true });
+      await fs.mkdir(path.join(fixture, "apps", "cloudflare"), { recursive: true });
+      await fs.writeFile(path.join(fixture, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n  - apps/*\n");
+      await fs.writeFile(path.join(fixture, "package.json"), JSON.stringify({ private: true }));
+      await fs.writeFile(path.join(fixture, "apps", "cloudflare", "package.json"), JSON.stringify({
+        name: "@murphai/cloudflare-runner",
+        dependencies: { "@murphai/hosted-execution": "workspace:*" },
+        devDependencies: { "@murphai/dev-only-fixture": "workspace:*" },
+        scripts: { build: "node -e 'process.exit(1)'" },
+      }));
+      await fs.writeFile(path.join(packageDir, "package.json"), JSON.stringify({
+        name: "@murphai/hosted-execution",
+        dependencies: { "@murphai/runtime-state": "workspace:*" },
+        scripts: { build: "node build.cjs" },
+      }));
+      const transitiveDir = path.join(fixture, "packages", "runtime-state");
+      await fs.mkdir(transitiveDir, { recursive: true });
+      await fs.writeFile(path.join(transitiveDir, "package.json"), JSON.stringify({
+        name: "@murphai/runtime-state",
+        scripts: { build: "node build.cjs" },
+      }));
+      await fs.writeFile(path.join(transitiveDir, "build.cjs"), "require('node:fs').writeFileSync('built.cjs', 'currentState');\n");
+      await fs.writeFile(path.join(transitiveDir, "built.cjs"), "staleState");
+      for (const name of ["dev-only-fixture", "unrelated-fixture"]) {
+        const dir = path.join(fixture, "packages", name);
+        await fs.mkdir(dir, { recursive: true });
+        await fs.writeFile(path.join(dir, "package.json"), JSON.stringify({
+          name: `@murphai/${name}`,
+          scripts: { build: "node -e 'process.exit(1)'" },
+        }));
+      }
+      await fs.writeFile(path.join(packageDir, "build.cjs"), [
+        "const fs = require('node:fs');",
+        "if (fs.readFileSync('../runtime-state/built.cjs', 'utf8') !== 'currentState') process.exit(1);",
+        "fs.copyFileSync('src/index.cjs', 'dist/index.cjs');",
+      ].join("\n"));
+      await fs.writeFile(path.join(packageDir, "src", "index.cjs"), "exports.newRouteHelper = () => 'current';\n");
+      await fs.writeFile(path.join(packageDir, "dist", "index.cjs"), "exports.oldRouteHelper = () => 'stale';\n");
+      runForegroundCommand.mockImplementation(async ({ command, args }) => {
+        if (args.includes("--filter-prod")) {
+          await new Promise<void>((resolve, reject) => {
+            execFile(command, [...args], { cwd: fixture }, (error) => error ? reject(error) : resolve());
+          });
+        }
+        if (args.includes("vitest")) {
+          scenarioArtifacts.push(await fs.readFile(path.join(packageDir, "dist", "index.cjs"), "utf8"));
+        }
+      });
+      await runHostedLocalE2eSuite({
+        env: {},
+        prepareRunnerBundle: false,
+        scenario: ["checkpoint-baseline", "foreground-reply-priority"],
+      });
+      expect(scenarioArtifacts.length).toBeGreaterThan(1);
+      for (const artifact of scenarioArtifacts) {
+        expect(artifact).toContain("newRouteHelper");
+        expect(artifact).not.toContain("oldRouteHelper");
+      }
+      expect(runForegroundCommand.mock.calls.filter(([call]) => call.args.includes("--filter-prod"))).toHaveLength(1);
+      expect(runForegroundCommand.mock.calls.some(([call]) => call.args.includes("runner:bundle:hosted-local"))).toBe(false);
+    } finally {
+      await fs.rm(fixture, { recursive: true, force: true });
+    }
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
     runForegroundCommand.mockResolvedValue(undefined);
@@ -583,6 +658,39 @@ describe("hosted-local E2E suite preparation", () => {
         MURPH_HOSTED_LOCAL_E2E_ISOLATION_REQUIRED: "1",
       }),
     );
+  });
+
+  test("stops before scenario launch when Worker dependency preparation fails", async () => {
+    runForegroundCommand.mockRejectedValueOnce(new Error("synthetic Worker dependency build failed"));
+    await expect(runHostedLocalE2eSuite({
+      env: {}, prepareRunnerBundle: false, scenario: "checkpoint-baseline",
+    })).rejects.toThrow("synthetic Worker dependency build failed");
+    expect(runForegroundCommand).toHaveBeenCalledTimes(1);
+    expect(runForegroundCommand.mock.calls[0]?.[0].args).toContain("--filter-prod");
+    expect(cleanupHostedRunnerImages).toHaveBeenCalledTimes(1);
+  });
+
+  test("closes scenario admission when Worker dependency preparation is interrupted", async () => {
+    const signals = captureSuiteSignalHandlers();
+    const originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    runForegroundCommand.mockImplementationOnce(async (input) => {
+      expect(input.args).toContain("--filter-prod");
+      emitCapturedSignal(signals.handlers, "SIGTERM");
+      throw new ForegroundCommandSignalError(input.label, "SIGTERM");
+    });
+    try {
+      await expect(runHostedLocalE2eSuite({
+        env: {}, prepareRunnerBundle: false, scenario: "checkpoint-baseline",
+      })).resolves.toEqual({ terminationSignal: "SIGTERM" });
+      expect(runForegroundCommand).toHaveBeenCalledTimes(1);
+      expect(process.exitCode).toBe(143);
+      expect(signals.handlers.get("SIGTERM")).toEqual([]);
+      expect(cleanupHostedRunnerImages).toHaveBeenCalledTimes(1);
+    } finally {
+      process.exitCode = originalExitCode;
+      signals.restore();
+    }
   });
 
   test("scrubs inherited web session authority before E2E preparation", async () => {


### PR DESCRIPTION
## Why and outcome

`hosted-local e2e --no-bundle` skipped runner assembly and copied existing Worker workspace artifacts even when their sources had changed. A new exported helper could therefore typecheck from source but be missing at Worker startup. Prepare the Worker's production workspace dependencies once at the existing suite preparation boundary before admitting scenarios.

The native pnpm dependency selector reuses declared package build scripts and topological ordering, excludes dev-only and unrelated packages, and uses the existing build concurrency setting. Runner bundle reuse remains intact. No new freshness cache or manifest is introduced.

## Product UX

- Effort: Patch to local E2E tooling.
- Result: Ready.
- Walkthrough: A no-bundle suite refreshes current Worker imports once, then runs its selected scenario batches. Build failure or interruption prevents scenario startup. Normal standalone up keeps full bundle preparation; direct internal skip-bundle callers continue to provide prepared artifacts. No member-facing behavior changes.

## Evidence

- Direct: An actual public-stack diagnostic copied a stale synthetic dist module and reproduced its missing new export. A per-stack prototype was removed because it would repeat preparation for each scenario.
- Regression: The final actual-suite test fails at unchanged HEAD when stale artifacts reach scenario admission. It passes after real synthetic pnpm workspace builds, proving transitive build order, exclusion of the Worker itself/dev-only/unrelated packages, current artifacts before multiple batches, and exactly one preparation per suite.
- Failure paths: Dependency build failure rejects before scenario launch; an interrupted foreground preparation closes admission and retains existing cleanup and signal-exit behavior.
- Focused: E2E suite and CLI tests: 56 passed. Foreground/process integration tests: 2 passed in isolation; an initial cold parallel run hit the unchanged MinIO readiness bound, and no timeout or process logic was changed.
- Typecheck: `pnpm --dir packages/hosted-local-harness typecheck` passed.
- Docs: Documentation drift and whitespace checks passed.
- Full ReviewGPT: Round 1 PASS on `74baaedf7aea935b8547abe0da31e8862ecb8926`; full snapshot, actual `gpt-6-pro`, exact response/turn hash verified, 441.85-second send and 425.67-second response-wait clocks, zero findings. Parent review also passed.
- Required CI: All four required contexts passed on `74baaedf7aea935b8547abe0da31e8862ecb8926`; host run `33956607788` passed all 20 executed jobs, including harness coverage, both host matrices, builds, bundle budget, and release aggregation. Stripe boundary passed in run `33956607960`. No Docker, production environment, or full private E2E run was invoked locally.

## Non-obvious affected surfaces

Private integration scenario groups using downloaded artifacts and `--no-bundle` now execute the bounded Worker dependency build once per suite. The current production closure is 20 workspace packages. Preparation stays outside scenario batches to avoid repeated builds. Production deployment validation, runner assembly, snapshot materialization, and lifecycle owners are unchanged.

## Architecture and reuse

- Existing systems reused: E2E suite admission, foreground command/cancellation and cleanup, pnpm workspace manifests/build scripts, and the current build concurrency setting.
- New logic: One no-bundle branch prepares the Worker dependency closure before existing scenario admission.
- New abstractions: None; no new helper, flag, cache, fingerprint, state owner, or dependency.
- Complexity intentionally avoided: No timestamp heuristic, source/hash ledger, per-scenario rebuild, or production validator changes.

## Complexity impact

- Guard: PASS — `pnpm complexity:diff`; debt 0 to 0, maximum 13 unchanged.
- Hotspots: None above 20 in the changed source file.
- Agent judgment: The existing preparation branch is the smallest owner that covers the public no-bundle command without repeated scenario work.

## Hot reply path impact

Not applicable; local E2E preparation adds no production database, provider, network, or awaited reply-path work.

## Murph initial provider input impact

Not applicable for individual and group runtimes. No instructions, tools, schemas, or provider-visible input changed; no input measurement required.

## Deployment concerns

- Deployment: not applicable
- Reason: Local test preparation only; no deployed runtime, schema, dependency or deployment configuration changes.

## Change-shape breakdown

Source +17/-0; tests/fixtures +108/-0; docs +57/-0; config/tooling and generated/other +0/-0. Total +182/-0 across four authored files. No binaries. Documentation consists of the package owner and execution plan.

## Changelog

- Changelog: not applicable
- Reason: Local developer tooling with no member-visible change.

ReviewGPT context sensitivity: sensitive
Reason: Local failure/cancellation ordering crosses suite and foreground process owners; full review explicitly requested.
ReviewGPT first-reviewed head: 74baaedf7aea935b8547abe0da31e8862ecb8926

Frog autofix issue: #2717
