### PR TITLE
test: prove checkpoint log independence without a polling deadline

### DIFF
--- a/packages/assistant-runtime/test/hosted-invocation-bridge.test.ts
+++ b/packages/assistant-runtime/test/hosted-invocation-bridge.test.ts
@@ -716,8 +716,13 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
     const finishedLogGate = new Promise<void>((resolve) => {
       releaseFinishedLog = resolve;
     });
+    let signalFinishedLogStarted!: () => void;
+    const finishedLogStarted = new Promise<void>((resolve) => {
+      signalFinishedLogStarted = resolve;
+    });
     let finishedLogSettled = false;
     calls.logWrite.mockImplementationOnce(async (request) => {
+      signalFinishedLogStarted();
       await finishedLogGate;
       finishedLogSettled = true;
       return { loggedCount: request.entries.length };
@@ -726,23 +731,22 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
       platform,
       vaultRoot,
     });
-    let checkpointSettled = false;
     const checkpoint = Promise.resolve(options.createCheckpointSnapshot(
       createCheckpointInput("idle_shutdown"),
-    )).then((result) => {
-      checkpointSettled = true;
-      return result;
-    });
+    ));
 
     let pendingLogDrain: Promise<void> | null = null;
     try {
-      await vi.waitFor(() => {
-        expect(checkpointSettled).toBe(true);
-      }, { timeout: 250 });
+      await expect(Promise.race([
+        checkpoint.then(() => "checkpoint"),
+        finishedLogStarted.then(() => "log write"),
+      ])).resolves.toBe("checkpoint");
       pendingLogDrain = drainHostedRuntimeLogWritesBestEffort();
-      await vi.waitFor(() => {
-        expect(calls.logWrite).toHaveBeenCalledOnce();
-      });
+      await expect(Promise.race([
+        finishedLogStarted.then(() => "log write"),
+        pendingLogDrain.then(() => "drain"),
+      ])).resolves.toBe("log write");
+      expect(calls.logWrite).toHaveBeenCalledOnce();
       expect(finishedLogSettled).toBe(false);
       await expect(checkpoint).resolves.toMatchObject({
         snapshotRef: {
@@ -755,9 +759,7 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
       await checkpoint;
     }
 
-    await vi.waitFor(() => {
-      expect(finishedLogSettled).toBe(true);
-    });
+    expect(finishedLogSettled).toBe(true);
   });
 
   it("keeps snapshot outcomes independent from an unavailable log port", async () => {


### PR DESCRIPTION
## Why and outcome

The checkpoint log-independence regression applied a 250 ms deadline to unrelated filesystem snapshot work. Compare checkpoint completion with the gated log writer's start event so archive speed cannot masquerade as a logging dependency. Preserve the blocked-log assertion and release/drain cleanup.

Frog autofix issue: #2934

## Product UX

- Effort: Not applicable — isolated test maintenance.
- Result: Not applicable
- Walkthrough: No member-facing path changes.

## Evidence

- Direct: A controlled 350 ms delay in the existing archive-builder seam fails the original 250 ms assertion and passes the candidate with the identical delay. A temporary mutation making the finished log directly awaited fails the candidate on event order without a test timeout; the finally block releases the gate. Omitting the finished record also fails promptly when its empty drain completes, preserving cleanup instead of waiting indefinitely. All diagnostic mutations were restored before committing.
- Coverage: The complete existing bridge suite passes all 69 tests. `pnpm --dir packages/assistant-runtime typecheck` passes with TypeScript 7. The changed test retains the real snapshot path, blocked log, returned snapshot reference, and completed drain assertions. All four required exact-head GitHub checks passed. Final full-patch ReviewGPT round 1 passed on `b4b8f6ce0a799221702e8cd1b0cb436124ee4c42` with no qualifying findings. Requested and actual model `gpt-6-pro`, exact response/turn identity, and a wait duration exceeding 545 seconds were verified; response SHA-256 `528e42056f5a4f90cbab727ceb24afb765c1b1893bda161731adab25453113c9`. An earlier response below the required duration was rejected and did not count as review evidence. The reviewer independently ran synthetic base/candidate controls using extracted production owners; those Node 22 checks are distinct from the local Node 24 Vitest suite and TypeScript check.

## Non-obvious affected surfaces

None. The only changed file is the existing checkpoint bridge test.

## Architecture and reuse

- Existing systems reused: Existing bridge fixture, real snapshot creation, log gate, drain owner, and native promises.
- New logic: Test-only event ordering replaces settlement polling against an incidental wall-clock deadline.
- New abstractions: None; one test-local promise signals the existing mock log writer's entry.
- Complexity intentionally avoided: No timeout increase, fake clock, production logging change, or new test harness.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base origin/main -- packages/assistant-runtime/test/hosted-invocation-bridge.test.ts`; the guard excludes isolated test files from authored-source complexity.
- Hotspots: No authored production JavaScript or TypeScript changed.
- Agent judgment: The single promise signal removes polling and settlement polling while keeping cleanup in its current owner.

## Hot reply path impact

- Path status: Not applicable — isolated regression test change.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Production source is unchanged.

## Murph initial provider input impact

- Individual Murph: Not applicable — no provider-input change.
- Group Murph: Not applicable — no provider-input change.
- Measurement method: Not run — test-only event ordering does not change assembled input.

## Deployment concerns

- Deployment: not applicable
- Reason: The change is confined to a test and cannot change deployed behavior.

## Change-shape breakdown

Classification rule: The existing Vitest file is tests / fixtures. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 16 | 14 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **16** | **14** |

## Changelog

- Changelog: not applicable
- Reason: Internal test maintenance has no member-visible behavior change.

ReviewGPT context sensitivity: routine
Classification reason: One isolated test preserves production behavior and existing cleanup.

ReviewGPT first-reviewed head: b4b8f6ce0a799221702e8cd1b0cb436124ee4c42
