### PR TITLE
Resume approved deliveries alongside queued device work

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-06-approval-mixed-mailbox.md
+++ b/agent-docs/exec-plans/active/2026-09-06-approval-mixed-mailbox.md
@@ -1,0 +1,63 @@
+# Deliver approved effects alongside queued device work
+
+Status: active
+Created: 2026-09-06
+Updated: 2026-09-06
+
+## Outcome and invariants
+
+Approved delivery continuations must run during the dirty foreground window
+when their mailbox batch also contains device-sync wakes. Keep mailbox import
+ordered, retain background work, and preserve exact approval and delivery owners.
+
+## Architecture
+
+The runtime pre-checkpoint prefetch classifier currently requires an entirely
+foreground-safe batch. The existing mixed-prefix test reproduces the resulting
+delay. Device-sync import only enqueues an existing system-mailbox record;
+execution is separately selected by the foreground-causal phase.
+
+Extend that classifier to admit queue-only device wakes alongside at least one
+already-supported foreground continuation. Reuse the same ordered importer and
+foreground-causal execution selector. Device-only batches and imports that can
+mutate canonical data remain checkpoint-gated. No new queue, state, schema,
+dependency, scheduler, selective cursor, or approval authority is needed.
+
+## Product UX: Patch
+
+- Outcome: Approved attachments resume without another conversation message.
+- Reaches: Dirty warm runtimes with a mixed device/continuation mailbox batch;
+  existing direct-route, approval-generation, denial, expiry, and retry checks remain.
+- Proof: Real bridge import and causal execution before idle checkpoint, one
+  delivery, queued device work retained, no background/provider-model execution.
+
+## Tasks
+
+1. Add failing mixed-batch delivery proof and preserve unsafe-import gates.
+2. Extend the existing classifier and update its protocol contract.
+3. Run focused runtime tests, typecheck, complexity guard, and parent review.
+4. Add a concise member-facing changelog; finish the scoped change and review.
+
+## Failure and deployment
+
+Existing bounded prefix, import failure, mailbox watermark, and retry behavior
+remain authoritative. Older runners retain the delay; newer runners accept the
+same persisted shapes. Deploy the runner through the normal Cloudflare release;
+no Web or Temporal protocol change or data migration is required.
+
+## Verification
+
+- Baseline: the new mixed-device regression fails before import/delivery at the
+  idle checkpoint; the existing active-import and canonical-write cases pass.
+- Runtime: full causal-input suite passed (41 tests), then final parameterized
+  approval/gate and callback selection passed (29 tests).
+- Changelog: production archive rendering passed (9 tests).
+- Final runtime and Web typechecks passed.
+- Complexity guard passed with unchanged debt and maximum. Existing large
+  orchestration functions are unchanged apart from one derived flag read.
+- Parent review: ordered import, bounded work, unchanged decoded authority,
+  causal-only execution, retained unattempted device item, single delivery,
+  and no model/provider-model entry are covered. Product UX: Ready for review.
+- Live model proof is not applicable: this continuation performs no model turn
+  and changes no prompt, tool availability, or authored reply.
+- Final review and required CI remain pending. No production mutation performed.

--- a/agent-docs/exec-plans/completed/2026-09-06-approval-mixed-mailbox.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-approval-mixed-mailbox.md
@@ -1,6 +1,6 @@
 # Deliver approved effects alongside queued device work
 
-Status: active
+Status: completed
 Created: 2026-09-06
 Updated: 2026-09-06
 
@@ -60,4 +60,15 @@ no Web or Temporal protocol change or data migration is required.
   and no model/provider-model entry are covered. Product UX: Ready for review.
 - Live model proof is not applicable: this continuation performs no model turn
   and changes no prompt, tool availability, or authored reply.
-- Final review and required CI remain pending. No production mutation performed.
+- Independent round-one review passed on f76684246bb37accdadb8997b2761d63f33e709a;
+  verified model metadata matches the requested model. No qualifying bugs or
+  material Complexity Collapse findings. Initial browser staging failed before
+  submission; the alternate configured lane completed the same review round.
+- Required CI passed on the reviewed code head (32 successes, three expected skips).
+- Parent final review passed. The refreshed base merges without conflicts.
+- The final plan-closure commit changes documentation only; source, tests, and
+  changelog are identical to the reviewed candidate. No new substantive review
+  is needed under the explanatory-docs exemption. Required final-head CI will
+  be verified in the PR rather than creating another plan-only closure commit.
+- No production mutation performed. Deployment remains a separate step.
+Completed: 2026-09-06

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -951,10 +951,14 @@ map only to the `read_shared` member with that exact id. Display name, handle,
 or member order cannot substitute, and the opaque id cannot appear in the
 answer.
 
-When a joined-group request, accepted-input completion, or closed
+When an approved-effect continuation, joined-group request, accepted-input completion, or closed
 `member.action.requested` reaches a dirty warm runtime, the mailbox prefetch may
 import it before the routine idle checkpoint only when the entire fetched
-prefix contains pre-checkpoint-safe system wakes.
+prefix contains pre-checkpoint-safe system wakes, optionally alongside
+queue-only `device-sync.wake` items. At least one foreground-safe wake must be
+present; a device-only prefix remains checkpoint-gated. Ordered import retains
+the device items in the existing system queue, while the foreground-causal
+execution selector services only the eligible continuations.
 One shared import context revalidates the decoded request adapter shape
 throughout that pre-checkpoint pass, including pre-assistant follow-up imports
 and foreground reruns. A consented-member request remains checkpoint-gated;
@@ -962,8 +966,8 @@ every accepted-input completion is admitted without a completion-kind context.
 Request import kicks the existing detached controller; completion import uses
 the existing foreground-causal delivery path, and a member action uses its
 existing provider-free foreground-causal service path. Neither starts or advances the
-at-least-180-second idle snapshot. Any unrelated system wake in that prefix
-keeps the whole system prefix checkpoint-gated. A progressed foreground-causal
+at-least-180-second idle snapshot. Any other unrelated system wake in that
+prefix keeps the whole system prefix checkpoint-gated. A progressed foreground-causal
 pass re-enters the existing bounded pass loop after admitting any newly arrived
 personal input first, so multiple safe items or a safe item imported during the
 preceding pass drain before checkpoint. No progress, retryable failure,

--- a/apps/web/changelog/entries/2026-09-06/approved-file-delivery-resumes.json
+++ b/apps/web/changelog/entries/2026-09-06/approved-file-delivery-resumes.json
@@ -8,7 +8,11 @@
     "title": "Faster delivery after file approval",
     "summary": "Queued device updates no longer hold up a file you have approved Murph to send.",
     "details": "Delivery resumes after approval without waiting for another message. Your approval still applies to the specific file and destination.",
-    "relevanceTags": ["messaging"],
-    "sourcePullRequests": []
+    "relevanceTags": [
+      "messaging"
+    ],
+    "sourcePullRequests": [
+      2982
+    ]
   }
 }

--- a/apps/web/changelog/entries/2026-09-06/approved-file-delivery-resumes.json
+++ b/apps/web/changelog/entries/2026-09-06/approved-file-delivery-resumes.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-06",
+  "order": 200,
+  "item": {
+    "id": "approved-file-delivery-resumes",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Faster delivery after file approval",
+    "summary": "Queued device updates no longer hold up a file you have approved Murph to send.",
+    "details": "Delivery resumes after approval without waiting for another message. Your approval still applies to the specific file and destination.",
+    "relevanceTags": ["messaging"],
+    "sourcePullRequests": []
+  }
+}

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -679,7 +679,7 @@ async function inspectHostedPreCheckpointSystemMailboxPrefetch(
   containsOnlyBrowserVaultRefreshWakes: boolean;
   containsOnlyDeviceSyncWakes: boolean;
   containsOnlyInitialMemberActivation: boolean;
-  containsOnlySafeSystemWakes: boolean;
+  canImportForPreCheckpointSystemWork: boolean;
   hasSystemWork: boolean;
 }> {
   const response = await prefetch.response;
@@ -744,13 +744,17 @@ async function inspectHostedPreCheckpointSystemMailboxPrefetch(
         && item.kind === "device-sync.wake"
       ),
     containsOnlyInitialMemberActivation,
-    containsOnlySafeSystemWakes: containsOnlyInitialMemberActivation
+    canImportForPreCheckpointSystemWork: containsOnlyInitialMemberActivation
       || (
-        response.items.length > 0
+        // Device wakes only enqueue pending work at import. Admit them with a
+        // foreground continuation; the causal execution selector leaves device
+        // service deferred. Device-only batches still wait for checkpointing.
+        response.items.some((item) => item.kind !== "device-sync.wake")
         && response.items.every((item) =>
           item.lane === "system"
           && (
-            item.kind === "runtime.pending-effects-reconcile-requested"
+            item.kind === "device-sync.wake"
+            || item.kind === "runtime.pending-effects-reconcile-requested"
             || item.kind === "member.action.requested"
             || item.kind === "assistant.ask.requested"
             || item.kind === "assistant.ask.completed"
@@ -6038,7 +6042,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
           return true;
         }
         const shouldImportSystemMailbox = input.systemMailboxAdmission === "all"
-          || preCheckpointSystemPrefetch?.containsOnlySafeSystemWakes === true;
+          || preCheckpointSystemPrefetch?.canImportForPreCheckpointSystemWork === true;
         if (!shouldImportSystemMailbox) {
           if (preCheckpointSystemPrefetch?.hasSystemWork !== true) {
             deferCheckpointAfterEmptyForegroundProbe(conversationImport);

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-causal-input.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-causal-input.test.ts
@@ -5,6 +5,7 @@ import {
   createBundleRef,
   createConsentedMemberAssistantAskRequestedWake,
   createDeferred,
+  createDeviceSyncSystemWakeForMailboxItem,
   createMailboxItem,
   createMailboxPort,
   createPlatform,
@@ -2523,20 +2524,27 @@ describe("hosted workspace runtime entrypoint", () => {test("keeps idle-window t
     }
   });
 
-  test("runs a late imported approval through the causal system owner before idle checkpoint", async () => {
+  test.each([false, true])("delivers an approval before idle checkpoint (mixed device prefix: %s)", async (mixedDevicePrefix) => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const events: string[] = [];
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const mailboxItems: HostedMailboxItem[] = [];
     const foregroundCausalOnlyValues: boolean[] = [];
     const approvalImportObserved = createDeferred<void>();
+    let checkpointStarted = false;
+    const deviceItem = createMailboxItem({
+      id: "mailbox_item_queued_device",
+      kind: "device-sync.wake",
+      lane: "system",
+      laneSeq: "1",
+    });
     const effectId = "effect_late_imported_approval";
     const approvalItem = createMailboxItem({
       dedupeKey: `runtime.pending-effects-reconcile-requested:${effectId}`,
       id: "mailbox_item_late_imported_approval",
       kind: "runtime.pending-effects-reconcile-requested",
       lane: "system",
-      laneSeq: "1",
+      laneSeq: mixedDevicePrefix ? "2" : "1",
     });
     const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
     const providerFetch = vi.fn<typeof fetch>(async () => {
@@ -2624,7 +2632,13 @@ describe("hosted workspace runtime entrypoint", () => {test("keeps idle-window t
       } satisfies HostedRuntimePlatform;
       const bridgeImporter = createHostedWorkspaceBridgeMailboxImporter({
         decodeMailboxPayload: {
-          async decode() {
+          async decode(input) {
+            if (input.itemRef.kind === "device-sync.wake") {
+              return {
+                status: "decoded",
+                wake: createDeviceSyncSystemWakeForMailboxItem(deviceItem),
+              };
+            }
             return {
               status: "decoded",
               wake: buildHostedExecutionPendingEffectsReconcileRequestedWake({
@@ -2653,7 +2667,14 @@ describe("hosted workspace runtime entrypoint", () => {test("keeps idle-window t
           }),
           {
             async createCheckpointSnapshot(snapshotInput) {
+              checkpointStarted = true;
               events.push(`snapshot:${snapshotInput.reason}`);
+              if (mixedDevicePrefix) {
+                const pending = (await readHostedSystemMailboxState(vaultRoot)).pending;
+                assert.deepEqual(pending.map((item) => [item.itemId, item.attemptCount]), [
+                  [deviceItem.id, 0],
+                ]);
+              }
               return {
                 snapshotRef: createBundleRef({
                   hash: "7".repeat(64),
@@ -2665,8 +2686,10 @@ describe("hosted workspace runtime entrypoint", () => {test("keeps idle-window t
             async importItem(item, context) {
               const outcome = await bridgeImporter(item, context);
               assert.equal(Object.hasOwn(outcome, "afterCheckpoint"), false);
-              events.push(`approval.import:${outcome.status}`);
-              approvalImportObserved.resolve();
+              events.push(`mailbox.import:${item.item.kind}:${outcome.status}`);
+              if (item.item.kind === approvalItem.kind) {
+                approvalImportObserved.resolve();
+              }
               return outcome;
             },
             platform,
@@ -2676,6 +2699,16 @@ describe("hosted workspace runtime entrypoint", () => {test("keeps idle-window t
               foregroundCausalOnlyValues.push(input.foregroundCausalOnly === true);
               events.push(`assistant.phase:${assistantPhaseCalls}`);
               if (assistantPhaseCalls === 1) {
+                if (mixedDevicePrefix) {
+                  setTimeout(() => {
+                    mailboxItems.push(deviceItem, approvalItem);
+                    runtimeWakeSignal.notify();
+                  }, 0);
+                  return {
+                    checkpointReason: "assistant_runtime_commit",
+                    progressed: true,
+                  };
+                }
                 return {
                   afterCheckpoint: async () => {
                     mailboxItems.push(approvalItem);
@@ -2690,6 +2723,11 @@ describe("hosted workspace runtime entrypoint", () => {test("keeps idle-window t
                   checkpointReason: "assistant_runtime_commit",
                   progressed: true,
                 };
+              }
+              // This proof ends at the first idle checkpoint. Background service
+              // after publication is covered by the system-mailbox scenarios.
+              if (mixedDevicePrefix && checkpointStarted) {
+                return { progressed: false };
               }
               return await runHostedWorkspaceAssistantPhase({
                 ...input,
@@ -2724,12 +2762,14 @@ describe("hosted workspace runtime entrypoint", () => {test("keeps idle-window t
         events.join(","),
       );
       assert.deepEqual(
-        (await readHostedSystemMailboxState(vaultRoot)).pending,
-        [],
+        (await readHostedSystemMailboxState(vaultRoot)).pending.map((item) => item.itemId),
+        mixedDevicePrefix ? [deviceItem.id] : [],
       );
       assert.equal(result.status, "scheduled");
-      assert.equal(result.nextWakeReason, "assistant");
-      assert.ok(Date.parse(result.nextWakeAt ?? "") > Date.parse(TEST_NOW));
+      if (!mixedDevicePrefix) {
+        assert.equal(result.nextWakeReason, "assistant");
+        assert.ok(Date.parse(result.nextWakeAt ?? "") > Date.parse(TEST_NOW));
+      }
     } finally {
       if (mocks.actualCollectHostedAssistantDeliverySideEffects) {
         mocks.collectHostedAssistantDeliverySideEffects.mockImplementation(
@@ -3037,7 +3077,9 @@ describe("hosted workspace runtime entrypoint", () => {test("keeps idle-window t
     });
   }
 
-  test("keeps a mixed causal and device prefix gated until after checkpoint", async () => {
+  test.each(["device-sync.wake", "health.daily-metric.reported"] as const)(
+    "keeps %s without an admissible foreground batch gated until checkpoint",
+    async (deferredKind) => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const events: string[] = [];
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
@@ -3050,7 +3092,7 @@ describe("hosted workspace runtime entrypoint", () => {test("keeps idle-window t
       const resultPromise = runHostedWorkspaceRuntimeJobInProcess(
         createWorkspaceRuntimeJobInput({
           request: {
-            attemptId: "attempt_synthetic_mixed_pending_effects_device_dirty_wake",
+            attemptId: "attempt_synthetic_mixed_pending_effects_canonical_dirty_wake",
             idleCheckpointDelayMs: 200,
             leaseGeneration: "7",
             userId: TEST_USER_ID,
@@ -3063,7 +3105,7 @@ describe("hosted workspace runtime entrypoint", () => {test("keeps idle-window t
             return {
               snapshotRef: createBundleRef({
                 hash: "b".repeat(64),
-                key: "users/bundles/member-synthetic/mixed-pending-effects-device.bundle.json",
+                key: "users/bundles/member-synthetic/mixed-pending-effects-canonical.bundle.json",
                 size: 512,
               }),
             };
@@ -3091,17 +3133,17 @@ describe("hosted workspace runtime entrypoint", () => {test("keeps idle-window t
               setTimeout(() => {
                 mailboxItems.push(
                   createMailboxItem({
-                    id: "mailbox_item_entrypoint_mixed_device",
-                    kind: "device-sync.wake",
+                    id: "mailbox_item_entrypoint_mixed_canonical",
+                    kind: deferredKind,
                     lane: "system",
                     laneSeq: "1",
                   }),
-                  createMailboxItem({
+                  ...(deferredKind === "device-sync.wake" ? [] : [createMailboxItem({
                     id: "mailbox_item_entrypoint_mixed_pending_effects",
                     kind: "runtime.pending-effects-reconcile-requested",
                     lane: "system",
                     laneSeq: "2",
-                  }),
+                  })]),
                 );
                 runtimeWakeSignal.notify();
               }, 0);
@@ -3126,17 +3168,19 @@ describe("hosted workspace runtime entrypoint", () => {test("keeps idle-window t
       assert.ok(
         idleCheckpointIndex < requireEventIndex(
           events,
-          "mailbox.importItem:mailbox_item_entrypoint_mixed_device",
+          "mailbox.importItem:mailbox_item_entrypoint_mixed_canonical",
         ),
         events.join(","),
       );
-      assert.ok(
-        idleCheckpointIndex < requireEventIndex(
-          events,
-          "mailbox.importItem:mailbox_item_entrypoint_mixed_pending_effects",
-        ),
-        events.join(","),
-      );
+      if (deferredKind !== "device-sync.wake") {
+        assert.ok(
+          idleCheckpointIndex < requireEventIndex(
+            events,
+            "mailbox.importItem:mailbox_item_entrypoint_mixed_pending_effects",
+          ),
+          events.join(","),
+        );
+      }
       assert.equal(result.status, "idle");
     } finally {
       await removeTempRoot(vaultRoot);


### PR DESCRIPTION
## Why and outcome

Approved file delivery could wait for the idle checkpoint when its continuation shared a mailbox batch with device-sync work. Admit those queue-only device records alongside eligible foreground continuations, then let the existing causal execution selector send the approved effect while device execution stays deferred.

Device-only batches and batches containing canonical-data imports remain checkpoint-gated. No new state or runtime owner is introduced.

## Product UX

- Effort: Patch.
- Result: Ready.
- Outcome: An approved file resumes without an additional conversation message when queued device work shares its fetched batch.
- Reaches: Dirty warm runtimes; existing approval generation, route, destination, denial, expiry, and retry boundaries remain authoritative.
- Proof: Real bridge import and causal runtime phase hand off exactly one delivery before idle checkpoint; device work remains queued with zero attempts and no model request.
- Exclusions: Unrelated canonical writes and device-only batches retain the idle gate.
- Walkthrough: Ready; no differences from plan. Provider transport is stubbed at the unchanged delivery boundary; production release verification remains separate.

## Evidence

- Regression fails on the base because the mixed prefix is still unimported at idle checkpoint.
- Full causal-input suite: 41 passed before the final additional negative-case parameterization.
- Final focused approval/gate and callback suite: 29 passed, including denied and superseded approval handling.
- Assistant Runtime typecheck: passed.
- Web typecheck: passed.
- Changelog production archive test: 9 passed.
- Complexity guard: passed; source debt 565 to 565, maximum 252 to 252.
- No live model run: no prompt, tools, model interpretation, or generated reply changes; the continuation has no model turn.
- Independent ReviewGPT: PASS on f76684246bb37accdadb8997b2761d63f33e709a; model metadata verified. No qualifying bugs or material Complexity Collapse findings.
- CI on both the reviewed code head and final plan-closure head `dd92b7d941492ca07e2500ef33eac1ed25c97973`: 32 passed, three expected skips.
- The final commit only archives the execution plan and records completed evidence. Source, tests, protocol, and changelog trees match the reviewed candidate exactly; no second substantive review is required.

## Non-obvious affected surfaces

The same existing pre-checkpoint batch classifier admits member-action and assistant-completion work. Their causal-input tests remain green; decoded request-target checks and the existing execution selector are unchanged.

## Architecture and reuse

- Existing systems reused: Bounded mailbox prefetch, ordered import, existing system-mailbox queue, foreground-causal selector, exact approved-effect dispatch.
- New logic: Permit queue-only device companions only when the fetched batch also includes an already-supported foreground-safe continuation.
- New abstractions: None. Renamed one derived flag to describe import eligibility accurately.
- Complexity intentionally avoided: No additional queue, scheduler, cursor, persisted state, schema, dependency, or approval owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: Existing orchestration hotspots remain unchanged in complexity. The only change in `runForegroundMailboxWakeIfWork` is a derived flag name; its complexity remains 40. Maximum remains 252 in the existing invocation orchestrator.
- Agent judgment: The correction belongs in the existing classifier. Refactoring the unrelated orchestration functions would broaden this fix without strengthening its invariant.

## Hot reply path impact

- Path status: Trusted completion admission changes; current-conversation admission retains its earlier priority branch.
- Database calls: No new database calls.
- Network/provider calls: No new endpoints or provider calls. The existing bounded prefix importer now stages device companions during the continuation pass, using the same sequential payload decode/import path and mailbox budget (default 50 imports).
- Other awaited latency: Existing queue writes for the fetched device companions move before idle checkpoint; their execution remains deferred. No added poll, retry, timeout, or background-service wait.
- Before/after proof: The mixed-prefix scenario fails before the correction and succeeds afterward with one delivery before checkpoint, retained unattempted device work, and zero model requests.

## Murph initial provider input impact

Not applicable for individual or group runtimes: no assembled instructions, tool/schema/generated guidance, conversation context, or provider-visible inputs change. This model-free continuation does not start a provider model request. Token measurement not run for that reason.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: Content-only changelog; production archive rendering test passed.
- Coverage: Existing production rendering and responsive presentation are unchanged; copy reviewed directly.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing Web and Temporal producers and old/new runners use identical mailbox, approval, and queue record shapes.
- Safe order: Normal Cloudflare runner release; no coordinated Web or Temporal change required.
- Rollback floor: Unchanged; this patch writes no new persisted shape.
- Expected exposure: Old warm runners may retain the delay until replaced during the normal rollout window.
- Reversibility: Reverting this classifier restores the old delay without a data migration.
- Convergence proof: Both base and head accept the same synthetic mixed mailbox envelope; only pre-checkpoint eligibility changes. Production rollout convergence is not yet verified.
- Post-deploy checks: Approve a synthetic file with queued device work, confirm prompt single delivery, and confirm the retained device event completes through normal background service.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source; test files are tests; plans and protocol notes are docs; authored changelog JSON is generated/other. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 9 | 5 |
| Tests / fixtures | 68 | 24 |
| Docs | 82 | 4 |
| Config / tooling | 0 | 0 |
| Generated / other | 18 | 0 |
| **Total** | 177 | 33 |

## Changelog

- Changelog: updated
- Items: 2026-09-06 · approved-file-delivery-resumes

ReviewGPT context sensitivity: sensitive
Classification reason: Hosted runtime ordering and external delivery timing.

ReviewGPT first-reviewed head: f76684246bb37accdadb8997b2761d63f33e709a
