### PR TITLE
Fix hosted checkpoint test hangs and stale integration fixtures

### DIFF
--- a/.agents/friction-log/20260905134910-hosted-integration-fixtures/friction.md
+++ b/.agents/friction-log/20260905134910-hosted-integration-fixtures/friction.md
@@ -11,10 +11,12 @@ Hosted integration proof should synchronize on an actual production lock and acc
 
 The Linq-first concurrency fixture waits indefinitely for a routing upsert when the seeded home route is unchanged and production correctly skips that write. The foreground replacement fixture assumes every new fence consumes a pristine slot, even when the same member retains a native-warm target.
 
+The checkpoint barrier also creates its deferred promise in an idle control Durable Object. After that context hibernates, workerd cancels its continuations even though release succeeds and a separate runner is still waiting. The regular Workers test pool masks this by forcing `no_handle_cross_request_promise_resolution`.
+
 ## Minimal Reproducible Example
 
 Run the four Telegram/Linq planner concurrency cases with PostgreSQL and the foreground-reply-priority hosted scenario after unified runner allocation.
 
 ## Context
 
-Synchronize the Linq-first fixture after the real member-row lock and before mailbox writes. Preserve the exact new fence, canonical progress, delivery, and untouched pristine inventory assertions. Add test-only checkpoint release/resume metadata for the separate Environment handoff timeout; its reply requirement remains unchanged.
+Synchronize the Linq-first fixture after the real member-row lock and before mailbox writes. Preserve the exact new fence, canonical progress, delivery, and untouched pristine inventory assertions. Create checkpoint waits in each live waiting request, and use an ordinary local Worker to prove they resume after the control object hibernates. The signed reply requirement remains unchanged.

--- a/.agents/friction-log/20260905134910-hosted-integration-fixtures/friction.md
+++ b/.agents/friction-log/20260905134910-hosted-integration-fixtures/friction.md
@@ -1,0 +1,20 @@
+---
+title: 'Hosted integration fixtures wait for omitted writes and ignore retained warmth'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Hosted integration proof should synchronize on an actual production lock and accept the supported same-member warm-target lifecycle while enforcing exact replacement fences.
+
+## Current Behavior
+
+The Linq-first concurrency fixture waits indefinitely for a routing upsert when the seeded home route is unchanged and production correctly skips that write. The foreground replacement fixture assumes every new fence consumes a pristine slot, even when the same member retains a native-warm target.
+
+## Minimal Reproducible Example
+
+Run the four Telegram/Linq planner concurrency cases with PostgreSQL and the foreground-reply-priority hosted scenario after unified runner allocation.
+
+## Context
+
+Synchronize the Linq-first fixture after the real member-row lock and before mailbox writes. Preserve the exact new fence, canonical progress, delivery, and untouched pristine inventory assertions. Add test-only checkpoint release/resume metadata for the separate Environment handoff timeout; its reply requirement remains unchanged.

--- a/agent-docs/exec-plans/completed/2026-09-05-checkpoint-barrier-context.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-checkpoint-barrier-context.md
@@ -1,0 +1,30 @@
+# Keep checkpoint barriers in the waiting request context
+
+Status: completed
+Created: 2026-09-05
+Updated: 2026-09-05
+
+## Goal and cause
+
+Fix the demonstrated test-only checkpoint hang that prevents unified runner integration and rollout proof. The barrier created its deferred promise in an idle control Durable Object. After that context hibernated, workerd canceled its continuations even though release succeeded and a separate runner remained busy.
+
+## Implementation
+
+Each waiting checkpoint request now creates its own wait. Shared test state contains a released flag and callbacks owned by those live requests. Release resumes all registered waiters. The original abort check, explicit-release semantics, real checkpoint handler, and foreground reply requirement remain intact. No production compatibility flag or runtime behavior changes.
+
+The normal Workers Vitest pool forces `no_handle_cross_request_promise_resolution`, so it cannot reproduce this behavior. The new regression launches an ordinary local Worker with the existing Wrangler dependency, imports the actual barrier implementation, and lets the separate control object pass the native hibernation window while two checkpoint requests remain active. The fixture rejects unexpected external-state access and uses no remote bindings or credentials.
+
+## Verification
+
+- Before the fix, the ordinary Worker regression failed: release returned true but the real checkpoint request did not resume.
+- After the fix, the regression passed, including two waiting requests after a 22-second control-owner idle interval.
+- All 24 existing hosted-local test-container control tests passed.
+- Cloudflare typecheck passed. The earlier Web typecheck and four PostgreSQL concurrency cases cover the unchanged companion fixture corrections in this PR.
+- Docs drift, complexity, and diff checks passed before final commit; source maximum remains below the hotspot threshold.
+
+## Review and remaining rollout gate
+
+Parent review verified that promises originate in the waiting request, releases are synchronous and exhaustive, and release-before-wait and the existing abort check remain valid. Final ReviewGPT is exempt for this test-only fixture/tooling change. The original control-object promise failure was demonstrated in real workerd, rather than inferred from mocks.
+
+Update PR #2963 and rerun exact-head public CI. After merge, rerun private integration, then merge the companion and complete the authorized protected production rollout. This plan records the completed test fix and does not claim deployment or full Linux integration success.
+Completed: 2026-09-05

--- a/agent-docs/exec-plans/completed/2026-09-05-hosted-integration-handoff-proof.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-hosted-integration-handoff-proof.md
@@ -1,0 +1,30 @@
+# Restore hosted integration fixture and handoff diagnostics
+
+Status: completed
+Created: 2026-09-05
+Updated: 2026-09-05
+
+## Goal and scope
+
+Correct demonstrated hosted integration fixture mismatches and expose checkpoint barrier progress so the remaining Environment handoff timeout can be diagnosed. This follow-up is part of the authorized unified runner merge and deployment; it does not complete the rollout.
+
+## Changes
+
+- Synchronize the Linq-first concurrency fixture after the real member-row lock and before mailbox writes. Unchanged home routing correctly skips its upsert.
+- Accept an exact replacement fence using either the same member-bound native-warm target or an observed pristine slot. Retained warmth must leave both observed pristine slots ready.
+- Emit test-only checkpoint release/resume metadata, including whether the paused request was aborted. The signed foreground reply, canonical progress, and checkpoint ownership assertions remain unchanged.
+
+## Verification
+
+- Four PostgreSQL Telegram/Linq planner concurrency cases passed on a separate local test database.
+- All 24 hosted-local test-container control tests passed.
+- Cloudflare typecheck and Web prepared typecheck passed.
+- Docs drift, complexity, and diff checks passed; source complexity maximum remains 15 with no hotspots above 20.
+- Local container E2E cannot start because the native init requires an unavailable platform capability. Linux integration remains necessary; this follow-up does not claim to fix or pass the Environment reply timeout.
+
+## Review and remaining rollout gate
+
+Parent review traced the real route-lock and retained-target owners. Final ReviewGPT is exempt under the low-risk tests/tooling route; only the test-only container subclass module gains metadata. No production auth, runtime, schema, configuration, or provider behavior changes.
+
+After this PR merges, rerun the private integration against the updated public revision, resolve any demonstrated timeout cause, then merge the companion and use the protected production deployment workflow. Production settings have not been changed by this task.
+Completed: 2026-09-05

--- a/apps/cloudflare/src/hosted-local-test/runner-container.ts
+++ b/apps/cloudflare/src/hosted-local-test/runner-container.ts
@@ -426,6 +426,13 @@ export function releaseShutdownCheckpointPublicationBarrier(userId: string): boo
 
   shutdownCheckpointPublicationBarriers.delete(normalizedUserId);
   barrier.release();
+  emitHostedExecutionStructuredLog({
+    component: "runner",
+    details: { barrierKind: barrier.target, checkpointBarrierStage: "released" },
+    message: "Hosted-local test released checkpoint publication.",
+    phase: "checkpoint",
+    userId: normalizedUserId,
+  });
   return true;
 }
 
@@ -459,6 +466,17 @@ export function wrapShutdownCheckpointPublicationBarrierForTest(
       userId,
     });
     await barrier.released;
+    emitHostedExecutionStructuredLog({
+      component: "runner",
+      details: {
+        barrierKind: barrier.target,
+        checkpointBarrierStage: "resumed",
+        requestAborted: request.signal.aborted,
+      },
+      message: "Hosted-local checkpoint request resumed after its test barrier.",
+      phase: "checkpoint",
+      userId,
+    });
     if (request.signal.aborted) {
       throw request.signal.reason instanceof Error
         ? request.signal.reason

--- a/apps/cloudflare/src/hosted-local-test/runner-container.ts
+++ b/apps/cloudflare/src/hosted-local-test/runner-container.ts
@@ -258,8 +258,8 @@ export type HostedLocalShutdownCheckpointPublicationBarrierState =
 interface HostedLocalShutdownCheckpointPublicationBarrier {
   entered: boolean;
   target: "canonical_runtime_commit" | "idle_shutdown" | "snapshot_start";
-  release(): void;
-  released: Promise<void>;
+  releaseWaiters: Array<() => void>;
+  released: boolean;
 }
 
 const shutdownCheckpointPublicationBarriers =
@@ -393,15 +393,11 @@ function armCheckpointPublicationBarrier(
     );
   }
 
-  let release = () => {};
-  const released = new Promise<void>((resolve) => {
-    release = resolve;
-  });
   shutdownCheckpointPublicationBarriers.set(normalizedUserId, {
     entered: false,
     target,
-    release,
-    released,
+    releaseWaiters: [],
+    released: false,
   });
 }
 
@@ -425,7 +421,8 @@ export function releaseShutdownCheckpointPublicationBarrier(userId: string): boo
   }
 
   shutdownCheckpointPublicationBarriers.delete(normalizedUserId);
-  barrier.release();
+  barrier.released = true;
+  for (const release of barrier.releaseWaiters.splice(0)) release();
   emitHostedExecutionStructuredLog({
     component: "runner",
     details: { barrierKind: barrier.target, checkpointBarrierStage: "released" },
@@ -465,7 +462,13 @@ export function wrapShutdownCheckpointPublicationBarrierForTest(
       phase: "checkpoint",
       userId,
     });
-    await barrier.released;
+    // The idle control object can hibernate while this request stays active.
+    // A promise created when arming belongs to that discarded request context;
+    // create each wait here so workerd can resume the live checkpoint owner.
+    await new Promise<void>((resolve) => {
+      if (barrier.released) resolve();
+      else barrier.releaseWaiters.push(resolve);
+    });
     emitHostedExecutionStructuredLog({
       component: "runner",
       details: {

--- a/apps/cloudflare/test/checkpoint-barrier-context.test.ts
+++ b/apps/cloudflare/test/checkpoint-barrier-context.test.ts
@@ -1,0 +1,46 @@
+import { fileURLToPath } from "node:url";
+import { expect, it, vi } from "vitest";
+import { unstable_dev } from "wrangler";
+
+it("resumes a checkpoint after its separate barrier-control object hibernates", async () => {
+  // The Workers Vitest pool forces no_handle_cross_request_promise_resolution.
+  // Use an ordinary local Worker so this regression keeps production semantics.
+  const worker = await unstable_dev(fileURLToPath(new URL("./fixtures/checkpoint-barrier-worker.ts", import.meta.url)), {
+    config: fileURLToPath(new URL("./fixtures/checkpoint-barrier.wrangler.json", import.meta.url)),
+    envFiles: [],
+    ip: "127.0.0.1",
+    port: 0,
+    inspectorPort: 0,
+    local: true,
+    persist: false,
+    logLevel: "none",
+    experimental: {
+      disableDevRegistry: true,
+      disableExperimentalWarning: true,
+      enableContainers: false,
+      forceLocal: true,
+      testMode: true,
+      watch: false,
+    },
+  });
+  try {
+    expect(await (await worker.fetch("/arm?target=control")).text()).toBe("armed");
+    const publications = Promise.all([
+      worker.fetch("/wait?target=opaque").then((response) => response.text()),
+      worker.fetch("/wait?target=opaque").then((response) => response.text()),
+    ]);
+    await vi.waitFor(async () => {
+      expect(await (await worker.fetch("/status?target=opaque")).text()).toBe("entered");
+    });
+    // Keep the real waiting checkpoint alive while its separate control object
+    // passes the native hibernation window without requests or keepalives.
+    await new Promise<void>((resolve) => setTimeout(resolve, 22_000));
+    expect(await (await worker.fetch("/release?target=control")).text()).toBe("true");
+    await expect(Promise.race([
+      publications,
+      new Promise<string[]>((resolve) => setTimeout(() => resolve(["checkpoint did not resume"]), 1_000)),
+    ])).resolves.toEqual(["checkpoint resumed", "checkpoint resumed"]);
+  } finally {
+    await worker.stop();
+  }
+});

--- a/apps/cloudflare/test/fixtures/checkpoint-barrier-worker.ts
+++ b/apps/cloudflare/test/fixtures/checkpoint-barrier-worker.ts
@@ -1,0 +1,54 @@
+import { DurableObject } from "cloudflare:workers";
+import {
+  armIdleSnapshotStartBarrier,
+  readShutdownCheckpointPublicationBarrierState,
+  releaseShutdownCheckpointPublicationBarrier,
+  wrapShutdownCheckpointPublicationBarrierForTest,
+} from "../../src/hosted-local-test/runner-container.ts";
+import { HOSTED_RUNNER_BOUND_USER_ID_HEADER } from "../../src/runner-outbound/headers.ts";
+
+interface BarrierEnvironment {
+  BARRIER: DurableObjectNamespace<CheckpointBarrier>;
+}
+
+export class CheckpointBarrier extends DurableObject<BarrierEnvironment> {
+  async fetch(request: Request): Promise<Response> {
+    const action = new URL(request.url).pathname;
+    const userId = "member_checkpoint_context";
+    if (action === "/arm") {
+      armIdleSnapshotStartBarrier(userId);
+      return new Response("armed");
+    }
+    if (action === "/release") {
+      return new Response(String(releaseShutdownCheckpointPublicationBarrier(userId)));
+    }
+    if (action === "/status") {
+      return new Response(readShutdownCheckpointPublicationBarrierState(userId));
+    }
+    const handler = wrapShutdownCheckpointPublicationBarrierForTest(
+      async () => new Response("checkpoint resumed"),
+    );
+    return await handler(new Request("https://snapshot.test/workspace-snapshots/start", {
+      headers: { [HOSTED_RUNNER_BOUND_USER_ID_HEADER]: userId },
+      method: "POST",
+    }), {
+      BUNDLES: {
+        get: rejectUnexpectedStateAccess,
+        put: rejectUnexpectedStateAccess,
+        delete: rejectUnexpectedStateAccess,
+      },
+      USER_RUNNER: { getByName: rejectUnexpectedStateAccess },
+    }, {});
+  }
+}
+
+export default {
+  async fetch(request: Request, env: BarrierEnvironment): Promise<Response> {
+    const target = new URL(request.url).searchParams.get("target") ?? "control";
+    return await env.BARRIER.getByName(target).fetch(request);
+  },
+};
+
+function rejectUnexpectedStateAccess(): never {
+  throw new Error("Barrier proof must not access external state.");
+}

--- a/apps/cloudflare/test/fixtures/checkpoint-barrier.wrangler.json
+++ b/apps/cloudflare/test/fixtures/checkpoint-barrier.wrangler.json
@@ -1,0 +1,27 @@
+{
+  "name": "checkpoint-barrier-context-test",
+  "main": "./checkpoint-barrier-worker.ts",
+  "compatibility_date": "2026-03-27",
+  "compatibility_flags": [
+    "nodejs_compat"
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "BARRIER",
+        "class_name": "CheckpointBarrier"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": [
+        "CheckpointBarrier"
+      ]
+    }
+  ],
+  "vars": {
+    "MURPH_HOSTED_EXECUTION_STDIO_LOGS": "0"
+  }
+}

--- a/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
@@ -345,10 +345,9 @@ describe.sequential("hosted local foreground reply priority e2e", () => {
         systemAttemptId: systemFence.attemptId,
         userId: systemMailboxProbe.userId,
       });
-      // Releasing the background owner lets it finish and shut down before the
-      // foreground provider starts on the claimed standby. The provider-start
-      // callback therefore uses durable handoff evidence below instead of
-      // reaching back into volatile instrumentation on the retired owner.
+      // The foreground starts under a new fence after the background owner
+      // settles. It may retain the same member-bound warm target or claim an
+      // observed pristine slot; durable handoff evidence covers either path.
       await expect(releaseForegroundPriorityOrderingBarrier({
         scenario: requireScenario(),
         userId: systemMailboxProbe.userId,
@@ -369,12 +368,13 @@ describe.sequential("hosted local foreground reply priority e2e", () => {
       expect(providerStart.activeFence.attemptId).not.toBe(
         systemFence.attemptId,
       );
-      expect(readyStandbySlotNames).toContain(
+      expect([systemFence.runnerContainerName, ...readyStandbySlotNames]).toContain(
         providerStart.activeFence.runnerContainerName,
       );
-      expect(providerStart.activeFence.runnerContainerName).not.toBe(
-        systemFence.runnerContainerName,
-      );
+      if (providerStart.activeFence.runnerContainerName === systemFence.runnerContainerName) {
+        await expect(waitForReadyStandbySlots(readyStandbySlotNames)).resolves
+          .toEqual(expect.arrayContaining(readyStandbySlotNames));
+      }
       if (!providerStart.systemLane) {
         throw new Error(await requireScenario().buildFailureMessage(
           systemMailboxProbe.userId,

--- a/apps/web/test/hosted-onboarding-linq-home-routing-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-home-routing-postgres.test.ts
@@ -2058,8 +2058,8 @@ describe.skipIf(!runPostgresConcurrencyProof)(
 
         const telegramRouteUpserted = createDeferred();
         const releaseTelegramUpsert = createDeferred();
-        const linqRouteUpsertReached = createDeferred();
-        const releaseLinqUpsert = createDeferred();
+        const linqRouteLockAcquired = createDeferred();
+        const releaseLinqRouteLock = createDeferred();
         const activationUpdated = createDeferred();
         const releaseActivation = createDeferred();
         const telegramPid = createDeferred<number>();
@@ -2080,14 +2080,18 @@ describe.skipIf(!runPostgresConcurrencyProof)(
         });
         const linqClient = linqBase.$extends({
           query: {
-            hostedMemberRouting: {
-              async upsert({ args, query }) {
-                if (startOrder === "linq-first") {
-                  linqRouteUpsertReached.resolve();
-                  await releaseLinqUpsert.promise;
-                }
-                return query(args);
-              },
+            async $queryRaw({ args, query }) {
+              const result = await query(args);
+              // An unchanged home route skips its upsert. Hold the actual
+              // member-row lock before the planner reaches mailbox writes.
+              if (
+                startOrder === "linq-first"
+                && args.sql.includes("FOR NO KEY UPDATE")
+              ) {
+                linqRouteLockAcquired.resolve();
+                await releaseLinqRouteLock.promise;
+              }
+              return result;
             },
           },
         });
@@ -2140,7 +2144,7 @@ describe.skipIf(!runPostgresConcurrencyProof)(
           const runLinq = () => {
             linqTransaction = linqClient.$transaction(async (tx) => {
               // Keep production planners on their ordinary transaction type;
-              // the extension changes only this test's routing-upsert timing.
+              // the extension changes only this test's route-lock timing.
               const prisma = tx as Prisma.TransactionClient;
               linqPid.resolve(await readBackendPid(prisma));
               const plan = await planHostedOnboardingLinqWebhook({
@@ -2183,7 +2187,7 @@ describe.skipIf(!runPostgresConcurrencyProof)(
               });
               releaseActivation.resolve();
               await activationTransaction;
-              await linqRouteUpsertReached.promise;
+              await linqRouteLockAcquired.promise;
             }
           }
 
@@ -2201,14 +2205,14 @@ describe.skipIf(!runPostgresConcurrencyProof)(
           } else {
             if (memberState === "active") {
               runLinq();
-              await linqRouteUpsertReached.promise;
+              await linqRouteLockAcquired.promise;
             }
             runTelegram();
             await waitForBlockedBackend({
               observer,
               pid: await telegramPid.promise,
             });
-            releaseLinqUpsert.resolve();
+            releaseLinqRouteLock.resolve();
           }
 
           await expect(
@@ -2249,7 +2253,7 @@ describe.skipIf(!runPostgresConcurrencyProof)(
           });
         } finally {
           releaseTelegramUpsert.resolve();
-          releaseLinqUpsert.resolve();
+          releaseLinqRouteLock.resolve();
           releaseActivation.resolve();
           await Promise.allSettled([
             activationTransaction,


### PR DESCRIPTION
## Why and outcome

The Environment handoff E2E hangs after releasing its checkpoint barrier: the promise was created in a separate idle Durable Object whose request context has hibernated. Create each wait in the live checkpoint request so explicit release resumes all waiting requests. A regression imports the actual barrier into an ordinary local Worker, because the normal Workers test pool disables the compatibility behavior that exposed the bug.

Also repair two demonstrated fixture mismatches: synchronize Linq-first concurrency on the real member-row lock rather than an omitted unchanged-route upsert, and accept the supported same-member warm target under an exact replacement fence while preserving untouched pristine inventory.

## Product UX

- Effort: Not applicable; test fixtures and test-only barrier coordination.
- Result: Not applicable.
- Walkthrough: Signed reply, canonical progress, ownership, and background exclusion requirements remain in place.

## Evidence

- Direct: Four PostgreSQL Telegram/Linq planner concurrency cases passed, including both previously timing-out Linq-first cases, on a separate local test database. Command: `MURPH_TEST_POSTGRES_CONCURRENCY=1 pnpm exec vitest run --config apps/web/vitest.workspace.ts --project hosted-web-onboarding-integrations --maxWorkers=1 --no-file-parallelism --no-coverage apps/web/test/hosted-onboarding-linq-home-routing-postgres.test.ts -t 'keeps .*planner mailbox writes deadlock-free'` with a local `DATABASE_URL`.
- Coverage: 24 hosted-local test-container controls passed with `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage --maxWorkers=1 --no-file-parallelism apps/cloudflare/test/hosted-local-test-runner-container.test.ts`.
- `pnpm --dir apps/cloudflare typecheck`, `pnpm --dir apps/web typecheck:prepared`, `pnpm docs:drift`, `pnpm complexity:diff`, and `git diff --check` passed.
- Before/after: the ordinary local Worker regression failed before the barrier fix (release returned true but the checkpoint did not resume). After the fix it passed with two requests resuming after the separate control object was idle for 22 seconds. Command: `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage --maxWorkers=1 --no-file-parallelism apps/cloudflare/test/checkpoint-barrier-context.test.ts`.
- Local full container E2E is unavailable because native init requires an unsupported platform capability. Canonical Linux integration remains the rollout gate. The regression uses no remote bindings, credentials, container engine, or compatibility opt-out.
- Final ReviewGPT: exempt under completion workflow's low-risk tests/tooling route. The only source edit changes test-only barrier coordination and metadata. Parent review traced the real route-lock, replacement-fence, retained-target, and request-context owners; production runtime behavior is unchanged.
- Exact-head public CI: [Murph Host Support](https://github.com/cobuildwithus/murph/actions/runs/33983382517) passed on `5ed514298bb9684af393c54843294b2fbfa72626`, including the real Worker regression. Web shard 2/4 passed on retry after Docker Hub rate-limited its initial database image pull before tests. Billing, hygiene, viewport, cardinality, and Temporal compatibility checks also passed.

## Non-obvious affected surfaces

None in production; the changed container module belongs to hosted-local test composition.

## Architecture and reuse

- Existing systems reused: Prisma query extension, real member-row lock, retained runner lifecycle, ready inventory, structured test logging, and the existing Wrangler dependency.
- New logic: Fixture synchronization after lock acquisition, exact retained-or-pristine target proof, and checkpoint waits owned by live requests with release/resume diagnostics.
- New abstractions: No new production abstraction; existing barrier state now holds per-request release callbacks. The ordinary Worker fixture rejects unexpected external-state access.
- Complexity intentionally avoided: No production changes, extra state owner, polling service, or dependency.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; source maximum 15 unchanged, debt 0.
- Hotspots: None above 20 in changed source.
- Agent judgment: The existing synchronization and diagnostics helpers keep this scoped; no further abstraction is justified.

## Hot reply path impact

- Path status: Not applicable; production reply behavior is unchanged.
- Database calls: None added in production.
- Network/provider calls: None added.
- Other awaited latency: Test-only lock and inventory observations.
- Before/after proof: Real concurrency cases pass; Linux handoff proof remains required.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no assembled instructions, tools, schemas, generated guidance, or other provider-visible input changed. Token measurement was not run because this PR changes test synchronization and diagnostics only.

## Deployment concerns

- Deployment: not applicable
- Reason: Test fixtures and test-only coordination do not change the production deployment contract. The broader unified fleet rollout still requires green private integration and its protected deployment gates.

## Change-shape breakdown

Classification rule: source path classified as Source despite test-only composition; test paths as Tests / fixtures; execution plans and friction record as Docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 31 | 10 |
| Tests / fixtures | 154 | 23 |
| Docs | 82 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **267** | **33** |

## Changelog

- Changelog: not applicable
- Reason: Internal test and diagnostic follow-up with no member-visible product change.
