### PR TITLE
refactor: consolidate hosted mailbox metadata in SQLite

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-06-vault-input-metadata.md
+++ b/agent-docs/exec-plans/active/2026-09-06-vault-input-metadata.md
@@ -1,0 +1,64 @@
+# Consolidate hosted mailbox metadata files
+
+Status: active
+Created: 2026-09-06
+Updated: 2026-09-06
+
+## Outcome and invariant
+
+Replace per-input mailbox metadata files with one durable SQLite store at the
+existing assistant-engine ownership boundary. Preserve raw acknowledgement IDs,
+blinded source IDs, private group context, input retention, and replay behavior.
+Sanitized assistant input records and model-visible assembly do not change.
+
+## Evidence and design
+
+Each hosted input currently creates an additional metadata file. These records
+share the input lifetime but have a distinct privacy classification, so merging
+them into sanitized inputs or substituting sourceRef IDs is incorrect. Reuse the
+same native runtime SQLite migrations, private filesystem helpers and assistant
+write lock already used by session routing and outbox indexing. Metadata remains
+durable truth, not a disposable projection.
+
+The new table has an input ID key and a validated metadata JSON value. DELETE
+journaling and closed handles retain one checkpoint file. Secure deletion erases
+expired quotes from retained database pages. Foreground reads use one handle and
+exact keyed lookups, with exact legacy fallback only when a current row is absent.
+No foreground legacy-directory scan is introduced. Existing residue maintenance
+validates legacy files, atomically inserts missing rows without overwriting current
+state, validates stored rows, then removes the old files. Interruption leaves
+readable duplicates. Pruning removes metadata only after its input no longer
+survives. No new dependency, scheduler, migration marker or recovery service.
+
+## Failure and deployment
+
+Corrupt or unsupported databases fail closed without obsolete legacy fallback.
+Malformed or symlinked legacy inventories are retained. New code reads both old
+and new storage. The metadata-capable runner is the rollback floor after the
+first database write; coordinated rollout must drain older bundles before
+converted workspaces reopen. Legacy support is removable after retained legacy
+checkpoints and workspaces have drained. No input schema or Web protocol changes.
+
+## Tasks and verification
+
+- Implement the single metadata owner and existing maintenance integration.
+- Test file count, private permissions, legacy/current precedence, migration
+  cancellation, corrupt database handling, quote erasure, and input pruning.
+- Run focused assistant-engine/runtime and runtime-state tests, typechecks,
+  complexity review, privacy review, required exact-head CI and final ReviewGPT.
+
+## Scope
+
+No message-policy changes, provider-input changes, canonical vault migration,
+new external calls, query-cache changes or ledger compression changes.
+
+## Local evidence
+
+- Assistant-engine focused storage/input/residue tests: 86 passed.
+- Hosted pending-input and turn-input regressions: 79 passed.
+- Runtime-state security and hosted bundle tests: 71 passed.
+- Assistant-engine and runtime-state typechecks passed.
+- Complexity diff passed; existing residue-planner hotspots are unchanged.
+- Parent review verified private context stays outside sanitized input records,
+  database pages erase retired quotes, and legacy fallback cannot override a
+  valid current row. External PR checks and final review follow publication.

--- a/agent-docs/exec-plans/completed/2026-09-06-vault-input-metadata.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-vault-input-metadata.md
@@ -1,6 +1,6 @@
 # Consolidate hosted mailbox metadata files
 
-Status: active
+Status: completed
 Created: 2026-09-06
 Updated: 2026-09-06
 
@@ -62,3 +62,22 @@ new external calls, query-cache changes or ledger compression changes.
 - Parent review verified private context stays outside sanitized input records,
   database pages erase retired quotes, and legacy fallback cannot override a
   valid current row. External PR checks and final review follow publication.
+
+## Completion review
+
+Final ReviewGPT round 1 passed on 49c4720a5486 with no qualifying findings. The
+captured response and model-attestation hashes match; the requested and observed
+model are gpt-6-pro on the Hercules lane, with more than six minutes of capture.
+The source-level review traced persistence, acknowledgement, private quote
+retirement, migration, pruning and snapshot consumers. Supplemental isolated
+probes covered interruption, overflow-page quote erasure and snapshot readback.
+Parent final review agrees: no unresolved accepted findings remain.
+
+An earlier too-fast response was retained as untrusted diagnostic only, and a
+browser lane failed before staging. Neither was counted as a completed round.
+The successful retry preserves the repository's normal review gate.
+
+Implementation and focused proof are complete. Plan closure changes documentation
+only; final-head CI and mergeability are the remaining handoff checks. This task
+opens the PR without merging or deploying it.
+Completed: 2026-09-06

--- a/docs/contracts/06-hosted-workspace-file-count.md
+++ b/docs/contracts/06-hosted-workspace-file-count.md
@@ -144,12 +144,24 @@ landing; record the chosen posture here so the decision is reviewable.
   directories after canonical import, or documenting an explicit indefinite raw
   evidence retention envelope with file-count tests.
 
-- `assistant-state/hosted-mailbox-input-items/*.json` is runtime coupling state:
-  each mapping exists only to relate one hosted mailbox row to its persisted
-  assistant input event. Runtime-residue pruning inventories both owner trees,
-  fails closed on malformed or symlinked entries, removes eligible input events
-  first, then removes every mapping whose input no longer survives. Mappings do
-  not have an independent retention window.
+- `.runtime/operations/assistant/state/hosted-mailbox-inputs.sqlite` is the
+  durable hosted mailbox metadata owner: actual acknowledgement IDs and private
+  group context remain separate from sanitized input events and their blinded
+  source IDs. Each accepted input adds a row, not a file. The store reuses the
+  runtime SQLite migrations and assistant write lock, uses DELETE journaling,
+  secure deletion and private file permissions, and closes each handle before
+  checkpointing. Its one file is portable operational state, not a rebuildable
+  projection. Runtime-residue maintenance removes rows only after their input
+  events no longer survive; metadata has no independent retention window.
+  Exact-ID legacy reads remain available for old `hosted-mailbox-input-items`
+  files. Maintenance validates the legacy inventory, commits missing rows without
+  overwriting current rows, validates the stored rows, and then removes legacy
+  files. An interrupted migration leaves readable duplicates. Malformed or
+  symlinked legacy entries block migration and pruning; a damaged database fails
+  closed rather than falling back to obsolete metadata. Remove legacy support
+  once all retained checkpoints and workspaces have drained those files. The
+  SQLite-capable runner is the rollback floor after its first metadata write;
+  an older runner must not reopen a converted workspace.
 
 - `ledger/inbox-captures/YYYY/YYYY-MM.jsonl` is the sole committed inbox
   metadata owner. Current v2 writes can add attachment bytes but add no

--- a/packages/assistant-engine/src/assistant/hosted-mailbox-input-items.ts
+++ b/packages/assistant-engine/src/assistant/hosted-mailbox-input-items.ts
@@ -1,11 +1,14 @@
 import type { Dirent } from 'node:fs'
-import { readdir, readFile } from 'node:fs/promises'
+import { chmod, lstat, readdir, readFile, unlink } from 'node:fs/promises'
 import path from 'node:path'
 import {
   assertAssistantStatePathHasNoSymlinks,
   ensureAssistantStateDir,
   parseVersionedJsonStateEnvelope,
-  writeAssistantStateVersionedJson,
+  applySqliteRuntimeMigrations,
+  openSqliteRuntimeDatabase,
+  readSqliteRuntimeUserVersion,
+  withImmediateTransaction,
   type AssistantStatePaths,
 } from '@murphai/runtime-state/node'
 import {
@@ -36,7 +39,6 @@ export interface HostedMailboxAssistantInputItem {
 }
 
 export interface HostedMailboxAssistantInputItemInventoryEntry {
-  filePath: string
   inputId: string
 }
 
@@ -58,18 +60,7 @@ export async function recordHostedMailboxAssistantInputItem(input: {
   await withAssistantRuntimeWriteLock(input.vault, async () => {
     const item = normalizeHostedMailboxAssistantInputItem(input)
     await ensureAssistantState(paths)
-    await ensureAssistantStateDir(
-      resolveHostedMailboxAssistantInputItemsDirectory(paths),
-    )
-    await writeAssistantStateVersionedJson({
-      filePath: resolveHostedMailboxAssistantInputItemPath({
-        inputId: item.inputId,
-        paths,
-      }),
-      schema: ASSISTANT_HOSTED_MAILBOX_INPUT_ITEM_SCHEMA,
-      schemaVersion: ASSISTANT_HOSTED_MAILBOX_INPUT_ITEM_SCHEMA_VERSION,
-      value: item,
-    })
+    await writeHostedMailboxAssistantInputItemAtPaths(paths, item)
   })
 }
 
@@ -84,17 +75,21 @@ export async function readHostedMailboxAssistantInputItemDetails(input: {
   }
   const paths = resolveAssistantStatePaths(input.vault)
   const items = new Map<string, HostedMailboxAssistantInputItem>()
-
-  for (const inputId of new Set(input.inputIds)) {
-    const normalizedInputId = normalizeAssistantInputEventId(inputId, 'inputId')
-    const item = await readHostedMailboxAssistantInputItemAtPaths({
-      inputId: normalizedInputId,
-      paths,
-      signal: input.signal,
-    })
-    if (item) {
-      items.set(item.inputId, item)
+  const database = await openHostedMailboxInputDatabase(paths)
+  try {
+    const statement = database?.prepare('SELECT item_json FROM mailbox_inputs WHERE input_id = ?')
+    for (const inputId of new Set(input.inputIds)) {
+      input.signal?.throwIfAborted()
+      const id = normalizeAssistantInputEventId(inputId, 'inputId')
+      const row = statement?.get(id)
+      const item = row
+        ? parseHostedMailboxInputRow(row, id)
+        : await readLegacyHostedMailboxAssistantInputItemAtPaths({ inputId: id, paths, signal: input.signal })
+      if (item) items.set(id, item)
     }
+    input.signal?.throwIfAborted()
+  } finally {
+    database?.close()
   }
 
   return items
@@ -108,30 +103,25 @@ export async function retireHostedMailboxAssistantInputItemContentAtPaths(input:
   input.signal?.throwIfAborted()
   const item = await readHostedMailboxAssistantInputItemAtPaths(input)
   input.signal?.throwIfAborted()
-  if (!item?.groupReactionContext) {
+  if (!item) {
     return false
   }
   const {
     groupReactionContext: _retiredGroupReactionContext,
     ...retired
   } = item
-  await writeAssistantStateVersionedJson({
-    filePath: resolveHostedMailboxAssistantInputItemPath({
-      inputId: item.inputId,
-      paths: input.paths,
-    }),
-    schema: ASSISTANT_HOSTED_MAILBOX_INPUT_ITEM_SCHEMA,
-    schemaVersion: ASSISTANT_HOSTED_MAILBOX_INPUT_ITEM_SCHEMA_VERSION,
-    value: retired,
-  })
+  await writeHostedMailboxAssistantInputItemAtPaths(input.paths, retired)
   input.signal?.throwIfAborted()
-  return true
+  return Boolean(item.groupReactionContext)
 }
 
-export async function readHostedMailboxAssistantInputItemInventory(
+async function readLegacyHostedMailboxAssistantInputItemInventory(
   paths: AssistantStatePaths,
   signal?: AbortSignal | null,
-): Promise<HostedMailboxAssistantInputItemInventory> {
+): Promise<{
+  records: Array<{ filePath: string; inputId: string; item: HostedMailboxAssistantInputItem }>
+  trusted: boolean
+}> {
   signal?.throwIfAborted()
   const directory = resolveHostedMailboxAssistantInputItemsDirectory(paths)
   let entries: Dirent[]
@@ -148,7 +138,7 @@ export async function readHostedMailboxAssistantInputItemInventory(
     throw error
   }
 
-  const records: HostedMailboxAssistantInputItemInventoryEntry[] = []
+  const records: Array<{ filePath: string; inputId: string; item: HostedMailboxAssistantInputItem }> = []
   let trusted = true
   for (const entry of entries) {
     signal?.throwIfAborted()
@@ -177,7 +167,7 @@ export async function readHostedMailboxAssistantInputItemInventory(
         trusted = false
         continue
       }
-      records.push({ filePath, inputId })
+      records.push({ filePath, inputId, item })
     } catch {
       signal?.throwIfAborted()
       trusted = false
@@ -185,6 +175,173 @@ export async function readHostedMailboxAssistantInputItemInventory(
   }
 
   return { records, trusted }
+}
+
+type MailboxInputDatabase = import('node:sqlite').DatabaseSync
+
+export function resolveHostedMailboxAssistantInputDatabasePath(paths: AssistantStatePaths): string {
+  return path.join(paths.assistantStateRoot, 'state', 'hosted-mailbox-inputs.sqlite')
+}
+
+async function openHostedMailboxInputDatabase(
+  paths: AssistantStatePaths,
+  create = false,
+): Promise<MailboxInputDatabase | null> {
+  const databasePath = resolveHostedMailboxAssistantInputDatabasePath(paths)
+  await assertAssistantStatePathHasNoSymlinks(databasePath)
+  try {
+    const stat = await lstat(databasePath)
+    if (!stat.isFile()) throw new TypeError('Hosted mailbox input database must be a regular file.')
+  } catch (error) {
+    if (!isMissingFileError(error)) throw error
+    if (!create) return null
+    await ensureAssistantStateDir(path.dirname(databasePath))
+  }
+  const database = openSqliteRuntimeDatabase(databasePath, {
+    readOnly: !create,
+    journalMode: 'DELETE',
+    synchronous: 'FULL',
+  })
+  try {
+    if (create) {
+      database.exec('PRAGMA secure_delete = ON')
+      applySqliteRuntimeMigrations(database, {
+        storeName: 'hosted mailbox inputs',
+        schemaVersion: 1,
+        migrations: [{
+          version: 1,
+          migrate(db) {
+            db.exec('CREATE TABLE mailbox_inputs (input_id TEXT PRIMARY KEY, item_json TEXT NOT NULL)')
+          },
+        }],
+      })
+      await chmod(databasePath, 0o600)
+    } else if (readSqliteRuntimeUserVersion(database) !== 1) {
+      throw new TypeError('Unsupported hosted mailbox input database version.')
+    }
+    return database
+  } catch (error) {
+    database.close()
+    throw error
+  }
+}
+
+function parseHostedMailboxInputRow(
+  row: Record<string, unknown>,
+  inputId: string,
+): HostedMailboxAssistantInputItem {
+  if (typeof row.item_json !== 'string') throw new TypeError('Invalid hosted mailbox input row.')
+  const item = normalizeHostedMailboxAssistantInputItem(JSON.parse(row.item_json))
+  if (item.inputId !== inputId) throw new TypeError('Hosted mailbox input row identity mismatch.')
+  return item
+}
+
+async function readHostedMailboxAssistantInputItemAtPaths(input: {
+  inputId: string
+  paths: AssistantStatePaths
+  signal?: AbortSignal | null
+}): Promise<HostedMailboxAssistantInputItem | null> {
+  input.signal?.throwIfAborted()
+  const database = await openHostedMailboxInputDatabase(input.paths)
+  try {
+    const row = database?.prepare('SELECT item_json FROM mailbox_inputs WHERE input_id = ?').get(input.inputId)
+    if (row) return parseHostedMailboxInputRow(row, input.inputId)
+  } finally {
+    database?.close()
+  }
+  return await readLegacyHostedMailboxAssistantInputItemAtPaths(input)
+}
+
+// The caller holds the runtime write lock. Commit current state before removing
+// its legacy copy, so an interrupted conversion remains readable.
+async function writeHostedMailboxAssistantInputItemAtPaths(
+  paths: AssistantStatePaths,
+  item: HostedMailboxAssistantInputItem,
+): Promise<void> {
+  const database = await openHostedMailboxInputDatabase(paths, true)
+  if (!database) throw new Error('Hosted mailbox input database was not created.')
+  try {
+    database.prepare(`INSERT INTO mailbox_inputs (input_id, item_json) VALUES (?, ?)
+      ON CONFLICT(input_id) DO UPDATE SET item_json = excluded.item_json
+      WHERE item_json != excluded.item_json`).run(item.inputId, JSON.stringify(item))
+  } finally {
+    database.close()
+  }
+  await removeLegacyHostedMailboxInput(paths, item.inputId)
+}
+
+async function removeLegacyHostedMailboxInput(paths: AssistantStatePaths, inputId: string): Promise<void> {
+  const filePath = resolveHostedMailboxAssistantInputItemPath({ paths, inputId })
+  await assertAssistantStatePathHasNoSymlinks(filePath)
+  try {
+    await unlink(filePath)
+  } catch (error) {
+    if (!isMissingFileError(error)) throw error
+  }
+}
+
+// Runtime-residue maintenance is the sole bulk migration and retention owner.
+// No foreground lookup scans the legacy directory; it falls back by exact ID.
+export async function consolidateHostedMailboxAssistantInputItemsAtPaths(
+  paths: AssistantStatePaths,
+  signal?: AbortSignal | null,
+): Promise<HostedMailboxAssistantInputItemInventory> {
+  const legacy = await readLegacyHostedMailboxAssistantInputItemInventory(paths, signal)
+  const database = await openHostedMailboxInputDatabase(paths, legacy.trusted && legacy.records.length > 0)
+  try {
+    if (database && legacy.trusted && legacy.records.length > 0) {
+      withImmediateTransaction(database, () => {
+        const insert = database.prepare('INSERT OR IGNORE INTO mailbox_inputs (input_id, item_json) VALUES (?, ?)')
+        for (const entry of legacy.records) {
+          signal?.throwIfAborted()
+          insert.run(entry.inputId, JSON.stringify(entry.item))
+        }
+      })
+    }
+    const records = new Map(legacy.records.map(({ inputId }) => [inputId, { inputId }]))
+    for (const row of database?.prepare('SELECT input_id, item_json FROM mailbox_inputs').iterate() ?? []) {
+      signal?.throwIfAborted()
+      const inputId = normalizeAssistantInputEventId(row.input_id, 'inputId')
+      parseHostedMailboxInputRow(row, inputId)
+      records.set(inputId, { inputId })
+    }
+    if (database && legacy.trusted) {
+      for (const entry of legacy.records) {
+        signal?.throwIfAborted()
+        await removeLegacyHostedMailboxInput(paths, entry.inputId)
+      }
+    }
+    return { records: [...records.values()], trusted: legacy.trusted }
+  } finally {
+    database?.close()
+  }
+}
+
+export async function removeHostedMailboxAssistantInputItemsAtPaths(input: {
+  inputIds: readonly string[]
+  paths: AssistantStatePaths
+  signal?: AbortSignal | null
+}): Promise<void> {
+  input.signal?.throwIfAborted()
+  if (input.inputIds.length === 0) return
+  const database = await openHostedMailboxInputDatabase(input.paths, true)
+  try {
+    // Remove legacy copies first: interruption can leave a current row, never
+    // resurrect an old context after deleting the current row.
+    for (const inputId of input.inputIds) {
+      input.signal?.throwIfAborted()
+      await removeLegacyHostedMailboxInput(input.paths, inputId)
+    }
+    if (database) withImmediateTransaction(database, () => {
+      const remove = database.prepare('DELETE FROM mailbox_inputs WHERE input_id = ?')
+      for (const inputId of input.inputIds) {
+        input.signal?.throwIfAborted()
+        remove.run(inputId)
+      }
+    })
+  } finally {
+    database?.close()
+  }
 }
 
 export function resolveHostedMailboxAssistantInputItemsDirectory(
@@ -203,7 +360,7 @@ function resolveHostedMailboxAssistantInputItemPath(input: {
   )
 }
 
-async function readHostedMailboxAssistantInputItemAtPaths(input: {
+async function readLegacyHostedMailboxAssistantInputItemAtPaths(input: {
   inputId: string
   paths: AssistantStatePaths
   signal?: AbortSignal | null

--- a/packages/assistant-engine/src/assistant/runtime-residue.ts
+++ b/packages/assistant-engine/src/assistant/runtime-residue.ts
@@ -34,7 +34,8 @@ import {
 } from './automation/intent-provenance.js'
 import { assistantInputIdFromInboxCaptureId } from './input-source.js'
 import {
-  readHostedMailboxAssistantInputItemInventory,
+  consolidateHostedMailboxAssistantInputItemsAtPaths,
+  removeHostedMailboxAssistantInputItemsAtPaths,
   resolveHostedMailboxAssistantInputItemsDirectory,
   type HostedMailboxAssistantInputItemInventory,
 } from './hosted-mailbox-input-items.js'
@@ -140,7 +141,7 @@ interface AssistantRuntimeResiduePrunePlan {
   evidenceGroups: EvidenceGroup[]
   inputEventPaths: string[]
   journalPaths: string[]
-  hostedMailboxInputItemPaths: string[]
+  hostedMailboxInputItemIds: string[]
   provenancePaths: string[]
   receiptPaths: string[]
 }
@@ -333,9 +334,11 @@ async function pruneAssistantRuntimeResidueAtPaths(input: {
   for (const filePath of plan.inputEventPaths) {
     await removeAssistantStateFile(filePath, input.signal)
   }
-  for (const filePath of plan.hostedMailboxInputItemPaths) {
-    await removeAssistantStateFile(filePath, input.signal)
-  }
+  await removeHostedMailboxAssistantInputItemsAtPaths({
+    inputIds: plan.hostedMailboxInputItemIds,
+    paths: input.paths,
+    signal: input.signal,
+  })
   for (const filePath of plan.receiptPaths) {
     await removeAssistantStateFile(filePath, input.signal)
   }
@@ -368,7 +371,7 @@ async function pruneAssistantRuntimeResidueAtPaths(input: {
     autoReplyEvidenceGroupsPruned: plan.evidenceGroups.length,
     autoReplyIntentProvenancePruned: plan.provenancePaths.length,
     hostedMailboxInputItemMappingsPruned:
-      plan.hostedMailboxInputItemPaths.length,
+      plan.hostedMailboxInputItemIds.length,
     inputEventsPruned: plan.inputEventPaths.length,
     receiptsPruned: plan.receiptPaths.length,
   }
@@ -889,12 +892,12 @@ function planAssistantRuntimeResiduePrune(input: {
       .filter(({ filePath }) => !inputEventPaths.has(filePath))
       .map(({ record }) => record.inputId),
   )
-  const hostedMailboxInputItemPaths =
+  const hostedMailboxInputItemIds =
     input.inventory.inputEvents.trusted &&
     input.inventory.hostedMailboxInputItems.trusted
       ? input.inventory.hostedMailboxInputItems.records
           .filter(({ inputId }) => !survivingInputIds.has(inputId))
-          .map(({ filePath }) => filePath)
+          .map(({ inputId }) => inputId)
       : []
 
   const receiptPaths: string[] = []
@@ -949,7 +952,7 @@ function planAssistantRuntimeResiduePrune(input: {
 
   return {
     evidenceGroups: prunableEvidenceGroups,
-    hostedMailboxInputItemPaths,
+    hostedMailboxInputItemIds,
     inputEventPaths: [...inputEventPaths],
     journalPaths,
     provenancePaths,
@@ -1129,7 +1132,7 @@ async function readAssistantRuntimeResidueInventory(input: {
         input.vault,
         input.signal,
       ),
-      readHostedMailboxAssistantInputItemInventory(input.paths, input.signal),
+      consolidateHostedMailboxAssistantInputItemsAtPaths(input.paths, input.signal),
       readInputEventInventory(
         input.directories.inputEvents,
         input.paths,

--- a/packages/assistant-engine/test/assistant-runtime-residue.test.ts
+++ b/packages/assistant-engine/test/assistant-runtime-residue.test.ts
@@ -43,6 +43,7 @@ import {
 } from '../src/assistant/automation/evidence.ts'
 import {
   recordHostedMailboxAssistantInputItem,
+  readHostedMailboxAssistantInputItemDetails,
 } from '../src/assistant/hosted-mailbox-input-items.ts'
 import {
   createAssistantOutboxIntent,
@@ -601,9 +602,9 @@ describe('assistant runtime residue pruning', () => {
       paths,
     }))
     await expectPathExists(resolveEvidencePath(paths, event.inputId))
-    await expectPathExists(
-      resolveHostedMailboxInputItemPath(paths, event.inputId),
-    )
+    expect((await readHostedMailboxAssistantInputItemDetails({
+      inputIds: [event.inputId], vault: vaultRoot,
+    })).get(event.inputId)?.mailboxItemId).toBe('mailbox-item-pending')
   })
 
   it('deletes old settled input events before deleting complete evidence groups', async () => {
@@ -687,10 +688,6 @@ describe('assistant runtime residue pruning', () => {
       inputId: event.inputId,
       paths,
     })
-    const laterDeletionPath = resolveHostedMailboxInputItemPath(
-      paths,
-      event.inputId,
-    )
     const controller = new AbortController()
     const reason = new Error('stop residue deletion')
     const signal = controller.signal
@@ -698,8 +695,7 @@ describe('assistant runtime residue pruning', () => {
     signal.throwIfAborted = () => {
       if (
         !signal.aborted &&
-        !existsSync(firstDeletionPath) &&
-        existsSync(laterDeletionPath)
+        !existsSync(firstDeletionPath)
       ) {
         controller.abort(reason)
       }
@@ -713,7 +709,9 @@ describe('assistant runtime residue pruning', () => {
       vault: vaultRoot,
     })).rejects.toBe(reason)
     await expectPathMissing(firstDeletionPath)
-    await expectPathExists(laterDeletionPath)
+    expect((await readHostedMailboxAssistantInputItemDetails({
+      inputIds: [event.inputId], vault: vaultRoot,
+    })).has(event.inputId)).toBe(true)
   })
 
   it('does not start residue pruning with an already-aborted signal', async () => {
@@ -736,7 +734,9 @@ describe('assistant runtime residue pruning', () => {
       signal: controller.signal,
       vault: vaultRoot,
     })).rejects.toBe(reason)
-    await expectPathExists(resolveHostedMailboxInputItemPath(paths, inputId))
+    expect((await readHostedMailboxAssistantInputItemDetails({
+      inputIds: [inputId], vault: vaultRoot,
+    })).has(inputId)).toBe(true)
   })
 
   it('retains orphaned mailbox mappings when any mapping file is malformed', async () => {
@@ -745,12 +745,12 @@ describe('assistant runtime residue pruning', () => {
     )
     const validInputId = createInputId('b')
     const malformedInputId = createInputId('c')
-    await recordHostedMailboxAssistantInputItem({
+    await writeLegacyHostedMailboxInputItem({
       inputId: validInputId,
       mailboxItemId: 'mailbox-item-valid',
       vault: vaultRoot,
     })
-    await recordHostedMailboxAssistantInputItem({
+    await writeLegacyHostedMailboxInputItem({
       inputId: malformedInputId,
       mailboxItemId: 'mailbox-item-malformed',
       vault: vaultRoot,
@@ -781,7 +781,7 @@ describe('assistant runtime residue pruning', () => {
       'assistant-runtime-residue-malformed-input-event-',
     )
     const inputId = createInputId('f')
-    await recordHostedMailboxAssistantInputItem({
+    await writeLegacyHostedMailboxInputItem({
       inputId,
       mailboxItemId: 'mailbox-item-untrusted-input-inventory',
       vault: vaultRoot,
@@ -803,7 +803,9 @@ describe('assistant runtime residue pruning', () => {
     })
 
     expect(result.hostedMailboxInputItemMappingsPruned).toBe(0)
-    await expectPathExists(resolveHostedMailboxInputItemPath(paths, inputId))
+    expect((await readHostedMailboxAssistantInputItemDetails({
+      inputIds: [inputId], vault: vaultRoot,
+    })).get(inputId)?.mailboxItemId).toBe('mailbox-item-untrusted-input-inventory')
   })
 
   it('retains orphaned mailbox mappings when the mapping inventory contains a symlink', async () => {
@@ -812,7 +814,7 @@ describe('assistant runtime residue pruning', () => {
     )
     const validInputId = createInputId('d')
     const symlinkInputId = createInputId('e')
-    await recordHostedMailboxAssistantInputItem({
+    await writeLegacyHostedMailboxInputItem({
       inputId: validInputId,
       mailboxItemId: 'mailbox-item-valid',
       vault: vaultRoot,
@@ -1790,4 +1792,19 @@ async function pathExists(filePath: string): Promise<boolean> {
   } catch {
     return false
   }
+}
+
+async function writeLegacyHostedMailboxInputItem(input: {
+  inputId: string
+  mailboxItemId: string
+  vault: string
+}): Promise<void> {
+  const paths = resolveAssistantStatePaths(input.vault)
+  const filePath = resolveHostedMailboxInputItemPath(paths, input.inputId)
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(filePath, JSON.stringify({
+    schema: 'murph.assistant-hosted-mailbox-input-item.v1',
+    schemaVersion: 1,
+    value: { inputId: input.inputId, mailboxItemId: input.mailboxItemId },
+  }))
 }

--- a/packages/assistant-engine/test/hosted-mailbox-input-items.test.ts
+++ b/packages/assistant-engine/test/hosted-mailbox-input-items.test.ts
@@ -1,0 +1,130 @@
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  readHostedMailboxAssistantInputItemDetails,
+  consolidateHostedMailboxAssistantInputItemsAtPaths,
+  recordHostedMailboxAssistantInputItem,
+  resolveHostedMailboxAssistantInputDatabasePath,
+  resolveHostedMailboxAssistantInputItemsDirectory,
+  retireHostedMailboxAssistantInputItemContentAtPaths,
+} from '../src/assistant/hosted-mailbox-input-items.ts'
+import { withAssistantRuntimeWriteLock } from '../src/assistant/runtime-write-lock.ts'
+import { resolveAssistantStatePaths } from '../src/assistant/store/paths.ts'
+import { createTempVaultContext } from './test-helpers.ts'
+
+function inputId(index: number): string {
+  return `ain_${index.toString(16).padStart(32, '0')}`
+}
+
+async function legacy(vault: string, index: number, mailboxItemId = `legacy-${index}`): Promise<string> {
+  const directory = resolveHostedMailboxAssistantInputItemsDirectory(resolveAssistantStatePaths(vault))
+  await mkdir(directory, { recursive: true })
+  const filePath = path.join(directory, `${inputId(index)}.json`)
+  await writeFile(filePath, JSON.stringify({
+    schema: 'murph.assistant-hosted-mailbox-input-item.v1',
+    schemaVersion: 1,
+    value: { inputId: inputId(index), mailboxItemId },
+  }))
+  return filePath
+}
+
+async function inventory(vault: string, signal?: AbortSignal) {
+  return withAssistantRuntimeWriteLock(vault, (paths) =>
+    consolidateHostedMailboxAssistantInputItemsAtPaths(paths, signal), signal)
+}
+
+async function read(vault: string, indices: number[]) {
+  return readHostedMailboxAssistantInputItemDetails({ vault, inputIds: indices.map(inputId) })
+}
+
+describe('hosted mailbox input metadata storage', () => {
+  it('keeps repeated writes in one private database with no per-input files or SQLite sidecars', async () => {
+    const { vaultRoot } = await createTempVaultContext('mailbox-metadata-files-')
+    const paths = resolveAssistantStatePaths(vaultRoot)
+    for (let index = 0; index < 20; index += 1) {
+      await recordHostedMailboxAssistantInputItem({
+        vault: vaultRoot, inputId: inputId(index), mailboxItemId: `mailbox-${index}`,
+      })
+    }
+    const databasePath = resolveHostedMailboxAssistantInputDatabasePath(paths)
+    const files = (await readdir(path.dirname(databasePath))).filter((file) => file.startsWith('hosted-mailbox-inputs'))
+    expect(files).toEqual(['hosted-mailbox-inputs.sqlite'])
+    expect(existsSync(resolveHostedMailboxAssistantInputItemsDirectory(paths))).toBe(false)
+    expect((await stat(databasePath)).mode & 0o777).toBe(0o600)
+    expect(await read(vaultRoot, [0, 19])).toEqual(new Map([
+      [inputId(0), { inputId: inputId(0), mailboxItemId: 'mailbox-0' }],
+      [inputId(19), { inputId: inputId(19), mailboxItemId: 'mailbox-19' }],
+    ]))
+  })
+
+  it('reads legacy metadata without migration on the foreground path, then consolidates during maintenance', async () => {
+    const { vaultRoot } = await createTempVaultContext('mailbox-metadata-migration-')
+    const filePath = await legacy(vaultRoot, 1)
+    expect((await read(vaultRoot, [1])).get(inputId(1))?.mailboxItemId).toBe('legacy-1')
+    expect(existsSync(filePath)).toBe(true)
+    expect(existsSync(resolveHostedMailboxAssistantInputDatabasePath(resolveAssistantStatePaths(vaultRoot)))).toBe(false)
+    expect(await inventory(vaultRoot)).toEqual({ records: [{ inputId: inputId(1) }], trusted: true })
+    expect(existsSync(filePath)).toBe(false)
+    expect((await read(vaultRoot, [1])).get(inputId(1))?.mailboxItemId).toBe('legacy-1')
+  })
+
+  it('preserves current metadata over a legacy duplicate left by interrupted publication', async () => {
+    const { vaultRoot } = await createTempVaultContext('mailbox-metadata-precedence-')
+    await recordHostedMailboxAssistantInputItem({
+      vault: vaultRoot, inputId: inputId(1), mailboxItemId: 'current', usageRunningLow: true,
+    })
+    const filePath = await legacy(vaultRoot, 1, 'obsolete')
+    await inventory(vaultRoot)
+    expect((await read(vaultRoot, [1])).get(inputId(1))).toEqual({
+      inputId: inputId(1), mailboxItemId: 'current', usageRunningLow: true,
+    })
+    expect(existsSync(filePath)).toBe(false)
+  })
+
+  it('can resume consolidation after cancellation interrupts legacy file removal', async () => {
+    const { vaultRoot } = await createTempVaultContext('mailbox-metadata-abort-')
+    const first = await legacy(vaultRoot, 1)
+    const second = await legacy(vaultRoot, 2)
+    const controller = new AbortController()
+    const reason = new Error('foreground resumed')
+    const check = controller.signal.throwIfAborted.bind(controller.signal)
+    controller.signal.throwIfAborted = () => {
+      if (!existsSync(first)) controller.abort(reason)
+      check()
+    }
+    await expect(inventory(vaultRoot, controller.signal)).rejects.toBe(reason)
+    expect(existsSync(second)).toBe(true)
+    expect((await read(vaultRoot, [1, 2])).size).toBe(2)
+    await inventory(vaultRoot)
+    expect(existsSync(second)).toBe(false)
+    expect((await read(vaultRoot, [1, 2])).size).toBe(2)
+  })
+
+  it('erases expired quoted content from database pages and preserves operational metadata', async () => {
+    const { vaultRoot } = await createTempVaultContext('mailbox-metadata-retention-')
+    const quote = 'synthetic quote that must leave the saved SQLite pages'
+    await recordHostedMailboxAssistantInputItem({
+      vault: vaultRoot, inputId: inputId(1), mailboxItemId: 'retained-id',
+      groupReactionContext: quote, groupParticipantAdded: true,
+    })
+    await withAssistantRuntimeWriteLock(vaultRoot, async (paths) => {
+      expect(await retireHostedMailboxAssistantInputItemContentAtPaths({ inputId: inputId(1), paths })).toBe(true)
+    })
+    expect((await read(vaultRoot, [1])).get(inputId(1))).toEqual({
+      inputId: inputId(1), mailboxItemId: 'retained-id', groupParticipantAdded: true,
+    })
+    expect((await readFile(resolveHostedMailboxAssistantInputDatabasePath(resolveAssistantStatePaths(vaultRoot)))).includes(Buffer.from(quote))).toBe(false)
+  })
+
+  it('fails closed on a corrupt current database instead of resurrecting legacy values', async () => {
+    const { vaultRoot } = await createTempVaultContext('mailbox-metadata-corrupt-')
+    await recordHostedMailboxAssistantInputItem({ vault: vaultRoot, inputId: inputId(1), mailboxItemId: 'current' })
+    const legacyPath = await legacy(vaultRoot, 1, 'obsolete')
+    await writeFile(resolveHostedMailboxAssistantInputDatabasePath(resolveAssistantStatePaths(vaultRoot)), 'invalid database')
+    await expect(read(vaultRoot, [1])).rejects.toThrow()
+    await expect(inventory(vaultRoot)).rejects.toThrow()
+    expect(existsSync(legacyPath)).toBe(true)
+  })
+})

--- a/packages/runtime-state/README.md
+++ b/packages/runtime-state/README.md
@@ -51,3 +51,13 @@ Assistant runtime state also has a single filesystem permission policy. The `@mu
 - legacy hosted-bundle snapshots may externalize large raw artifacts under `vault/raw/**` into separate encrypted content-addressed objects. Direct-R2 v2 snapshots include restored workspace bytes in the encrypted archive instead of producing artifact sidecars.
 - hosted per-user env overrides live in a separate encrypted object and are not folded into the workspace snapshot
 - downstream packages should consume these helpers instead of inventing their own per-package runtime path conventions or versioning schemes
+
+Hosted mailbox input metadata is durable operational state in
+`.runtime/operations/assistant/state/hosted-mailbox-inputs.sqlite`, separate from
+sanitized assistant input events. It uses the existing runtime SQLite migration
+and lock owners, DELETE journaling, secure deletion, and one closed private file
+per checkpoint. The assistant-engine owner migrates legacy per-input JSON files
+during residue maintenance and retains rows only while their input events
+survive. This database is not a disposable projection: loss or corruption fails
+closed. The first database write establishes a SQLite-capable runner rollback
+floor; old runners cannot consume converted workspace metadata.

--- a/packages/runtime-state/src/assistant-local-state-descriptors.ts
+++ b/packages/runtime-state/src/assistant-local-state-descriptors.ts
@@ -167,6 +167,10 @@ export const assistantLocalStateDescriptors: readonly VaultLocalStatePathDescrip
     ".runtime/operations/assistant/state/group-participant-display-names.json",
     "Bounded presentation-only group participant display-name cache that moves with hosted workspace continuity.",
   ),
+  definePortableAssistantFile(
+    ".runtime/operations/assistant/state/hosted-mailbox-inputs.sqlite",
+    "Durable hosted mailbox acknowledgement identities and private input context, retained with their assistant input events.",
+  ),
   definePortableRebuildableAssistantFile(
     ".runtime/operations/assistant/state/outbox-dedupe.sqlite",
     "Assistant exact outbox dedupe projection that moves with hosted delivery continuity and can be rebuilt from durable intents.",


### PR DESCRIPTION
## Why and outcome

Each accepted hosted mailbox input currently creates another metadata JSON file. Store those records in one durable SQLite database, using the existing runtime-state owner and write lock. Preserve mailbox identity and private group context outside the sanitized input event.

Existing idle residue maintenance imports validated legacy records before removing their files. Current database rows win over interrupted-migration duplicates; foreground reads look up only requested records.

## Product UX

- Effort: Not applicable — internal persistence change.
- Result: Ready for review.
- Walkthrough: Hosted inputs retain the same acknowledgement, group-context and quote-retention behavior.

## Evidence

- Direct: 86 assistant-engine tests across hosted-mailbox-input-items, assistant-input-source, assistant-runtime-residue and assistant-input-store; 79 assistant-runtime tests across hosted-runtime-pending-input-index and hosted-runtime-turn-input; 71 runtime-state tests across assistant-state-security and hosted-bundle.
- Coverage: One private database replaces per-input files; interruption and retry preserve records; malformed data fails closed; quote retirement erases text from SQLite pages; pending-input acknowledgement and portable snapshot inclusion remain covered.
- Typechecks: `pnpm --dir packages/assistant-engine typecheck` and `pnpm --dir packages/runtime-state typecheck` pass. `git diff --check` passes. Final-head CI passes, including the release checks aggregate. Final ReviewGPT round 1 PASS on 49c4720a5486 with an attested gpt-6-pro response; the final commit only closes the implementation plan. No unresolved findings.

## Non-obvious affected surfaces

Group quote retirement uses SQLite secure deletion and preserves non-content routing flags. Runtime residue deletes metadata only after input events. Snapshot descriptors classify the database as durable portable state, never a rebuildable projection. Focused tests cover these boundaries.

## Architecture and reuse

- Existing systems reused: Runtime write lock, private-directory helpers, SQLite migration/open helpers, portable assistant-state descriptors and idle residue maintenance.
- New logic: Transactional legacy import, row-based deletion and quote retirement, exact-ID legacy fallback while migration is incomplete.
- New abstractions: One table owned by the existing hosted mailbox metadata module; public caller APIs retain their meaning.
- Complexity intentionally avoided: No background service, migration marker, additional queue, dual-write protocol or input-event schema change.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`.
- Hotspots: Existing `planAssistantRuntimeResiduePrune` (43) and `planAssistantGeneratedDeliveryPrune` (34) remain unchanged in complexity. Changed code maps metadata IDs to their storage owner.
- Agent judgment: The database removes filesystem fanout while preserving one explicit owner. Further decomposition of the unchanged prune planner would broaden this PR.

## Hot reply path impact

- Path status: Touched — durable mailbox metadata persistence and lookup.
- Database calls: One local database handle per record write or requested-ID read batch; one upsert per write and one SELECT per requested ID. Write handles initialize schema through the existing helper; SQLite busy timeout remains 5 seconds. No SQL retries added.
- Network/provider calls: None added.
- Other awaited latency: Existing runtime lock and private-directory creation; exact legacy-file fallback only for requested IDs missing from the database. Full legacy inventory remains idle maintenance.
- Before/after proof: Synthetic 20-input fixture verifies one SQLite file and no new metadata sidecars. Acknowledgement regressions pass; production latency was not measured.

## Murph initial provider input impact

Not applicable for individual and group turns: no prompt assembler, tools, schemas, guidance or provider-visible input changes. Measurement not run; this changes the storage behind existing metadata APIs.

## Deployment concerns

- Deployment: applicable
- Supported skew: New runners read legacy JSON and database records. Old runners cannot read newly written database records.
- Safe order: Drain old runner ownership before a converted workspace can be reassigned. Deploy as a coordinated runner-format upgrade; do not enable mixed old/new access to converted workspaces.
- Rollback floor: This reader version after the first database-backed write or legacy-file removal.
- Expected exposure: New accepted inputs use the database immediately; existing records converge during normal idle residue maintenance.
- Reversibility: Restoring old code requires an explicit reverse export or a pre-conversion checkpoint, with reconciliation of subsequent inputs.
- Convergence proof: Interrupted import and stale-legacy precedence tests prove restart safety; malformed metadata remains retained.
- Post-deploy checks: Confirm snapshots include the new database, legacy file counts decline on idle workspaces, and pending acknowledgements and quote retirement succeed.

## Change-shape breakdown

Classification rule: Test paths are tests, Markdown is documentation, remaining TypeScript is source. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 215 | 51 |
| Tests / fixtures | 163 | 16 |
| Docs | 111 | 6 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **489** | **73** |

## Changelog

- Changelog: not applicable
- Reason: Internal storage maintenance; no member-visible behavior change.

ReviewGPT context sensitivity: sensitive
Classification reason: Durable mailbox identity, private group content retention and snapshot portability.
ReviewGPT first-reviewed head: 49c4720a54869ebd58b475c2116418ffa7e96dfd
