### PR TITLE
fix(tooling): handle large ReviewGPT archive listings

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-05-review-archive-listing-buffer.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-review-archive-listing-buffer.md
@@ -1,0 +1,42 @@
+# Bound large ReviewGPT archive listings
+
+Status: completed
+Created: 2026-09-05
+Updated: 2026-09-05
+
+## Goal and scope
+
+Allow guarded ReviewGPT ZIP listings above Node's default subprocess buffer to
+complete through the existing privacy and repomix owners. Extend the existing
+registry dependency patch in source and emitted JavaScript; retain its capture
+identity protections. No browser, runtime, credential policy, or dependency
+version changes are part of the fix. Dependency changes require human merge.
+
+## Cause and decisions
+
+- The public `runReviewGpt` dry-run API fails before privacy classification with
+  truncated ZIP paths. A synthetic 1,432,012-byte listing independently produces
+  `ENOBUFS` at the default buffer, while the bounded 64 MiB call reads its tail.
+- Add the same 64 MiB maximum to both existing listing calls in source and dist.
+  Keep failure handling and complete-list privacy classification unchanged.
+- Use public `pnpm patch-commit` and retain the prior patch. Inspect its generated
+  lockfile peer-key normalization separately from the three patch-hash changes.
+- Reuse Frog #2799 for this cause and #2685/#2755 for generated peer-key churn.
+  This tooling-only outcome needs no member changelog or product UX replay.
+
+## Verification and completion
+
+- Actual installed public API: oversized safe archive reaches repomix with its
+  late source marker; a synthetic dotenv entry after the old limit is rejected.
+  Both regressions fail before the patch and pass afterward; six existing
+  capture-identity tests continue to pass.
+- Frozen install, dependency policy, focused TypeScript 7, docs drift, and complexity
+  checks pass. Non-patch whitespace passes; the generated patch has one required
+  blank context record flagged by the plain whitespace check. Complexity excludes tests and vendor patch text;
+  manual inspection confirms four constant options and no new branches.
+- Dependency audit remains failing: 93 advisories (7 low, 43 moderate, 42 high,
+  1 critical), with no package version or integrity changes. Install-script
+  approvals and exclusions remain unchanged; blocked builds were reviewed.
+- Finish with a scoped commit, complete draft PR, full canonical review and exact
+  required CI. Preserve the checkout and open issue for human merge handoff.
+Completed: 2026-09-05

--- a/patches/@cobuild__review-gpt@0.5.145.patch
+++ b/patches/@cobuild__review-gpt@0.5.145.patch
@@ -31,6 +31,26 @@ index d4d31ac9172093d9b0b84df0e1fd3a22dbab189b..6600d0abd4c81ce58250efb7f55bd193
              candidate.precedingUserTurnIndex === committedUserTurn.turnIndex &&
              matchesStoredCaptureValue(candidate.precedingUserMessageSignature, capture.committedUserTurn.signature));
          if (pendingAssistantMatches.length > 1) {
+diff --git a/dist/review-gpt-lib.mjs b/dist/review-gpt-lib.mjs
+index 65d9b9ca92011d1751f0e6b4a19aa9bee1bef702..2af81964fa14375f69d3cad22076c8a24a3456f0 100644
+--- a/dist/review-gpt-lib.mjs
++++ b/dist/review-gpt-lib.mjs
+@@ -1126,6 +1126,7 @@ export function formatSensitiveArtifactFailure(zipPath, findings) {
+ }
+ function listAllZipEntries(zipPath) {
+     const result = spawnSync('unzip', ['-Z1', zipPath], {
++        maxBuffer: 64 * 1024 * 1024,
+         encoding: 'utf8',
+     });
+     if (result.status !== 0) {
+@@ -1209,6 +1210,7 @@ function buildRepomixIgnorePaths(repoRoot, configuredPatterns, generatedPaths) {
+ function listZipManifestPaths(repoRoot, zipPath) {
+     const result = spawnSync('unzip', ['-Z1', zipPath], {
+         cwd: repoRoot,
++        maxBuffer: 64 * 1024 * 1024,
+         encoding: 'utf8',
+     });
+     if (result.status !== 0) {
 diff --git a/dist/thread-cli.mjs b/dist/thread-cli.mjs
 index 02756c3b597e2970392f7c29ef669318e2a4037f..5e9cb84d2e8a945cec0d3b2d6c4b9188744f81ff 100644
 --- a/dist/thread-cli.mjs
@@ -141,6 +161,26 @@ index dfdd71b7d5f53e0aed0ad438cb9b95c7892912d0..16caf02fa705b92cb231152d6a834c85
          candidate.precedingUserTurnIndex === committedUserTurn.turnIndex &&
          matchesStoredCaptureValue(candidate.precedingUserMessageSignature, capture.committedUserTurn.signature),
      );
+diff --git a/src/review-gpt-lib.mts b/src/review-gpt-lib.mts
+index 7a4a5ab6b4121fadbf294bf0c9d5a4f7e6af9dde..651d53290b2f83682fb41793f93dca18ca9dfd29 100644
+--- a/src/review-gpt-lib.mts
++++ b/src/review-gpt-lib.mts
+@@ -1560,6 +1560,7 @@ export function formatSensitiveArtifactFailure(
+ 
+ function listAllZipEntries(zipPath: string): string[] {
+   const result = spawnSync('unzip', ['-Z1', zipPath], {
++    maxBuffer: 64 * 1024 * 1024,
+     encoding: 'utf8',
+   });
+   if (result.status !== 0) {
+@@ -1660,6 +1661,7 @@ function buildRepomixIgnorePaths(repoRoot: string, configuredPatterns: string[],
+ function listZipManifestPaths(repoRoot: string, zipPath: string): string[] {
+   const result = spawnSync('unzip', ['-Z1', zipPath], {
+     cwd: repoRoot,
++    maxBuffer: 64 * 1024 * 1024,
+     encoding: 'utf8',
+   });
+   if (result.status !== 0) {
 diff --git a/src/thread-cli.mts b/src/thread-cli.mts
 index 0159d95b3196142b6d407e3c773aa512bdc31b7a..f9d04169a1f277bf03bc32bd9316d65e7de8f28f 100644
 --- a/src/thread-cli.mts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ patchedDependencies:
     hash: 679266b778f8ed833acc0ead5be87d57dbcff877ce899a72fbec8052563ab4fb
     path: patches/@cobuild__repo-tools@0.1.17.patch
   '@cobuild/review-gpt@0.5.145':
-    hash: a78e60b4a37fb46cb8b3cb341b47aa4facd2b097a72ff337369ee9f4581a2536
+    hash: 75d9d1238d8f131e557033982ded82b005c93421f7f09aa7cf58aa4fa8a59f12
     path: patches/@cobuild__review-gpt@0.5.145.patch
   incur@0.4.5:
     hash: 0205cee2a49c283710c432d91b890aeea525b3aa30bcef68fa16b293f71de8a3
@@ -95,7 +95,7 @@ importers:
         version: 0.1.17(patch_hash=679266b778f8ed833acc0ead5be87d57dbcff877ce899a72fbec8052563ab4fb)
       '@cobuild/review-gpt':
         specifier: ^0.5.145
-        version: 0.5.145(patch_hash=a78e60b4a37fb46cb8b3cb341b47aa4facd2b097a72ff337369ee9f4581a2536)(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
+        version: 0.5.145(patch_hash=75d9d1238d8f131e557033982ded82b005c93421f7f09aa7cf58aa4fa8a59f12)(@cfworker/json-schema@4.1.1)(typescript@7.0.2)
       '@elevenlabs/elevenlabs-js':
         specifier: 2.62.0
         version: 2.62.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -11210,7 +11210,7 @@ snapshots:
 
   '@cobuild/repo-tools@0.1.17(patch_hash=679266b778f8ed833acc0ead5be87d57dbcff877ce899a72fbec8052563ab4fb)': {}
 
-  '@cobuild/review-gpt@0.5.145(patch_hash=a78e60b4a37fb46cb8b3cb341b47aa4facd2b097a72ff337369ee9f4581a2536)(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
+  '@cobuild/review-gpt@0.5.145(patch_hash=75d9d1238d8f131e557033982ded82b005c93421f7f09aa7cf58aa4fa8a59f12)(@cfworker/json-schema@4.1.1)(typescript@7.0.2)':
     dependencies:
       '@cobuild/repo-tools': 0.1.17(patch_hash=679266b778f8ed833acc0ead5be87d57dbcff877ce899a72fbec8052563ab4fb)
       incur: 0.4.5(patch_hash=0205cee2a49c283710c432d91b890aeea525b3aa30bcef68fa16b293f71de8a3)
@@ -17893,8 +17893,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.3.0(eslint@9.39.4(jiti@2.7.0))
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -17916,7 +17916,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -17927,22 +17927,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -17953,7 +17953,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3

--- a/scripts/review-gpt-archive-listing.test.ts
+++ b/scripts/review-gpt-archive-listing.test.ts
@@ -1,0 +1,99 @@
+import { spawnSync } from "node:child_process";
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const packageModule = pathToFileURL(path.resolve("node_modules/@cobuild/review-gpt/dist/review-gpt-lib.mjs")).href;
+let fixtureRoot: string;
+let fixtureEnv: NodeJS.ProcessEnv;
+
+function run(command: string, args: string[], input?: string) {
+  const result = spawnSync(command, args, {
+    cwd: fixtureRoot,
+    env: fixtureEnv,
+    encoding: "utf8",
+    input,
+    maxBuffer: 8 * 1024 * 1024,
+    timeout: 60_000,
+  });
+  if (result.status !== 0) throw new Error(`${command} fixture failed: ${result.error ?? result.stderr}`);
+  return result.stdout;
+}
+
+async function prepareReview(archive: string, repomix: "xml" | "none") {
+  await writeFile(path.join(fixtureRoot, "review.config.sh"), [
+    'package_script="package-fixture.sh"',
+    'browser_profile="fixture"',
+    'managed_browser_user_data_dir="browser-fixture"',
+    'managed_browser_profile="fixture"',
+    `repomix_attachment_format="${repomix}"`,
+  ].join("\n") + "\n");
+  await writeFile(path.join(fixtureRoot, "package-fixture.sh"),
+    `#!/usr/bin/env bash\nset -euo pipefail\nprintf 'ZIP: %s (fixture)\\n' "$(dirname "$0")/${archive}"\n`);
+  const output = run(process.execPath, ["--input-type=module", "-e", `
+    const { runReviewGpt } = await import(${JSON.stringify(packageModule)});
+    try {
+      const result = await runReviewGpt({ dryRun: true, artifacts: true,
+        browserPath: process.execPath, config: "review.config.sh", prompt: ["Synthetic archive check"] },
+        { cwd: process.cwd() });
+      console.log("RESULT:" + JSON.stringify({ ok: true, dryRun: result.dryRun }));
+    } catch (error) {
+      console.log("RESULT:" + JSON.stringify({ ok: false, error: String(error).slice(0, 500) }));
+    }
+  `]);
+  const line = output.split("\n").find((value) => value.startsWith("RESULT:"));
+  if (!line) throw new Error("Review fixture did not return its dry-run outcome.");
+  return JSON.parse(line.slice("RESULT:".length)) as { ok: boolean; dryRun?: boolean; error?: string };
+}
+
+describe.sequential("installed ReviewGPT archive listings", () => {
+  beforeAll(async () => {
+    const tempRoot = process.env.MURPH_VITEST_TEMP_ROOT;
+    if (!tempRoot) throw new Error("MURPH_VITEST_TEMP_ROOT is required.");
+    fixtureRoot = await mkdtemp(path.join(tempRoot, "review-archive-"));
+    fixtureEnv = {
+      PATH: process.env.PATH,
+      HOME: fixtureRoot,
+      TMPDIR: fixtureRoot,
+      GIT_CONFIG_GLOBAL: process.platform === "win32" ? "NUL" : "/dev/null",
+      GIT_CONFIG_NOSYSTEM: "1",
+      SYSTEMROOT: process.env.SYSTEMROOT,
+    };
+    run("git", ["init", "--quiet"]);
+    await mkdir(path.join(fixtureRoot, "padding"));
+    await mkdir(path.join(fixtureRoot, "src"));
+    const names = Array.from({ length: 8_000 }, (_, index) =>
+      `padding/${String(index).padStart(5, "0")}-${"a".repeat(160)}.txt`);
+    for (const name of names) await writeFile(path.join(fixtureRoot, name), "");
+    names.push("src/late.ts");
+    await writeFile(path.join(fixtureRoot, "src/late.ts"), "export const archiveTailProbe = true;\n");
+    run("zip", ["--quiet", "safe.zip", "-@"], names.join("\n") + "\n");
+    expect(Buffer.byteLength(run("unzip", ["-Z1", "safe.zip"]))).toBeGreaterThan(1024 * 1024);
+    // Keep one real source beyond the old listing limit for the repomix path.
+    await rm(path.join(fixtureRoot, "padding"), { recursive: true });
+    await copyFile(path.join(fixtureRoot, "safe.zip"), path.join(fixtureRoot, "sensitive.zip"));
+    await writeFile(path.join(fixtureRoot, ".env"), "SYNTHETIC_FIXTURE=true\n");
+    run("zip", ["--quiet", "sensitive.zip", ".env"]);
+  });
+
+  afterAll(async () => {
+    if (fixtureRoot) await rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("prepares oversized safe listings through both privacy and repomix manifest owners", async () => {
+    const result = await prepareReview("safe.zip", "xml");
+    expect(result).toEqual({ ok: true, dryRun: true });
+    const repomix = await readFile(path.join(fixtureRoot, "repo.repomix.xml"), "utf8");
+    expect(repomix).toContain("src/late.ts");
+    expect(repomix).toContain("archiveTailProbe");
+  });
+
+  it("still rejects a sensitive entry after the old buffer limit", async () => {
+    const result = await prepareReview("sensitive.zip", "none");
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain(".env");
+    expect(result.error).toContain("credential-shaped file(s)");
+  });
+});


### PR DESCRIPTION
## Why and outcome

Large guarded ReviewGPT snapshots exceeded Node's default one-megabyte `spawnSync` output buffer, producing truncated path listings before review staging. Both existing ZIP readers now allow up to 64 MiB, so safe snapshots proceed through privacy classification and repomix while sensitive entries remain rejected.

Frog autofix issue: #2799

This dependency patch and lockfile change requires human merge. The automation will leave the issue open and preserve its checkout.

## Product UX

- Effort: Not applicable — internal review tooling.
- Result: Not applicable.
- Walkthrough: Safe oversized archives prepare successfully; credential-shaped files after the old limit still block preparation.

## Evidence

- Direct: `pnpm test:repo-tools scripts/review-gpt-archive-listing.test.ts scripts/review-gpt-capture-identity.test.ts` — 8 passed. Both new cases fail against the old installed public API. The corrected fixture calls `runReviewGpt` with a real synthetic ZIP and dry-run preparation; no browser or model calls occur in these tests.
- Coverage: A 1,432,012-byte listing exceeds the old bound. The late source marker reaches the real repomix output; a synthetic `.env` at the archive tail produces the actual credential-shaped rejection. Six capture-identity tests preserve the pre-existing dependency patch.
- Cause: The same synthetic listing returns `ENOBUFS` with the default buffer and a missing tail; an explicit 64 MiB buffer returns status 0 and the full tail.
- Passed: frozen install, dependency policy guard, focused TypeScript 7 check, docs drift, complexity guard, and non-patch whitespace inspection. The generated patch contains one blank context record flagged by plain `git diff --check`; no added source line has trailing whitespace.
- Dependency audit: **failing**, 93 advisories (7 low, 43 moderate, 42 high, 1 critical). Package versions and integrity records are unchanged. This PR does not remediate those advisories.
- Blocked install scripts were reviewed with `pnpm deps:ignored-builds`; no build approval, release-age exclusion, trust-policy exception, or manifest changed.
- Canonical full round 1 ReviewGPT: **PASS** on `2e642bb02b1ec9e3d950df0e45f977f5aac319f5`, requested/actual `gpt-6-pro`, exact turn and response hash verified. Send-to-capture 558.345s; response-wait-to-capture 545.766s. The full guarded ZIP was supplemented through supported prompt context with exact hashed dependency owner spans. Earlier missing-context/short-duration capture and two pre-send CDP staging failures received no review credit.
- Independent review additionally exercised synthetic archive overflow, malformed archives, and output beyond the new bound on Node 22; this complements, and does not replace, the locally passed repository Node ≥24 installed-package suite.
- All four exact-head required contexts passed: CLI host matrix (macOS and Ubuntu), Release checks (Ubuntu), and Required hosted Stripe billing boundary. [Host CI](https://github.com/cobuildwithus/murph/actions/runs/33957029795), [billing CI](https://github.com/cobuildwithus/murph/actions/runs/33957029839).

## Non-obvious affected surfaces

The existing `@cobuild/review-gpt` capture-identity patch remains intact. Public `pnpm patch-commit` also normalized cyclic ESLint peer snapshot keys alongside the three patch-hash references; an independent parsed comparison proves the entire lockfile structure equal to the fixed base after exactly the intended patch-hash substitution and one-to-one rekeying of three ESLint snapshots and their dependency references. All 2,081 snapshots are accounted for; no other differences were ignored. Frozen installation succeeds.

## Architecture and reuse

- Existing systems reused: Both existing ZIP readers, complete-list sensitive-path classification, repomix manifest preparation, public pnpm patch support, and the installed public dry-run API.
- New logic: Four constant `maxBuffer` options across source and emitted JavaScript.
- New abstractions: None; the existing owners already perform the required work.
- Complexity intentionally avoided: No alternative archive parser, streaming pipeline, retry, privacy bypass, or review timing change.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`; tests and vendor patch text are outside its authored-source metric.
- Hotspots: No new production function or branch; manually inspected both existing listing calls.
- Agent judgment: Constant bounded options are sufficient for the reproduced failure.

## Hot reply path impact

- Path status: Not applicable — developer review preparation only.
- Database calls: None.
- Network/provider calls: None added.
- Other awaited latency: No Murph runtime change.
- Before/after proof: Actual archive preparation regression above.

## Murph initial provider input impact

Not applicable for individual and group Murph runtimes: no instructions, tools, schemas, or provider input builders changed. No provider-input measurement was run.

## Deployment concerns

- Deployment: not applicable
- Reason: Development dependency patch only; frozen installation reproduces it. No hosted rollout or runtime configuration change.

## Change-shape breakdown

Classification rule: The generated dependency patch and lockfile are tooling artifacts, the public-API regression is tests, and the completed plan is docs. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 99 | 0 |
| Docs | 42 | 0 |
| Config / tooling | 51 | 11 |
| Generated / other | 0 | 0 |
| **Total** | **192** | **11** |

## Changelog

- Changelog: not applicable
- Reason: Internal review preparation tooling only.

ReviewGPT first-reviewed head: 2e642bb02b1ec9e3d950df0e45f977f5aac319f5
ReviewGPT context sensitivity: sensitive
Classification reason: Dependency patch modifies archive handling at the review artifact privacy boundary.
