### PR TITLE
test(cloudflare): replace restore wiring mocks with encrypted roundtrips

### DIFF
--- a/apps/cloudflare/test/container-workspace-restore-preparation.test.ts
+++ b/apps/cloudflare/test/container-workspace-restore-preparation.test.ts
@@ -1,158 +1,279 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
-const mocks = vi.hoisted(() => ({
-  createArtifactStore: vi.fn(),
-  createInternalFetch: vi.fn(),
-  createLogPort: vi.fn(),
-  createSnapshotPort: vi.fn(),
-  createTrustedInternalFetch: vi.fn(),
-  createWorkspacePort: vi.fn(),
-  prepareVaultRoot: vi.fn(),
-  readCommitTimeoutMs: vi.fn(),
-  resolveTransport: vi.fn(),
-  startPreparation: vi.fn(),
-}));
-
-vi.mock("@murphai/assistant-runtime/hosted-workspace-restore-preparation", () => ({
-  startHostedWorkspaceRestorePreparation: mocks.startPreparation,
-}));
-
-vi.mock("@murphai/assistant-runtime/hosted-runtime-worker-contracts", () => ({
-  readHostedRunnerCommitTimeoutMs: mocks.readCommitTimeoutMs,
-}));
-
-vi.mock("../src/hosted-runner-warm-workspace.js", () => ({
-  prepareHostedRunnerWarmWorkspaceVaultRoot: mocks.prepareVaultRoot,
-}));
-
-vi.mock("../src/runtime-platform/artifact-store.js", () => ({
-  createCloudflareArtifactStore: mocks.createArtifactStore,
-}));
-
-vi.mock("../src/runtime-platform/log-port.js", () => ({
-  createHostedWebRuntimeLogPort: mocks.createLogPort,
-}));
-
-vi.mock("../src/runtime-platform/provider-fetch.js", () => ({
-  createCloudflareHostedInternalFetch: mocks.createInternalFetch,
-  createCloudflareHostedTrustedInternalFetch: mocks.createTrustedInternalFetch,
-}));
-
-vi.mock("../src/runtime-platform/web-control-transport.js", () => ({
-  resolveHostedWebControlTransport: mocks.resolveTransport,
-}));
-
-vi.mock("../src/runtime-platform/workspace-port.js", () => ({
-  createHostedWebWorkspacePort: mocks.createWorkspacePort,
-}));
-
-vi.mock("../src/runtime-platform/workspace-snapshot-port.js", () => ({
-  createCloudflareWorkspaceSnapshotPort: mocks.createSnapshotPort,
-}));
-
-import type {
-  HostedWorkspaceRestorePreparation,
-} from "@murphai/assistant-runtime/hosted-workspace-restore-preparation";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HostedWorkspaceState } from "@murphai/hosted-execution/runtime-control";
 import {
-  prepareHostedContainerWorkspaceRestore,
-} from "../src/container-workspace-restore-preparation.js";
-import type {
-  HostedExecutionWorkspaceInvocationJobInput,
-} from "../src/runner-job-transport.js";
+  buildHostedWorkspaceSnapshotV2Aad,
+  buildHostedWorkspaceSnapshotV2FingerprintSha256,
+  encodeHostedWorkspaceSnapshotV2DataKey,
+  HOSTED_WORKSPACE_SNAPSHOT_ENCRYPTION_SCHEME,
+  HOSTED_WORKSPACE_SNAPSHOT_REF_SCHEMA,
+  HOSTED_WORKSPACE_SNAPSHOT_UPLOAD_KIND,
+  type HostedWorkspaceSnapshotV2Ref,
+} from "@murphai/hosted-execution/workspace-snapshot-v2";
+import { collectHostedWorkspaceSnapshotArchivePlan } from "@murphai/runtime-state/node";
 
-function createPreparation(vaultRoot: string): HostedWorkspaceRestorePreparation {
-  return {
-    adoptRuntimeAbortGuard: vi.fn(),
-    phaseLogger: {
-      close: vi.fn(),
-      emit: vi.fn(),
-      failOpenPhases: vi.fn(() => []),
+import { prepareHostedContainerWorkspaceRestore } from "../src/container-workspace-restore-preparation.ts";
+import { resolveHostedRunnerWarmWorkspaceVaultRoot } from "../src/hosted-runner-warm-workspace.ts";
+import { CLOUDFLARE_HOSTED_RUNTIME_BASE_URLS } from "../src/internal-hosts.ts";
+import type { HostedExecutionWorkspaceInvocationJobInput } from "../src/runner-job-transport.ts";
+import {
+  HOSTED_PROVIDER_EGRESS_TOKEN_HEADER,
+  HOSTED_RUNNER_BOUND_USER_ID_HEADER,
+  HOSTED_RUNTIME_ATTEMPT_ID_HEADER,
+  HOSTED_RUNTIME_LEASE_GENERATION_HEADER,
+  HOSTED_RUNTIME_WORKSPACE_VERSION_HEADER,
+} from "../src/runner-outbound/headers.ts";
+import { HOSTED_RUNNER_WEB_CONTROL_ROUTES } from "../src/runtime-platform/web-control-transport.ts";
+import { hostedWorkspaceSnapshotObjectKey } from "../src/storage-paths.ts";
+import { createEncryptedWorkspaceSnapshotFile } from "../src/workspace-snapshot-local.ts";
+
+const NOW = "2026-08-27T15:00:00.000Z";
+const SNAPSHOT_NOTE = "Checkpointed synthetic workspace.\n";
+const RESIDENT_NOTE = "Resident workspace must survive rejected restore.\n";
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await Promise.all(temporaryRoots.splice(0).map((root) =>
+    rm(root, { force: true, recursive: true })
+  ));
+});
+
+describe("container workspace restore preparation", () => {
+  it.each([true, false])(
+    "restores encrypted bytes through the real composition (prepared: %s)",
+    async (prepared) => {
+      const fixture = await createFixture();
+      const job = createJob(fixture, prepared);
+      const requests = serveSnapshot(fixture);
+
+      const preparation = await prepareHostedContainerWorkspaceRestore({
+        job,
+        signal: new AbortController().signal,
+      });
+      const result = await preparation.promise;
+
+      expect(result.restored).toMatchObject({
+        mode: "snapshot",
+        restoreWasCold: true,
+        vaultRoot: fixture.vaultRoot,
+      });
+      expect(result.workspaceRead.workspace).toEqual(fixture.workspace);
+      expect(await readFile(path.join(preparation.vaultRoot, "note.md"), "utf8"))
+        .toBe(SNAPSHOT_NOTE);
+      await expect(stat(path.join(preparation.vaultRoot, "resident-only.md")))
+        .rejects.toMatchObject({ code: "ENOENT" });
+      for (const root of [
+        preparation.vaultRoot,
+        result.restored.assistantStateRoot,
+        result.restored.operatorHomeRoot,
+      ]) {
+        expect((await stat(root)).mode & 0o777).toBe(0o700);
+      }
+
+      const controlRequests = requests.filter((request) => request.url !== fixture.getUrl);
+      expect(controlRequests.map((request) => new URL(request.url).pathname).sort())
+        .toEqual([
+          HOSTED_RUNNER_WEB_CONTROL_ROUTES.workspaceRead.path,
+          ...(prepared ? [] : [
+            `/workspace-snapshots/${fixture.ref.snapshotId}/data-key/unwrap`,
+            `/workspace-snapshots/${fixture.ref.snapshotId}/presign-get`,
+          ]),
+        ].sort());
+      for (const request of controlRequests) {
+        expect(request.headers.get(HOSTED_RUNNER_BOUND_USER_ID_HEADER)).toBe(job.request.userId);
+        expect(request.headers.get(HOSTED_RUNTIME_ATTEMPT_ID_HEADER)).toBe(job.request.attemptId);
+        expect(request.headers.get(HOSTED_RUNTIME_LEASE_GENERATION_HEADER)).toBe(job.request.leaseGeneration);
+        expect(request.headers.get(HOSTED_RUNTIME_WORKSPACE_VERSION_HEADER)).toBe(job.request.workspaceVersion);
+        expect(request.headers.has(HOSTED_PROVIDER_EGRESS_TOKEN_HEADER)).toBe(false);
+      }
+      const downloads = requests.filter((request) => request.url === fixture.getUrl);
+      expect(downloads).toHaveLength(1);
+      expect(downloads[0]?.method).toBe("GET");
+      for (const header of [
+        HOSTED_RUNNER_BOUND_USER_ID_HEADER,
+        HOSTED_RUNTIME_ATTEMPT_ID_HEADER,
+        HOSTED_RUNTIME_LEASE_GENERATION_HEADER,
+        HOSTED_RUNTIME_WORKSPACE_VERSION_HEADER,
+        HOSTED_PROVIDER_EGRESS_TOKEN_HEADER,
+      ]) {
+        expect(downloads[0]?.headers.has(header)).toBe(false);
+      }
     },
-    promise: new Promise<never>(() => undefined),
-    runtimePhaseStartedAt: "2026-08-27T15:00:00.000Z",
+  );
+
+  it.each([
+    { patch: { version: "11" }, errorName: "HostedWorkspaceRuntimeJobWorkspaceVersionMismatchError" },
+    { patch: { userId: "member_other_workspace" }, errorName: "HostedWorkspaceRunnerUserMismatchError" },
+  ])("preserves resident files when workspace admission rejects $errorName", async ({ patch, errorName }) => {
+    const fixture = await createFixture();
+    const requests = serveSnapshot(fixture, { ...fixture.workspace, ...patch });
+    const preparation = await prepareHostedContainerWorkspaceRestore({
+      job: createJob(fixture, true),
+      signal: new AbortController().signal,
+    });
+
+    await expect(preparation.promise).rejects.toMatchObject({ name: errorName });
+    expect(requests.map((request) => new URL(request.url).pathname))
+      .toEqual([HOSTED_RUNNER_WEB_CONTROL_ROUTES.workspaceRead.path]);
+    await expectResidentFiles(fixture);
+  });
+
+  it("preserves resident files when the selected encrypted snapshot is corrupted", async () => {
+    const fixture = await createFixture();
+    fixture.encryptedBytes[0] = fixture.encryptedBytes[0]! ^ 0xff;
+    const requests = serveSnapshot(fixture);
+    const preparation = await prepareHostedContainerWorkspaceRestore({
+      job: createJob(fixture, true),
+      signal: new AbortController().signal,
+    });
+
+    await expect(preparation.promise).rejects.toThrow(/authenticate data/u);
+    expect(requests.some((request) => request.url === fixture.getUrl)).toBe(true);
+    await expectResidentFiles(fixture);
+  });
+});
+
+async function expectResidentFiles(fixture: Fixture): Promise<void> {
+  expect(await readFile(path.join(fixture.vaultRoot, "note.md"), "utf8"))
+    .toBe(RESIDENT_NOTE);
+  expect(await readFile(path.join(fixture.vaultRoot, "resident-only.md"), "utf8"))
+    .toBe(RESIDENT_NOTE);
+}
+
+type Fixture = Awaited<ReturnType<typeof createFixture>>;
+
+async function createFixture() {
+  const temporaryRoot = await mkdtemp(path.join(tmpdir(), "container-restore-proof-"));
+  temporaryRoots.push(temporaryRoot);
+  const userId = `member_restore_${randomUUID()}`;
+  const vaultRoot = resolveHostedRunnerWarmWorkspaceVaultRoot(userId);
+  temporaryRoots.push(path.dirname(path.dirname(vaultRoot)));
+  await mkdir(vaultRoot, { recursive: true });
+  await writeFile(path.join(vaultRoot, "note.md"), RESIDENT_NOTE);
+  await writeFile(path.join(vaultRoot, "resident-only.md"), RESIDENT_NOTE);
+  const durableRoot = path.join(temporaryRoot, "source");
+  const sourceVaultRoot = path.join(durableRoot, "vault");
+  const operatorHomeRoot = path.join(durableRoot, "operator-home");
+  await mkdir(sourceVaultRoot, { recursive: true });
+  await mkdir(operatorHomeRoot, { recursive: true });
+  await writeFile(path.join(sourceVaultRoot, "note.md"), SNAPSHOT_NOTE);
+  const snapshotId = "snapshot_container_restore";
+  const objectKey = await hostedWorkspaceSnapshotObjectKey({ snapshotId, userId });
+  const aad = buildHostedWorkspaceSnapshotV2Aad({ objectKey, snapshotId, userId });
+  const dataKey = encodeHostedWorkspaceSnapshotV2DataKey(
+    Uint8Array.from({ length: 32 }, (_, index) => index + 1),
+  );
+  const archivePlan = await collectHostedWorkspaceSnapshotArchivePlan({
+    durableRoot,
+    operatorHomeRoot,
+    vaultRoot: sourceVaultRoot,
+  });
+  const encrypted = await createEncryptedWorkspaceSnapshotFile({
+    aad,
+    archiveEntries: archivePlan.entries,
+    dataKey,
+    durableRoot,
+    ivBase64: Buffer.from(Uint8Array.from({ length: 12 }, (_, index) => index + 10))
+      .toString("base64url"),
+    maxEncryptedBytes: 16 * 1024 * 1024,
+    outputDir: path.join(temporaryRoot, "scratch"),
+  });
+  const ref: HostedWorkspaceSnapshotV2Ref = {
+    archive: {
+      compression: encrypted.compression,
+      encryptedByteSize: encrypted.encryptedByteSize,
+      encryptedObjectSha256: encrypted.encryptedObjectSha256,
+      fileCount: encrypted.fileCount,
+      format: "tar",
+      plaintextArchiveSha256: encrypted.plaintextArchiveSha256,
+      totalPlainBytes: encrypted.totalPlainBytes,
+    },
+    createdAt: NOW,
+    encryption: {
+      aad,
+      ivBase64: encrypted.ivBase64,
+      rootKeyId: "root_key_restore_test",
+      scheme: HOSTED_WORKSPACE_SNAPSHOT_ENCRYPTION_SCHEME,
+      wrappedDataKey: "wrapped_data_key_test",
+    },
+    objectKey,
+    schema: HOSTED_WORKSPACE_SNAPSHOT_REF_SCHEMA,
+    snapshotId,
+    upload: HOSTED_WORKSPACE_SNAPSHOT_UPLOAD_KIND,
+    userId,
+  };
+  const workspace: HostedWorkspaceState = {
+    checkpointedAt: NOW,
+    createdAt: NOW,
+    snapshotRef: ref,
+    updatedAt: NOW,
+    userId,
+    version: "12",
+  };
+  const issuedAt = new Date().toISOString().replace(/[:-]/gu, "").replace(/\.\d{3}Z$/u, "Z");
+  const getUrl = `https://r2.example.test/restore.enc?X-Amz-Date=${issuedAt}&X-Amz-Expires=3600`;
+  return {
+    dataKey,
+    encryptedBytes: new Uint8Array(await readFile(encrypted.encryptedFilePath)),
+    getUrl,
+    ref,
     vaultRoot,
+    workspace,
   };
 }
 
-function createJob(): HostedExecutionWorkspaceInvocationJobInput {
+function createJob(fixture: Fixture, prepared: boolean): HostedExecutionWorkspaceInvocationJobInput {
   return {
     kind: "workspace-invocation",
-    preparedSnapshotRestore: {
-      dataKey: "snapshot-data-key",
-      getUrl: "https://snapshot.example.test/prepared",
-      snapshotFingerprint: "a".repeat(64),
-    },
+    ...(prepared ? {
+      preparedSnapshotRestore: {
+        dataKey: fixture.dataKey,
+        getUrl: fixture.getUrl,
+        snapshotFingerprint: buildHostedWorkspaceSnapshotV2FingerprintSha256(fixture.ref),
+      },
+    } : {}),
     request: {
       attemptId: "attempt_restore_preparation",
       leaseGeneration: "7",
-      providerEgressToken: "provider-egress-token",
-      userId: "member_restore_preparation",
-      workspaceVersion: "12",
+      providerEgressToken: "synthetic-provider-egress-token",
+      userId: fixture.workspace.userId,
+      workspaceVersion: fixture.workspace.version,
     },
-    runtime: {
-      commitTimeoutMs: 4_321,
-    },
+    runtime: { commitTimeoutMs: 4_321 },
   };
 }
 
-describe("container workspace restore preparation", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.prepareVaultRoot.mockResolvedValue(
-      "/tmp/murph-restore-preparation/durable/vault",
-    );
-    mocks.readCommitTimeoutMs.mockReturnValue(4_321);
-    mocks.resolveTransport.mockReturnValue({ mode: "proxy" });
-    mocks.createInternalFetch.mockReturnValue(fetch);
-    mocks.createTrustedInternalFetch.mockReturnValue(fetch);
-    mocks.createArtifactStore.mockReturnValue({ get: vi.fn(), put: vi.fn() });
-    mocks.createLogPort.mockReturnValue({ write: vi.fn() });
-    mocks.createWorkspacePort.mockReturnValue({ checkpoint: vi.fn(), read: vi.fn() });
-    mocks.createSnapshotPort.mockReturnValue({ restoreWorkspaceSnapshot: vi.fn() });
+function serveSnapshot(fixture: Fixture, workspace = fixture.workspace): Request[] {
+  const requests: Request[] = [];
+  const workspaceUrl = new URL(
+    HOSTED_RUNNER_WEB_CONTROL_ROUTES.workspaceRead.path,
+    CLOUDFLARE_HOSTED_RUNTIME_BASE_URLS.webControlPlane,
+  ).href;
+  const snapshotBase = `${CLOUDFLARE_HOSTED_RUNTIME_BASE_URLS.workspaceSnapshotStore}/workspace-snapshots/${fixture.ref.snapshotId}`;
+  vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init);
+    requests.push(request);
+    if (request.url === workspaceUrl) {
+      return Response.json({ fetchedAt: NOW, workspace });
+    }
+    if (request.url === `${snapshotBase}/data-key/unwrap`) {
+      return Response.json({ dataKey: fixture.dataKey });
+    }
+    if (request.url === `${snapshotBase}/presign-get`) {
+      return Response.json({
+        expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+        getUrl: fixture.getUrl,
+      });
+    }
+    if (request.url === fixture.getUrl) {
+      return new Response(fixture.encryptedBytes);
+    }
+    throw new Error("Unexpected request during container restore proof.");
   });
-
-  it("starts the authoritative package preparation with one fenced restore platform", async () => {
-    const job = createJob();
-    const signal = new AbortController().signal;
-    const preparation = createPreparation(
-      "/tmp/murph-restore-preparation/durable/vault",
-    );
-    mocks.startPreparation.mockReturnValue(preparation);
-
-    await expect(prepareHostedContainerWorkspaceRestore({
-      job,
-      signal,
-    })).resolves.toBe(preparation);
-
-    expect(mocks.prepareVaultRoot).toHaveBeenCalledOnce();
-    expect(mocks.prepareVaultRoot).toHaveBeenCalledWith(job.request.userId);
-    expect(mocks.readCommitTimeoutMs).toHaveBeenCalledWith(4_321);
-    expect(mocks.startPreparation).toHaveBeenCalledOnce();
-    expect(mocks.startPreparation).toHaveBeenCalledWith({
-      job,
-      platform: {
-        artifactStore: mocks.createArtifactStore.mock.results[0]?.value,
-        logPort: mocks.createLogPort.mock.results[0]?.value,
-        workspacePort: mocks.createWorkspacePort.mock.results[0]?.value,
-        workspaceSnapshotPort: mocks.createSnapshotPort.mock.results[0]?.value,
-      },
-      signal,
-      vaultRoot: preparation.vaultRoot,
-    });
-
-    const workspacePortInput = mocks.createWorkspacePort.mock.calls[0]?.[0];
-    expect(
-      workspacePortInput.workspaceCheckpointBridge.readCurrentLease(),
-    ).toEqual({
-      attemptId: job.request.attemptId,
-      leaseGeneration: job.request.leaseGeneration,
-      providerEgressToken: job.request.providerEgressToken,
-      userId: job.request.userId,
-      workspaceVersion: job.request.workspaceVersion,
-    });
-    expect(mocks.createSnapshotPort).toHaveBeenCalledWith(expect.objectContaining({
-      preparedSnapshotRestore: job.preparedSnapshotRestore,
-      workspaceCheckpointBridge: workspacePortInput.workspaceCheckpointBridge,
-    }));
-  });
-});
+  return requests;
+}


### PR DESCRIPTION
## Why and outcome

Container restore preparation was tested through nine module mocks, so its single wiring assertion could pass without restoring any workspace bytes. Replace it with five cases that run the actual container preparation, workspace transport, package restore owner, and encrypted archive restoration into temporary directories.

Prepared and fallback restores now prove file replacement and private permissions. Admission rejection and corrupted ciphertext prove resident files survive failure; captured HTTP requests prove exact lease headers and that provider authority does not reach R2.

## Product UX

- Effort: Not applicable — internal test replacement only.
- Result: Not applicable.
- Walkthrough: No member-facing behavior changes; production restore code is unchanged.

## Evidence

- Direct: Real tar/zstd/encryption roundtrips through `prepareHostedContainerWorkspaceRestore`, with only HTTP responses supplied by the test. Prepared restore avoids unwrap/presign requests; fallback restore carries the bound member, attempt, generation, and workspace version. Restored vault, assistant state, and operator home directories are private. Wrong member/version admission and AES-GCM authentication failure preserve resident contents.
- Coverage: The package suite retains lazy loading, abort propagation, and exact single-consumption adoption. Existing snapshot preparation tests retain expiry, fingerprint, retry-budget, and parallel fallback coverage.
- Passed: `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage --silent=true apps/cloudflare/test/container-workspace-restore-preparation.test.ts apps/cloudflare/test/workspace-snapshot-restore-preparation.test.ts` — 2 files, 15 tests.
- Passed: `pnpm exec vitest run --config packages/assistant-runtime/vitest.config.ts --no-coverage --silent=true packages/assistant-runtime/test/hosted-workspace-restore-preparation.test.ts` — 1 file, 3 tests.
- Passed: `pnpm --dir apps/cloudflare typecheck`, `pnpm complexity:diff`, and `git diff --check`.
- Parent candidate review passed. Final ReviewGPT is exempt under the completion workflow for this test-only proof replacement. Required CI passed on the final authored head; no live Cloudflare or production operation was performed.

## Non-obvious affected surfaces

None. The test composes existing package entrypoints without changing production owners.

## Architecture and reuse

- Existing systems reused: Container restore preparation, workspace lease transport, encrypted snapshot writer/reader, archive planner, existing Vitest lane, and temporary filesystem.
- New logic: Five test scenarios replace one mocked wiring test; no product logic.
- New abstractions: No shared abstraction; local fixture and HTTP-response helpers keep the synthetic setup in its existing test file.
- Complexity intentionally avoided: No framework, dependency, production seam, service, state owner, or duplicate restoration implementation.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`; the guard excludes test-only changes and reports no authored source changes.
- Hotspots: No changed production functions; no source hotspots reported.
- Agent judgment: The additional fixture code earns direct persistence and authority proof. Keeping the helper local avoids cross-suite coupling; no further abstraction is justified.

## Hot reply path impact

- Path status: Not applicable — production restore and foreground code are unchanged.
- Database calls: None added or moved.
- Network/provider calls: None added or moved in production.
- Other awaited latency: None added or moved in production.
- Before/after proof: The diff changes one test file only.

## Murph initial provider input impact

Not applicable for individual or group runtimes: no prompt, tool, schema, or provider-input code changes.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: This test replacement does not change production code, configuration, runtime protocols, or deploy boundaries.

## Change-shape breakdown

Classification rule: The only changed path is an authored test under `apps/cloudflare/test`; no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 262 | 141 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **262** | **141** |

## Changelog

- Changelog: not applicable
- Reason: Internal test quality improvement with no member-visible behavior change.
