### PR TITLE
perf(device-sync): eliminate redundant source admission reads

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1856,6 +1856,11 @@ Last verified: 2026-09-04
   new successors never write the envelope or consult its completed-resource
   names. Every partial continuation preserves `lastSyncCompletedAt`; only
   terminal current full work may advance it.
+- Junction summary and workout import preparation share their fresh post-provider
+  source read with historical evidence evaluation through pure admission helpers.
+  Empty historical segments retain their post-fetch authority without a second
+  read; actual canonical imports still recheck authority afterward. Reads are
+  never reused across provider fetches, stream candidates, or job executions.
 - Junction workout streams stay inside that existing resource/day continuation
   owner. Before the workout index, the existing control-plane current-import
   admission predicate intersects with the current Junction provider inventory

--- a/agent-docs/exec-plans/completed/2026-09-05-reduce-sync-reads.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-reduce-sync-reads.md
@@ -1,0 +1,72 @@
+# Reduce redundant device-sync source reads
+
+Status: completed
+Created: 2026-09-05
+Updated: 2026-09-05
+
+## Outcome and invariants
+
+Reduce Vercel callbacks by eliminating repeated Junction source reads within a
+single uninterrupted admission decision. Preserve fresh authority after provider
+fetches and canonical imports, disconnect/reconnect fences, exact coverage and
+retry behavior, and hosted/local source semantics.
+
+## Owner and evidence
+
+The Junction provider composes source admission and canonical import. Its hosted
+source reader calls the existing signed device-sync snapshot route. Source-scoped
+summary and workout admission perform duplicate reads, while empty historical
+segments repeat their post-fetch read without an intervening asynchronous effect.
+Ordinary timeseries already reuse a source read and need no new cache.
+
+## Design
+
+Pass one current source set explicitly to pure admission helpers. Re-read after
+an actual canonical import; retain the first post-provider read for empty results.
+Keep authoritative state in the current Web/local store owners. Add no persisted
+state, TTL, dependency, protocol field, timer, or cross-job cache. Wire formats
+remain unchanged, so old and new Web/Worker combinations remain compatible.
+
+## Tasks
+
+1. Add focused call-count and authority-boundary regressions and prove baseline failure.
+2. Remove duplicate reads at the provider composition sites.
+3. Run focused provider regressions, package typecheck, complexity and parent review.
+4. Record measured synthetic reductions and remaining deployment validation; commit.
+
+## Verification
+
+Synthetic provider jobs exercise empty/populated historical segments, source-scoped
+summaries and workouts, source failures, disconnect/reconnect during provider and
+import work, and repeat jobs. Existing ordinary-timeseries reuse and historical
+coverage regressions remain green. Production savings require deploying the runner
+and comparing the snapshot route's traffic under comparable sync load.
+
+## Progress
+
+- Removed redundant reads from source-scoped summary/workout admission and empty
+  historical segments. The shared live reader preserves hosted/local fallback;
+  historical evidence evaluation now requires explicit source input and is pure.
+- Synthetic baseline comparison: six regressions fail against the original source
+  because of duplicate reads; the same cases pass with the change. Summary reads
+  fall from two to one, first scoped workout admission from two to one, and empty
+  historical post-fetch reads from two to one. Populated historical segments retain
+  both their pre-import and post-import reads.
+- Replaced a read-ordinal-based epoch test with provider-boundary-driven state
+  changes. The existing post-canonical-import epoch test remains passing.
+- Final focused verification: 339 tests passed across admission source reads,
+  blood-pressure backfill, ordinary timeseries source reuse, provider backfill,
+  workout streams, history, history recovery, and provider resources.
+- `pnpm --dir packages/device-syncd typecheck` passed.
+- `pnpm complexity:diff --base HEAD` passed against the unchanged base: debt
+  406 to 406 and maximum complexity 145 to 145. Reviewed changed executeJob,
+  importTimeseriesPreciseSnapshots, importTimeseriesResourceSnapshot and workout
+  composition; the existing large resource executor is unchanged.
+- Parent review and `git diff --check` passed. No dependencies, schema, protocol,
+  scheduling, prompts, tools, or public behavior changed. Changelog is not
+  applicable: this is internal callback work reduction without a new member-facing
+  contract. No new repository-actionable Frog friction was encountered.
+- Production deployment is separate. The runner bundle must be deployed before
+  savings occur; compare snapshot requests and CPU under comparable workload.
+  PR-level external review and exact-head CI are tracked by the PR lifecycle.
+Completed: 2026-09-05

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -1646,40 +1646,47 @@ export function createJunctionDeviceSyncProvider(
         );
     const {
       providerRecordsSeen: historicalSummaryHasFetchedRecords,
-      snapshots: summaries,
+      snapshots: historicalSummaries,
     } = summaryFetchResult;
-    const sourceScopedHistoricalSummaryHasRecords =
-      job.kind === "backfill" && sourceProviderSlug
-        ? await hasJunctionSourceScopedAdmittedSnapshotRecords({
-            context,
-            snapshots: summaries,
-            sourceProviderSlug,
-            sourceProviders,
-          })
-        : false;
     const profileSummaryResult = summaryPhaseComplete
       ? { checked: false, records: [] }
       : await fetchProfileSummaryOnce(context, skippedOptionalResources);
     const profileMetadataPatch = profileSummaryResult.checked
       ? buildJunctionProfileSummaryCheckedMetadataPatch(context)
       : {};
-    if (profileSummaryResult.records.length > 0) {
-      summaries[JUNCTION_PROFILE_SUMMARY_RESOURCE] = profileSummaryResult.records;
-    }
+    const summaries = profileSummaryResult.records.length > 0
+      ? { ...historicalSummaries, [JUNCTION_PROFILE_SUMMARY_RESOURCE]: profileSummaryResult.records }
+      : historicalSummaries;
     const summaryHasFetchedRecords = hasJunctionSnapshotRecords(summaries);
-    const preparedSummaryImport =
-      job.kind === "backfill"
+    const yieldedEmptyBackfill = job.kind === "backfill"
       && !summaryHasFetchedRecords
-      && context.shouldYield?.() === true
+      && context.shouldYield?.() === true;
+    const historicalSummarySource = job.kind === "backfill" ? sourceProviderSlug : null;
+    const currentSummarySources = !yieldedEmptyBackfill || historicalSummarySource
+      ? await readJunctionImportSources(context)
+      : context.account.sources ?? [];
+    const sourceScopedHistoricalSummaryHasRecords =
+      historicalSummarySource
+        ? hasJunctionSourceScopedAdmittedSnapshotRecords({
+            listedSources: currentSummarySources,
+            snapshots: historicalSummaries,
+            sourceProviderSlug: historicalSummarySource,
+            sourceProviders,
+          })
+        : false;
+    const preparedSummaryImport =
+      yieldedEmptyBackfill
         ? prepareJunctionImportSnapshotForSources(
             summaries,
             sourceProviders,
             context.account.sources ?? [],
           )
-        : await prepareJunctionImportSnapshot(
-            context,
+        : prepareJunctionImportSnapshotForSources(
             summaries,
             sourceProviders,
+            currentSummarySources,
+            {},
+            { allowUnlistedSources: context.connectionSourceAdmissionMode !== "listed_only" },
           );
     const importConnections = preparedSummaryImport.connections;
     const importSummaries = preparedSummaryImport.snapshots;
@@ -4389,10 +4396,7 @@ export function createJunctionDeviceSyncProvider(
       applyFetchedProviderRecordEvidence(fetchedProviderRecordIdentityEvidence);
 
       try {
-        const currentSources: readonly JunctionImportAdmissionSource[] =
-          context.listConnectionSources
-            ? await context.listConnectionSources()
-            : context.account.sources ?? [];
+        const currentSources = await readJunctionImportSources(context);
         const importSourceIdentities = resolveJunctionAccountSourceIdentities(currentSources);
         if (
           sourceProviderSlug
@@ -4493,16 +4497,18 @@ export function createJunctionDeviceSyncProvider(
               canonicalEventCount >= providerRecordCount ? 0 : providerRecordCount;
             unresolvedProviderRecordsWithoutStableIdentity = unresolvedProviderRecordCount > 0;
           }
-        }
-        if (
-          sourceProviderSlug
-          && options.sourceStatusRequirement === "connected"
-        ) {
-          postFetchSourceAdmission = await resolveJunctionCurrentSourceAdmission(
-            context,
-            sourceProviderSlug,
-            options.sourceLifecycleEpoch,
-          );
+          // Import introduces another asynchronous boundary; empty segments
+          // retain the post-fetch read instead of fetching it twice.
+          if (
+            sourceProviderSlug
+            && options.sourceStatusRequirement === "connected"
+          ) {
+            postFetchSourceAdmission = await resolveJunctionCurrentSourceAdmission(
+              context,
+              sourceProviderSlug,
+              options.sourceLifecycleEpoch,
+            );
+          }
         }
       } catch (error) {
         if (
@@ -5135,9 +5141,8 @@ export function createJunctionDeviceSyncProvider(
       };
     }
 
-    const currentSources = input.context.listConnectionSources
-      && (sourceLifecycleFence || records.length > 0 || input.authorizedLocalDay)
-      ? await input.context.listConnectionSources()
+    const currentSources = sourceLifecycleFence || records.length > 0 || input.authorizedLocalDay
+      ? await readJunctionImportSources(input.context)
       : input.context.account.sources ?? [];
     if (
       sourceLifecycleFence
@@ -5154,8 +5159,7 @@ export function createJunctionDeviceSyncProvider(
     }
 
     const sourceScopedHistoricalRecordsSeen = input.sourceProviderSlug
-      ? await hasJunctionSourceScopedAdmittedSnapshotRecords({
-          context: input.context,
+      ? hasJunctionSourceScopedAdmittedSnapshotRecords({
           listedSources: currentSources,
           options: { projectAccountSourceIdentities: calendarDayAggregate },
           snapshots: { [input.resource]: records },
@@ -5422,18 +5426,21 @@ export function createJunctionDeviceSyncProvider(
         const sourceScopedFeature = input.sourceProviderSlug
           ? withJunctionSourceProviderFallback(feature, input.sourceProviderSlug)
           : feature;
+        const currentSources = await readJunctionImportSources(input.context);
         historicalRecordsSeen ||= input.sourceProviderSlug
-          ? await hasJunctionSourceScopedAdmittedSnapshotRecords({
-              context: input.context,
+          ? hasJunctionSourceScopedAdmittedSnapshotRecords({
+              listedSources: currentSources,
               snapshots: { workout_stream: [sourceScopedFeature] },
               sourceProviderSlug: input.sourceProviderSlug,
               sourceProviders: input.sourceProviders,
             })
           : false;
-        const preparedImport = await prepareJunctionImportSnapshot(
-          input.context,
+        const preparedImport = prepareJunctionImportSnapshotForSources(
           { workout_stream: [sourceScopedFeature] },
           input.sourceProviders,
+          currentSources,
+          {},
+          { allowUnlistedSources: input.context.connectionSourceAdmissionMode !== "listed_only" },
         );
         if (hasJunctionSnapshotRecords(preparedImport.snapshots)) {
           await commitPreparedJunctionCanonicalImport(
@@ -8157,6 +8164,14 @@ function sanitizeJunctionImportConnections(
   });
 }
 
+async function readJunctionImportSources(
+  context: ProviderJobContext,
+): Promise<readonly JunctionImportAdmissionSource[]> {
+  return context.listConnectionSources
+    ? await context.listConnectionSources()
+    : context.account.sources ?? [];
+}
+
 async function prepareJunctionImportSnapshot(
   context: ProviderJobContext,
   snapshots: Record<string, unknown[]>,
@@ -8164,10 +8179,7 @@ async function prepareJunctionImportSnapshot(
   options: JunctionImportSnapshotSanitizeOptions = {},
   sourceStatusRequirement: JunctionImportSourceStatusRequirement = "not_disconnected",
 ): Promise<PreparedJunctionImportSnapshot> {
-  const currentSources: readonly JunctionImportAdmissionSource[] =
-    context.listConnectionSources
-      ? await context.listConnectionSources()
-      : context.account.sources ?? [];
+  const currentSources = await readJunctionImportSources(context);
   const sourceIdentities = options.projectAccountSourceIdentities
     ? mergeJunctionAccountSourceIdentities(
         resolveJunctionAccountSourceIdentities(currentSources),
@@ -8187,21 +8199,14 @@ async function prepareJunctionImportSnapshot(
   );
 }
 
-async function hasJunctionSourceScopedAdmittedSnapshotRecords(input: {
-  context: ProviderJobContext;
-  listedSources?: readonly JunctionImportAdmissionSource[];
+function hasJunctionSourceScopedAdmittedSnapshotRecords(input: {
+  listedSources: readonly JunctionImportAdmissionSource[];
   options?: JunctionImportSnapshotSanitizeOptions;
   snapshots: Record<string, unknown[]>;
   sourceProviderSlug: string;
   sourceProviders: readonly JunctionProviderConnection[];
-}): Promise<boolean> {
-  const listedSources: readonly JunctionImportAdmissionSource[] = input.listedSources
-    ?? (input.context.listConnectionSources
-      ? await input.context.listConnectionSources({
-          sourceProviderSlug: input.sourceProviderSlug,
-        })
-      : input.context.account.sources ?? []);
-  const sourceAuthorities = listedSources.filter((source) =>
+}): boolean {
+  const sourceAuthorities = input.listedSources.filter((source) =>
     areJunctionProviderSlugsDataEquivalent(
       source.sourceProviderSlug,
       input.sourceProviderSlug,

--- a/packages/device-syncd/test/junction-admission-source-reads.test.ts
+++ b/packages/device-syncd/test/junction-admission-source-reads.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  createAccount,
+  createConnectionSource,
+  createJob,
+  createJunctionJobContext,
+  createJunctionProvider,
+  createJunctionWorkoutStreamJobContext,
+  createJunctionWorkoutStreamResourceJob,
+  createJunctionWorkoutStreamSource,
+  createJunctionWorkoutStreamTestProvider,
+  executeJunctionJob,
+} from "./junction-provider.harness.ts";
+import { createJsonResponse, readUrl } from "./helpers.ts";
+
+test.each(["connected", "disconnected", "unavailable", "local"] as const)(
+  "summary evidence and import share post-provider sources (%s)", async (scenario) => {
+    const source = createConnectionSource();
+    let liveSource = source;
+    let profileFetched = false;
+    const events: string[] = [];
+    const imported: string[] = [];
+    const failure = new Error("Synthetic source read failure");
+    const provider = createJunctionProvider(async (input) => {
+      const pathname = new URL(readUrl(input)).pathname;
+      if (pathname === "/v2/user/providers/junction-user-1") {
+        return createJsonResponse({ providers: [{
+          id: "provider-garmin-1", slug: "garmin", status: "connected",
+          resource_availability: { activity: true },
+        }] });
+      }
+      if (pathname === "/v2/summary/activity/junction-user-1") {
+        events.push("summary");
+        return createJsonResponse({ data: [{
+          id: "activity-read-reuse", connectionId: "provider-garmin-1", steps: 4321,
+        }] });
+      }
+      assert.equal(pathname, "/v2/summary/profile/junction-user-1");
+      events.push("profile");
+      profileFetched = true;
+      if (scenario === "disconnected") {
+        liveSource = createConnectionSource({ status: "disconnected" });
+      }
+      return createJsonResponse({ data: [] });
+    }, { summaryResources: ["activity", "profile"], timeseriesResources: [] });
+    const context = createJunctionJobContext({
+      account: createAccount({ sources: [{ ...source, resourceCount: 1 }] }),
+      connectionSourceAdmissionMode: "listed_only",
+      listConnectionSources: scenario === "local" ? undefined : async () => {
+        if (events.length > 0) events.push("sources");
+        if (profileFetched && scenario === "unavailable") throw failure;
+        return [liveSource];
+      },
+      importSnapshot: async (snapshot) => {
+        events.push("import");
+        imported.push(JSON.stringify(snapshot));
+        return { imported: true };
+      },
+    });
+    const run = () => executeJunctionJob(provider, context, createJob("backfill", {
+      sourceProviderSlug: "garmin",
+      windowStart: "2026-04-02T00:00:00.000Z",
+      windowEnd: "2026-04-03T00:00:00.000Z",
+    }));
+    if (scenario === "unavailable") {
+      await assert.rejects(run, (error) => error === failure);
+      assert.deepEqual(events, ["summary", "profile", "sources"]);
+      assert.equal(imported.length, 0);
+      return;
+    }
+    await run();
+    assert.deepEqual(events.slice(0, events.indexOf("import") + 1), scenario === "local"
+      ? ["summary", "profile", "import"]
+      : ["summary", "profile", "sources", "import"]);
+    assert.equal(imported.some((snapshot) => snapshot.includes('"steps":4321')),
+      scenario !== "disconnected");
+  },
+);
+
+test.each([false, true])("workout admission reuses each fresh stream read (disconnect: %s)", async (disconnect) => {
+  const events: string[] = [];
+  let streamCount = 0;
+  const source = createJunctionWorkoutStreamSource();
+  let liveSource = source;
+  const harness = createJunctionWorkoutStreamTestProvider({
+    listWorkoutIds: () => ["workout-first", "workout-second"],
+    streamResponse: () => {
+      events.push("stream");
+      streamCount += 1;
+      if (disconnect && streamCount === 2) {
+        liveSource = { ...source, status: "disconnected" };
+      }
+      return createJsonResponse({
+        time: [1_775_131_200, 1_775_133_000],
+        heartrate: [100, 160], distance: [0, 5_000],
+      });
+    },
+  });
+  await executeJunctionJob(harness.provider, createJunctionWorkoutStreamJobContext({
+    listConnectionSources: async () => {
+      if (streamCount > 0) events.push("sources");
+      return [liveSource];
+    },
+    importSnapshot: async () => {
+      events.push("import");
+      return { imported: true };
+    },
+  }), createJunctionWorkoutStreamResourceJob({ sourceProviderSlug: "garmin" }));
+
+  assert.deepEqual(events, [
+    "stream", "sources", "import", "stream", "sources", ...(disconnect ? [] : ["import"]),
+  ]);
+});

--- a/packages/device-syncd/test/junction-blood-pressure-backfill.test.ts
+++ b/packages/device-syncd/test/junction-blood-pressure-backfill.test.ts
@@ -2182,13 +2182,11 @@ test("maximum-cardinality schedule-time history queries 396 keys once and offers
 });
 
 test.each([
-  ["before provider discovery", 1, 0, 0, 0],
-  ["after provider discovery", 3, 1, 0, 0],
-  ["after timeseries fetch", 4, 1, 1, 0],
-  ["after snapshot preparation", 5, 1, 1, 0],
+  ["before provider discovery", 0, 0, 0],
+  ["after provider discovery", 1, 0, 0],
+  ["after timeseries fetch", 1, 1, 0],
 ] as const)("an old source epoch is fenced %s", async (
-  _label,
-  supersedeAtRead,
+  boundary,
   expectedProviderListRequests,
   expectedTimeseriesRequests,
   expectedImportCalls,
@@ -2235,7 +2233,6 @@ test.each([
     ).jobs,
     "caffeine",
   );
-  let sourceReads = 0;
   const result = await requireValue(provider.jobExecutor).executeJob(
     createJobContext({
       account: createAccount({ sources: [epochOneSource] }),
@@ -2244,11 +2241,13 @@ test.each([
         return importWithRealJunctionNormalizer(snapshot);
       },
       listConnectionSources: async () => {
-        sourceReads += 1;
-        return sourceReads >= supersedeAtRead ? [epochTwoSource] : [epochOneSource];
+        const superseded = boundary === "before provider discovery"
+          || (boundary === "after provider discovery" && providerListRequests.count > 0)
+          || (boundary === "after timeseries fetch" && requests.length > 0);
+        return superseded ? [epochTwoSource] : [epochOneSource];
       },
     }),
-    toJobRecord(job, 200 + supersedeAtRead),
+    toJobRecord(job, 200),
   );
 
   assert.equal(result.metadataPatch, undefined);
@@ -4199,6 +4198,45 @@ test("retryable post-fetch failures preserve raw evidence and replay the anchore
       boundary,
     );
   }
+});
+
+test.each([false, true])("historical source reads follow actual import work (records: %s)", async (hasRecords) => {
+  const requests: TimeseriesRequest[] = [];
+  const provider = createProvider({
+    bloodPressureRecords: hasRecords ? [{
+      id: "bp-source-read-bound",
+      timestamp: "2026-05-12T08:30:00.000Z",
+      systolic: 120,
+      diastolic: 78,
+    }] : [],
+    requests,
+  });
+  const scheduled = createScheduledBloodPressureJob(provider);
+  const source = createSourceSummary("omron");
+  const events: string[] = [];
+  const context = createJobContext({
+    listConnectionSources: async () => {
+      if (requests.length > 0) events.push("sources");
+      return [source];
+    },
+    importSnapshot: async (snapshot) => {
+      events.push("import");
+      return importWithRealJunctionNormalizer(snapshot);
+    },
+  });
+  const result = await requireValue(provider.jobExecutor).executeJob(context, toJobRecord({
+    ...scheduled,
+    payload: {
+      ...scheduled.payload,
+      historicalWindowStart: "2026-05-12T00:00:00.000Z",
+      windowStart: "2026-05-12T00:00:00.000Z",
+      windowEnd: "2026-05-13T00:00:00.000Z",
+    },
+  }, 144));
+
+  assert.deepEqual(events, hasRecords ? ["sources", "import", "sources"] : ["sources"]);
+  assert.equal(requests.filter((request) => request.resource === "blood_pressure").length, 1);
+  assert.equal(result.scheduledJobs?.length ?? 0, hasRecords ? 0 : 1);
 });
 
 test("an empty successful segment retries when its post-fetch source reread fails", async () => {


### PR DESCRIPTION
## Why and outcome

Junction source-scoped summaries and workout streams repeated live source reads
for historical evidence and import preparation. Empty historical segments also
repeated their post-fetch read without an intervening import. In hosted execution,
each read invokes the signed Web device-sync snapshot endpoint.

Share one fresh source set within each admission decision and re-read after an
actual canonical import. The historical evidence helper is now pure; a small
private reader centralizes the existing hosted/local fallback. There is no cache,
new state, or change to sync cadence.

## Product UX

- Effort: Not applicable — internal callback reduction; no user-facing behavior changes.
- Result: Ready — focused provider scenarios preserve imports, source fences and recovery.
- Walkthrough: Connected, disconnected, unavailable and local source paths; disconnect during profile/stream fetch; empty and populated history; reconnect during provider fetch and after canonical import.

## Evidence

- Direct: Six new call/order regressions fail against the base source and pass with the implementation. Summary admission reads drop 2→1; the first source-scoped workout import drops 2→1; empty historical post-fetch reads drop 2→1. Populated history retains both pre-import and post-import reads.
- Coverage: 339 tests passed across the eight files below. Existing history coverage, retry, disconnect, reconnect, local fallback and ordinary timeseries reuse remain covered.

```sh
pnpm --dir packages/device-syncd exec vitest run --config vitest.config.ts --no-coverage \
  test/junction-admission-source-reads.test.ts \
  test/junction-blood-pressure-backfill.test.ts \
  test/junction-timeseries-source-reuse.test.ts \
  test/junction-provider-backfill.test.ts \
  test/junction-provider-workout-stream.test.ts \
  test/junction-provider-history.test.ts \
  test/junction-provider-history-recovery.test.ts \
  test/junction-provider-resources.test.ts
pnpm --dir packages/device-syncd typecheck
pnpm complexity:diff --base HEAD^
git diff --check HEAD^
```

Typecheck, complexity and diff checks passed. Final ReviewGPT round 1 passed
on `37f7b5752f27cae44d1014376b8d1ec754c20099`: zero findings and zero accepted
issues. The Mountain lane confirmed `gpt-6-pro`, the attached full snapshot and
exact response identity; capture took about 366 seconds. The review traced
summary/profile admission, each workout stream, empty/populated history, local
fallback and lifecycle fences. Its evidence is substantive and matches this
patch; the reviewer inspected tests but did not execute them. Source shape stayed
61 additions / 56 deletions, with no remediation or tooling retry needed.
All 33 reported CI checks passed on the reviewed head, including the release
gate, workspace build/typecheck, package coverage, Web tests/build, runner budget,
and Temporal compatibility. Current-base merge-tree validation passed. No
production deployment or savings measurement is claimed by these synthetic results.

## Non-obvious affected surfaces

Local device-sync uses the same provider: its account-source fallback remains
covered. The source-epoch regression now changes state at provider boundaries
rather than at an arbitrary read ordinal; the separate post-import epoch test
remains passing. Profile-only records stay excluded from historical summary
evidence as before.

## Architecture and reuse

- Existing systems reused: Signed hosted source reader, local account projection, pure import preparation, existing canonical import and lifecycle fences.
- New logic: Reuse one source result within the same admission decision; perform the second historical read only after an actual import.
- New abstractions: One private live-reader helper removes repeated hosted/local fallback branches. Historical evidence takes explicit source input instead of hiding network I/O.
- Complexity intentionally avoided: No TTL, cross-job cache, scheduler, background task, dependency, protocol or additional state owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base HEAD^`; debt 406→406, maximum 145→145.
- Hotspots: Reviewed affected executeJob (106), importTimeseriesPreciseSnapshots (42), importTimeseriesResourceSnapshot (27), and importJunctionWorkoutStreamWindow (32). The other existing hotspots, including executeResourceJob (145), are outside this correction.
- Agent judgment: Shared reads and pure evidence make I/O ownership explicit. Broader provider decomposition would expand scope without reducing the demonstrated callback duplication.

## Hot reply path impact

- Path status: Not applicable — changes are inside device-sync provider execution, not conversational admission or reply generation.
- Database calls: No new calls; hosted snapshot invocations decrease in the tested cases.
- Network/provider calls: No new calls or altered retry/timeout policy.
- Other awaited latency: No added external dependency; fresh reads remain at provider/import boundaries.
- Before/after proof: Call-count and ordering assertions above; unchanged canonical imports and lifecycle behavior.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no assembled instructions,
tools, generated guidance, or provider-visible input builders changed.
Measurement not run because this patch changes device-sync I/O composition only.

ReviewGPT first-reviewed head: 37f7b5752f27cae44d1014376b8d1ec754c20099
ReviewGPT context sensitivity: sensitive
Classification reason: Hosted source-authority checks are composed around health-data imports.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing snapshot request/response and canonical state formats are unchanged; both runner versions use the same Web contract.
- Safe order: Deploy the runner bundle through its existing release path; no coordinated Web or database rollout is required.
- Rollback floor: No new floor or persisted format is introduced; existing platform floors still apply.
- Expected exposure: Old warm runners keep existing request volume until replaced.
- Reversibility: Reverting the runner code restores the previous read counts without data migration.
- Convergence proof: Shared wire contracts are unchanged; local provider tests exercise both hosted-style live readers and local fallback. Deployed bundle convergence remains a release-time check.
- Post-deploy checks: Verify the deployed runner revision, compare snapshot calls/CPU under comparable sync load, and inspect bounded sync failure and completion aggregates.

## Change-shape breakdown

Classification rule: Production TypeScript is source, test paths are tests,
and owner/plan Markdown is docs. No binary, generated, dependency or config changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 61 | 56 |
| Tests / fixtures | 162 | 10 |
| Docs | 77 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **300** | **66** |

## Changelog

- Changelog: not applicable
- Reason: Internal callback work reduction without a new member-facing contract or measured user-visible performance promise.
