### PR TITLE
Keep document and meal schema proof independent of CLI builds

### DIFF
--- a/packages/cli/test/cli-expansion-document-meal.test.ts
+++ b/packages/cli/test/cli-expansion-document-meal.test.ts
@@ -524,18 +524,12 @@ test(
   'document and meal command schemas expose the expansion and mutation surfaces',
   async () => {
     const cli = createDocumentMealSchemaCli()
-    const documentImportSchema = JSON.parse(
-      await runRawSourceCli(['document', 'import', '--schema', '--format', 'json']),
-    ) as SchemaEnvelope
+    const documentImportSchema = await readCommandSchema(cli, ['document', 'import'])
     const documentEditSchema = await readCommandSchema(cli, ['document', 'edit'])
     const documentDeleteSchema = await readCommandSchema(cli, ['document', 'delete'])
     const documentListSchema = await readCommandSchema(cli, ['document', 'list'])
-    const mealAddSchema = JSON.parse(
-      await runRawSourceCli(['meal', 'add', '--schema', '--format', 'json']),
-    ) as SchemaEnvelope
-    const mealImportJsonSchema = JSON.parse(
-      await runRawSourceCli(['meal', 'import-json', '--schema', '--format', 'json']),
-    ) as SchemaEnvelope
+    const mealAddSchema = await readCommandSchema(cli, ['meal', 'add'])
+    const mealImportJsonSchema = await readCommandSchema(cli, ['meal', 'import-json'])
     const mealEditSchema = await readCommandSchema(cli, ['meal', 'edit'])
     const mealDeleteSchema = await readCommandSchema(cli, ['meal', 'delete'])
     const mealListSchema = await readCommandSchema(cli, ['meal', 'list'])


### PR DESCRIPTION
## Why and outcome

The document/meal schema aggregate still sent three commands through built CLI runtime preparation inside its 45-second test budget. In a fresh installed checkout it timed out before its assertions; the unchanged warm run passed. Reuse the existing in-process production command registrations for those three schemas, matching the other seven commands and keeping every schema assertion and the existing timeout.

Frog autofix issue: #2930

## Product UX

- Effort: Not applicable — internal test harness only.
- Result: Not applicable.
- Walkthrough: The focused schema proof runs without a built CLI tree; member behavior is unchanged.

## Evidence

- Direct: The original documented focused command failed at 45,023ms in a fresh installed checkout, then passed in 13,640ms after runtime artifacts existed. Temporary diagnostic assertions proved complete parsed-JSON equality between the three built-entry schemas and the existing in-process helper before removing the diagnostic assertions.
- Regression: The changed focused aggregate passed in 60ms with the task-owned CLI build directory temporarily absent, and did not recreate it. The directory was restored afterward. All original schema assertions and the 45-second budget remain.
- Focused: `pnpm --dir packages/cli exec vitest run --config vitest.config.ts --no-coverage test/cli-expansion-document-meal.test.ts` passed all 11 tests. `pnpm --dir packages/cli typecheck`, `pnpm complexity:diff`, frozen installation, and `git diff --check` passed.
- All four required GitHub checks passed on `8f23008c273e34e944661f310c89e690bc7130f5`: both CLI host matrices, Release checks, and the hosted Stripe billing boundary. [Host Support run](https://github.com/cobuildwithus/murph/actions/runs/34045401833) and [billing run](https://github.com/cobuildwithus/murph/actions/runs/34045401803) are green.

## Non-obvious affected surfaces

None. Only the existing schema aggregate changes.

## Architecture and reuse

- Existing systems reused: `createDocumentMealSchemaCli` and `readCommandSchema`, which compose the production document and meal command registrations.
- New logic: Three existing schema reads use the same helper as the other seven.
- New abstractions: None; the existing schema helper already owns this test boundary.
- Complexity intentionally avoided: No preparation hook, timeout increase, subprocess retry, or new fixture owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; no authored production JavaScript or TypeScript source changes to analyze.
- Hotspots: No production function changes.
- Agent judgment: Reusing the established helper removes unnecessary runtime preparation without expanding the test harness.

## Hot reply path impact

- Path status: Not applicable — test-only schema proof.
- Database calls: None added.
- Network/provider calls: None added.
- Other awaited latency: None added to a runtime path.
- Before/after proof: The schema proof passes without built CLI artifacts and preserves complete schema equality.

## Murph initial provider input impact

- Individual Murph: Not applicable — no provider-input change.
- Group Murph: Not applicable — no provider-input change.
- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Production schemas unchanged; test acquisition only.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Only a test harness changes.

## Change-shape breakdown

Classification rule: The sole changed file is tests/fixtures. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 3 | 9 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **3** | **9** |

## Changelog

- Changelog: not applicable
- Reason: Internal developer test reliability only.

ReviewGPT first-reviewed head: 8f23008c273e34e944661f310c89e690bc7130f5
ReviewGPT context sensitivity: routine
Classification reason: A contained test-only correction with exact schema-equivalence proof. Full ReviewGPT is explicitly requested by the automation.

## ReviewGPT evidence

- Full round 1 PASS with no findings on `8f23008c273e34e944661f310c89e690bc7130f5`. The full snapshot, exact file/base blobs, empty review deltas, committed turn, and captured response hash were verified. Requested and captured model metadata both identify `gpt-6-pro`; the response prose reported its model as unknown, so attribution uses the verified metadata.
- The reviewer independently traced complete leaf schemas through production registration, schema/vault-context/LLM wrappers, and remaining compiled-entrypoint coverage. This was a static review; local test results above are separate.
- Response SHA-256: `48aef788415c343937d9edab677e3f453f5d60dce32d2838fa49751374429b83`. Measured Send-to-capture: 489.973 seconds; wait-to-capture: 485.791 seconds. The exact invocation-owned target is closed and absent.
- An earlier 186-second result was invalid under the 270-second minimum and was not credited. The successful retry used the same head and round with a fresh full snapshot.
