### PR TITLE
Preserve unclassified Postgres connection counts in database monitoring

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-06-db-telemetry-state.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-db-telemetry-state.md
@@ -1,0 +1,48 @@
+# Preserve unlabeled Postgres connection counts
+
+Status: completed
+
+## Outcome and owner
+
+Keep observed Postgres connection counts usable when a state label is empty or
+omitted. The existing Cloudflare metric parser owns normalization; missing
+families, branch/role isolation, alert admission, and retries retain their owners.
+
+## Evidence and approach
+
+The state aggregator currently rejects every connection-state series if any
+state label is falsy. Reproduce this with synthetic mixed-state scrapes before
+changing production code. Prometheus permits empty labels and treats omission
+as equivalent. Retain those observed counts under the empty state key instead
+of dropping the whole family. Keep PgBouncer pool-label validation strict.
+
+This is a parser change with no dependency, new state owner, migration, retry,
+or provider call. A Cloudflare release activates it; old retained samples stay
+historical. Production warnings alone cannot distinguish absent series from
+unusable labels, so the live trigger remains unconfirmed without scrape evidence.
+
+## Proof
+
+- Failing-then-passing parser and scheduled-monitor regressions for unlabeled
+  counts, normal states, and concrete saturation/aborted-state alerts.
+- Missing family and missing branch/role/pool labels remain incomplete.
+- Focused database-health suite, Cloudflare typecheck, complexity guard, and diff
+  review. Internal operator monitoring only; no member changelog.
+
+## Results
+
+- Before the fix, both parser cases failed with the connection-state family
+  marked missing. The three-check monitor reproduction recorded a failed first
+  sample, a telemetry page on the second, and a deferred alert on the third.
+- After the fix, all four database-health test files passed (134 tests). The
+  monitor's final persistence assertion also passed: all three samples retain
+  the synthetic total with no retry or page.
+- `pnpm --filter @murphai/cloudflare-runner typecheck` passed after the change.
+- `pnpm complexity:diff` passed with unchanged file debt and maximum complexity.
+  Existing parser/evaluator hotspots are outside the changed aggregation logic;
+  splitting them would broaden this correction without improving its contract.
+- Parent diff review confirmed no dependency, schema, state-owner, retry,
+  delivery, credential, or unrelated changes. Deployment and live scrape
+  confirmation remain separate from the local reproduction and fix.
+Updated: 2026-09-06
+Completed: 2026-09-06

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -304,6 +304,13 @@ Postgres and PgBouncer families require the provider's explicit
 `planetscale_role="primary"` label; missing role metadata makes that family
 incomplete instead of treating mixed or replica data as primary.
 
+Postgres connection-state series with empty or omitted state labels retain their
+observed counts under the empty state key. They contribute to total utilization
+without inventing a named state or discarding other states. This follows
+[Prometheus empty-label semantics](https://prometheus.io/docs/concepts/data_model/).
+An absent primary family stays unknown; PgBouncer pool labels still require a
+nonempty value.
+
 Discovery selects exactly one target by organization, database name, and branch
 name. The configured branch ID then filters the selected Prometheus payload's
 metric series. Both selectors are required because one organization can have

--- a/apps/cloudflare/src/database-health/metrics.ts
+++ b/apps/cloudflare/src/database-health/metrics.ts
@@ -639,8 +639,10 @@ function sumByLabel(
 ): Record<string, number> | null {
   const totals: Record<string, number> = {};
   for (const point of points) {
-    const key = point.labels[label];
-    if (!key) {
+    // Unclassified Postgres counts remain observed counts. Prometheus treats
+    // empty and omitted labels alike; pool identifiers still require a value.
+    const key = point.labels[label] ?? "";
+    if (!key && label !== CONNECTION_STATE_LABEL) {
       return null;
     }
     totals[key] = (totals[key] ?? 0) + point.value;

--- a/apps/cloudflare/test/database-health-metrics.test.ts
+++ b/apps/cloudflare/test/database-health-metrics.test.ts
@@ -14,6 +14,37 @@ import { buildMetricsBody } from "./helpers/database-health.ts";
 const BRANCH_ID = "branch_test";
 
 describe("PlanetScale database health metrics", () => {
+  it.each(["empty", "omitted"])(
+    "retains Postgres counts with an %s state label alongside actionable states",
+    (stateLabel) => {
+      let body = buildMetricsBody({
+        branchId: BRANCH_ID,
+        postgresStates: { "": 4, active: 40, "idle in transaction (aborted)": 1 },
+      });
+      if (stateLabel === "omitted") {
+        body = body.replace(',planetscale_connection_state=""', "");
+      }
+      const observation = parsePlanetScaleDatabaseMetricObservation(body, BRANCH_ID);
+
+      expect(observation.missingMetrics).toEqual([]);
+      expect(observation.snapshot.postgresConnectionStates).toEqual({
+        "": 4,
+        active: 40,
+        "idle in transaction (aborted)": 1,
+      });
+      expect(observation.snapshot.postgresConnections).toBe(45);
+      expect(evaluateDatabaseMetricSnapshot(observation.snapshot, null)).toEqual([
+        {
+          connections: 45,
+          kind: "postgres_connection_saturation",
+          limit: 50,
+          ratio: 0.9,
+        },
+        { count: 1, kind: "postgres_aborted_connections" },
+      ]);
+    },
+  );
+
   it("normalizes the requested connection signals for the configured branch", () => {
     const snapshot = parsePlanetScaleDatabaseMetrics(
       buildMetricsBody({
@@ -52,6 +83,48 @@ describe("PlanetScale database health metrics", () => {
         idle: 6,
       },
     });
+  });
+
+  it.each(["absent", "wrong branch", "replica", "missing role"])(
+    "keeps the Postgres-state family unknown for %s series",
+    (shape) => {
+      const body = buildMetricsBody({ branchId: BRANCH_ID })
+        .split("\n")
+        .map((line) => {
+          if (!line.startsWith("planetscale_postgres_connection_state{")) {
+            return line;
+          }
+          switch (shape) {
+            case "absent":
+              return "";
+            case "wrong branch":
+              return line.replace(BRANCH_ID, "branch_other");
+            case "replica":
+              return line.replace('planetscale_role="primary"', 'planetscale_role="replica"');
+            default:
+              return line.replace(',planetscale_role="primary"', "");
+          }
+        }).join("\n");
+      const observation = parsePlanetScaleDatabaseMetricObservation(body, BRANCH_ID);
+
+      expect(observation.missingMetrics).toEqual(["planetscale_postgres_connection_state"]);
+      expect(observation.snapshot.postgresConnections).toBeNull();
+      expect(observation.snapshot.postgresConnectionStates).toBeNull();
+    },
+  );
+
+  it.each(["empty", "omitted"])("keeps an %s PgBouncer pool label incomplete", (shape) => {
+    let body = buildMetricsBody({ branchId: BRANCH_ID }).replaceAll(
+      'planetscale_pgbouncer_pool="active"',
+      'planetscale_pgbouncer_pool=""',
+    );
+    if (shape === "omitted") {
+      body = body.replace(',planetscale_pgbouncer_pool=""', "");
+    }
+    const observation = parsePlanetScaleDatabaseMetricObservation(body, BRANCH_ID);
+
+    expect(observation.missingMetrics).toEqual(["planetscale_pgbouncer_pools_server"]);
+    expect(observation.snapshot.serverPoolStates).toBeNull();
   });
 
   it("alerts on wait, local server saturation, Postgres state, and connection-error deltas", () => {

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -64,6 +64,36 @@ describe("database health monitor", () => {
     vi.restoreAllMocks();
   });
 
+  it("does not retry or page for observed Postgres counts without a state", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const harness = createMonitorHarness({
+      metricsBody: buildMetricsBody({
+        branchId: BRANCH_ID,
+        postgresStates: { "": 3, active: 5, idle: 5 },
+      }),
+    });
+
+    const results = [];
+    for (const slot of [1, 2, 3]) {
+      results.push(await harness.runScheduledCheck(FIVE_MINUTES_MS * slot));
+    }
+    expect(results).toEqual([1, 2, 3].map(() => ({
+      conditions: [],
+      outcome: "healthy",
+      sampleStatus: "ok",
+    })));
+    expect(harness.planetScaleRequests).toHaveLength(6);
+    expect(harness.retryWaits).toEqual([]);
+    expect(harness.primaryLinqRequests).toEqual([]);
+    expect(harness.monitor.readAlertState()).toMatchObject({
+      consecutiveScrapeFailures: 0,
+      incidentOpen: false,
+    });
+    expect(harness.monitor.readRecentSamples()).toEqual([1, 2, 3].map(() =>
+      expect.objectContaining({ postgresConnections: 13, scrapeStatus: "ok" })
+    ));
+  });
+
   it("persists samples and sends no Linq page for healthy database metrics", async () => {
     const harness = createMonitorHarness();
 


### PR DESCRIPTION
## Why and outcome

A Postgres connection-state scrape containing one empty or omitted state label currently loses the entire family, including usable named states. Synthetic scheduled checks reproduce a missing-metric page after two checks. Preserve those observed counts under the empty state key so total utilization and named-state alerts remain usable.

## Product UX

- Effort: Not applicable — internal operator monitoring parser correction.
- Result: Ready.
- Walkthrough: Unclassified counts no longer produce false telemetry pages. Missing primary metric families still page, and saturation and aborted-state conditions still alert.

## Evidence

- Direct: Before the fix, two parser regressions failed and three scheduled checks produced failed, alert-sent, and deferred outcomes. After the fix, three healthy samples retain the counts without retries or provider sends.
- Coverage: 134 tests passed across database-health metrics, monitor, store, and Worker suites using `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage` with the four database-health test files.
- `pnpm --filter @murphai/cloudflare-runner typecheck` passed.
- `pnpm complexity:diff` and `git diff --check` passed.
- The final focused monitor persistence assertion passed separately. ReviewGPT round 1 passed on `5ba1cbff0ff1ec52652d26915d3b76b64cbd23a3` with no qualifying findings; the captured response hash and `gpt-6-pro` model proof were verified. All required CI checks passed on the reviewed head. The release workflow passed on attempt 2 after an unchanged workspace scheduling test failed on attempt 1; the isolated local test also passed. [Release CI](https://github.com/cobuildwithus/murph/actions/runs/34053487126)

## Non-obvious affected surfaces

Postgres utilization includes unclassified observed counts; regression proof crosses the saturation threshold and retains an aborted-state alert. Empty or omitted PgBouncer pool labels remain incomplete. Absent, wrong-branch, replica, and role-less Postgres families remain unknown.

## Architecture and reuse

- Existing systems reused: Existing metric parser, state aggregator, evaluator, SQLite sample store, and scheduled monitor.
- New logic: Preserve the empty Postgres state bucket while retaining strict pool-label validation.
- New abstractions: None; the existing aggregator owns this normalization.
- Complexity intentionally avoided: No new dependencies, retries, provider calls, storage, migrations, or monitoring owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; changed-file debt 26 to 26, maximum 38 to 38.
- Hotspots: `parsePlanetScaleDatabaseMetricObservation` (38) and `evaluateDatabaseMetricSnapshot` (28) are unchanged. The correction is in `sumByLabel`.
- Agent judgment: Further refactoring would broaden this focused semantic correction without simplifying its contract.

## Hot reply path impact

- Path status: Not applicable — isolated platform cron monitoring.
- Database calls: None added.
- Network/provider calls: None added.
- Other awaited latency: None added.
- Before/after proof: Healthy three-check regression requires six discovery/scrape requests and no confirmation waits.

## Murph initial provider input impact

Not applicable to individual or group Murph: no instructions, tools, schemas, generated guidance, or provider-visible input changes.

## Risks

The reproduced parser defect can produce missing-state alerts. Existing production warning metadata cannot distinguish absent series from rejected state labels; the live trigger is not yet confirmed. This change does not silence genuinely absent metric families.

ReviewGPT context sensitivity: sensitive
Classification reason: Production operator monitoring interprets an external provider metric contract and controls alert eligibility.
ReviewGPT first-reviewed head: 5ba1cbff0ff1ec52652d26915d3b76b64cbd23a3

## Deployment concerns

- Deployment: applicable
- Supported skew: Cloudflare-only parser change; Web and warm runner containers do not consume the normalized metric state.
- Safe order: Merge reviewed source, then deploy through the protected Murph Cloud workflow.
- Rollback floor: No new floor; preserve existing database-alert two-recipient admission requirements.
- Expected exposure: The next scheduled database-health collection uses the new parser.
- Reversibility: A forward correction can restore parser behavior without a schema migration; historical samples remain historical.
- Convergence proof: Existing stored samples and alert state retain their shapes; monitor/store/Worker regression suites pass.
- Post-deploy checks: Verify the deployed public source contains this commit and inspect bounded database-health cron outcomes and missing-metric warning aggregates without inducing a production failure.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source; test files are tests; README and completed execution plan are docs. No binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 2 |
| Tests / fixtures | 103 | 0 |
| Docs | 55 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **162** | **2** |

## Changelog

- Changelog: not applicable
- Reason: Internal operator monitoring correction with no member-facing feature or assistant behavior change.


Deployment: [production workflow](https://github.com/cobuildwithus/murph-cloud/actions/runs/34056115612) passed all pre-deploy gates, live endpoint smoke tests, and active Cloudflare deployment-state verification. Public source `835573709cbea008f33289674412602ddf738614` includes this merge; the metrics parser, monitor, and store blobs match the reviewed PR head. Worker version: `3a620ad7-9112-4f31-8c8e-e87e2cf26238`.
