### PR TITLE
refactor: add compatible Brotli ledger readers

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-06-vault-shard-codec.md
+++ b/agent-docs/exec-plans/active/2026-09-06-vault-shard-codec.md
@@ -44,3 +44,19 @@ also recognizes Brotli; a synthetic export retained exact archive bytes and reje
 an ambiguous raw/Brotli pair. Core typecheck, codec tests, complexity and shell syntax
 checks passed again. The first external review was already running on the prior
 head; a follow-up review is required for this production delta.
+
+## Round 1 disposition
+
+ReviewGPT reviewed the original head and reported one High finding: the generic
+write-policy suffix list omitted Brotli, so a canonical amendment could create a
+raw sibling and break rollback. The finding is valid for that historical head and
+already corrected by commit 3334253fe954 before response capture. Current-head
+source rejects this failure path by sharing the archive suffix list, and the real
+write-batch rollback regression passes. No additional production remediation is
+accepted from this result. Remaining corrections are review evidence and the
+isolated frozen-layout documentation expectation, so the non-production disposition
+exception applies. Round 2 will review the full current patch including the fix.
+
+CI's only platform-b failure was the frozen-layout test expecting the old documented
+suffix display. Align that isolated expectation with the Brotli-capable doc. No
+runtime contract or generated registry changes are required.

--- a/agent-docs/exec-plans/active/2026-09-06-vault-shard-codec.md
+++ b/agent-docs/exec-plans/active/2026-09-06-vault-shard-codec.md
@@ -1,0 +1,35 @@
+# Read Brotli ledger archives through existing storage owners
+
+## Outcome
+
+Prepare every canonical event and integration-ingest reader, amendment and query source classifier for lossless `.jsonl.br` archives. Keep new closed-month publication on gzip until this reader release has deployed and drained. Reuse native Node codecs and existing limits, receipts, locks and atomic publication.
+
+## Scope
+
+- One small shared codec module for the two existing ledger owners.
+- Logical paths and append receipts remain representation-neutral.
+- Preserve gzip and legacy integration ZIP reads; reject ambiguous representations.
+- Exercise malformed/truncated archives, bounded decode, late amendments, query discovery and exports through existing owner APIs.
+- Follow with writer activation and idle gzip conversion in a separate PR.
+
+## Verification
+
+Pending focused core/query tests, typechecks, complexity guard, CI and final review.
+
+## Codec decision
+
+Use native Brotli at quality 5. Synthetic corruption testing reproduced silent
+truncated-frame acceptance in the supported Node Zstandard decoder. Brotli rejects
+truncation without a custom framing validator or another dependency. Private-vault
+measurements were inspected only in memory; no source data or identifiers are
+included in this change. Keep the existing outer snapshot compression and query DB.
+
+## Local evidence
+
+- Core ledger suites: 52 tests passed; quality-5 codec regressions rerun and passed.
+- Query source manifest: 8 tests passed, including Brotli discovery and reads.
+- Core and query typechecks passed.
+- Complexity guard passed. Existing integration novelty scan hotspots (32, 27,
+  24) retain their prior complexity and behavior; only archive dispatch changes.
+- No dependency, wire receipt, query schema or provider-input changes.
+- Required CI and final review pending.

--- a/agent-docs/exec-plans/active/2026-09-06-vault-shard-codec.md
+++ b/agent-docs/exec-plans/active/2026-09-06-vault-shard-codec.md
@@ -33,3 +33,14 @@ included in this change. Keep the existing outer snapshot compression and query 
   24) retain their prior complexity and behavior; only archive dispatch changes.
 - No dependency, wire receipt, query schema or provider-input changes.
 - Required CI and final review pending.
+
+## Canonical writer and export follow-through
+
+The full write-batch rollback probe exposed a separate archive suffix list in the
+write-policy owner. Export and reuse that list in the ingest reader, including
+Brotli, so generic writes and canonical archived amendments agree. The probe now
+passes without creating a raw sibling. Standalone data-bundle conflict detection
+also recognizes Brotli; a synthetic export retained exact archive bytes and rejected
+an ambiguous raw/Brotli pair. Core typecheck, codec tests, complexity and shell syntax
+checks passed again. The first external review was already running on the prior
+head; a follow-up review is required for this production delta.

--- a/agent-docs/exec-plans/completed/2026-09-06-vault-shard-codec.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-vault-shard-codec.md
@@ -60,3 +60,21 @@ exception applies. Round 2 will review the full current patch including the fix.
 CI's only platform-b failure was the frozen-layout test expecting the old documented
 suffix display. Align that isolated expectation with the Brotli-capable doc. No
 runtime contract or generated registry changes are required.
+
+## Completion review
+
+ReviewGPT round 2 passed on the implementation head with no qualifying
+findings remaining. The captured response and model-attestation hashes match; the
+requested and observed model are gpt-6-pro on the Hercules lane, with more than six
+minutes of response capture. The review traced actual storage consumers and
+receipt/recovery boundaries and was substantive for this scope. Parent final
+review agrees: no unresolved accepted findings remain.
+
+The subsequent base update and plan closure change only documentation and isolated
+layout proof; production behavior, runtime configuration and contracts are unchanged.
+Focused proof passed, including 10 layout checks on the producer branch. Final-head
+CI and current-base mergeability remain the handoff checks. Implementation is complete;
+no merge or deployment is performed by this task.
+Status: completed
+Updated: 2026-09-06
+Completed: 2026-09-06

--- a/docs/contracts/01-vault-layout.md
+++ b/docs/contracts/01-vault-layout.md
@@ -48,7 +48,7 @@ Status: frozen current contract plus health extension fence
   ledger/inbox-captures/YYYY/YYYY-MM.jsonl
   derived/inbox/<captureId>/attachments/<attachmentId>/attempts/<attempt>/result.json
   ledger/assessments/YYYY/YYYY-MM.jsonl
-  ledger/events/YYYY/YYYY-MM.jsonl[.gz]
+  ledger/events/YYYY/YYYY-MM.jsonl[.gz|.br]
   ledger/integration-ingests/YYYY/YYYY-MM.jsonl
   ledger/metric-samples/<metric>/YYYY/YYYY-MM.jsonl
   ledger/samples/<stream>/YYYY/YYYY-MM.jsonl
@@ -138,3 +138,18 @@ Generated artifact: `packages/contracts/generated/vault-metadata.schema.json`
 - Published version strings are immutable.
 - Any incompatible change must mint a new version string and either ship an explicit core migration or fail closed until one exists.
 - `packages/core` owns the future migration seam and versioned write behavior. Current older-format vaults fail closed until an explicit upgrade step is registered, and query/CLI paths must not keep legacy reads alive by silently rewriting stored records during reads.
+
+### Brotli shard reader compatibility
+
+Canonical event and integration-ingest owners also read `.jsonl.br` and preserve
+that encoding on late append and rollback. Gzip and legacy integration ZIP reads
+remain supported. Logical `.jsonl` paths, complete decompressed byte receipts,
+row validation and existing compressed/uncompressed limits are unchanged. Multiple
+physical representations still fail closed. Brotli uses its standard bounded window; large-window extensions are disabled. Query source discovery includes Brotli event shards.
+
+This reader release continues publishing new closed-month archives as gzip. Deploy
+and drain it across every workspace consumer before enabling Brotli publication
+or migrating existing gzip archives. Once Brotli is written, this reader release
+is the rollback floor; downgrade requires an explicit lossless conversion first.
+Compatibility readers remain until retained snapshots and supported imports no
+longer contain those representations.

--- a/packages/contracts/test/vault-layout-validation.test.ts
+++ b/packages/contracts/test/vault-layout-validation.test.ts
@@ -484,7 +484,7 @@ describe("vault layout exports", () => {
       `${VAULT_LAYOUT.inboxCaptureLedgerDirectory}/YYYY/YYYY-MM.jsonl`,
       `${DERIVED_DIRECTORY}/inbox/<captureId>/attachments/<attachmentId>/attempts/<attempt>/result.json`,
       `${VAULT_LAYOUT.assessmentLedgerDirectory}/YYYY/YYYY-MM.jsonl`,
-      `${VAULT_LAYOUT.eventLedgerDirectory}/YYYY/YYYY-MM.jsonl[.gz]`,
+      `${VAULT_LAYOUT.eventLedgerDirectory}/YYYY/YYYY-MM.jsonl[.gz|.br]`,
       `${VAULT_LAYOUT.integrationIngestLedgerDirectory}/YYYY/YYYY-MM.jsonl`,
       `${VAULT_LAYOUT.metricSampleLedgerDirectory}/<metric>/YYYY/YYYY-MM.jsonl`,
       `${VAULT_LAYOUT.sampleLedgerDirectory}/<stream>/YYYY/YYYY-MM.jsonl`,

--- a/packages/core/src/event-ledger-storage.ts
+++ b/packages/core/src/event-ledger-storage.ts
@@ -3,9 +3,14 @@ import { createReadStream, createWriteStream, promises as fs } from "node:fs";
 import { StringDecoder } from "node:string_decoder";
 import { Transform, Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import { createGunzip, createGzip, gzipSync, gunzipSync } from "node:zlib";
+import { createGunzip, createGzip } from "node:zlib";
 
 import { prepareFileAtomicExclusive, writeFileAtomic } from "./atomic-write.ts";
+import {
+  compressShard,
+  decompressShard,
+  type ShardCompression,
+} from "./shard-compression.ts";
 import { VAULT_LAYOUT } from "./constants.ts";
 import { VaultError } from "./errors.ts";
 import { pathExists, walkVaultFiles, walkVaultFilesInterruptible } from "./fs.ts";
@@ -22,7 +27,7 @@ export const MAX_EVENT_LEDGER_SHARD_BYTES = 256 * 1024 * 1024;
 export const MAX_EVENT_LEDGER_ARCHIVE_BYTES = 128 * 1024 * 1024;
 
 export interface EventLedgerShardSource {
-  kind: "jsonl" | "gzip";
+  kind: "jsonl" | ShardCompression;
   logicalPath: string;
   sourcePath: string;
 }
@@ -42,11 +47,10 @@ export interface ArchiveClosedEventLedgerShardsResult {
 }
 
 function isEventLedgerSourcePath(relativePath: string): boolean {
-  return isEventLedgerLogicalPath(relativePath)
-    || (
-      relativePath.endsWith(".jsonl.gz")
-      && isEventLedgerLogicalPath(relativePath.slice(0, -".gz".length))
-    );
+  return ["", ".gz", ".br"].some((suffix) =>
+    relativePath.endsWith(`.jsonl${suffix}`)
+    && isEventLedgerLogicalPath(suffix ? relativePath.slice(0, -suffix.length) : relativePath)
+  );
 }
 
 export function isEventLedgerLogicalPath(relativePath: string): boolean {
@@ -74,6 +78,9 @@ function requireEventLedgerLogicalPath(relativePath: string): string {
 
 function toEventLedgerShardSource(relativePath: string): EventLedgerShardSource {
   const normalized = normalizeRelativeVaultPath(relativePath);
+  if (normalized.endsWith(".jsonl.br")) {
+    return { kind: "brotli", logicalPath: normalized.slice(0, -3), sourcePath: normalized };
+  }
   if (normalized.endsWith(".jsonl.gz")) {
     return {
       kind: "gzip",
@@ -97,7 +104,7 @@ function assertUnambiguousEventLedgerSources(
     if (prior) {
       throw new VaultError(
         "EVENT_LEDGER_SHARD_AMBIGUOUS",
-        `Event ledger shard "${source.logicalPath}" has both plain and gzip representations.`,
+        `Event ledger shard "${source.logicalPath}" has multiple physical representations.`,
         { relativePath: source.logicalPath },
       );
     }
@@ -150,23 +157,15 @@ export async function resolveEventLedgerShardSource(
   relativePath: string,
 ): Promise<EventLedgerShardSource | null> {
   const logicalPath = requireEventLedgerLogicalPath(relativePath);
-  const plainPath = resolveVaultPath(vaultRoot, logicalPath).absolutePath;
-  const gzipPath = resolveVaultPath(vaultRoot, `${logicalPath}.gz`).absolutePath;
-  const [plainExists, gzipExists] = await Promise.all([
-    pathExists(plainPath),
-    pathExists(gzipPath),
-  ]);
-  if (plainExists && gzipExists) {
-    throw new VaultError(
-      "EVENT_LEDGER_SHARD_AMBIGUOUS",
-      `Event ledger shard "${logicalPath}" has both plain and gzip representations.`,
-      { relativePath: logicalPath },
-    );
-  }
-  if (gzipExists) {
-    return { kind: "gzip", logicalPath, sourcePath: `${logicalPath}.gz` };
-  }
-  return plainExists ? { kind: "jsonl", logicalPath, sourcePath: logicalPath } : null;
+  const candidates = await Promise.all(["", ".gz", ".br"].map(async (suffix) => {
+    const sourcePath = `${logicalPath}${suffix}`;
+    return await pathExists(resolveVaultPath(vaultRoot, sourcePath).absolutePath)
+      ? toEventLedgerShardSource(sourcePath)
+      : null;
+  }));
+  const sources = candidates.filter((source) => source !== null);
+  assertUnambiguousEventLedgerSources(sources);
+  return sources[0] ?? null;
 }
 
 async function readBoundedEventLedgerSourceBytes(
@@ -185,7 +184,7 @@ async function readBoundedEventLedgerSourceBytes(
       { relativePath: source.sourcePath },
     );
   }
-  const maxStoredBytes = source.kind === "gzip"
+  const maxStoredBytes = source.kind !== "jsonl"
     ? MAX_EVENT_LEDGER_ARCHIVE_BYTES
     : MAX_EVENT_LEDGER_SHARD_BYTES;
   if (stats.size > maxStoredBytes) {
@@ -211,9 +210,7 @@ async function readBoundedEventLedgerSourceBytes(
     return storedBytes;
   }
   try {
-    const bytes = gunzipSync(storedBytes, {
-      maxOutputLength: MAX_EVENT_LEDGER_SHARD_BYTES,
-    });
+    const bytes = decompressShard(storedBytes, source.kind, MAX_EVENT_LEDGER_SHARD_BYTES);
     signal?.throwIfAborted();
     return bytes;
   } catch (error) {
@@ -358,7 +355,7 @@ export async function createArchivedEventLedgerShardContentReceipt(
   logicalPath: string,
 ): Promise<EventLedgerShardContentReceipt | null> {
   const source = await resolveEventLedgerShardSource(vaultRoot, logicalPath);
-  if (!source || source.kind !== "gzip") {
+  if (!source || source.kind === "jsonl") {
     return null;
   }
   const bytes = await readBoundedEventLedgerSourceBytes(vaultRoot, source);
@@ -374,7 +371,7 @@ export async function inspectArchivedEventLedgerShardAppend(input: {
   vaultRoot: string;
 }): Promise<"applied" | "base" | null> {
   const source = await resolveEventLedgerShardSource(input.vaultRoot, input.targetRelativePath);
-  if (!source || source.kind !== "gzip") {
+  if (!source || source.kind === "jsonl") {
     return null;
   }
   const bytes = await readBoundedEventLedgerSourceBytes(input.vaultRoot, source);
@@ -414,7 +411,11 @@ export async function inspectArchivedEventLedgerShardAppend(input: {
   );
 }
 
-function buildVerifiedEventLedgerArchive(bytes: Uint8Array, relativePath: string): Buffer {
+function buildVerifiedEventLedgerArchive(
+  bytes: Uint8Array,
+  relativePath: string,
+  kind: ShardCompression,
+): Buffer {
   if (bytes.byteLength > MAX_EVENT_LEDGER_SHARD_BYTES) {
     throw new VaultError(
       "EVENT_LEDGER_SHARD_TOO_LARGE",
@@ -422,20 +423,20 @@ function buildVerifiedEventLedgerArchive(bytes: Uint8Array, relativePath: string
       { byteSize: bytes.byteLength, relativePath },
     );
   }
-  const archive = gzipSync(bytes, { level: 6 });
+  const archive = compressShard(bytes, kind);
   if (archive.byteLength > MAX_EVENT_LEDGER_ARCHIVE_BYTES) {
     throw new VaultError(
       "EVENT_LEDGER_SHARD_TOO_LARGE",
-      `Event ledger archive "${relativePath}.gz" exceeds its compressed size limit.`,
-      { byteSize: archive.byteLength, relativePath: `${relativePath}.gz` },
+      `Event ledger archive "${relativePath}" exceeds its compressed size limit.`,
+      { byteSize: archive.byteLength, relativePath },
     );
   }
-  const verified = gunzipSync(archive, { maxOutputLength: MAX_EVENT_LEDGER_SHARD_BYTES });
+  const verified = decompressShard(archive, kind, MAX_EVENT_LEDGER_SHARD_BYTES);
   if (!verified.equals(Buffer.from(bytes))) {
     throw new VaultError(
       "EVENT_LEDGER_ARCHIVE_INVALID",
       "Event ledger archive verification failed.",
-      { relativePath: `${relativePath}.gz` },
+      { relativePath },
     );
   }
   return archive;
@@ -446,7 +447,8 @@ async function rewriteArchivedEventLedgerShard(
   source: EventLedgerShardSource,
   bytes: Uint8Array,
 ): Promise<void> {
-  const archive = buildVerifiedEventLedgerArchive(bytes, source.logicalPath);
+  if (source.kind === "jsonl") throw new TypeError("Expected an archived event shard.");
+  const archive = buildVerifiedEventLedgerArchive(bytes, source.sourcePath, source.kind);
   await writeFileAtomic(
     resolveVaultPath(vaultRoot, source.sourcePath).absolutePath,
     archive,
@@ -469,7 +471,7 @@ export async function appendArchivedEventLedgerShard(input: {
   vaultRoot: string;
 }): Promise<{ originalSize: number }> {
   const source = await resolveEventLedgerShardSource(input.vaultRoot, input.targetRelativePath);
-  if (!source || source.kind !== "gzip") {
+  if (!source || source.kind === "jsonl") {
     throw new VaultError(
       "EVENT_LEDGER_SHARD_NOT_ARCHIVED",
       "Event ledger shard is not archived.",
@@ -511,7 +513,7 @@ export async function truncateArchivedEventLedgerShard(input: {
   vaultRoot: string;
 }): Promise<void> {
   const source = await resolveEventLedgerShardSource(input.vaultRoot, input.targetRelativePath);
-  if (!source || source.kind !== "gzip") {
+  if (!source || source.kind === "jsonl") {
     throw new VaultError(
       "EVENT_LEDGER_SHARD_NOT_ARCHIVED",
       "Event ledger shard is not archived.",
@@ -697,6 +699,11 @@ async function archivePlainEventLedgerShard(
 ): Promise<{ archiveByteCount: number; repaired: boolean; sourceByteCount: number }> {
   signal?.throwIfAborted();
   const plainAbsolutePath = resolveVaultPath(vaultRoot, source.logicalPath).absolutePath;
+  if (await pathExists(resolveVaultPath(vaultRoot, `${source.logicalPath}.br`).absolutePath)) {
+    throw new VaultError("EVENT_LEDGER_SHARD_AMBIGUOUS", "Event ledger shard has multiple representations.", {
+      relativePath: source.logicalPath,
+    });
+  }
   const gzipSource = {
     kind: "gzip" as const,
     logicalPath: source.logicalPath,

--- a/packages/core/src/integration-ingests.ts
+++ b/packages/core/src/integration-ingests.ts
@@ -5,11 +5,8 @@ import { createInterface } from "node:readline";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import {
-  createGunzip,
-  createGzip,
   crc32,
   deflateRawSync,
-  gzipSync,
   inflateRawSync,
 } from "node:zlib";
 
@@ -27,6 +24,14 @@ import {
   prepareFileAtomicExclusive,
   writeFileAtomic,
 } from "./atomic-write.ts";
+import {
+  compressShard,
+  createShardCompressor,
+  createShardDecompressor,
+  isShardCompression,
+  shardCompressionFromPath,
+  type ShardCompression,
+} from "./shard-compression.ts";
 import { VAULT_LAYOUT } from "./constants.ts";
 import { VaultError } from "./errors.ts";
 import { pathExists, walkVaultFiles } from "./fs.ts";
@@ -43,7 +48,6 @@ export const MAX_INTEGRATION_INGEST_ZIP_ENTRY_BYTES = 256 * 1024 * 1024;
 const INTEGRATION_INGEST_NOVELTY_MAX_SCAN_BYTES = 8 * 1024 * 1024;
 const INTEGRATION_INGEST_NOVELTY_MAX_SCAN_ROWS = 64;
 const INTEGRATION_INGEST_NOVELTY_SCAN_CHUNK_BYTES = 64 * 1024;
-const INTEGRATION_INGEST_ARCHIVE_GZIP_LEVEL = 6;
 const INTEGRATION_INGEST_APPEND_PLAN_AUTHORITY = Symbol("integration-ingest-append-plan-authority");
 const INTEGRATION_INGEST_ID_INSPECTION_AUTHORITY = Symbol("integration-ingest-id-inspection-authority");
 
@@ -189,7 +193,7 @@ interface RawIntegrationIngestJsonlRow {
   sourcePath: string;
 }
 
-type IntegrationIngestRowSourceKind = "jsonl" | "gzip" | "zip";
+type IntegrationIngestRowSourceKind = "jsonl" | ShardCompression | "zip";
 
 interface IntegrationIngestRowSource {
   kind: IntegrationIngestRowSourceKind;
@@ -230,7 +234,7 @@ interface IntegrationIngestNoveltyTailScanResult {
   unsafe: boolean;
 }
 
-const INTEGRATION_INGEST_ARCHIVE_SUFFIXES = [".gz", ".zip"] as const;
+const INTEGRATION_INGEST_ARCHIVE_SUFFIXES = [".gz", ".br", ".zip"] as const;
 const ZIP_EOCD_SIGNATURE = 0x06054b50;
 const ZIP_CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
 const ZIP_LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
@@ -1368,6 +1372,7 @@ export async function archiveClosedIntegrationIngestShards(
       if (
         await pathExists(resolveVaultPath(input.vaultRoot, gzipPath).absolutePath)
         || await pathExists(resolveVaultPath(input.vaultRoot, zipPath).absolutePath)
+        || await pathExists(resolveVaultPath(input.vaultRoot, `${logicalPath}.br`).absolutePath)
       ) {
         blockedShardCount += 1;
         continue;
@@ -1534,7 +1539,8 @@ async function recoverInterruptedClosedIntegrationIngestArchivesLocked(input: {
       continue;
     }
     scannedConflictCount += 1;
-    if (await pathExists(resolveVaultPath(input.vaultRoot, zipPath).absolutePath)) {
+    if (await pathExists(resolveVaultPath(input.vaultRoot, zipPath).absolutePath)
+      || await pathExists(resolveVaultPath(input.vaultRoot, `${logicalPath}.br`).absolutePath)) {
       continue;
     }
 
@@ -1548,7 +1554,7 @@ async function recoverInterruptedClosedIntegrationIngestArchivesLocked(input: {
           logicalPath,
           signal: input.signal,
         }),
-        validateGzippedIntegrationIngestSource({
+        validateCompressedIntegrationIngestSource({
           absolutePath: gzipAbsolutePath,
           logicalPath,
           signal: input.signal,
@@ -1637,7 +1643,7 @@ async function archiveClosedIntegrationIngestShardLocked(input: {
       await pipeline(
         sourceStream,
         meter,
-        createGzip({ level: INTEGRATION_INGEST_ARCHIVE_GZIP_LEVEL }),
+        createShardCompressor("gzip"),
         targetStream,
         { signal: input.signal },
       );
@@ -1645,7 +1651,7 @@ async function archiveClosedIntegrationIngestShardLocked(input: {
       await pipeline(
         sourceStream,
         meter,
-        createGzip({ level: INTEGRATION_INGEST_ARCHIVE_GZIP_LEVEL }),
+        createShardCompressor("gzip"),
         targetStream,
       );
     }
@@ -1654,7 +1660,7 @@ async function archiveClosedIntegrationIngestShardLocked(input: {
       sha256: sourceHash.digest("hex"),
     };
     sourceReceiptHolder.value = sourceReceipt;
-    const validated = await validateGzippedIntegrationIngestSource({
+    const validated = await validateCompressedIntegrationIngestSource({
       absolutePath: tempAbsolutePath,
       logicalPath: input.logicalPath,
       signal: input.signal,
@@ -1793,7 +1799,7 @@ async function validateRawIntegrationIngestSource(input: {
   };
 }
 
-async function validateGzippedIntegrationIngestSource(input: {
+async function validateCompressedIntegrationIngestSource(input: {
   absolutePath: string;
   logicalPath: string;
   signal: AbortSignal | null;
@@ -1802,7 +1808,7 @@ async function validateGzippedIntegrationIngestSource(input: {
   const hash = createHash("sha256");
   let byteLength = 0;
   let finalByte: number | null = null;
-  const lineStream = await openGzippedIntegrationIngestLineStream(
+  const lineStream = await openCompressedIntegrationIngestLineStream(
     input.absolutePath,
     input.sourcePath,
     input.signal,
@@ -1819,7 +1825,7 @@ async function validateGzippedIntegrationIngestSource(input: {
     crlfDelay: Infinity,
   });
   const rowCount = await validateIntegrationIngestRows(lines, {
-    kind: "gzip",
+    kind: shardCompressionFromPath(input.sourcePath),
     logicalPath: input.logicalPath,
     sourcePath: input.sourcePath,
   }, input.signal);
@@ -1922,8 +1928,8 @@ async function* openIntegrationIngestSourceByteChunks(
     }
     return;
   }
-  if (source.kind === "gzip") {
-    yield* readBoundedGzippedIntegrationIngestChunks(absolutePath, source.sourcePath);
+  if (isShardCompression(source.kind)) {
+    yield* readBoundedCompressedIntegrationIngestChunks(absolutePath, source.sourcePath);
     return;
   }
   yield Buffer.from(await readZippedIntegrationIngestJsonlText(vaultRoot, source), "utf8");
@@ -1994,8 +2000,8 @@ export async function appendArchivedIntegrationIngestShard({
     };
   }
 
-  if (source.kind === "gzip") {
-    await rewriteGzippedIntegrationIngestArchive({
+  if (isShardCompression(source.kind)) {
+    await rewriteCompressedIntegrationIngestArchive({
       appendPayload: Buffer.from(appendPayload, "utf8"),
       source,
       vaultRoot,
@@ -2033,8 +2039,8 @@ export async function truncateArchivedIntegrationIngestShard({
   if (inspection.byteLength === expectedBaseByteLength) {
     return;
   }
-  if (source.kind === "gzip") {
-    await rewriteGzippedIntegrationIngestArchive({
+  if (isShardCompression(source.kind)) {
+    await rewriteCompressedIntegrationIngestArchive({
       source,
       truncateByteLength: expectedBaseByteLength,
       vaultRoot,
@@ -2162,7 +2168,7 @@ async function* parseIntegrationIngestJsonlLines(
   source: IntegrationIngestRowSource,
 ): AsyncGenerator<RawIntegrationIngestJsonlRow> {
   let lineNumber = 0;
-  let retainedGzipRowError: VaultError | null = null;
+  let retainedArchiveRowError: VaultError | null = null;
   const lineIterator = lines[Symbol.asyncIterator]();
   let iteratorNeedsClose = true;
 
@@ -2190,8 +2196,8 @@ async function* parseIntegrationIngestJsonlLines(
           `Integration ingest row in "${source.sourcePath}" exceeds the ${MAX_INTEGRATION_INGEST_JOURNAL_ROW_BYTES}-byte journal limit.`,
           { lineNumber, relativePath: source.sourcePath, rowPayloadBytes: lineBytes },
         );
-        if (source.kind === "gzip") {
-          retainedGzipRowError ??= error;
+        if (isShardCompression(source.kind)) {
+          retainedArchiveRowError ??= error;
           continue;
         }
         throw error;
@@ -2205,8 +2211,8 @@ async function* parseIntegrationIngestJsonlLines(
           lineNumber,
           cause: error instanceof Error ? error.message : String(error),
         });
-        if (source.kind === "gzip") {
-          retainedGzipRowError ??= invalidJson;
+        if (isShardCompression(source.kind)) {
+          retainedArchiveRowError ??= invalidJson;
           continue;
         }
         throw invalidJson;
@@ -2219,10 +2225,10 @@ async function* parseIntegrationIngestJsonlLines(
       };
     }
   } finally {
-    if (iteratorNeedsClose && source.kind === "gzip") {
+    if (iteratorNeedsClose && isShardCompression(source.kind)) {
       try {
         while (!(await lineIterator.next()).done) {
-          // Keep the gzip error owner alive when a row consumer fails early.
+          // Keep the decompressor error owner alive when a row consumer fails early.
         }
       } catch {
         // Preserve the consumer's original typed row error.
@@ -2232,8 +2238,8 @@ async function* parseIntegrationIngestJsonlLines(
     }
   }
 
-  if (retainedGzipRowError) {
-    throw retainedGzipRowError;
+  if (retainedArchiveRowError) {
+    throw retainedArchiveRowError;
   }
 }
 
@@ -2249,9 +2255,9 @@ async function openIntegrationIngestLineStream(
       ...(signal ? { signal } : {}),
     });
   }
-  if (source.kind === "gzip") {
+  if (isShardCompression(source.kind)) {
     const absolutePath = resolveVaultPath(vaultRoot, source.sourcePath).absolutePath;
-    return await openGzippedIntegrationIngestLineStream(
+    return await openCompressedIntegrationIngestLineStream(
       absolutePath,
       source.sourcePath,
       signal,
@@ -2264,7 +2270,7 @@ async function listIntegrationIngestRowSources(
   vaultRoot: string,
 ): Promise<IntegrationIngestRowSource[]> {
   const sources = new Map<string, IntegrationIngestRowSource>();
-  for (const extension of [".jsonl", ".jsonl.gz", ".jsonl.zip"] as const) {
+  for (const extension of [".jsonl", ".jsonl.gz", ".jsonl.br", ".jsonl.zip"] as const) {
     const paths = await walkVaultFiles(vaultRoot, VAULT_LAYOUT.integrationIngestLedgerDirectory, {
       extension,
     });
@@ -2295,6 +2301,9 @@ async function listIntegrationIngestRowSourcesForLogicalPaths(
 }
 
 function integrationIngestRowSourceFromPath(sourcePath: string): IntegrationIngestRowSource {
+  if (sourcePath.endsWith(".jsonl.br")) {
+    return { kind: "brotli", logicalPath: sourcePath.slice(0, -3), sourcePath };
+  }
   if (sourcePath.endsWith(".jsonl.gz")) {
     return {
       kind: "gzip",
@@ -2339,8 +2348,8 @@ async function readIntegrationIngestSourceText(
   if (source.kind === "jsonl") {
     return readFile(absolutePath, "utf8");
   }
-  if (source.kind === "gzip") {
-    return readGzippedIntegrationIngestJsonlText(absolutePath, source.sourcePath);
+  if (isShardCompression(source.kind)) {
+    return readCompressedIntegrationIngestJsonlText(absolutePath, source.sourcePath);
   }
   return readZippedIntegrationIngestJsonlText(vaultRoot, source);
 }
@@ -2359,8 +2368,8 @@ async function writeIntegrationIngestArchiveText(
   }
 
   const archivePath = resolveVaultPath(vaultRoot, source.sourcePath).absolutePath;
-  if (source.kind === "gzip") {
-    const archive = gzipSync(content);
+  if (isShardCompression(source.kind)) {
+    const archive = compressShard(content, source.kind);
     assertIntegrationIngestArchiveReplacementSize(content, archive, source.sourcePath);
     await writeFileAtomic(archivePath, archive);
     return;
@@ -2376,21 +2385,21 @@ async function writeIntegrationIngestArchiveText(
   );
 }
 
-async function rewriteGzippedIntegrationIngestArchive(input: {
+async function rewriteCompressedIntegrationIngestArchive(input: {
   appendPayload?: Buffer;
   source: IntegrationIngestRowSource;
   truncateByteLength?: number;
   vaultRoot: string;
 }): Promise<void> {
-  if (input.source.kind !== "gzip") {
+  if (!isShardCompression(input.source.kind)) {
     throw new VaultError(
       "INTEGRATION_INGEST_ARCHIVE_UNSUPPORTED",
-      `Integration ingest archive "${input.source.sourcePath}" is not gzip.`,
+      `Integration ingest archive "${input.source.sourcePath}" is not a streaming archive.`,
       { relativePath: input.source.sourcePath },
     );
   }
   if (input.appendPayload && input.truncateByteLength !== undefined) {
-    throw new TypeError("Gzip integration ingest rewrite cannot append and truncate together.");
+    throw new TypeError("Compressed integration ingest rewrite cannot append and truncate together.");
   }
 
   const archivePath = resolveVaultPath(input.vaultRoot, input.source.sourcePath).absolutePath;
@@ -2399,7 +2408,7 @@ async function rewriteGzippedIntegrationIngestArchive(input: {
     let outputByteLength = 0;
     const outputChunks = async function* (): AsyncGenerator<Buffer> {
       let remaining = input.truncateByteLength ?? Number.POSITIVE_INFINITY;
-      for await (const chunk of readBoundedGzippedIntegrationIngestChunks(
+      for await (const chunk of readBoundedCompressedIntegrationIngestChunks(
         archivePath,
         input.source.sourcePath,
       )) {
@@ -2439,14 +2448,14 @@ async function rewriteGzippedIntegrationIngestArchive(input: {
 
     await pipeline(
       Readable.from(outputChunks()),
-      createGzip({ level: INTEGRATION_INGEST_ARCHIVE_GZIP_LEVEL }),
+      createShardCompressor(shardCompressionFromPath(input.source.sourcePath)),
       createWriteStream(tempAbsolutePath, { flags: "wx", mode: 0o600 }),
     );
     const expectedReceipt = {
       byteLength: outputByteLength,
       sha256: outputHash.digest("hex"),
     };
-    const validated = await validateGzippedIntegrationIngestSource({
+    const validated = await validateCompressedIntegrationIngestSource({
       absolutePath: tempAbsolutePath,
       logicalPath: input.source.logicalPath,
       signal: null,
@@ -2480,21 +2489,22 @@ function sortIntegrationIngestRowSources(
 function integrationIngestSourceKindOrder(kind: IntegrationIngestRowSourceKind): number {
   if (kind === "jsonl") return 0;
   if (kind === "gzip") return 1;
-  return 2;
+  if (kind === "brotli") return 2;
+  return 3;
 }
 
-async function readGzippedIntegrationIngestJsonlText(
+async function readCompressedIntegrationIngestJsonlText(
   absolutePath: string,
   relativePath: string,
 ): Promise<string> {
   return readBoundedIntegrationIngestArchiveText(
-    readBoundedGzippedIntegrationIngestChunks(absolutePath, relativePath),
+    readBoundedCompressedIntegrationIngestChunks(absolutePath, relativePath),
     relativePath,
-    "gzip",
+    shardCompressionFromPath(relativePath),
   );
 }
 
-async function openGzippedIntegrationIngestLineStream(
+async function openCompressedIntegrationIngestLineStream(
   absolutePath: string,
   relativePath: string,
   signal: AbortSignal | null = null,
@@ -2503,41 +2513,42 @@ async function openGzippedIntegrationIngestLineStream(
   await assertIntegrationIngestArchiveCompressedSize(absolutePath, relativePath);
   return Readable.from(
     readBoundedIntegrationIngestArchiveChunks(
-      createGzippedIntegrationIngestReadStream(absolutePath, signal),
+      createCompressedIntegrationIngestReadStream(absolutePath, relativePath, signal),
       relativePath,
-      "gzip",
+      shardCompressionFromPath(relativePath),
       signal,
       inspectChunk,
     ),
   );
 }
 
-async function* readBoundedGzippedIntegrationIngestChunks(
+async function* readBoundedCompressedIntegrationIngestChunks(
   absolutePath: string,
   relativePath: string,
   signal: AbortSignal | null = null,
 ): AsyncGenerator<Buffer> {
   await assertIntegrationIngestArchiveCompressedSize(absolutePath, relativePath);
   yield* readBoundedIntegrationIngestArchiveChunks(
-    createGzippedIntegrationIngestReadStream(absolutePath, signal),
+    createCompressedIntegrationIngestReadStream(absolutePath, relativePath, signal),
     relativePath,
-    "gzip",
+    shardCompressionFromPath(relativePath),
     signal,
   );
 }
 
-function createGzippedIntegrationIngestReadStream(
+function createCompressedIntegrationIngestReadStream(
   absolutePath: string,
+  relativePath: string,
   signal: AbortSignal | null,
 ): NodeJS.ReadableStream {
   const compressed = createReadStream(
     absolutePath,
     signal ? { signal } : undefined,
   );
-  const gunzip = createGunzip();
-  compressed.once("error", (error) => gunzip.destroy(error));
-  gunzip.once("close", () => compressed.destroy());
-  return compressed.pipe(gunzip);
+  const decompressor = createShardDecompressor(shardCompressionFromPath(relativePath));
+  compressed.once("error", (error) => decompressor.destroy(error));
+  decompressor.once("close", () => compressed.destroy());
+  return compressed.pipe(decompressor);
 }
 
 async function assertIntegrationIngestArchiveCompressedSize(
@@ -2564,7 +2575,7 @@ async function assertIntegrationIngestArchiveCompressedSize(
 async function* readBoundedIntegrationIngestArchiveChunks(
   chunks: AsyncIterable<Buffer | string>,
   relativePath: string,
-  archiveKind: "gzip" | "zip",
+  archiveKind: ShardCompression | "zip",
   signal: AbortSignal | null = null,
   inspectChunk?: (chunk: Buffer) => void,
 ): AsyncGenerator<Buffer> {
@@ -2601,7 +2612,7 @@ async function* readBoundedIntegrationIngestArchiveChunks(
 async function readBoundedIntegrationIngestArchiveText(
   chunks: AsyncIterable<Buffer | string>,
   relativePath: string,
-  archiveKind: "gzip" | "zip",
+  archiveKind: ShardCompression | "zip",
 ): Promise<string> {
   const buffers: Buffer[] = [];
   let byteSize = 0;

--- a/packages/core/src/integration-ingests.ts
+++ b/packages/core/src/integration-ingests.ts
@@ -32,6 +32,7 @@ import {
   shardCompressionFromPath,
   type ShardCompression,
 } from "./shard-compression.ts";
+import { INTEGRATION_INGEST_ARCHIVE_SUFFIXES } from "./write-policy.ts";
 import { VAULT_LAYOUT } from "./constants.ts";
 import { VaultError } from "./errors.ts";
 import { pathExists, walkVaultFiles } from "./fs.ts";
@@ -234,7 +235,6 @@ interface IntegrationIngestNoveltyTailScanResult {
   unsafe: boolean;
 }
 
-const INTEGRATION_INGEST_ARCHIVE_SUFFIXES = [".gz", ".br", ".zip"] as const;
 const ZIP_EOCD_SIGNATURE = 0x06054b50;
 const ZIP_CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
 const ZIP_LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
@@ -2270,7 +2270,7 @@ async function listIntegrationIngestRowSources(
   vaultRoot: string,
 ): Promise<IntegrationIngestRowSource[]> {
   const sources = new Map<string, IntegrationIngestRowSource>();
-  for (const extension of [".jsonl", ".jsonl.gz", ".jsonl.br", ".jsonl.zip"] as const) {
+  for (const extension of [".jsonl", ...INTEGRATION_INGEST_ARCHIVE_SUFFIXES.map((suffix) => `.jsonl${suffix}`)]) {
     const paths = await walkVaultFiles(vaultRoot, VAULT_LAYOUT.integrationIngestLedgerDirectory, {
       extension,
     });

--- a/packages/core/src/shard-compression.ts
+++ b/packages/core/src/shard-compression.ts
@@ -1,0 +1,53 @@
+import {
+  constants,
+  createGunzip,
+  createGzip,
+  createBrotliCompress,
+  createBrotliDecompress,
+  gunzipSync,
+  gzipSync,
+  brotliCompressSync,
+  brotliDecompressSync,
+} from "node:zlib";
+
+export type ShardCompression = "gzip" | "brotli";
+
+const BROTLI_COMPRESSION_OPTIONS = {
+  params: { [constants.BROTLI_PARAM_QUALITY]: 5 },
+};
+
+export function isShardCompression(kind: string): kind is ShardCompression {
+  return kind === "gzip" || kind === "brotli";
+}
+
+export function shardCompressionFromPath(relativePath: string): ShardCompression {
+  if (relativePath.endsWith(".gz")) return "gzip";
+  if (relativePath.endsWith(".br")) return "brotli";
+  throw new TypeError("Expected a gzip or Brotli shard path.");
+}
+
+export function compressShard(bytes: Uint8Array | string, kind: ShardCompression): Buffer {
+  return kind === "gzip"
+    ? gzipSync(bytes, { level: 6 })
+    : brotliCompressSync(bytes, BROTLI_COMPRESSION_OPTIONS);
+}
+
+export function decompressShard(
+  bytes: Uint8Array,
+  kind: ShardCompression,
+  maxOutputLength: number,
+): Buffer {
+  return kind === "gzip"
+    ? gunzipSync(bytes, { maxOutputLength })
+    : brotliDecompressSync(bytes, { maxOutputLength });
+}
+
+export function createShardCompressor(kind: ShardCompression) {
+  return kind === "gzip"
+    ? createGzip({ level: 6 })
+    : createBrotliCompress(BROTLI_COMPRESSION_OPTIONS);
+}
+
+export function createShardDecompressor(kind: ShardCompression) {
+  return kind === "gzip" ? createGunzip() : createBrotliDecompress();
+}

--- a/packages/core/src/write-policy.ts
+++ b/packages/core/src/write-policy.ts
@@ -74,7 +74,7 @@ interface PrepareVerifiedTargetOptions {
   createParentDirectory: boolean;
 }
 
-const INTEGRATION_INGEST_ARCHIVE_SUFFIXES = [".gz", ".zip"] as const;
+export const INTEGRATION_INGEST_ARCHIVE_SUFFIXES = [".gz", ".br", ".zip"] as const;
 
 async function pathExists(absolutePath: string): Promise<boolean> {
   try {

--- a/packages/core/test/compressed-ledger-storage.test.ts
+++ b/packages/core/test/compressed-ledger-storage.test.ts
@@ -6,7 +6,10 @@ import path from "node:path";
 import { brotliCompressSync, brotliDecompressSync } from "node:zlib";
 import { afterEach, test } from "vitest";
 import {
+  buildIntegrationIngestAppendPlan,
   buildIntegrationIngestRecord,
+  runCanonicalWrite,
+  stageIntegrationIngestAppendPlan,
   initializeVault,
   listEventLedgerShardSources,
   readEvent,
@@ -91,6 +94,19 @@ test("Brotli integration shards preserve exact content through append replay and
   await appendArchivedIntegrationIngestShard({ ...input, payload });
   assert.ok(await readIntegrationIngestById(vaultRoot, next.id));
   await truncateArchivedIntegrationIngestShard(input);
+  assert.deepEqual(brotliDecompressSync(await fs.readFile(archivePath)), bytes);
+  const plan = await buildIntegrationIngestAppendPlan(vaultRoot, [next], { allowArchivedShardAmendments: true });
+  const conflictPath = "bank/synthetic-conflict.md";
+  await fs.mkdir(path.dirname(path.join(vaultRoot, conflictPath)), { recursive: true });
+  await fs.writeFile(path.join(vaultRoot, conflictPath), "existing\n");
+  await assert.rejects(runCanonicalWrite({
+    vaultRoot, operationType: "synthetic_archive_rollback", summary: "Synthetic rollback proof",
+    mutate: async ({ batch }) => {
+      await stageIntegrationIngestAppendPlan(batch, plan);
+      await batch.stageTextWrite(conflictPath, "replacement\n", { overwrite: false });
+    },
+  }), { code: "VAULT_FILE_EXISTS" });
+  await assert.rejects(fs.access(path.join(vaultRoot, logicalPath)));
   assert.deepEqual(brotliDecompressSync(await fs.readFile(archivePath)), bytes);
   await fs.writeFile(path.join(vaultRoot, `${logicalPath}.gz`), compressShard(bytes, "gzip"));
   await assert.rejects(readIntegrationIngestById(vaultRoot, first.id), { code: "INTEGRATION_INGEST_SHARD_REPRESENTATION_CONFLICT" });

--- a/packages/core/test/compressed-ledger-storage.test.ts
+++ b/packages/core/test/compressed-ledger-storage.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { brotliCompressSync, brotliDecompressSync } from "node:zlib";
+import { afterEach, test } from "vitest";
+import {
+  buildIntegrationIngestRecord,
+  initializeVault,
+  listEventLedgerShardSources,
+  readEvent,
+  readIntegrationIngestById,
+  upsertEvent,
+} from "../src/index.ts";
+import {
+  appendArchivedIntegrationIngestShard,
+  createArchivedIntegrationIngestShardContentReceipt,
+  truncateArchivedIntegrationIngestShard,
+} from "../src/integration-ingests.ts";
+import {
+  appendArchivedEventLedgerShard,
+  createArchivedEventLedgerShardContentReceipt,
+  truncateArchivedEventLedgerShard,
+} from "../src/event-ledger-storage.ts";
+import { compressShard, decompressShard } from "../src/shard-compression.ts";
+
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+async function createVault() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "murph-brotli-ledger-"));
+  roots.push(root);
+  await initializeVault({ vaultRoot: root, createdAt: "2026-01-01T00:00:00.000Z" });
+  return root;
+}
+
+test.each(["gzip", "brotli"] as const)("%s decode enforces output bounds and rejects truncated frames", (kind) => {
+  const content = Buffer.from("synthetic evidence\n".repeat(1000));
+  const archive = compressShard(content, kind);
+  assert.deepEqual(decompressShard(archive, kind, content.length), content);
+  assert.throws(() => decompressShard(archive, kind, 128));
+  assert.throws(() => decompressShard(archive.subarray(0, -3), kind, content.length));
+});
+
+test("Brotli event shards preserve logical reads, late writes and rollback receipts", async () => {
+  const vaultRoot = await createVault();
+  const event = await upsertEvent({ vaultRoot, payload: {
+    kind: "note", title: "Synthetic archive", note: "Exact retained evidence.", occurredAt: "2026-01-02T00:00:00.000Z",
+  } });
+  const rawPath = path.join(vaultRoot, event.ledgerFile);
+  const bytes = await fs.readFile(rawPath);
+  await fs.writeFile(`${rawPath}.br`, brotliCompressSync(bytes));
+  await fs.unlink(rawPath);
+  assert.equal((await listEventLedgerShardSources(vaultRoot))[0]?.kind, "brotli");
+  assert.equal((await readEvent({ vaultRoot, eventId: event.eventId })).event.title, "Synthetic archive");
+  const receipt = await createArchivedEventLedgerShardContentReceipt(vaultRoot, event.ledgerFile);
+  assert.ok(receipt);
+  const input = { vaultRoot, targetRelativePath: event.ledgerFile,
+    expectedBaseByteLength: receipt.byteLength, expectedBaseSha256: receipt.sha256 };
+  await appendArchivedEventLedgerShard({ ...input, payload: '{"id":"evt_synthetic_late"}\n' });
+  await appendArchivedEventLedgerShard({ ...input, payload: '{"id":"evt_synthetic_late"}\n' });
+  await truncateArchivedEventLedgerShard(input);
+  assert.deepEqual(brotliDecompressSync(await fs.readFile(`${rawPath}.br`)), bytes);
+  await fs.writeFile(rawPath, bytes);
+  await assert.rejects(listEventLedgerShardSources(vaultRoot), { code: "EVENT_LEDGER_SHARD_AMBIGUOUS" });
+});
+
+test("Brotli integration shards preserve exact content through append replay and rollback", async () => {
+  const vaultRoot = await createVault();
+  const logicalPath = "ledger/integration-ingests/2026/2026-01.jsonl";
+  const makeRecord = (id: string) => buildIntegrationIngestRecord({
+    id, provider: "synthetic", source: "device", importedAt: "2026-01-02T00:00:00.000Z",
+    parts: [], eventOutputs: [], eventIdsComplete: true, sampleIds: [], sampleIdsComplete: true,
+    eventCount: 0, sampleCount: 0,
+  });
+  const first = makeRecord("xfm_SyntheticFirst");
+  const next = makeRecord("xfm_SyntheticNext");
+  const bytes = Buffer.from(`${JSON.stringify(first)}\n`);
+  const archivePath = path.join(vaultRoot, `${logicalPath}.br`);
+  await fs.mkdir(path.dirname(archivePath), { recursive: true });
+  await fs.writeFile(archivePath, brotliCompressSync(bytes));
+  assert.ok(await readIntegrationIngestById(vaultRoot, first.id));
+  const receipt = await createArchivedIntegrationIngestShardContentReceipt(vaultRoot, logicalPath);
+  assert.equal(receipt?.sha256, createHash("sha256").update(bytes).digest("hex"));
+  const input = { vaultRoot, targetRelativePath: logicalPath,
+    expectedBaseByteLength: bytes.length, expectedBaseSha256: receipt!.sha256 };
+  const payload = `${JSON.stringify(next)}\n`;
+  await appendArchivedIntegrationIngestShard({ ...input, payload });
+  await appendArchivedIntegrationIngestShard({ ...input, payload });
+  assert.ok(await readIntegrationIngestById(vaultRoot, next.id));
+  await truncateArchivedIntegrationIngestShard(input);
+  assert.deepEqual(brotliDecompressSync(await fs.readFile(archivePath)), bytes);
+  await fs.writeFile(path.join(vaultRoot, `${logicalPath}.gz`), compressShard(bytes, "gzip"));
+  await assert.rejects(readIntegrationIngestById(vaultRoot, first.id), { code: "INTEGRATION_INGEST_SHARD_REPRESENTATION_CONFLICT" });
+});
+
+test("malformed Brotli shards fail closed through both public readers", async () => {
+  const vaultRoot = await createVault();
+  for (const family of ["events", "integration-ingests"]) {
+    const archivePath = path.join(vaultRoot, `ledger/${family}/2026/2026-01.jsonl.br`);
+    await fs.mkdir(path.dirname(archivePath), { recursive: true });
+    await fs.writeFile(archivePath, "not an archive");
+  }
+  await assert.rejects(readEvent({ vaultRoot, eventId: "evt_synthetic_missing" }), { code: "EVENT_LEDGER_ARCHIVE_INVALID" });
+  await assert.rejects(readIntegrationIngestById(vaultRoot, "xfm_SyntheticMissing"), { code: "INTEGRATION_INGEST_ARCHIVE_INVALID" });
+});

--- a/packages/query/src/vault-source.ts
+++ b/packages/query/src/vault-source.ts
@@ -313,7 +313,9 @@ export function isCanonicalQuerySourcePath(relativePath: string): boolean {
   for (const root of CANONICAL_JSONL_ROOTS) {
     if (
       root === VAULT_LAYOUT.eventLedgerDirectory
-      && isCanonicalPathUnderRoot(normalized, root, ".jsonl.gz")
+      && [".jsonl.gz", ".jsonl.br"].some((extension) =>
+        isCanonicalPathUnderRoot(normalized, root, extension)
+      )
     ) {
       return true;
     }

--- a/packages/query/test/vault-source-manifest.test.ts
+++ b/packages/query/test/vault-source-manifest.test.ts
@@ -3,6 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 
+import { brotliCompressSync } from "node:zlib";
+
 import { afterEach, test } from "vitest";
 
 import { CURRENT_VAULT_FORMAT_VERSION, VAULT_LAYOUT } from "@murphai/contracts";
@@ -272,4 +274,18 @@ test("isCanonicalQuerySourcePath matches the shared source families", () => {
   );
   assert.equal(isCanonicalQuerySourcePath("../vault.json"), false);
   assert.equal(isCanonicalQuerySourcePath("experiments\\trial.md"), false);
+});
+
+
+test("Brotli event archives enter the source manifest and canonical query reads", async () => {
+  const vaultRoot = await createTempVaultRoot();
+  const relativePath = "ledger/events/2026/2026-04.jsonl.br";
+  await mkdir(path.dirname(path.join(vaultRoot, relativePath)), { recursive: true });
+  await writeFile(path.join(vaultRoot, relativePath), brotliCompressSync(
+    '{"id":"evt_brotli_synthetic","kind":"note","title":"Archive discovery","occurredAt":"2026-04-01T00:00:00.000Z"}\n',
+  ));
+  assert.equal(isCanonicalQuerySourcePath(relativePath), true);
+  assert.deepEqual((await listCanonicalSourceManifest(vaultRoot)).map((entry) => entry.relativePath), [relativePath]);
+  const snapshot = await readVaultSourceStrict(vaultRoot);
+  assert.ok(snapshot.entities.some((entity) => entity.entityId === "evt_brotli_synthetic"));
 });

--- a/scripts/package-data-context.sh
+++ b/scripts/package-data-context.sh
@@ -160,7 +160,7 @@ collect_tree_files() {
 
 is_canonical_integration_ingest_archive() {
   local relative_path="$1"
-  [[ "$relative_path" =~ ^ledger/integration-ingests/[0-9]{4}/[0-9]{4}-(0[1-9]|1[0-2])\.jsonl\.(gz|zip)$ ]]
+  [[ "$relative_path" =~ ^ledger/integration-ingests/[0-9]{4}/[0-9]{4}-(0[1-9]|1[0-2])\.jsonl\.(gz|br|zip)$ ]]
 }
 
 should_copy_tree_file() {
@@ -241,7 +241,7 @@ assert_single_integration_ingest_shard_representations() {
     relative_path="${source_path#"$staged_vault_root"/}"
     if [[ "$relative_path" =~ ^ledger/integration-ingests/[0-9]{4}/[0-9]{4}-(0[1-9]|1[0-2])\.jsonl$ ]]; then
       current_logical_path="$relative_path"
-    elif [[ "$relative_path" =~ ^ledger/integration-ingests/[0-9]{4}/[0-9]{4}-(0[1-9]|1[0-2])\.jsonl\.(gz|zip)$ ]]; then
+    elif [[ "$relative_path" =~ ^ledger/integration-ingests/[0-9]{4}/[0-9]{4}-(0[1-9]|1[0-2])\.jsonl\.(gz|br|zip)$ ]]; then
       current_logical_path="${relative_path%.*}"
     else
       continue
@@ -254,7 +254,7 @@ assert_single_integration_ingest_shard_representations() {
     previous_logical_path="$current_logical_path"
   done < <(
     find "$staged_vault_root/ledger/integration-ingests" -type f \
-      \( -name '*.jsonl' -o -name '*.jsonl.gz' -o -name '*.jsonl.zip' \) \
+      \( -name '*.jsonl' -o -name '*.jsonl.gz' -o -name '*.jsonl.br' -o -name '*.jsonl.zip' \) \
       -print 2>/dev/null | LC_ALL=C sort || true
   )
 }


### PR DESCRIPTION
## Why and outcome

Prepare canonical event and integration-ingest storage for smaller Brotli archives. Both existing owners now read `.jsonl.br`, preserve that encoding through late append/replay/rollback, and expose the same logical `.jsonl` identity. Query discovery includes compressed event shards.

This is the consumer-first half of the change: new closed-month publication stays on gzip. A separate PR enables Brotli publication and idle conversion after these readers deploy and drain.

## Product UX

- Effort: Not applicable — internal archive representation.
- Result: Ready for review.
- Walkthrough: Historical reads, retained evidence and backdated writes retain their existing semantics.

## Evidence

- Direct: 52 core tests across `compressed-ledger-storage`, `event-ledger-storage` and `integration-ingests`; 8 query source-manifest tests; quality-5 codec tests rerun (5 passed).
- Coverage: Both owners read and amend Brotli, preserve exact decompressed bytes across replay/rollback, reject malformed/truncated input, enforce output limits and fail closed on multiple representations. Query manifest and canonical entity reads include Brotli.
- Checks: Core, query and contracts typechecks pass; 378 contracts tests pass, including frozen layout proof. Synthetic standalone export preserves Brotli bytes and rejects conflicting copies. Complexity guard passes. Final-head CI passes, including the release aggregate and required branch checks.

## Non-obvious affected surfaces

Archived append receipts and rollback remain representation-neutral. Existing gzip and ZIP regressions pass. Foreground source discovery recognizes the new extension; new archive publication remains unchanged.

## Architecture and reuse

- Existing systems reused: Canonical storage owners, write locks, atomic replacements, row validation, receipt verification and compressed/uncompressed limits.
- New logic: Brotli codec dispatch, source-path recognition, shared write-policy suffixes and standalone export conflict detection.
- New abstractions: One small shared native codec module, used by both existing owners; archive recognition reuses the write-policy owner.
- Complexity intentionally avoided: No dependency, subprocess, custom archive envelope, database, migration marker or separate storage owner. Supported Node's experimental Zstandard decoder failed a truncated-frame probe; mature native Brotli avoids a custom integrity workaround.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`.
- Hotspots: Existing integration novelty functions `scanIntegrationIngestNoveltyTail` (32), `inspectIntegrationIngestIdsForImportedAt` (27), and `visitRaw` (24) retain prior behavior and complexity. `assertWriteTargetPolicy` (30) also retains its existing complexity; its suffix list now has one shared owner.
- Agent judgment: Shared codec dispatch keeps the two real consumers composable. Reworking unrelated novelty scans would broaden this format-compatibility change.

## Hot reply path impact

- Path status: Touched only where existing canonical event reads resolve a physical shard.
- Database calls: None added.
- Network/provider calls: None added.
- Other awaited latency: One additional file-existence check per exact event-shard resolution, parallel with the existing plain/gzip checks. Integration discovery includes one additional archive suffix. No new retries, remote calls or maintenance on the reply path.
- Before/after proof: Logical read and amendment regressions pass. Production latency was not measured.

## Murph initial provider input impact

Not applicable for individual and group turns: no prompts, tools, schemas or provider-visible input assembly changes. Measurement not run.

## Deployment concerns

- Deployment: applicable
- Supported skew: New readers accept plain, gzip and Brotli; legacy integration ZIP remains supported. Old readers cannot read Brotli.
- Safe order: Deploy and drain this reader release across workspace readers, writers and export consumers before enabling the follow-up producer.
- Rollback floor: Unchanged until Brotli first appears; this compatible reader release then becomes the floor.
- Expected exposure: Existing vault publication remains gzip in this PR. Imported Brotli archives use the new reader path.
- Reversibility: Prior to producer activation ordinary rollback remains possible for gzip-only vaults. Brotli-bearing vaults need explicit lossless conversion before downgrade.
- Convergence proof: Format-preserving append/replay/rollback tests and existing format compatibility tests pass.
- Post-deploy checks: Confirm all consumers are on the compatible reader, query discovery works, and no representation conflicts appear before activating writers.

## Change-shape breakdown

Classification rule: Test paths are tests, Markdown is documentation, other TypeScript is source. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 175 | 102 |
| Tests / fixtures | 141 | 1 |
| Docs | 96 | 1 |
| Config / tooling | 3 | 3 |
| Generated / other | 0 | 0 |
| **Total** | **415** | **107** |

## Changelog

- Changelog: not applicable
- Reason: Internal storage representation; no member-visible behavior change.

ReviewGPT context sensitivity: sensitive
Classification reason: Canonical ledger persistence, bounded archive decoding and rollback receipts.
ReviewGPT first-reviewed head: a2d3b9a4e05ce9055a2ba8c161305f6c914909e0

Final ReviewGPT: Round 2 PASS on f755a12d9e1d; attested gpt-6-pro response. Subsequent changes only close the implementation plan. No unresolved accepted findings.
