### PR TITLE
Fix clean Web builds for clinical retrieval tests

### DIFF
--- a/.agents/friction-log/20260904202051-fresh-worktree-web/friction.md
+++ b/.agents/friction-log/20260904202051-fresh-worktree-web/friction.md
@@ -23,3 +23,7 @@ In a fresh repository checkout, run `pnpm install --frozen-lockfile`, then `pnpm
 ## Context
 
 Focused connected-app tests pass, but the missing unrelated declaration blocks the full Web typecheck for a narrow assistant background-work change.
+
+## Related entrypoint
+
+The same missing source-mapping prerequisite also affected the declared `@murphai/vault-usecases/clinical-records` entrypoint used by the clinical retrieval test. Add that entrypoint to the existing Web TypeScript paths so a fresh Web build does not depend on a prior vault-usecases package build.

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -36,6 +36,9 @@
       "@murphai/clinical-records/retrieval-limits": [
         "../../packages/clinical-records/src/retrieval-limits.ts"
       ],
+      "@murphai/vault-usecases/clinical-records": [
+        "../../packages/vault-usecases/src/clinical-records.ts"
+      ],
       "@murphai/contracts": [
         "../../packages/contracts/src/index.ts"
       ],


### PR DESCRIPTION
## Why and outcome

A clinical retrieval test imports a declared vault-usecases subpath that Web TypeScript did not map to source. Fresh Web builds therefore failed with TS2307 unless that package had already been built. Add the missing entry to the existing TypeScript paths so clean builds resolve the same public export.

## Product UX

- Effort: Internal build repair.
- Result: Ready. No member-facing behavior or interface changes.

## Evidence

- Fresh frozen workspace install; no prebuilt clinical-records declaration artifact.
- The original paths reproduce TS2307 for the clinical retrieval test through the real Web TypeScript runner.
- `pnpm --dir apps/web typecheck`: pass with the mapping.
- `pnpm --dir apps/web test:prepared -- test/clinical-records-retrieval.test.ts`: 48 passed.
- Diff and privacy review: pass. All required CI and the current full public release verification passed on `717a70c6a2da2c6c87fc9fc0d533d88210382d11`, including Web production build, typecheck, all four Web test shards, and package coverage.

## Non-obvious affected surfaces

The existing clinical retrieval integration test remains in Web typechecking. Its runtime import already resolves through the existing Vitest package-export aliases.

## Architecture and reuse

- Existing systems reused: Web TypeScript paths and the package-declared clinical-records export.
- New logic: None; the existing TypeScript resolver receives one missing declared entrypoint mapping.
- New abstractions: None; the existing Web tsconfig paths remain the source-resolution owner.
- Complexity intentionally avoided: No preparatory package build, test exclusion, dependency, or resolver mechanism.

## Complexity impact

- Guard: Not applicable; JSON configuration and explanatory Markdown only.
- Hotspots: No authored JS/TS changes.
- Agent judgment: One missing entry in the existing source mapping is the smallest correction.

## Hot reply path impact

- Path status: Untouched. The new mapping serves a test import; no production caller, database operation, provider request, or awaited runtime work changes.

## Murph initial provider input impact

Unchanged for both individual and group runtimes. No prompts, tools, schemas, or provider input assembly changes.

## Deployment concerns

- Deployment: not applicable
- Reason: Build-time resolution of an existing test import only. No runtime protocol, deployed configuration, environment variable, or schema changes.

## Change-shape breakdown

Classification: JSON paths are config/tooling; the existing Frog entry update is explanatory documentation. No binaries.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 0 | 0 |
| Docs | 4 | 0 |
| Config / tooling | 3 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **7** | **0** |

## Changelog

- Changelog: not applicable
- Reason: Internal build repair; member-facing behavior is unchanged.

## Review

Parent review verified the public export, missing clean-build artifact, existing Vitest resolution, and before/after Web typecheck. Final ReviewGPT is not required for this low-risk test-build mapping and explanatory documentation change. The related fresh-checkout prerequisite is recorded in the existing Frog entry rather than a duplicate report.
