### PR TITLE
Diagnose post-checkpoint lease version drift

### DIFF
--- a/.agents/friction-log/20260905051606-checkpoint-log-independence/friction.md
+++ b/.agents/friction-log/20260905051606-checkpoint-log-independence/friction.md
@@ -1,0 +1,26 @@
+---
+title: 'Checkpoint log independence test has a 250 ms wall-clock dependency'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The checkpoint bridge regression should prove that a queued log write cannot hold checkpoint completion, with deterministic control over unrelated snapshot work.
+
+## Current Behavior
+
+On an unchanged checkout, the focused bridge suite passed 53 cases but failed the queued-finished-record case at its 250 ms checkpoint-settlement assertion. Running that case alone reproduced the same failure. This prevents a clean local baseline for adjacent checkpoint diagnostics before any production source is edited. The cause has not been localized beyond the existing test's wall-clock assertion; this report does not establish that production logging blocks checkpoint completion.
+
+## Minimal Reproducible Example
+
+Run the existing test on an unchanged checkout:
+
+```sh
+pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --no-coverage test/hosted-invocation-bridge.test.ts -t 'does not wait for the queued finished record before returning a checkpoint'
+```
+
+Inspect the test's `vi.waitFor` checkpoint-settlement assertion with `timeout: 250` and its real snapshot setup. Reproduce without changing checkpoint behavior or increasing production deadlines.
+
+## Context
+
+Discovered while establishing the baseline for a separate telemetry-only checkpoint change. Preserve this regression's asynchronous-log independence claim; investigate whether deterministic snapshot preparation or another existing harness seam can remove the incidental runtime dependency. No test or production workaround was applied.

--- a/agent-docs/exec-plans/active/2026-09-05-checkpoint-lease-telemetry.md
+++ b/agent-docs/exec-plans/active/2026-09-05-checkpoint-lease-telemetry.md
@@ -1,0 +1,48 @@
+# Diagnose post-checkpoint lease version drift
+
+Status: active
+Created: 2026-09-05
+Updated: 2026-09-05
+
+## Goal
+
+Distinguish whether a lease-version mismatch after a Web checkpoint reflects the returned workspace version or different workspace progress. Preserve checkpoint acceptance, validation, retry, and delivery behavior exactly.
+
+## Evidence and ownership
+
+A production conversation canary timed out waiting for a reply that was eventually delivered. Its foreground import failed at post-Web checkpoint lease validation. Existing diagnostics identify the stage and stale workspace version, but omit the returned checkpoint outcome and the live lease's relation to that returned version. The cause remains unresolved; no functional correction is justified yet.
+
+The runtime checkpoint bridge owns lease validation. The existing foreground mailbox failure event owns this observation. No new event, network call, persistence owner, or monitoring service is needed. Existing runtime progress and hot-admission PRs do not change this boundary or answer this question.
+
+## Scope and constraints
+
+- ReviewGPT implements a narrowly typed, bounded diagnostic projection into the existing failure pipeline, plus focused synthetic tests and required owner documentation.
+- Record only booleans or bounded enums needed to distinguish these outcomes. Never record raw versions, identities, credentials, payloads, or member content.
+- Preserve all success paths, error codes and stages, throws, lease reads, callback counts, retries, and checkpoint semantics.
+- No functional fix, schema, dependency, access, retention, or deployment-policy change.
+- Old readers must accept the optional fields and old writers may omit them.
+
+## Tasks
+
+1. Completed: obtained and inspected ReviewGPT's implementation patch; production source matches that patch.
+2. Verify both diagnostic outcomes, absent diagnostics on unrelated failures, sensitive-value exclusion, and unchanged checkpoint outcomes through focused tests and typecheck.
+3. Review the complete candidate, run complexity and documentation checks, and create a scoped candidate commit and PR.
+4. Run final ReviewGPT on the pushed candidate concurrently with required CI. Resolve findings under the current disposition policy.
+5. Merge and deploy only if the final patch remains telemetry-only and every canonical gate is satisfied. Otherwise preserve the concrete blocker.
+6. Verify the deployed revision and use a bounded aggregate query on natural failures. Absence of a recurrence does not prove the underlying bug resolved.
+
+## Verification
+
+- ReviewGPT implementation completed with verified model identity. Local inspection confirms two booleans only on the existing foreground failure event; no new effect, validation ordering, success semantics, or shared parser change.
+- New diagnostic cases: 30 passed, covering accepted/conflict responses, both version relations, unchanged checks/effect counts, successful and unrelated outcomes, and hostile metadata exclusion through the actual foreground log seam and existing parser.
+- Runtime semantic typecheck passed after three local test-only corrections: explicit return types on two synthetic error factories and removal of a checkpoint reason from a no-progress test result. Production source remains ReviewGPT-authored.
+- Complexity passed: checkpoint bridge maximum 6 to 8, zero debt; workspace runner maximum 71 and debt 59 unchanged. Its three existing hotspots are unchanged orchestration functions; this observation does not justify refactoring them.
+- Log privacy guard, documentation drift, and diff whitespace checks passed. Documentation gardening passed with zero issues. Full affected suites passed 209/210; the sole failure is the same pre-existing 250 ms queued-log assertion proved on the unchanged base. All 30 new cases pass in both the focused and full runs.
+- Before implementation, the bridge suite passed 53/54, and the existing 250 ms queued-log independence assertion failed both in the full file and alone. The public-safe Frog entry records that reproducible baseline gap without claiming its cause or applying a workaround.
+- Required CI, pushed-candidate final ReviewGPT, merge, and canonical protected rollout remain pending. No live replay or production mutation beyond the explicitly authorized telemetry rollout is permitted.
+
+## Decisions
+
+- One telemetry improvement selected for this sweep.
+- Internal-only observation; no member-visible changelog or product-flow change.
+- Diagnostic overhead must be constant and restricted to an existing failure path.

--- a/agent-docs/exec-plans/completed/2026-09-05-checkpoint-lease-telemetry.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-checkpoint-lease-telemetry.md
@@ -1,6 +1,6 @@
 # Diagnose post-checkpoint lease version drift
 
-Status: active
+Status: completed
 Created: 2026-09-05
 Updated: 2026-09-05
 
@@ -25,11 +25,11 @@ The runtime checkpoint bridge owns lease validation. The existing foreground mai
 ## Tasks
 
 1. Completed: obtained and inspected ReviewGPT's implementation patch; production source matches that patch.
-2. Verify both diagnostic outcomes, absent diagnostics on unrelated failures, sensitive-value exclusion, and unchanged checkpoint outcomes through focused tests and typecheck.
-3. Review the complete candidate, run complexity and documentation checks, and create a scoped candidate commit and PR.
-4. Run final ReviewGPT on the pushed candidate concurrently with required CI. Resolve findings under the current disposition policy.
-5. Merge and deploy only if the final patch remains telemetry-only and every canonical gate is satisfied. Otherwise preserve the concrete blocker.
-6. Verify the deployed revision and use a bounded aggregate query on natural failures. Absence of a recurrence does not prove the underlying bug resolved.
+2. Completed: verified both diagnostic outcomes, absent diagnostics on unrelated failures, sensitive-value exclusion, and unchanged checkpoint outcomes through focused tests and typecheck.
+3. Completed: parent reviewed the complete candidate; complexity and documentation checks passed; candidate committed and published as PR #2932.
+4. Final ReviewGPT round 1 passed on commit 63b54a07a0abac620e6d44a92dc42c02062b9eb1 with no qualifying finding; required CI continues separately.
+5. Operational follow-up: merge and deploy only after final-head CI and every canonical gate pass. The automation retains this condition and the exact natural-traffic query; no rollout is claimed here.
+6. Operational follow-up: verify the deployed revision and aggregate natural failures by the two boolean fields. Absence of recurrence means unexercised telemetry, not a resolved underlying issue.
 
 ## Verification
 
@@ -39,10 +39,13 @@ The runtime checkpoint bridge owns lease validation. The existing foreground mai
 - Complexity passed: checkpoint bridge maximum 6 to 8, zero debt; workspace runner maximum 71 and debt 59 unchanged. Its three existing hotspots are unchanged orchestration functions; this observation does not justify refactoring them.
 - Log privacy guard, documentation drift, and diff whitespace checks passed. Documentation gardening passed with zero issues. Full affected suites passed 209/210; the sole failure is the same pre-existing 250 ms queued-log assertion proved on the unchanged base. All 30 new cases pass in both the focused and full runs.
 - Before implementation, the bridge suite passed 53/54, and the existing 250 ms queued-log independence assertion failed both in the full file and alone. The public-safe Frog entry records that reproducible baseline gap without claiming its cause or applying a workaround.
-- Required CI, pushed-candidate final ReviewGPT, merge, and canonical protected rollout remain pending. No live replay or production mutation beyond the explicitly authorized telemetry rollout is permitted.
+- Final ReviewGPT round 1: PASS on the pushed candidate above, with verified gpt-6-pro model identity. Independent review exercised 76 base/head bridge scenarios and the projection/privacy cases; it did not claim full Vitest reruns. No finding was accepted or left unresolved.
+- Parent final review confirms production source remains telemetry-only. The parser and structured sanitizer match the previously observed ready Web revision, supporting old-reader compatibility without a coordinated release.
+- This implementation plan closes with the reviewed code and proof recorded. Final-head CI, merge, canonical protected rollout, and read-only observation remain operational follow-ups owned by the same automation. No merge or deployment is claimed, and no runtime behavior or test assertion was changed to bypass the baseline gap.
 
 ## Decisions
 
 - One telemetry improvement selected for this sweep.
 - Internal-only observation; no member-visible changelog or product-flow change.
 - Diagnostic overhead must be constant and restricted to an existing failure path.
+Completed: 2026-09-05

--- a/docs/hosted-runtime-log-database.md
+++ b/docs/hosted-runtime-log-database.md
@@ -239,6 +239,28 @@ Return only those aggregates. Never return `subject_key` values or raw JSON.
 If natural traffic produces no recurrence, report zero events; do not generate
 production traffic to exercise the telemetry.
 
+### Foreground checkpoint lease drift diagnostics
+
+The existing `runner.error` / `foreground_mailbox_import_failed` row adds only
+`checkpointResponseCheckpointed` and `checkpointLeaseMatchesResponse` booleans
+when the local `HostedRuntimeBridgeCheckpointLeaseError` reports
+`stale_workspace_version` at `after_web_checkpoint`. The second boolean compares
+the already-read live lease's workspace version with `response.workspace.version`;
+the first distinguishes accepted (`true`) from conflict (`false`) Web responses.
+A match describes that observation only: it does not prove why the lease moved
+or why a conversation reply was delayed.
+
+`checkpoint-bridge.ts` derives the pair at the existing validation owner, without
+another lease read. `workspace-runner.ts` explicitly projects both booleans from
+that typed error onto the foreground failure row. It does not spread arbitrary
+error properties or metadata, traverse arbitrary causes, or change the shared
+safe-error diagnostics or redacted-JSON parser. Both fields are omitted for
+other errors/stages, missing or non-boolean metadata, successful calls, and other
+log events. The existing code, stage, message, request-version validation,
+checkpoint result handling, retry behavior, and snapshot effects are unchanged.
+No raw versions, attempts, generations, identities, paths, user content, provider
+payloads, credentials, or additional error strings enter this projection.
+
 ## Append and deletion serialization
 
 Every append runs in one short transaction:

--- a/packages/assistant-runtime/src/hosted-runtime/checkpoint-bridge.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/checkpoint-bridge.ts
@@ -33,6 +33,10 @@ export class HostedRuntimeBridgeCheckpointLeaseError extends Error {
   constructor(
     readonly code: HostedRuntimeBridgeCheckpointLeaseErrorCode,
     readonly stage: HostedRuntimeBridgeCheckpointLeaseStage,
+    readonly postWebCheckpoint?: {
+      responseCheckpointed: boolean;
+      leaseMatchesResponse: boolean;
+    },
   ) {
     super(`Hosted runtime bridge checkpoint lease validation failed ${stage}.`);
     this.name = "HostedRuntimeBridgeCheckpointLeaseError";
@@ -166,6 +170,7 @@ export async function checkpointHostedRuntimeBridgeWebWorkspace(
   requireCheckpointLeaseMatchesRequest({
     lease: await input.readCurrentLease(),
     request: input.request,
+    response,
     stage: "after_web_checkpoint",
     userId: input.userId,
   });
@@ -176,6 +181,7 @@ export async function checkpointHostedRuntimeBridgeWebWorkspace(
 function requireCheckpointLeaseMatchesRequest(input: {
   lease: HostedRuntimeBridgeCheckpointLease | null;
   request: HostedWorkspaceCheckpointRequest;
+  response?: HostedWorkspaceCheckpointResponse;
   stage: HostedRuntimeBridgeCheckpointLeaseStage;
   userId: string;
 }): HostedRuntimeBridgeCheckpointLease {
@@ -192,7 +198,17 @@ function requireCheckpointLeaseMatchesRequest(input: {
     throw new HostedRuntimeBridgeCheckpointLeaseError("stale_lease_generation", input.stage);
   }
   if (input.lease.workspaceVersion !== input.request.expectedWorkspaceVersion) {
-    throw new HostedRuntimeBridgeCheckpointLeaseError("stale_workspace_version", input.stage);
+    throw new HostedRuntimeBridgeCheckpointLeaseError(
+      "stale_workspace_version",
+      input.stage,
+      input.stage === "after_web_checkpoint" && input.response
+        ? {
+            responseCheckpointed: input.response.checkpointed,
+            leaseMatchesResponse:
+              input.lease.workspaceVersion === input.response.workspace.version,
+          }
+        : undefined,
+    );
   }
 
   return input.lease;

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts
@@ -53,6 +53,9 @@ import type {
 } from "./vault-share-projection.ts";
 
 import {
+  HostedRuntimeBridgeCheckpointLeaseError,
+} from "./checkpoint-bridge.ts";
+import {
   buildHostedMailboxImportRedactedStatus,
   HostedMailboxImportCheckpointConflictError,
   HostedMailboxImportCheckpointUserMismatchError,
@@ -2776,6 +2779,7 @@ async function writeHostedForegroundMailboxImportFailureRuntimeLog(context: {
         failureNames: failure.name ? [failure.name] : [],
         failureSummaries: failure.summary ? [failure.summary] : [],
         nestedErrorCode: failure.errorCode,
+        ...failure.checkpointLeaseDiagnostics,
       },
     },
     now: context.input.now,
@@ -3660,13 +3664,35 @@ async function runHostedMailboxPostCheckpointEffectBestEffort(
 }
 
 function buildHostedMailboxPostCheckpointEffectFailureLog(error: unknown): {
+  checkpointLeaseDiagnostics?: {
+    checkpointResponseCheckpointed: boolean;
+    checkpointLeaseMatchesResponse: boolean;
+  };
   codeDetail: string | null;
   errorCode: string;
   name: string | null;
   summary: string | null;
 } {
   const diagnostics = buildHostedExecutionSafeErrorDiagnostics(error);
+  // The shared sanitizer intentionally drops arbitrary error properties. Project
+  // only these booleans from the local lease error, never spread its metadata.
+  const postWebCheckpoint = error instanceof HostedRuntimeBridgeCheckpointLeaseError
+    && error.code === "stale_workspace_version"
+    && error.stage === "after_web_checkpoint"
+    ? error.postWebCheckpoint
+    : undefined;
+  const responseCheckpointed = postWebCheckpoint?.responseCheckpointed;
+  const leaseMatchesResponse = postWebCheckpoint?.leaseMatchesResponse;
   return {
+    ...(typeof responseCheckpointed === "boolean"
+      && typeof leaseMatchesResponse === "boolean"
+      ? {
+          checkpointLeaseDiagnostics: {
+            checkpointResponseCheckpointed: responseCheckpointed,
+            checkpointLeaseMatchesResponse: leaseMatchesResponse,
+          },
+        }
+      : {}),
     codeDetail: normalizeHostedMailboxPostCheckpointFailureValue(diagnostics?.errorCodeDetail),
     errorCode: typeof diagnostics?.errorCode === "string" ? diagnostics.errorCode : "runtime_error",
     name: normalizeHostedMailboxPostCheckpointFailureValue(diagnostics?.errorName),

--- a/packages/assistant-runtime/test/hosted-invocation-bridge.test.ts
+++ b/packages/assistant-runtime/test/hosted-invocation-bridge.test.ts
@@ -70,6 +70,8 @@ import {
 } from "../src/hosted-runtime.ts";
 import {
   HostedRuntimeBridgeCheckpointLeaseError,
+  checkpointHostedRuntimeBridgeWebWorkspace,
+  checkpointHostedRuntimeBridgeWorkspace,
   type HostedRuntimeBridgeCheckpointLease,
   type HostedRuntimeBridgeCheckpointLeaseErrorCode,
   type HostedRuntimeBridgeCheckpointLeaseStage,
@@ -109,6 +111,155 @@ afterEach(async () => {
   await Promise.all(cleanupPaths.splice(0).map(async (target) => {
     await rm(target, { force: true, recursive: true });
   }));
+});
+
+describe("checkpoint bridge post-Web lease diagnostics", () => {
+  const request = {
+    attemptId: "attempt_synthetic_lease_diagnostic",
+    expectedWorkspaceVersion: "930000000000000001",
+    leaseGeneration: "940000000000000001",
+    reason: "active_turn_input",
+    snapshotRef: null,
+  } satisfies HostedWorkspaceCheckpointRequest;
+  const lease = {
+    attemptId: request.attemptId,
+    leaseGeneration: request.leaseGeneration,
+    providerEgressToken: "synthetic-private-egress-token",
+    userId: "member_synthetic_lease_diagnostic",
+    workspaceVersion: request.expectedWorkspaceVersion,
+  } satisfies HostedRuntimeBridgeCheckpointLease;
+  const responseVersion = "930000000000000002";
+  const differentVersion = "930000000000000003";
+  const response = createCheckpointResponse({
+    snapshotRef: null,
+    userId: lease.userId,
+    version: responseVersion,
+  });
+
+  for (const checkpointed of [true, false]) {
+    for (const matchesResponse of [true, false]) {
+      it(`projects checkpointed=${checkpointed}, matchesResponse=${matchesResponse} without new effects`, async () => {
+        let liveLease: HostedRuntimeBridgeCheckpointLease = lease;
+        const readCurrentLease = vi.fn(async () => liveLease);
+        const snapshotWorkspace = vi.fn(async () => new Uint8Array([1, 2, 3]));
+        const writeBundle = vi.fn(async () => null);
+        const checkpointWorkspace = vi.fn(async () => {
+          liveLease = {
+            ...lease,
+            workspaceVersion: matchesResponse ? responseVersion : differentVersion,
+          };
+          return { ...response, checkpointed };
+        });
+
+        const error = await expectLeaseFailure(checkpointHostedRuntimeBridgeWorkspace({
+          checkpointWorkspace,
+          readCurrentLease,
+          request,
+          snapshotWorkspace,
+          userId: lease.userId,
+          writeBundle,
+        }), { code: "stale_workspace_version", stage: "after_web_checkpoint" });
+
+        expect(error.postWebCheckpoint).toEqual({
+          responseCheckpointed: checkpointed,
+          leaseMatchesResponse: matchesResponse,
+        });
+        expect(error.message).toBe(
+          "Hosted runtime bridge checkpoint lease validation failed after_web_checkpoint.",
+        );
+        expect(readCurrentLease).toHaveBeenCalledTimes(4);
+        expect(snapshotWorkspace).toHaveBeenCalledOnce();
+        expect(writeBundle).toHaveBeenCalledOnce();
+        expect(checkpointWorkspace).toHaveBeenCalledExactlyOnceWith(request);
+        for (const sensitive of [
+          ...Object.values(lease), responseVersion, differentVersion,
+        ]) {
+          expect(JSON.stringify(error)).not.toContain(sensitive);
+        }
+      });
+    }
+
+    it(`returns checkpointed=${checkpointed} responses unchanged when the lease has not drifted`, async () => {
+      const checkpointResponse = { ...response, checkpointed };
+      const checkpointWorkspace = vi.fn(async () => checkpointResponse);
+      const readCurrentLease = vi.fn(async () => lease);
+      await expect(checkpointHostedRuntimeBridgeWebWorkspace({
+        checkpointWorkspace, readCurrentLease, request, userId: lease.userId,
+      })).resolves.toBe(checkpointResponse);
+      expect(checkpointResponse).not.toHaveProperty("postWebCheckpoint");
+      expect(checkpointWorkspace).toHaveBeenCalledExactlyOnceWith(request);
+      expect(readCurrentLease).toHaveBeenCalledTimes(2);
+    });
+  }
+
+  it.each([
+    [1, "before_snapshot"],
+    [2, "before_bundle_write"],
+    [3, "before_web_checkpoint"],
+  ] as const)("omits response metadata on lease read %i at %s", async (staleRead, stage) => {
+    let leaseReads = 0;
+    const readCurrentLease = vi.fn(async () => {
+      leaseReads += 1;
+      return leaseReads === staleRead
+        ? { ...lease, workspaceVersion: responseVersion }
+        : lease;
+    });
+    const snapshotWorkspace = vi.fn(async () => new Uint8Array([1]));
+    const writeBundle = vi.fn(async () => null);
+    const checkpointWorkspace = vi.fn(async () => response);
+    const error = await expectLeaseFailure(checkpointHostedRuntimeBridgeWorkspace({
+      checkpointWorkspace, readCurrentLease, request, snapshotWorkspace,
+      userId: lease.userId, writeBundle,
+    }), { code: "stale_workspace_version", stage });
+    expect(error.postWebCheckpoint).toBeUndefined();
+    expect(readCurrentLease).toHaveBeenCalledTimes(staleRead);
+    expect(snapshotWorkspace).toHaveBeenCalledTimes(staleRead > 1 ? 1 : 0);
+    expect(writeBundle).toHaveBeenCalledTimes(staleRead > 2 ? 1 : 0);
+    expect(checkpointWorkspace).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing_lease", null],
+    ["stale_user", { ...lease, userId: "member_synthetic_other" }],
+    ["stale_attempt", { ...lease, attemptId: "attempt_synthetic_other" }],
+    ["stale_lease_generation", { ...lease, leaseGeneration: "940000000000000002" }],
+  ] as const)("omits response metadata for post-Web %s", async (code, liveLease) => {
+    const readCurrentLease = vi.fn<() => Promise<HostedRuntimeBridgeCheckpointLease | null>>()
+      .mockResolvedValueOnce(lease)
+      .mockResolvedValueOnce(liveLease);
+    const checkpointWorkspace = vi.fn(async () => response);
+    const error = await expectLeaseFailure(checkpointHostedRuntimeBridgeWebWorkspace({
+      checkpointWorkspace, readCurrentLease, request, userId: lease.userId,
+    }), { code, stage: "after_web_checkpoint" });
+    expect(error.postWebCheckpoint).toBeUndefined();
+    expect(readCurrentLease).toHaveBeenCalledTimes(2);
+    expect(checkpointWorkspace).toHaveBeenCalledExactlyOnceWith(request);
+  });
+
+  it("preserves the response user check before the post-Web lease read", async () => {
+    const readCurrentLease = vi.fn(async () => lease);
+    const checkpointWorkspace = vi.fn(async () => ({
+      ...response, workspace: { ...response.workspace, userId: "member_synthetic_other" },
+    }));
+    const error = await expectLeaseFailure(checkpointHostedRuntimeBridgeWebWorkspace({
+      checkpointWorkspace, readCurrentLease, request, userId: lease.userId,
+    }), { code: "workspace_user_mismatch", stage: "after_web_checkpoint" });
+    expect(error.postWebCheckpoint).toBeUndefined();
+    expect(readCurrentLease).toHaveBeenCalledOnce();
+    expect(checkpointWorkspace).toHaveBeenCalledExactlyOnceWith(request);
+  });
+
+  it("rethrows a callback failure unchanged without a post-Web lease read", async () => {
+    const failure = new Error("Synthetic Web checkpoint failure.");
+    const readCurrentLease = vi.fn(async () => lease);
+    const checkpointWorkspace = vi.fn(async () => { throw failure; });
+    await expect(checkpointHostedRuntimeBridgeWebWorkspace({
+      checkpointWorkspace, readCurrentLease, request, userId: lease.userId,
+    })).rejects.toBe(failure);
+    expect(failure).not.toHaveProperty("postWebCheckpoint");
+    expect(readCurrentLease).toHaveBeenCalledOnce();
+    expect(checkpointWorkspace).toHaveBeenCalledExactlyOnceWith(request);
+  });
 });
 
 describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
@@ -384,7 +535,7 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
           vaultRoot,
         });
 
-        await expectLeaseFailure(
+        const error = await expectLeaseFailure(
           options.createCheckpointSnapshot(createCheckpointInput("idle_shutdown")),
           {
             code: staleMutation.code,
@@ -392,6 +543,7 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
           },
         );
 
+        expect(error.postWebCheckpoint).toBeUndefined();
         expect(calls.startSnapshotSession).toHaveBeenCalledTimes(
           stageCase.expectedStartCount,
         );
@@ -3079,7 +3231,7 @@ async function expectLeaseFailure(
     code: HostedRuntimeBridgeCheckpointLeaseErrorCode;
     stage: HostedRuntimeBridgeCheckpointLeaseStage;
   },
-): Promise<void> {
+): Promise<HostedRuntimeBridgeCheckpointLeaseError> {
   let thrown: unknown;
   try {
     await operation;
@@ -3093,4 +3245,5 @@ async function expectLeaseFailure(
   }
   expect(thrown.code).toBe(expected.code);
   expect(thrown.stage).toBe(expected.stage);
+  return thrown;
 }

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-runner.test.ts
@@ -50,6 +50,10 @@ import {
   parseHostedRuntimeLogRequest,
 } from "@murphai/hosted-execution/parsers";
 import {
+  buildHostedExecutionSafeErrorDiagnostics,
+  sanitizeHostedExecutionStructuredLogDetails,
+} from "@murphai/hosted-execution";
+import {
   ASSISTANT_USAGE_SCHEMA,
   type AssistantUsageRecord,
 } from "@murphai/hosted-execution/assistant-usage";
@@ -86,6 +90,10 @@ import {
 import {
   createHostedConversationMailboxImportItem,
 } from "../src/hosted-runtime/mailbox-conversation-import.ts";
+import {
+  checkpointHostedRuntimeBridgeWebWorkspace,
+  HostedRuntimeBridgeCheckpointLeaseError,
+} from "../src/hosted-runtime/checkpoint-bridge.ts";
 import {
   createEmptyHostedMailboxImportState,
   readHostedMailboxImportState,
@@ -164,6 +172,237 @@ async function runHostedWorkspaceUntilIdleOrBudget(
     await drainHostedRuntimeLogWritesBestEffort();
   }
 }
+
+describe("foreground checkpoint lease diagnostics", () => {
+  const requestVersion = "930000000000000001";
+  const responseVersion = "930000000000000002";
+  const differentVersion = "930000000000000003";
+  const privateValues = {
+    attemptId: "attempt_synthetic_private_lease",
+    leaseGeneration: "940000000000000001",
+    providerEgressToken: "synthetic-private-egress-token",
+    providerPayload: "synthetic-private-provider-payload",
+    userContent: "synthetic-private-content-without-a-redaction-pattern",
+    path: "/home/synthetic-private/lease.txt",
+    email: "synthetic-private@example.invalid",
+  };
+
+  function createBridgeCheckpoint(checkpointed: boolean, liveVersion: string) {
+    let workspaceVersion = requestVersion;
+    const readCurrentLease = vi.fn(async () => ({
+      attemptId: privateValues.attemptId,
+      leaseGeneration: privateValues.leaseGeneration,
+      providerEgressToken: privateValues.providerEgressToken,
+      userId: TEST_USER_ID,
+      workspaceVersion,
+    }));
+    const checkpointWorkspace = vi.fn(async () => {
+      workspaceVersion = liveVersion;
+      return {
+        checkpointed,
+        workspace: createWorkspaceState({
+          redactedStatus: { status: privateValues.userContent },
+          version: responseVersion,
+        }),
+      };
+    });
+    return {
+      checkpoint: (request: HostedWorkspaceCheckpointRequest) =>
+        checkpointHostedRuntimeBridgeWebWorkspace({
+          checkpointWorkspace, readCurrentLease, request, userId: TEST_USER_ID,
+        }),
+      checkpointWorkspace,
+      readCurrentLease,
+    };
+  }
+
+  for (const checkpointed of [true, false]) {
+    for (const matchesResponse of [true, false]) {
+      test(`logs only the typed pair for checkpointed=${checkpointed}, matchesResponse=${matchesResponse}`, async () => {
+        const bridge = createBridgeCheckpoint(
+          checkpointed, matchesResponse ? responseVersion : differentVersion,
+        );
+        const { logRequests, warnings } = await runForegroundCheckpointDiagnosticTest({
+          attemptId: privateValues.attemptId,
+          leaseGeneration: privateValues.leaseGeneration,
+          requestVersion,
+          async checkpoint(request) {
+            try {
+              return await bridge.checkpoint(request);
+            } catch (error) {
+              assert.ok(error instanceof HostedRuntimeBridgeCheckpointLeaseError);
+              assert.equal(error.code, "stale_workspace_version");
+              assert.equal(error.stage, "after_web_checkpoint");
+              assert.ok(error.postWebCheckpoint);
+              // Extra own/nested properties must not become a log-field escape hatch.
+              Object.assign(error.postWebCheckpoint, privateValues, {
+                expectedWorkspaceVersion: requestVersion,
+                returnedWorkspaceVersion: responseVersion,
+                currentWorkspaceVersion: differentVersion,
+              });
+              Object.assign(error, privateValues, {
+                context: { checkpointLeaseMatchesResponse: privateValues.userContent },
+                details: { checkpointResponseCheckpointed: privateValues.providerPayload },
+              });
+              const generic = buildHostedExecutionSafeErrorDiagnostics(error);
+              expect(generic).not.toHaveProperty("checkpointLeaseMatchesResponse");
+              expect(generic).not.toHaveProperty("checkpointResponseCheckpointed");
+              throw error;
+            }
+          },
+        });
+        const entries = logRequests.flatMap((request) => request.entries);
+        const failures = entries.filter((entry) =>
+          entry.errorCode === "foreground_mailbox_import_failed"
+        );
+        expect(failures).toHaveLength(1);
+        const failure = failures[0]!;
+        expect(failure).toMatchObject({
+          component: "mailbox",
+          eventCode: "runner.error",
+          level: "warn",
+          phase: "active_turn_input",
+        });
+        expect(failure.redactedJson).toEqual({
+          failureCodeDetails: ["stale_workspace_version"],
+          failureNames: [],
+          failureSummaries: [
+            "Hosted runtime bridge checkpoint lease validation failed after_web_checkpoint.",
+          ],
+          nestedErrorCode: "checkpoint_error",
+          checkpointResponseCheckpointed: checkpointed,
+          checkpointLeaseMatchesResponse: matchesResponse,
+        });
+        expect(parseHostedRuntimeLogRequest({ entries: [failure] }).entries[0]?.redactedJson)
+          .toEqual(failure.redactedJson);
+        const sanitized = sanitizeHostedExecutionStructuredLogDetails(failure.redactedJson);
+        // The existing structured sanitizer omits empty arrays, but retains both booleans.
+        expect(sanitized).toEqual({
+          failureCodeDetails: ["stale_workspace_version"],
+          failureSummaries: [
+            "Hosted runtime bridge checkpoint lease validation failed after_web_checkpoint.",
+          ],
+          nestedErrorCode: "checkpoint_error",
+          checkpointResponseCheckpointed: checkpointed,
+          checkpointLeaseMatchesResponse: matchesResponse,
+        });
+        expect(parseHostedRuntimeLogRequest({ entries: [{ ...failure, redactedJson: sanitized }] })
+          .entries[0]?.redactedJson).toEqual(sanitized);
+        for (const entry of entries.filter((entry) => entry !== failure)) {
+          expect(entry.redactedJson ?? {}).not.toHaveProperty("checkpointResponseCheckpointed");
+          expect(entry.redactedJson ?? {}).not.toHaveProperty("checkpointLeaseMatchesResponse");
+        }
+        for (const sensitive of [
+          ...Object.values(privateValues), TEST_USER_ID,
+          requestVersion, responseVersion, differentVersion,
+        ]) {
+          expect(JSON.stringify({ logRequests, warnings })).not.toContain(sensitive);
+        }
+        expect(bridge.readCurrentLease).toHaveBeenCalledTimes(2);
+        expect(bridge.checkpointWorkspace).toHaveBeenCalledOnce();
+      });
+    }
+
+    test(`does not enrich an unchanged-lease checkpointed=${checkpointed} response`, async () => {
+      const bridge = createBridgeCheckpoint(checkpointed, requestVersion);
+      const { logRequests } = await runForegroundCheckpointDiagnosticTest({
+        attemptId: privateValues.attemptId,
+        checkpoint: bridge.checkpoint,
+        expectFailure: !checkpointed,
+        leaseGeneration: privateValues.leaseGeneration,
+        requestVersion,
+      });
+      for (const request of logRequests) {
+        for (const entry of request.entries) {
+          expect(entry.redactedJson ?? {}).not.toHaveProperty("checkpointResponseCheckpointed");
+          expect(entry.redactedJson ?? {}).not.toHaveProperty("checkpointLeaseMatchesResponse");
+        }
+      }
+      expect(bridge.readCurrentLease).toHaveBeenCalledTimes(2);
+      expect(bridge.checkpointWorkspace).toHaveBeenCalledOnce();
+    });
+  }
+
+  test("projects the checked primitive values without rereading supplied metadata", async () => {
+    const responseCheckpointed = vi.fn()
+      .mockReturnValueOnce(false).mockReturnValue(privateValues.userContent);
+    const leaseMatchesResponse = vi.fn()
+      .mockReturnValueOnce(true).mockReturnValue(privateValues.providerPayload);
+    const metadata = Object.defineProperties({}, {
+      responseCheckpointed: { get: responseCheckpointed },
+      leaseMatchesResponse: { get: leaseMatchesResponse },
+    });
+    const error = Object.assign(new HostedRuntimeBridgeCheckpointLeaseError(
+      "stale_workspace_version", "after_web_checkpoint",
+    ), { postWebCheckpoint: metadata });
+    const { logRequests, warnings } = await runForegroundCheckpointDiagnosticTest({
+      attemptId: privateValues.attemptId,
+      checkpoint: async () => { throw error; },
+      leaseGeneration: privateValues.leaseGeneration,
+      requestVersion,
+    });
+    const failure = logRequests.flatMap((request) => request.entries)
+      .find((entry) => entry.errorCode === "foreground_mailbox_import_failed");
+    expect(failure?.redactedJson).toMatchObject({
+      checkpointResponseCheckpointed: false,
+      checkpointLeaseMatchesResponse: true,
+    });
+    expect(responseCheckpointed).toHaveBeenCalledOnce();
+    expect(leaseMatchesResponse).toHaveBeenCalledOnce();
+    for (const sensitive of Object.values(privateValues)) {
+      expect(JSON.stringify({ logRequests, warnings })).not.toContain(sensitive);
+    }
+  });
+
+  const metadata = { responseCheckpointed: true, leaseMatchesResponse: true };
+  test.each([
+    ["untyped lookalike", (): Error => Object.assign(new Error("Synthetic callback failure."), {
+      name: "HostedRuntimeBridgeCheckpointLeaseError",
+      code: "stale_workspace_version",
+      stage: "after_web_checkpoint",
+      postWebCheckpoint: metadata,
+    })],
+    ["other stage", () => new HostedRuntimeBridgeCheckpointLeaseError(
+      "stale_workspace_version", "before_web_checkpoint", metadata,
+    )],
+    ["other code", () => new HostedRuntimeBridgeCheckpointLeaseError(
+      "stale_attempt", "after_web_checkpoint", metadata,
+    )],
+    ["missing metadata", () => new HostedRuntimeBridgeCheckpointLeaseError(
+      "stale_workspace_version", "after_web_checkpoint",
+    )],
+    ["non-boolean accepted flag", () => Object.assign(
+      new HostedRuntimeBridgeCheckpointLeaseError("stale_workspace_version", "after_web_checkpoint"),
+      { postWebCheckpoint: { ...metadata, responseCheckpointed: privateValues.userContent } },
+    )],
+    ["non-boolean match flag", () => Object.assign(
+      new HostedRuntimeBridgeCheckpointLeaseError("stale_workspace_version", "after_web_checkpoint"),
+      { postWebCheckpoint: { ...metadata, leaseMatchesResponse: privateValues.providerPayload } },
+    )],
+    ["arbitrary cause wrapper", () => new Error("Synthetic callback wrapper.", {
+      cause: new HostedRuntimeBridgeCheckpointLeaseError(
+        "stale_workspace_version", "after_web_checkpoint", metadata,
+      ),
+    })],
+    ["non-error throw", (): string => "Synthetic callback failure."],
+  ] as const)("does not project metadata from %s", async (_label, createError) => {
+    const { logRequests, warnings } = await runForegroundCheckpointDiagnosticTest({
+      attemptId: privateValues.attemptId,
+      checkpoint: async () => { throw createError(); },
+      leaseGeneration: privateValues.leaseGeneration,
+      requestVersion,
+    });
+    const failure = logRequests.flatMap((request) => request.entries)
+      .find((entry) => entry.errorCode === "foreground_mailbox_import_failed");
+    assert.ok(failure);
+    expect(failure.redactedJson).not.toHaveProperty("checkpointResponseCheckpointed");
+    expect(failure.redactedJson).not.toHaveProperty("checkpointLeaseMatchesResponse");
+    expect(() => parseHostedRuntimeLogRequest({ entries: [failure] })).not.toThrow();
+    for (const sensitive of Object.values(privateValues)) {
+      expect(JSON.stringify({ logRequests, warnings })).not.toContain(sensitive);
+    }
+  });
+});
 
 describe("runHostedWorkspaceUntilIdleOrBudget", () => {
   test("carries two initial conversation inputs through singleton foreground reruns before checkpointing", async () => {
@@ -10255,6 +10494,91 @@ async function runConversationHandledThroughScenario(input: {
       now: () => TEST_NOW,
     });
   } finally {
+    await rm(vaultRoot, { force: true, recursive: true });
+  }
+}
+
+async function runForegroundCheckpointDiagnosticTest(input: {
+  attemptId: string;
+  checkpoint: HostedRuntimeWorkspacePort["checkpoint"];
+  expectFailure?: boolean;
+  leaseGeneration: string;
+  requestVersion: string;
+}) {
+  const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-foreground-lease-"));
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const logRequests: HostedRuntimeLogRequest[] = [];
+  const items: HostedMailboxItem[] = [];
+  const artifactPutCalls: string[] = [];
+  const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
+  const platform = createPlatform({
+    artifactPutCalls,
+    logRequests,
+    mailboxPort: createMailboxPort({ items }).mailboxPort,
+    workspacePort: { checkpoint: input.checkpoint },
+  });
+  const checkpointRuntimeRedactedStatus = vi.fn(async (
+    checkpoint: HostedWorkspaceRunnerRuntimeStatusCheckpointInput,
+  ) => await platform.workspacePort.checkpoint({
+    attemptId: input.attemptId,
+    expectedWorkspaceVersion: input.requestVersion,
+    leaseGeneration: input.leaseGeneration,
+    nextWakeAt: checkpoint.nextWakeAt ?? null,
+    nextWakeReason: checkpoint.nextWakeReason ?? null,
+    reason: checkpoint.reason,
+    redactedStatus: checkpoint.redactedStatus,
+    snapshotRef: null,
+  }));
+  try {
+    await runHostedWorkspaceUntilIdleOrBudget({
+      checkpointRequestBuilder: createHostedWorkspaceCheckpointRequestBuilder({
+        attemptId: input.attemptId,
+        expectedWorkspaceVersion: input.requestVersion,
+        leaseGeneration: input.leaseGeneration,
+        snapshotRef: null,
+      }),
+      checkpointRuntimeRedactedStatus,
+      expectedUserId: TEST_USER_ID,
+      importItem: async () => ({ status: "imported" }),
+      limitPerLane: 10,
+      now: () => TEST_NOW,
+      platform,
+      requestId: "request_synthetic_foreground_lease",
+      runtimeWakeSignal,
+      async runAssistantPhase() {
+        items.push(createMailboxItem());
+        runtimeWakeSignal.notify();
+        await vi.waitFor(() => {
+          if (input.expectFailure !== false) {
+            expect(logRequests.flatMap((request) => request.entries).filter((entry) =>
+              entry.errorCode === "foreground_mailbox_import_failed"
+            )).toHaveLength(1);
+          } else {
+            expect(checkpointRuntimeRedactedStatus).toHaveResolvedTimes(1);
+          }
+        });
+        return { progressed: false };
+      },
+      vaultRoot,
+      workspace: createWorkspaceState({
+        // Existing receipt authority makes the late import checkpoint its progress.
+        redactedStatus: {
+          hostedCanonicalWriteReceiptLogByteSize: 1,
+          hostedCanonicalWriteReceiptLogSha256: "a".repeat(64),
+        },
+        version: input.requestVersion,
+      }),
+    });
+    expect(checkpointRuntimeRedactedStatus).toHaveBeenCalledOnce();
+    expect(artifactPutCalls).toEqual([]);
+    if (input.expectFailure === false) {
+      expect(logRequests.flatMap((request) => request.entries).filter((entry) =>
+        entry.errorCode === "foreground_mailbox_import_failed"
+      )).toHaveLength(0);
+    }
+    return { logRequests, warnings: warn.mock.calls };
+  } finally {
+    warn.mockRestore();
     await rm(vaultRoot, { force: true, recursive: true });
   }
 }


### PR DESCRIPTION
## Why and outcome

A foreground mailbox import can reject a lease version after Web returns a checkpoint. Existing diagnostics identify the stage and stale version but cannot distinguish a lease matching the returned workspace from different concurrent progress.

The existing failure event now records two bounded booleans: whether Web checkpointed and whether the already-read lease matches the response version. This narrows a future investigation; it does not establish the cause or correct delayed replies.

## Product UX

- Effort: Not applicable — internal failure diagnostics only.
- Result: Not applicable — no member-facing flow changes.
- Walkthrough: Lease validation, accepted/conflict handling, success paths, delivery, retries, and checkpoint effects retain their existing behavior.

## Evidence

- Direct: ReviewGPT implemented the production patch. Thirty new local Vitest cases pass through real bridge callbacks and the foreground wake/import/checkpoint/log seam, including all accepted/conflict and matching/different combinations, unchanged failures and effect counts, success/absence cases, malformed metadata, and privacy rejection.
- Coverage: Both affected suites ran in full: 209 passed, one failed. The sole failure is the existing 250 ms queued-finished-log independence assertion, reproduced before any source change both in the base suite (53/54) and alone. No timeout workaround or assertion weakening was applied. The required Frog entry records this baseline gap.
- Passed: assistant-runtime semantic typecheck; raw log payload guard; docs drift and gardening (zero issues); diff whitespace check; complexity guard.
- Local test-only adjustments to ReviewGPT's patch: two explicit synthetic factory return types and removal of a checkpoint reason from a no-progress fixture result. Production code is unchanged from its patch.
- Final ReviewGPT round 1 passed on `63b54a07a0abac620e6d44a92dc42c02062b9eb1` with verified gpt-6-pro identity and no qualifying findings. It independently checked 76 base/head bridge scenarios and the projection/privacy cases.
- Final head `0aaa25f1ae1514dcc921d179d3afaa4b0ee48863` adds only execution-plan closure and evidence; production, tests, and diagnostic owner content are unchanged from the reviewed head. This explanatory-doc delta uses the final-review exemption. Required CI on the final head remains pending.

## Non-obvious affected surfaces

The existing structured sanitizer and runtime-log parser preserve both booleans without code or allowlist changes. Tests exercise both boundaries. Both reader files are identical at the previously observed ready Web revision and this PR's base. The typed lease error is rethrown unchanged by the existing workspace port, so no arbitrary cause traversal is added.

## Architecture and reuse

- Existing systems reused: checkpoint bridge lease validation, typed lease error, mailbox failure diagnostic helper, existing foreground `runner.error` event, and signed runtime-log pipeline.
- New logic: derive and validate two optional boolean observations on the existing error path.
- New abstractions: None; an optional typed pair extends the existing error and diagnostic result.
- Complexity intentionally avoided: no new event, observer service, storage, retry owner, lease read, provider operation, or monitoring pipeline.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base b371cb17a3f2f724191eabb0d824d888cf675d49 -- packages/assistant-runtime/src/hosted-runtime/checkpoint-bridge.ts packages/assistant-runtime/src/hosted-runtime/workspace-runner.ts`.
- Hotspots: existing `runHostedWorkspaceUntilIdleOrBudget` (71), `rebuildHostedWorkspaceRunnerAssistantInputBatchAfterSelectedPrefixRepair` (25), and `mergeDeferredPostCheckpointWake` (23) are unchanged. Runner debt stays 59; checkpoint bridge debt stays zero and maximum changes from 6 to 8.
- Agent judgment: keep the observation at its existing owners; broader orchestration refactoring is not justified by this gap.

## Hot reply path impact

- Path status: Touched only to carry optional failure metadata; successful checkpoint checks keep their existing order.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved. No timeout, retry, or fallback changes; constant in-memory comparison and two scalar fields on an existing failure write.
- Before/after proof: full bridge tests retain four lease reads, one snapshot, one bundle write, and one Web checkpoint. Web-only cases retain two reads and one checkpoint. Earlier rejection paths retain their effect counts.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no prompts, tools, generated guidance, request assembly, or provider-visible input changed.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

ReviewGPT first-reviewed head: 63b54a07a0abac620e6d44a92dc42c02062b9eb1
ReviewGPT context sensitivity: sensitive
Classification reason: hosted execution diagnostics and privacy boundaries require a full snapshot despite behavior preservation.

## Deployment concerns

- Deployment: applicable
- Supported skew: current Web parser and structured sanitizer accept the optional booleans; old runners omit them. No event registry, schema, or shared reader changes.
- Safe order: after required verification, deploy the Worker/runner bundle through protected Murph Cloud. No tandem Web release or migration is needed for these fields.
- Rollback floor: unchanged; prior runners omit the optional observation. Any operational rollback still requires its own explicit authorization.
- Expected exposure: at most two booleans on each existing foreground import failure for the specific typed post-Web stale-version error; no success volume increase or raw versions/identifiers/content.
- Reversibility: removing the writer restores previous diagnostics without state migration.
- Convergence proof: unchanged reader parses both old and new event shapes in tests; protected rollout must establish the serving Worker and runner revision.
- Post-deploy checks: aggregate natural foreground import failures by `checkpointResponseCheckpointed` and `checkpointLeaseMatchesResponse`, including missing-field counts. If no matching failure occurs, record the telemetry as unexercised; never synthesize traffic or infer the underlying issue resolved.

## Change-shape breakdown

Classification rule: runtime implementation is source; test paths are tests; diagnostic owner, execution plan, and required Frog report are docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 43 | 1 |
| Tests / fixtures | 479 | 2 |
| Docs | 99 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **621** | **3** |

## Changelog

- Changelog: not applicable
- Reason: internal diagnostic evidence only; no member-visible behavior change.
