### PR TITLE
Expose bounded network codes on hosted fetch failures

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-06-device-sync-transport-diagnostics.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-device-sync-transport-diagnostics.md
@@ -1,0 +1,45 @@
+# Bounded hosted fetch network diagnostics
+
+Status: completed
+Created: 2026-09-06
+Updated: 2026-09-06
+
+## Goal
+
+Distinguish nested network failure codes on existing hosted fetch failure logs without changing transport, retry, authority, or product behavior.
+
+## Evidence and ownership
+
+A read-only investigation found recurring artifact upload failures before an HTTP response, with generic TypeError classification and no caller cancellation or timeout signal. The deployed R2 service-code recovery covers a different boundary. The underlying network cause remains unproven. Open progress diagnostics do not cover this signal.
+
+The current control-plane fetch error owner retains only the direct cause classification. Two synthetic cases with nested ECONNRESET and UND_ERR_SOCKET fail because buildHostedRuntimeSafeErrorMetadata omits that distinction. Existing classifications pass.
+
+## Scope and constraints
+
+ReviewGPT authors production implementation and substantive revisions. Extend only existing control-plane fetch diagnostics and their safe metadata projection, focused tests, and the affected owner contract. Preserve typed errors, cancellation, retry policy, write fences, timeouts and success paths. No new event, network request, state, dependency, queue, scheduler, arbitrary error text, address, port, URL, stack or payload.
+
+Use a finite allowlist and bounded cause traversal. Omit unknown or unsafe values. Retain existing observability retention and sampling; one optional small field per existing failure event adds bounded storage cost and no event volume.
+
+## Tasks
+
+1. Reproduce the missing signal with synthetic tests (done: two expected failures).
+2. Obtain and inspect exact ReviewGPT implementation (done; applied the captured unified diff exactly).
+3. Run focused boundary and transport regressions, affected typecheck, privacy/docs and complexity checks; inspect complete diff (done: 279 tests pass, typecheck and all guards pass; no complexity hotspots above 20).
+4. Close this implementation plan and publish the tested candidate. Final ReviewGPT and exact-head CI are tracked on the PR by the original task owner.
+5. Merge/deploy only under established telemetry authority after required gates and exact release-scope proof. Record any blocker honestly.
+
+## Observation and retention
+
+Question: do natural failed fetches carry a known nested socket, DNS, connection or transport timeout code? After a verified rollout, query existing failure events over 24 hours grouped by operation, existing failure kind, and the optional network code. Treat missing codes as unavailable evidence and layered events as logs, not distinct incidents. Do not trigger failures or replay. Retain this finite field if it distinguishes causes under existing retention; reassess or remove if natural failures show no diagnostic value. No separate observer or ledger.
+
+## Verification
+
+- Before patch: focused control-plane-fetch-diagnostics tests fail 2/2 only for absent fetchNetworkErrorCode.
+- Candidate: all 279 tests in focused diagnostics, response-body, runner-platform and runtime transport suites pass. Cloudflare typecheck passes after ordinary Prisma generation. Logging/privacy, docs drift, complexity and whitespace guards pass. Complexity maximums are 17 and 16 for the two changed source files; no hotspots above 20.
+- Native local socket reproduction: a synthetic server closed after request data; Node fetch threw TypeError with nested UND_ERR_SOCKET. This demonstrates the error shape, not the production cause.
+- Parent review: production changes are additive diagnostic projection only. Nine finite codes, at most four cause objects, no new data/event/network/state owner. Tests preserve old wrapper behavior, privacy and exact composed request/event counts.
+- ReviewGPT returned a validated gpt-6-pro response; the exact captured inline patch applied without changes after the artifact downloader hit known issue #2588. The exact authoring documentation correction removes the incorrect packet-supplied fourteen-day Workers retention claim; current official Workers Logs maximum is seven days, and no configuration is changed. The short correction initially lacked capture-time model metadata; the supported thread export subsequently proved the exact committed turn, completed response, gpt-6-pro metadata and identical correction patch.
+- PR exact-head CI and final ReviewGPT remain separate completion gates; telemetry merge/deployment remains conditional on gates and release-scope authority.
+- Product UX and real-Codex journeys: internal metadata only; no prompt, tool, reply, UI, or member-visible behavior changes.
+- Frog: existing issue #2662 covers the supplied-worktree guard failure; sanctioned helper from primary created this isolated checkout. No new entry.
+Completed: 2026-09-06

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -486,6 +486,22 @@ Cloudflare keeps only the wake-payload decryption lane plus the worker-owned cal
 
 ## Private Operational Telemetry
 
+Existing hosted fetch-failure logs may include `fetchNetworkErrorCode`: the first
+exact allowlisted code (`ECONNREFUSED`, `ECONNRESET`, `ENOTFOUND`, `EPIPE`,
+`ETIMEDOUT`, `UND_ERR_SOCKET`, `UND_ERR_CONNECT_TIMEOUT`, `UND_ERR_HEADERS_TIMEOUT`,
+`UND_ERR_BODY_TIMEOUT`) in at most four cause-chain objects, including the direct
+fetch error. Capture reads only own `code`/`cause` data properties, stops on cycles
+or unsafe inspection, and revalidates the optional wrapper field before safe
+metadata projection; unavailable or unapproved values are omitted, not inferred.
+It adds no error text, stack, endpoint, socket, header, or payload data and changes
+no classification, abort, retry, authority, persistence, request, or event count.
+Existing Workers log volume, sampling, and retention settings remain unchanged;
+see the documented [maximum seven-day Workers Logs retention](https://developers.cloudflare.com/workers/observability/logs/workers-logs/#limits).
+After a separately gated rollout, observe existing
+aggregates for 24 hours for known socket/DNS/connection/timeout codes versus
+unavailable; do not induce production failures or replay. Retain the field only
+while it has diagnostic value under that policy.
+
 ### Web-control preflight rejections
 
 Ordinary runtime callers select a branded route descriptor from the same

--- a/apps/cloudflare/src/runtime-platform/control-plane-fetch.ts
+++ b/apps/cloudflare/src/runtime-platform/control-plane-fetch.ts
@@ -16,6 +16,19 @@ const HOSTED_RUNTIME_FETCH_CAUSE_NAMES = new Set([
   "TypeError",
 ]);
 
+const HOSTED_RUNTIME_FETCH_NETWORK_ERROR_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENOTFOUND",
+  "EPIPE",
+  "ETIMEDOUT",
+  "UND_ERR_SOCKET",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+]);
+const HOSTED_RUNTIME_FETCH_NETWORK_ERROR_MAX_DEPTH = 4;
+
 export type HostedRuntimeControlPlaneFetchCauseKind =
   | "abort"
   | "cloudflare_rpc_destroy"
@@ -29,6 +42,7 @@ export interface HostedRuntimeControlPlaneFetchFailureDiagnostics {
   fetchCauseCode: HostedExecutionErrorCode;
   fetchCauseKind: HostedRuntimeControlPlaneFetchCauseKind;
   fetchCauseName?: string;
+  fetchNetworkErrorCode?: string;
   fetchRequestSignalAborted: boolean;
   fetchTimeoutMs: number;
   fetchTimeoutSignalAborted: boolean;
@@ -48,6 +62,7 @@ export class HostedRuntimeControlPlaneFetchError extends Error {
   readonly hostedRuntimeFetchCauseCode: HostedExecutionErrorCode;
   readonly hostedRuntimeFetchCauseKind: HostedRuntimeControlPlaneFetchCauseKind;
   readonly hostedRuntimeFetchCauseName?: string;
+  readonly hostedRuntimeFetchNetworkErrorCode?: string;
   readonly hostedRuntimeFetchRequestSignalAborted: boolean;
   readonly hostedRuntimeFetchTimeoutMs: number;
   readonly hostedRuntimeFetchTimeoutSignalAborted: boolean;
@@ -68,6 +83,10 @@ export class HostedRuntimeControlPlaneFetchError extends Error {
     const causeName = readHostedRuntimeFetchCauseName(input.cause);
     if (causeName) {
       this.hostedRuntimeFetchCauseName = causeName;
+    }
+    const networkErrorCode = readHostedRuntimeFetchNetworkErrorCode(input.cause);
+    if (networkErrorCode) {
+      this.hostedRuntimeFetchNetworkErrorCode = networkErrorCode;
     }
     this.hostedRuntimeFetchCallerSignalAborted =
       input.signalState.callerSignalAborted;
@@ -114,11 +133,13 @@ export function readHostedRuntimeControlPlaneFetchFailureDiagnostics(
         const fetchCauseName = readHostedRuntimeFetchCauseNameValue(
           record.hostedRuntimeFetchCauseName,
         );
+        const fetchNetworkErrorCode = readHostedRuntimeFetchNetworkErrorCodeMetadata(record);
         return {
           fetchCallerSignalAborted,
           fetchCauseCode,
           fetchCauseKind,
           ...(fetchCauseName ? { fetchCauseName } : {}),
+          ...(fetchNetworkErrorCode ? { fetchNetworkErrorCode } : {}),
           fetchRequestSignalAborted,
           fetchTimeoutMs,
           fetchTimeoutSignalAborted,
@@ -263,6 +284,52 @@ function readHostedRuntimeFetchCauseNameValue(value: unknown): string | null {
   }
   const normalized = value.trim();
   return HOSTED_RUNTIME_FETCH_CAUSE_NAMES.has(normalized) ? normalized : null;
+}
+
+// Only own data properties are diagnostic inputs; never evaluate error accessors.
+function readHostedRuntimeFetchNetworkErrorCode(error: unknown): string | null {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+
+  try {
+    for (let depth = 0; depth < HOSTED_RUNTIME_FETCH_NETWORK_ERROR_MAX_DEPTH; depth += 1) {
+      if (!current || typeof current !== "object" || seen.has(current)) {
+        break;
+      }
+      seen.add(current);
+      const code = Object.getOwnPropertyDescriptor(current, "code");
+      if (code && !Object.hasOwn(code, "value")) {
+        return null;
+      }
+      const networkErrorCode = readHostedRuntimeFetchNetworkErrorCodeValue(code?.value);
+      if (networkErrorCode) {
+        return networkErrorCode;
+      }
+      const cause = Object.getOwnPropertyDescriptor(current, "cause");
+      current = cause && Object.hasOwn(cause, "value") ? cause.value : null;
+    }
+  } catch {
+    // Descriptor inspection can fail (for example, on a revoked Proxy).
+    // Optional diagnostics must never replace the original fetch failure.
+  }
+  return null;
+}
+
+function readHostedRuntimeFetchNetworkErrorCodeMetadata(error: object): string | null {
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(error, "hostedRuntimeFetchNetworkErrorCode");
+    return descriptor && Object.hasOwn(descriptor, "value")
+      ? readHostedRuntimeFetchNetworkErrorCodeValue(descriptor.value)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function readHostedRuntimeFetchNetworkErrorCodeValue(value: unknown): string | null {
+  return typeof value === "string" && HOSTED_RUNTIME_FETCH_NETWORK_ERROR_CODES.has(value)
+    ? value
+    : null;
 }
 
 function readHostedRuntimeFetchCauseKind(

--- a/apps/cloudflare/src/runtime-platform/diagnostics.ts
+++ b/apps/cloudflare/src/runtime-platform/diagnostics.ts
@@ -243,6 +243,9 @@ export function buildHostedRuntimeSafeErrorMetadata(
           ...(fetchFailureDiagnostics.fetchCauseName
             ? { fetchCauseName: fetchFailureDiagnostics.fetchCauseName }
             : {}),
+          ...(fetchFailureDiagnostics.fetchNetworkErrorCode
+            ? { fetchNetworkErrorCode: fetchFailureDiagnostics.fetchNetworkErrorCode }
+            : {}),
           fetchRequestSignalAborted:
             fetchFailureDiagnostics.fetchRequestSignalAborted,
           fetchTimeoutMs: fetchFailureDiagnostics.fetchTimeoutMs,

--- a/apps/cloudflare/test/control-plane-fetch-diagnostics.test.ts
+++ b/apps/cloudflare/test/control-plane-fetch-diagnostics.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { deriveHostedExecutionErrorCode } from "@murphai/hosted-execution";
+
+import {
+  HostedRuntimeControlPlaneFetchError,
+  readHostedRuntimeControlPlaneFetchFailureDiagnostics,
+  shouldRetryHostedRuntimeReplaySafeRead,
+} from "../src/runtime-platform/control-plane-fetch.ts";
+import { buildHostedRuntimeSafeErrorMetadata } from "../src/runtime-platform/diagnostics.ts";
+
+const signalState = {
+  callerSignalAborted: false,
+  requestSignalAborted: false,
+  timeoutMs: 1000,
+  timeoutSignalAborted: false,
+};
+const legacyMetadata = {
+  errorCode: "type_error",
+  errorMessagePresent: true,
+  errorName: "Error",
+  fetchCallerSignalAborted: false,
+  fetchCauseCode: "type_error",
+  fetchCauseKind: "fetch_failed",
+  fetchCauseName: "TypeError",
+  fetchRequestSignalAborted: false,
+  fetchTimeoutMs: 1000,
+  fetchTimeoutSignalAborted: false,
+};
+
+function createFailure(cause: unknown = new TypeError("fetch failed")) {
+  return new HostedRuntimeControlPlaneFetchError({
+    cause,
+    description: "Synthetic fetch",
+    signalState,
+  });
+}
+
+function readMetadata(error: unknown) {
+  return buildHostedRuntimeSafeErrorMetadata(
+    new Error("Synthetic wrapper", { cause: error }),
+    { includeSafeErrorText: false },
+  );
+}
+
+function captureNetworkCause(cause: unknown) {
+  return createFailure(new TypeError("fetch failed", { cause }));
+}
+
+describe("hosted fetch network diagnostics", () => {
+  it.each([
+    "ECONNRESET", "UND_ERR_SOCKET", "ECONNREFUSED", "ENOTFOUND", "EPIPE",
+    "ETIMEDOUT", "UND_ERR_CONNECT_TIMEOUT", "UND_ERR_HEADERS_TIMEOUT", "UND_ERR_BODY_TIMEOUT",
+  ])("preserves the bounded nested %s code through an outer wrapper", (code) => {
+    const failure = captureNetworkCause(Object.assign(
+      new Error("synthetic transport detail"),
+      {
+        code,
+        stack: "synthetic private stack",
+        address: "192.0.2.10",
+        port: 43210,
+        url: "https://example.invalid/private",
+        socket: { remoteAddress: "192.0.2.11" },
+        headers: { authorization: "synthetic-private-credential" },
+        payload: "synthetic-private-payload",
+      },
+    ));
+    const errorCode = code.includes("TIMEOUT") ? "timeout" : "type_error";
+    expect(readMetadata(failure)).toEqual({
+      ...legacyMetadata, errorCode, fetchCauseCode: errorCode, fetchNetworkErrorCode: code,
+    });
+  });
+
+  it.each([
+    { label: "missing", code: undefined },
+    { label: "null", code: null },
+    { label: "numeric", code: 123 },
+    { label: "unknown", code: "ERR_SYNTHETIC" },
+    { label: "private", code: "https://example.invalid/private" },
+    { label: "oversized", code: `ECONNRESET${"x".repeat(4096)}` },
+    { label: "whitespace", code: " ECONNRESET " },
+    { label: "lowercase", code: "econnreset" },
+    { label: "boxed", code: new String("ECONNRESET") },
+  ])("omits $label codes at capture and forged-wrapper projection", ({ code }) => {
+    expect(readMetadata(captureNetworkCause({ code }))).toEqual(legacyMetadata);
+    expect(readMetadata({
+      ...createFailure(),
+      hostedRuntimeFetchNetworkErrorCode: code,
+    })).toEqual(legacyMetadata);
+  });
+
+  it("does not coerce code values or enumerate error keys", () => {
+    const coerce = vi.fn(() => { throw new Error("Synthetic coercion"); });
+    const ownKeys = vi.fn(() => { throw new Error("Synthetic enumeration"); });
+    const cause = new Proxy({ code: { [Symbol.toPrimitive]: coerce } }, { ownKeys });
+    expect(readMetadata(captureNetworkCause(cause))).toEqual(legacyMetadata);
+    expect(coerce).not.toHaveBeenCalled();
+    expect(ownKeys).not.toHaveBeenCalled();
+  });
+
+  it("uses the nearest known code, including a direct code", () => {
+    const cause = Object.assign(new TypeError("fetch failed", {
+      cause: { code: "UND_ERR_SOCKET" },
+    }), { code: "ECONNRESET" });
+    expect(readMetadata(createFailure(cause)).fetchNetworkErrorCode).toBe("ECONNRESET");
+    expect(readMetadata(captureNetworkCause({
+      code: "ERR_SYNTHETIC",
+      cause: { code: "UND_ERR_SOCKET" },
+    })).fetchNetworkErrorCode).toBe("UND_ERR_SOCKET");
+  });
+
+  it.each([2, 3, 100])("bounds capture with %s intermediate causes", (count) => {
+    let cause: unknown = { code: "ECONNRESET" };
+    for (let index = 0; index < count; index += 1) {
+      cause = { cause };
+    }
+    expect(readMetadata(captureNetworkCause(cause))).toEqual(count === 2
+      ? { ...legacyMetadata, fetchNetworkErrorCode: "ECONNRESET" }
+      : legacyMetadata);
+  });
+
+  it("bounds descriptor work even when each cause is a fresh object", () => {
+    const descriptor = vi.fn((_target: object, property: string | symbol): PropertyDescriptor => ({
+      configurable: true,
+      value: property === "cause" ? new Proxy({}, { getOwnPropertyDescriptor: descriptor }) : undefined,
+    }));
+    const failure = captureNetworkCause(new Proxy({}, { getOwnPropertyDescriptor: descriptor }));
+    expect(failure.hostedRuntimeFetchNetworkErrorCode).toBeUndefined();
+    // The direct TypeError plus three nested objects; only code and cause are inspected.
+    expect(descriptor.mock.calls.map(([, property]) => property)).toEqual([
+      "code", "cause", "code", "cause", "code", "cause",
+    ]);
+  });
+
+  it("stops at cycles without rescanning their descriptors", () => {
+    const target: { cause?: unknown } = {};
+    const descriptor = vi.fn(Reflect.getOwnPropertyDescriptor);
+    target.cause = new Proxy(target, { getOwnPropertyDescriptor: descriptor });
+    expect(readMetadata(captureNetworkCause(target.cause))).toEqual(legacyMetadata);
+    expect(descriptor).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["code", "cause"])("adds no nested %s getter reads to legacy classification", (property) => {
+    const getter = vi.fn(() => undefined);
+    const nested = Object.defineProperty({}, property, { get: getter });
+    const cause = new TypeError("fetch failed", { cause: nested });
+    deriveHostedExecutionErrorCode(cause);
+    const legacyReads = getter.mock.calls.length;
+    getter.mockClear();
+    const failure = createFailure(cause);
+    expect(readHostedRuntimeControlPlaneFetchFailureDiagnostics(failure))
+      .not.toHaveProperty("fetchNetworkErrorCode");
+    expect(getter).toHaveBeenCalledTimes(legacyReads);
+  });
+
+  it("does not capture inherited codes or add inherited cause getter reads", () => {
+    const getter = vi.fn(() => undefined);
+    const prototype = Object.defineProperty({ code: "ECONNRESET" }, "cause", { get: getter });
+    const cause = new TypeError("fetch failed", { cause: Object.create(prototype) });
+    deriveHostedExecutionErrorCode(cause);
+    const legacyReads = getter.mock.calls.length;
+    getter.mockClear();
+    expect(createFailure(cause).hostedRuntimeFetchNetworkErrorCode).toBeUndefined();
+    expect(getter).toHaveBeenCalledTimes(legacyReads);
+  });
+
+  it.each(["code", "cause"])("omits the code when %s descriptor inspection throws", (property) => {
+    const cause = new Proxy({ cause: { code: "ECONNRESET" } }, {
+      getOwnPropertyDescriptor(target, key) {
+        if (key === property) {
+          throw new Error("Synthetic descriptor failure");
+        }
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
+    });
+    expect(readMetadata(captureNetworkCause(cause))).toEqual(legacyMetadata);
+  });
+
+  it("rejects optional-field getters, inherited values and throwing descriptors at projection", () => {
+    const failure = createFailure();
+    const getter = vi.fn(() => { throw new Error("Synthetic wrapper accessor"); });
+    Object.defineProperty(failure, "hostedRuntimeFetchNetworkErrorCode", { get: getter });
+    expect(readMetadata(failure)).toEqual(legacyMetadata);
+    expect(getter).not.toHaveBeenCalled();
+    const forged = { ...createFailure() };
+    Reflect.deleteProperty(forged, "hostedRuntimeFetchNetworkErrorCode");
+    Object.setPrototypeOf(forged, { hostedRuntimeFetchNetworkErrorCode: "ECONNRESET" });
+    expect(readMetadata(forged)).toEqual(legacyMetadata);
+    expect(readMetadata(new Proxy(createFailure(), {
+      getOwnPropertyDescriptor(target, key) {
+        if (key === "hostedRuntimeFetchNetworkErrorCode") {
+          throw new Error("Synthetic wrapper descriptor failure");
+        }
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
+    }))).toEqual(legacyMetadata);
+  });
+
+  it("keeps legacy wrappers without the optional field unchanged", () => {
+    const failure = createFailure();
+    Reflect.deleteProperty(failure, "hostedRuntimeFetchNetworkErrorCode");
+    expect(readMetadata(failure)).toEqual(legacyMetadata);
+    expect(readMetadata(new Error("Synthetic ordinary failure")))
+      .not.toHaveProperty("fetchNetworkErrorCode");
+  });
+
+  it.each([
+    { state: signalState, retryable: true, kind: "fetch_failed" },
+    { state: { ...signalState, callerSignalAborted: true }, retryable: false, kind: "abort" },
+    { state: { ...signalState, requestSignalAborted: true }, retryable: false, kind: "fetch_failed" },
+    { state: { ...signalState, timeoutSignalAborted: true }, retryable: false, kind: "timeout" },
+  ])("keeps $kind classification and signal-based retryability", ({ state, retryable, kind }) => {
+    for (const code of [undefined, "ECONNRESET", "UND_ERR_CONNECT_TIMEOUT"]) {
+      const cause = new TypeError("fetch failed", { cause: { code } });
+      const failure = new HostedRuntimeControlPlaneFetchError({
+        cause, description: "Synthetic fetch", signalState: state,
+      });
+      expect(failure.cause).toBe(cause);
+      const errorCode = code === "UND_ERR_CONNECT_TIMEOUT" ? "timeout" : "type_error";
+      expect(failure.code).toBe(errorCode);
+      expect(failure.name).toBe("Error");
+      expect(readMetadata(failure)).toEqual({
+        ...legacyMetadata,
+        errorCode,
+        fetchCauseCode: errorCode,
+        fetchCauseKind: kind,
+        fetchCallerSignalAborted: state.callerSignalAborted,
+        fetchRequestSignalAborted: state.requestSignalAborted,
+        fetchTimeoutSignalAborted: state.timeoutSignalAborted,
+        ...(code ? { fetchNetworkErrorCode: code } : {}),
+      });
+      expect(shouldRetryHostedRuntimeReplaySafeRead({ attempt: 1, error: failure })).toBe(retryable);
+      expect(shouldRetryHostedRuntimeReplaySafeRead({ attempt: 2, error: failure })).toBe(false);
+    }
+  });
+
+  it("does not make an unknown failure retryable merely because a nested code is known", () => {
+    const failure = createFailure(new Error("Synthetic failure", { cause: { code: "ECONNRESET" } }));
+    expect(readMetadata(failure)).toMatchObject({
+      errorCode: "runtime_error", fetchCauseKind: "unknown", fetchNetworkErrorCode: "ECONNRESET",
+    });
+    expect(shouldRetryHostedRuntimeReplaySafeRead({ attempt: 1, error: failure })).toBe(false);
+  });
+});

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -10356,28 +10356,88 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     expect(rejectedError).toMatchObject({ retryable });
   });
 
-  it("classifies artifact upload transport failures as retryable", async () => {
-    const fetchMock = vi.fn(async () => {
-      throw new Error("fetch failed");
-    });
-    const platform = buildTestHostedExecutionRuntimePlatform({
-      boundUserId: "member_123",
-      fetchImpl: fetchMock as typeof fetch,
-    });
-
-    let rejectedError: unknown;
-    try {
-      await platform.artifactStore.put({
-        bytes: new Uint8Array([1, 2, 3]),
-        sha256: "a".repeat(64),
+  it.each([undefined, "ECONNRESET", "UND_ERR_SOCKET"])(
+    "keeps artifact upload behavior and existing logs with network code %s",
+    async (code) => {
+      const cause = {
+        code,
+        address: "192.0.2.10",
+        port: 43210,
+        socket: { remoteAddress: "192.0.2.11" },
+        url: "https://example.invalid/private",
+        headers: { authorization: "synthetic-private-credential" },
+        payload: "synthetic-private-payload",
+      };
+      const failure = code
+        ? new TypeError("fetch failed", { cause })
+        : new Error("fetch failed");
+      let fail = true;
+      const fetchMock = vi.fn(async () => {
+        if (fail) {
+          throw failure;
+        }
+        return new Response(null, { status: 204 });
       });
-    } catch (error) {
-      rejectedError = error;
-    }
+      const platform = buildTestHostedExecutionRuntimePlatform({
+        boundUserId: "member_123",
+        fetchImpl: fetchMock as typeof fetch,
+      });
+      const artifact = { bytes: new Uint8Array([1, 2, 3]), sha256: "a".repeat(64) };
 
-    expect(rejectedError).toBeInstanceOf(HostedRuntimeArtifactWriteError);
-    expect(rejectedError).toMatchObject({ retryable: true });
-  });
+      let rejectedError: unknown;
+      try {
+        await platform.artifactStore.put(artifact);
+      } catch (error) {
+        rejectedError = error;
+      }
+      expect(rejectedError).toBeInstanceOf(HostedRuntimeArtifactWriteError);
+      expect(rejectedError).toMatchObject({ retryable: true, cause: { cause: failure } });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const logs = mocks.emitHostedExecutionStructuredLog.mock.calls.map(([input]) => input);
+      expect(logs.map((input) => input.message)).toEqual([
+        "Hosted runtime artifact upload started.",
+        "Hosted runtime artifact upload authority headers prepared.",
+        "Hosted runtime internal request started.",
+        "Hosted runtime internal request failed.",
+        "Hosted runtime upstream request failed.",
+        "Hosted runtime artifact upload failed before response.",
+      ]);
+      expect(logs[5]).toMatchObject({
+        component: "hosted.runtime.artifact-store",
+        level: "warn",
+        phase: "checkpoint",
+        details: {
+          errorCode: code ? "type_error" : "runtime_error",
+          fetchCauseCode: code ? "type_error" : "runtime_error",
+          fetchCauseKind: "fetch_failed",
+          fetchCauseName: code ? "TypeError" : "Error",
+          fetchCallerSignalAborted: false,
+          fetchRequestSignalAborted: false,
+          fetchTimeoutSignalAborted: false,
+          ...(code ? { fetchNetworkErrorCode: code } : {}),
+        },
+      });
+      if (!code) {
+        expect(logs[5].details).not.toHaveProperty("fetchNetworkErrorCode");
+      }
+      const serialized = JSON.stringify(logs);
+      for (const hidden of [
+        "192.0.2.10", "43210", "192.0.2.11", "example.invalid",
+        "synthetic-private-credential", "synthetic-private-payload", artifact.sha256,
+      ]) {
+        expect(serialized).not.toContain(hidden);
+      }
+
+      fail = false;
+      await platform.artifactStore.put(artifact);
+      await platform.artifactStore.put(artifact);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledTimes(12);
+      for (const [input] of mocks.emitHostedExecutionStructuredLog.mock.calls.slice(6)) {
+        expect(input.details).not.toHaveProperty("fetchNetworkErrorCode");
+      }
+    },
+  );
 
   it("validates the workspace lease immediately before web checkpoint callbacks", async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({


### PR DESCRIPTION
## Why

Hosted fetch failures can wrap a useful network code inside a generic TypeError. Existing failure logs retain the outer classification but lose the network distinction, leaving recurring artifact transport failures unexplained.

This telemetry-only change adds an optional, finite network error code to the existing fetch failure diagnostics. It preserves existing error classifications and transport behavior. It does not claim to repair the underlying production failure.

## Product UX

Internal-only operational metadata. No member-facing actions, meaning, delivery, UI, prompt, or recovery behavior changes. Ready: focused evidence and parent review pass.

## Evidence

- Before implementation: two synthetic regression cases failed solely because the nested code was absent.
- A local ephemeral socket that closes after receiving a request makes native Node fetch throw TypeError with nested UND_ERR_SOCKET. No production request or raw network metadata was recorded.
- Baseline: 33 focused response-body/transport tests, 207 runner-platform tests, Cloudflare typecheck and logging privacy guard pass.
- Candidate: all 279 tests pass across control-plane-fetch-diagnostics, hosted-response-body, runner-platform and runtime-invocation-transport-failure using the Cloudflare Node Vitest config. Cloudflare typecheck, logs:guard, docs:drift, complexity:diff and whitespace checks pass.
- ReviewGPT authored the production patch, which was applied exactly. Final round 1: **PASS**, zero findings, on `dfa670853a7ccd88d8541b6c733c34dc254652b9`; full snapshot on Eragon, gpt-6-pro response-model metadata, approximately ten minutes of waited review. Independent executable probes covered base/head retry equivalence, bounded descriptor work and real structured-log serialization. The reviewer used Node 22; repository tests and CI supply the declared-runtime proof.
- Tooling retries: an earlier 246-second response was below the required 270-second minimum and did not count; a retry-only option was rejected before submission. The accepted retry remained substantive round 1 on the unchanged head. No findings were received, accepted or rejected; no remediation was required.
- Exact-head CI: all four required checks pass (aggregate Release, both CLI host matrices and Stripe); 32 checks succeed and two expected checks are skipped. PR-body evidence checks pass.
- Natural production code attribution: unavailable until a verified rollout and another natural failure.

## Non-obvious affected surfaces

The shared diagnostic projection serves existing artifact, snapshot, and control-plane fetch failure logs. Success paths and retry decisions remain unchanged; focused transport regressions cover these boundaries.

## Architecture and reuse

- Existing systems reused: control-plane fetch error owner, safe error metadata builder, structured failure logs and existing retention.
- New logic: optional closed-vocabulary network cause projection.
- New abstractions: bounded internal diagnostic reader only; no new state owner.
- Complexity intentionally avoided: no new event, retry, queue, scheduler, dependency, configuration, or error-text collection.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` passes for both changed source files.
- Hotspots: none above 20; control-plane fetch maximum stays 17 and safe metadata maximum increases from 15 to 16.
- Agent judgment: bounded diagnostic projection is justified by the reproduced attribution gap.

## Hot reply path impact

- DB calls: None.
- Network/provider calls: None added or moved.
- Other awaited latency: None. Diagnostic projection runs synchronously only when wrapping/reading a failed fetch.
- Before/after proof: focused composed fetch tests preserve success, request count, existing failure events, abort flags and retry classification.

## Murph initial provider input impact

Not applicable to individual or group runtimes: no provider-visible input, prompts, tools, schemas or assembled guidance changed. No tokenizer measurement required.

<!-- ReviewGPT context sensitivity: sensitive -->
<!-- Classification reason: hosted execution diagnostic metadata and privacy boundary. -->

## Deployment concerns

- Deployment: applicable
- Supported skew: optional metadata only; old producers omit the field and existing consumers tolerate it.
- Safe order: ordinary reviewed hosted runtime release; no Web, database, schema or configuration migration required. This task has not deployed: the private workflow resolves current main, which contains separate assistant behavior changes beyond this telemetry-only authorization. A separately approved normal release must include the merged patch.
- Rollback floor: unchanged; existing storage/authority compatibility constraints still apply.
- Expected exposure: one small optional field on existing failure events, no extra event volume or external calls. Existing retention and sampling remain unchanged.
- Reversibility: a later reviewed removal can omit the field; no data migration or repair needed.
- Convergence proof: verify the exact deployed runtime source/image and query existing failed-fetch aggregates after natural traffic.
- Post-deploy checks: observe 24 hours grouped by operation, failure kind and the finite network code. Missing fields remain unknown, layered log events are not unique incidents, and no production failures/replays are triggered. Retain only while diagnostically useful under existing retention.

## Change-shape breakdown

Classification: runtime TypeScript is source; test paths are tests; README and completed plan are docs. No binaries or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 70 | 0 |
| Tests / fixtures | 323 | 19 |
| Docs | 61 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **454** | **19** |

## Changelog

- Changelog: not applicable
- Reason: internal failure metadata only; no member-visible feature, fix or behavior change.

ReviewGPT first-reviewed head: dfa670853a7ccd88d8541b6c733c34dc254652b9
