### PR TITLE
docs(test): explain DOM setup before component imports

### DIFF
--- a/apps/web/test/render-client-component.tsx
+++ b/apps/web/test/render-client-component.tsx
@@ -41,6 +41,14 @@ type RenderClientComponentOptions = {
   visibilityState?: DocumentVisibilityState;
 };
 
+/**
+ * For components that choose browser behavior at module evaluation (such as
+ * Base UI), first render a placeholder with `requireButton: false`, then
+ * dynamically import the component and call `rerender`. A static import runs
+ * before this helper installs DOM globals and can leave controls inert.
+ * See `labs-page.test.tsx` for this sequence, cleanup, and the inline-style
+ * `getComputedStyle` shim needed by its real popup controls in Linkedom.
+ */
 export async function renderClientComponent(
   element: ReactElement,
 ): Promise<RenderClientComponentResult<HTMLButtonElement>>;


### PR DESCRIPTION
## Why and outcome

The shared DOM harness installs browser globals when called, but some component dependencies choose their browser effects when imported. Add a usage note at the helper explaining the existing placeholder-render, dynamic-import, and rerender sequence, with the composed Labs test as the working example.

Frog autofix issue: #2962

## Product UX

- Effort: Not applicable — internal test-harness documentation only.
- Result: Not applicable.
- Walkthrough: Developers are directed to the existing composed example, including cleanup and its popup style shim.

## Evidence

- Direct: Fresh processes using the effective installed Base UI dependency select a no-op without `document` and React's layout effect when `document` exists before import.
- Coverage: `pnpm exec vitest run --config apps/web/vitest.config.ts --no-coverage apps/web/test/labs-page.test.tsx` passes all 14 existing composed tests.
- Scoped ESLint, `pnpm complexity:diff`, and `git diff --check` pass.
- Removing the sole new JSDoc block reproduces the base file byte for byte. There is no executable or type-contract change; a separate typecheck is not needed for the comment.
- Parent candidate review: full one-file diff, source-backed claim, working example, scope, and privacy checked. All four required CI checks pass on `648555f6e54b0d09ac945297d35eed5d862369a4` (Host CI run 34044735753).
- Full round-one ReviewGPT: PASS on that same head, with selected and response model `gpt-6-pro`, exact turn and response-hash attestation, and more than 423 seconds of response wait. The reviewer independently checked the complete changed/base blobs, helper setup/cleanup, Labs import order, and popup interaction assertions. Local test execution remains the evidence reported above.

## Non-obvious affected surfaces

None. The documented example already contains the required setup.

## Architecture and reuse

- Existing systems reused: `renderClientComponent`, dynamic imports, `rerender`, and the existing Labs composed tests.
- New logic: None; eight documentation lines only.
- New abstractions: None; the existing harness already supports this sequence.
- Complexity intentionally avoided: No new rendering API, module-reset wrapper, dependency, or test mock.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; no authored JavaScript or TypeScript logic changes to analyze.
- Hotspots: None introduced or modified by this comment.
- Agent judgment: A note beside the existing helper is sufficient; no additional mechanism is justified.

## Hot reply path impact

Not applicable. Test-harness documentation adds no database, network/provider, or other awaited work to Murph's reply path.

## Murph initial provider input impact

Not applicable for both individual and group runtimes. No prompt, tool, schema, fixture input, or provider-visible field changes. Full-input measurements were not run because this is a harness usage comment.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal test documentation changes no deployed code or compatibility boundary.

## Change-shape breakdown

Classification uses primary purpose: the eight added lines are JSDoc in a test helper. No binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 0 | 0 |
| Docs | 8 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **8** | **0** |

## Changelog

- Changelog: not applicable
- Reason: Internal developer documentation only; no member-visible change.

ReviewGPT first-reviewed head: 648555f6e54b0d09ac945297d35eed5d862369a4
ReviewGPT context sensitivity: routine
Classification reason: One comment documents an existing test-harness sequence; executable source and product contracts are unchanged.
