### PR TITLE
Fix clean Vercel builds for clinical retrieval tests

### DIFF
--- a/.agents/friction-log/20260905123708-web-clinical-retrieval/friction.md
+++ b/.agents/friction-log/20260905123708-web-clinical-retrieval/friction.md
@@ -1,0 +1,20 @@
+---
+title: 'Web clinical retrieval test requires unbuilt vault-usecases declarations'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+A clean Web production build and its focused clinical retrieval test resolve declared public workspace imports without unrelated package build artifacts.
+
+## Current Behavior
+
+The clinical retrieval test imports the public vault-usecases clinical-records entrypoint, but Web overrides the root TypeScript paths without mapping this entrypoint. Its shared Vitest source resolver also omits the entrypoint. A production build fails with TS2307 unless vault-usecases declaration output already exists.
+
+## Minimal Reproducible Example
+
+In a fresh checkout, install the frozen lockfile, prepare the Web generated prerequisites, and run `pnpm --dir apps/web typecheck:prepared` without building vault-usecases. The clinical retrieval test cannot resolve its public import.
+
+## Context
+
+The missing source mappings allow cached or broad workspace builds to hide a clean Web build failure. The task adds only the required public entrypoint to the existing Web TypeScript and shared test resolver configurations.

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -234,6 +234,9 @@
       "@murphai/query/browser-replica-server": [
         "../../packages/query/src/browser-replica-server.ts"
       ],
+      "@murphai/vault-usecases/clinical-records": [
+        "../../packages/vault-usecases/src/clinical-records.ts"
+      ],
       "@murphai/core": [
         "../../packages/core/src/index.ts"
       ],

--- a/config/workspace-source-resolution.ts
+++ b/config/workspace-source-resolution.ts
@@ -19,6 +19,7 @@ export const HOSTED_WEB_WORKSPACE_SOURCE_ENTRY_RELATIVE_PATHS = {
   "@murphai/messaging-ingress": "../../packages/messaging-ingress/package.json",
   "@murphai/runtime-state": "../../packages/runtime-state/src/index.ts",
   "@murphai/query": "../../packages/query/src/index.ts",
+  "@murphai/vault-usecases": "../../packages/vault-usecases/src/index.ts",
   "@murphai/core": "../../packages/core/src/index.ts",
   "@murphai/importers": "../../packages/importers/src/index.ts",
   "@murphai/inboxd": "../../packages/inboxd/src/index.ts",


### PR DESCRIPTION
## Why and outcome

Clean Vercel production builds fail during Web typechecking because the clinical retrieval test imports `@murphai/vault-usecases/clinical-records`, but Web's source mappings omit that public entrypoint. Broad workspace builds can hide the failure by leaving compiled declarations behind.

Add the explicit TypeScript entrypoint and register vault-usecases with the existing public-export source resolver. Clean typechecking and the composed clinical retrieval test now succeed without building vault-usecases first.

## Product UX

- Effort: Not applicable; build and test module resolution only.
- Result: Ready.
- Walkthrough: Existing clinical retrieval behavior and test coverage are preserved.

## Evidence

- Direct: Reproduced the original TS2307 locally using the unchanged base configuration with no vault-usecases dist directory; the corrected Web configuration passes.
- `DATABASE_URL=<synthetic-local-database> pnpm --dir apps/web typecheck`: passed; final `typecheck:prepared` also passed.
- `pnpm exec vitest run --config apps/web/vitest.config.ts apps/web/test/clinical-records-retrieval.test.ts --no-coverage`: 48 passed.
- `pnpm test:repo-tools scripts/workspace-source-resolution.test.ts`: 8 passed.
- `pnpm exec vitest run --config apps/web/vitest.config.ts apps/web/test/next-config.test.ts apps/web/test/next-config-workflow.test.ts --no-coverage`: 53 passed.
- `pnpm complexity:diff` and `git diff --check`: passed.
- Coverage: Fresh frozen-lockfile installation, generated Web prerequisites, existing composed retrieval proof, shared resolver tests, and Next configuration tests exercise the failure and adjacent configuration consumers. Production migrations and secret-dependent preflights were not run locally. Required CI and the managed production build remain release gates.

## Non-obvious affected surfaces

The existing shared source registry also supplies Next transpile package names and repository-tool test aliases; focused configuration and resolver tests pass.

## Architecture and reuse

- Existing systems reused: Web TypeScript paths and the public-export workspace source resolver.
- New logic: None; four configuration lines register the existing package and public entrypoint.
- New abstractions: None; existing resolver ownership is sufficient.
- Complexity intentionally avoided: No extra package build step, wildcard source mapping, dependency, or suppressed typecheck.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`.
- Hotspots: None above 20; maximum remains 11 and debt remains zero.
- Agent judgment: The smallest correction is explicit source registration at the existing configuration owners.

## Hot reply path impact

Not applicable; no runtime handler or awaited operation changes.

## Murph initial provider input impact

Not applicable for individual or group Murph; no prompts, tools, schemas, or provider-visible input changes.

## Deployment concerns

- Deployment: not applicable
- Reason: Module resolution for an existing test is corrected; no runtime protocol, persisted shape, migration, or external authority changes. Verify the next managed Vercel production candidate completes successfully after merge.

## Change-shape breakdown

Classification rule: TypeScript/JSON resolution configuration is config/tooling; the public-safe Frog report is documentation. No binary or generated artifacts.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 0 | 0 |
| Docs | 20 | 0 |
| Config / tooling | 4 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **24** | **0** |

## Changelog

- Changelog: not applicable
- Reason: Internal build recovery only; no member-visible behavior changes.
