### PR TITLE
Keep paused checkpoint test requests alive in outbound Workers

### DIFF
--- a/.agents/friction-log/20260905134910-hosted-integration-fixtures/friction.md
+++ b/.agents/friction-log/20260905134910-hosted-integration-fixtures/friction.md
@@ -20,3 +20,5 @@ Run the four Telegram/Linq planner concurrency cases with PostgreSQL and the for
 ## Context
 
 Synchronize the Linq-first fixture after the real member-row lock and before mailbox writes. Preserve the exact new fence, canonical progress, delivery, and untouched pristine inventory assertions. Create checkpoint waits in each live waiting request, and use an ordinary local Worker to prove they resume after the control object hibernates. The signed reply requirement remains unchanged.
+
+The ordinary Worker regression originally delegated every request to a Durable Object. That missed outbound Worker hung-request detection: a request-owned deferred promise without pending I/O is canceled immediately. Reproduce with the same actual barrier called directly by Worker fetch as well as by a Durable Object, then hold both beyond the control owner's hibernation window. A request-owned timer wait preserves liveness while the shared release flag retains explicit test control.

--- a/agent-docs/exec-plans/completed/2026-09-05-checkpoint-barrier-request-liveness.md
+++ b/agent-docs/exec-plans/completed/2026-09-05-checkpoint-barrier-request-liveness.md
@@ -1,0 +1,21 @@
+# Keep paused checkpoint requests alive in the outbound Worker
+
+Status: completed
+Created: 2026-09-05
+Updated: 2026-09-05
+
+## Goal and reproduced cause
+
+Unblock the authorized unified runner merge and protected rollout. The prior request-owned deferred promise fixed a hibernated control-object context, but the actual outbound Worker has no pending I/O while awaiting that promise. Workerd cancels the request as hung. An ordinary Wrangler regression reproduces the same error for two Worker requests while two Durable Object requests resume successfully.
+
+## Implementation
+
+Keep only the shared release flag. Each waiting checkpoint polls it using a short request-owned timer, preserving pending I/O and avoiding callbacks across request contexts. Exit on abort and keep the original abort rejection before the real checkpoint handler. Extend the existing real-workerd regression to cover both request contexts through the actual barrier implementation after the separate control object hibernates.
+
+## Verification and completion
+
+- Before: expanded real-workerd regression fails with hung-request errors for both Worker requests.
+- After: all four real-workerd requests resume; both focused files pass (25 tests). Cloudflare typecheck, docs drift, complexity and diff checks pass. Changed source has no hotspots above 20, maximum 15 unchanged.
+- Parent review: the existing barrier object remains captured across release/re-arm, all waits observe explicit release, aborted requests cannot publish, and each wait has only one pending timer with at most a 25 ms release-observation delay. Production imports remain excluded by existing controls. Final ReviewGPT is exempt for test-only tooling; no member-visible changelog applies.
+- Merge the test-only follow-up after exact-head CI, then rerun private integration before the companion merge and protected production rollout. No production deployment is claimed by this plan.
+Completed: 2026-09-05

--- a/apps/cloudflare/src/hosted-local-test/runner-container.ts
+++ b/apps/cloudflare/src/hosted-local-test/runner-container.ts
@@ -258,7 +258,6 @@ export type HostedLocalShutdownCheckpointPublicationBarrierState =
 interface HostedLocalShutdownCheckpointPublicationBarrier {
   entered: boolean;
   target: "canonical_runtime_commit" | "idle_shutdown" | "snapshot_start";
-  releaseWaiters: Array<() => void>;
   released: boolean;
 }
 
@@ -396,7 +395,6 @@ function armCheckpointPublicationBarrier(
   shutdownCheckpointPublicationBarriers.set(normalizedUserId, {
     entered: false,
     target,
-    releaseWaiters: [],
     released: false,
   });
 }
@@ -422,7 +420,6 @@ export function releaseShutdownCheckpointPublicationBarrier(userId: string): boo
 
   shutdownCheckpointPublicationBarriers.delete(normalizedUserId);
   barrier.released = true;
-  for (const release of barrier.releaseWaiters.splice(0)) release();
   emitHostedExecutionStructuredLog({
     component: "runner",
     details: { barrierKind: barrier.target, checkpointBarrierStage: "released" },
@@ -462,13 +459,12 @@ export function wrapShutdownCheckpointPublicationBarrierForTest(
       phase: "checkpoint",
       userId,
     });
-    // The idle control object can hibernate while this request stays active.
-    // A promise created when arming belongs to that discarded request context;
-    // create each wait here so workerd can resume the live checkpoint owner.
-    await new Promise<void>((resolve) => {
-      if (barrier.released) resolve();
-      else barrier.releaseWaiters.push(resolve);
-    });
+    // Outbound Worker requests need pending I/O to avoid workerd's hung-request
+    // cancellation. Create timers in this live request, never in the separate
+    // control object whose request context may have already hibernated.
+    while (!barrier.released && !request.signal.aborted) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 25));
+    }
     emitHostedExecutionStructuredLog({
       component: "runner",
       details: {

--- a/apps/cloudflare/test/checkpoint-barrier-context.test.ts
+++ b/apps/cloudflare/test/checkpoint-barrier-context.test.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from "node:url";
 import { expect, it, vi } from "vitest";
 import { unstable_dev } from "wrangler";
 
-it("resumes a checkpoint after its separate barrier-control object hibernates", async () => {
+it("resumes Worker and Durable Object checkpoints after their control object hibernates", async () => {
   // The Workers Vitest pool forces no_handle_cross_request_promise_resolution.
   // Use an ordinary local Worker so this regression keeps production semantics.
   const worker = await unstable_dev(fileURLToPath(new URL("./fixtures/checkpoint-barrier-worker.ts", import.meta.url)), {
@@ -27,7 +27,9 @@ it("resumes a checkpoint after its separate barrier-control object hibernates", 
     expect(await (await worker.fetch("/arm?target=control")).text()).toBe("armed");
     const publications = Promise.all([
       worker.fetch("/wait?target=opaque").then((response) => response.text()),
+      worker.fetch("/wait?target=worker").then((response) => response.text()),
       worker.fetch("/wait?target=opaque").then((response) => response.text()),
+      worker.fetch("/wait?target=worker").then((response) => response.text()),
     ]);
     await vi.waitFor(async () => {
       expect(await (await worker.fetch("/status?target=opaque")).text()).toBe("entered");
@@ -39,7 +41,7 @@ it("resumes a checkpoint after its separate barrier-control object hibernates", 
     await expect(Promise.race([
       publications,
       new Promise<string[]>((resolve) => setTimeout(() => resolve(["checkpoint did not resume"]), 1_000)),
-    ])).resolves.toEqual(["checkpoint resumed", "checkpoint resumed"]);
+    ])).resolves.toEqual(Array(4).fill("checkpoint resumed"));
   } finally {
     await worker.stop();
   }

--- a/apps/cloudflare/test/fixtures/checkpoint-barrier-worker.ts
+++ b/apps/cloudflare/test/fixtures/checkpoint-barrier-worker.ts
@@ -13,39 +13,45 @@ interface BarrierEnvironment {
 
 export class CheckpointBarrier extends DurableObject<BarrierEnvironment> {
   async fetch(request: Request): Promise<Response> {
-    const action = new URL(request.url).pathname;
-    const userId = "member_checkpoint_context";
-    if (action === "/arm") {
-      armIdleSnapshotStartBarrier(userId);
-      return new Response("armed");
-    }
-    if (action === "/release") {
-      return new Response(String(releaseShutdownCheckpointPublicationBarrier(userId)));
-    }
-    if (action === "/status") {
-      return new Response(readShutdownCheckpointPublicationBarrierState(userId));
-    }
-    const handler = wrapShutdownCheckpointPublicationBarrierForTest(
-      async () => new Response("checkpoint resumed"),
-    );
-    return await handler(new Request("https://snapshot.test/workspace-snapshots/start", {
-      headers: { [HOSTED_RUNNER_BOUND_USER_ID_HEADER]: userId },
-      method: "POST",
-    }), {
-      BUNDLES: {
-        get: rejectUnexpectedStateAccess,
-        put: rejectUnexpectedStateAccess,
-        delete: rejectUnexpectedStateAccess,
-      },
-      USER_RUNNER: { getByName: rejectUnexpectedStateAccess },
-    }, {});
+    return await handleBarrierRequest(request);
   }
+}
+
+async function handleBarrierRequest(request: Request): Promise<Response> {
+  const action = new URL(request.url).pathname;
+  const userId = "member_checkpoint_context";
+  if (action === "/arm") {
+    armIdleSnapshotStartBarrier(userId);
+    return new Response("armed");
+  }
+  if (action === "/release") {
+    return new Response(String(releaseShutdownCheckpointPublicationBarrier(userId)));
+  }
+  if (action === "/status") {
+    return new Response(readShutdownCheckpointPublicationBarrierState(userId));
+  }
+  const handler = wrapShutdownCheckpointPublicationBarrierForTest(
+    async () => new Response("checkpoint resumed"),
+  );
+  return await handler(new Request("https://snapshot.test/workspace-snapshots/start", {
+    headers: { [HOSTED_RUNNER_BOUND_USER_ID_HEADER]: userId },
+    method: "POST",
+  }), {
+    BUNDLES: {
+      get: rejectUnexpectedStateAccess,
+      put: rejectUnexpectedStateAccess,
+      delete: rejectUnexpectedStateAccess,
+    },
+    USER_RUNNER: { getByName: rejectUnexpectedStateAccess },
+  }, {});
 }
 
 export default {
   async fetch(request: Request, env: BarrierEnvironment): Promise<Response> {
     const target = new URL(request.url).searchParams.get("target") ?? "control";
-    return await env.BARRIER.getByName(target).fetch(request);
+    return target === "worker"
+      ? await handleBarrierRequest(request)
+      : await env.BARRIER.getByName(target).fetch(request);
   },
 };
 


### PR DESCRIPTION
## Why and outcome

Cloudflare cancels a paused test checkpoint in an outbound Worker because its deferred promise has no pending I/O. Use a short timer owned by the waiting request to observe explicit release, and remove cross-request callbacks. The ordinary Wrangler regression now exercises the actual barrier in both Worker and Durable Object requests after the separate control object hibernates.

## Product UX

- Effort: Not applicable; test-only checkpoint coordination.
- Result: Not applicable.
- Walkthrough: Real checkpoint publication, explicit release, and abort rejection remain required.

## Evidence

- Direct: Before the fix, the expanded ordinary-workerd regression reproduced hung-request cancellation for both Worker requests while both Durable Object requests resumed. After the fix, all four requests resumed after a 22-second idle interval for the control object.
- Coverage: `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage --maxWorkers=1 --no-file-parallelism apps/cloudflare/test/checkpoint-barrier-context.test.ts apps/cloudflare/test/hosted-local-test-runner-container.test.ts` passed: 25 tests in two files, including production-entrypoint exclusion and abort controls.
- `pnpm --dir apps/cloudflare typecheck`, `pnpm docs:drift`, `pnpm complexity:diff`, and `git diff --check` passed.
- Full Linux integration remains required before the private companion merge and protected rollout. Local full container E2E cannot start because the container init requires an unsupported platform capability; the direct workerd regression uses no container engine, remote bindings, credentials, or compatibility opt-out.
- Parent review verified captured barrier identity across release/re-arm, independent concurrent waits, bounded timer lifetime, and abort rejection before publication. Final ReviewGPT is exempt under the low-risk tests/tooling route. Exact-head [Murph Host Support CI](https://github.com/cobuildwithus/murph/actions/runs/33986086299) passed on `c39f0bfdc18ee9a46eea07703f503081ceb1a108`, including the expanded actual-workerd regression. All 32 PR checks passed.

## Non-obvious affected surfaces

None in production; the source module is confined to hosted-local test composition.

## Architecture and reuse

- Existing systems reused: Existing barrier release flag, outbound wrapper, and ordinary Wrangler regression.
- New logic: Poll the release flag with one 25 ms timer per held request; stop waiting on abort.
- New abstractions: None in production. A fixture helper allows the same actual barrier to run under Worker fetch and Durable Object fetch.
- Complexity intentionally avoided: Removed the callback registry and cross-request promise resolution; no new dependency or production compatibility setting.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; changed source maximum 15 unchanged, debt 0.
- Hotspots: None above 20 in changed source.
- Agent judgment: The existing release flag and request-owned timers replace more complex callback coordination; no further abstraction is justified.

## Hot reply path impact

- Path status: Not applicable; production reply behavior is unchanged.
- Database calls: None added.
- Network/provider calls: None added.
- Other awaited latency: At most a 25 ms timer interval to observe release in the test-only barrier, subject to runtime scheduling.
- Before/after proof: Actual workerd failure reproduced, then all four held requests resumed after the fix.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no assembled instructions, tools, schemas, generated guidance, or other provider-visible input changed. Token measurement was not run because this PR changes test synchronization only.

## Deployment concerns

- Deployment: not applicable
- Reason: Test-only coordination and fixtures do not change the production deployment contract. The broader unified fleet rollout still requires green private integration and protected deployment gates.

## Change-shape breakdown

Classification rule: Source paths remain Source despite test-only composition; test paths are Tests / fixtures; the execution plan and friction record are Docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 6 | 10 |
| Tests / fixtures | 37 | 29 |
| Docs | 23 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **66** | **39** |

## Changelog

- Changelog: not applicable
- Reason: Internal test harness correction with no member-visible product change.
