### PR TITLE
Fix wearable notification dedupe conflicts on retry

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -428,6 +428,14 @@ Last verified: 2026-09-04
   remain the fail-closed backstop. The existing `runtime_recheck_requested`
   signal remains facts-only. This adds no mailbox item, direct wake, provider
   fallback, queue, or second preference owner.
+- Wearable recovery-notice materialization serializes on its existing source
+  row before revalidating eligibility and rereading the episode's mailbox key.
+  A pending item keeps its original immutable payload and is re-signaled after
+  commit; retries never rebuild it with a later timestamp, copy, or route.
+  Consumed items remain terminal. Crypto preparation stays outside the bounded
+  database-only transaction, and strict mailbox payload-conflict checks remain
+  unchanged. Each serial candidate adds one exact source-row lock and at most
+  one unique mailbox read, with no new external calls or pooled concurrency.
 - Exact Cloudflare runtime completion sends `runtime_owner_released` only when
   Web observes actionable work. Its opaque runtime-attempt pointer may clear the
   accepted-processing horizon only for that same owner; stale callbacks cannot

--- a/agent-docs/exec-plans/completed/2026-09-06-mailbox-notification-replay.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-mailbox-notification-replay.md
@@ -1,0 +1,54 @@
+# Wearable notification replay
+
+## Outcome and invariant
+
+Repeated device-sync applies reuse one immutable recovery notification per
+silence episode, without false mailbox payload conflicts. Preserve current
+source, access, outreach, recent-inbound, and direct-route eligibility checks.
+
+## Evidence and ownership
+
+The source-delivery-stall materializer rebuilds pending notifications using
+each attempt's timestamp under an episode-stable key. Mailbox dedupe correctly
+detects different payload hashes. Fix the materializer; retain strict mailbox
+comparison and the existing stored notification as authority.
+
+Serialize materialization on the existing source row, then reread the mailbox
+identity after eligibility checks. Return an existing item without rebuilding
+its envelope. No new state, queue, dependency, or protocol is needed. Crypto
+preparation stays outside the bounded database transaction; signaling stays
+after commit. Concurrent callbacks converge on the first stored item.
+
+## Product UX
+
+- Outcome: Preserve the existing single private wearable check-in.
+- Reaches: Initial, pending, consumed, concurrent, and newly ineligible episodes.
+- Proof: Focused replay and suppression tests, mailbox regression tests, Web
+  typecheck, scoped lint, and parent diff review. Live delivery is outside this
+  local patch's proof.
+
+## Verification and delivery
+
+- [x] Reproduce the repeated-pending append defect: the updated replay test
+  failed because the original materializer attempted another append.
+- [x] Implement reuse with serialized first materialization.
+- [x] Run focused tests: 205 passed across the materializer, runtime apply,
+  prepared mailbox append, and mailbox store. The final expanded materializer
+  suite passes 27 tests, including overlapping attempts and failed-signal retry.
+- [x] Web typecheck, scoped ESLint, and complexity guard pass. The transaction
+  callback retains its existing complexity of 23; no new abstraction is needed.
+- [x] Parent review confirms unchanged eligibility and envelope contracts,
+  source-before-mailbox lock ordering, and post-commit signaling. Privacy and
+  diff checks pass. Product UX: Ready for the bounded retry correction.
+
+Local proof covers application concurrency using a serialized transaction
+fixture; it does not claim a live provider send or production deployment.
+Final source, test, and owner-document changes are ready for a scoped commit.
+
+Web-only implementation change; existing rows and envelope schemas are
+unchanged. No Cloudflare release or database migration is required. Mixed old
+Web instances may continue logging conflicts until they finish draining.
+Changelog: internal retry correction with unchanged copy and delivery policy.
+Status: completed
+Updated: 2026-09-06
+Completed: 2026-09-06

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -50,7 +50,7 @@ not a guarantee that every claim was checked in this cleanup.
 | `agent-docs/product-marketing-context.md` | Product/marketing decisions. | Product/marketing decisions | High | 2026-07-15 |
 | `agent-docs/user-interviews.md` | User research method. | User research method | Medium | 2026-07-12 |
 | `agent-docs/QUALITY_SCORE.md` | Current quality posture by area. | Current repo quality posture | Medium | 2026-04-06 |
-| `agent-docs/RELIABILITY.md` | Reliability guardrails, request-local artifact PUT recovery, durable retry ownership, and accepted-mailbox progress evidence. | Runtime reliability policy | High | 2026-09-05 |
+| `agent-docs/RELIABILITY.md` | Reliability guardrails, request-local artifact PUT recovery, immutable wearable notification replay, durable retry ownership, and accepted-mailbox progress evidence. | Runtime reliability policy | High | 2026-09-06 |
 | `agent-docs/operations/stripe-effect-compatibility-cutover.md` | Hosted billing operations. | Hosted billing operations | High | 2026-08-28 |
 | `agent-docs/SECURITY.md` | Security constraints, trust boundaries, hosted media receipt recovery and atomic retirement, and escalation rules. | Security policy | High | 2026-09-05 |
 | `agent-docs/compliance/README.md` | Compliance reference-pack overview, launch minimums, and official source links for consumer health-data obligations. | Compliance docs index | High | 2026-04-29 |

--- a/apps/web/src/lib/device-sync/source-delivery-stall-notice.ts
+++ b/apps/web/src/lib/device-sync/source-delivery-stall-notice.ts
@@ -74,6 +74,10 @@ export async function materializeHostedSourceDeliveryStallNotice(input: {
   if (!Number.isFinite(now.getTime())) {
     return;
   }
+  const policy = readSourceRecoveryNoticePolicy(input.candidate.sourceProviderSlug);
+  if (!policy) {
+    return;
+  }
   const notificationKey = buildHostedSourceDeliveryStallNoticeKey(input.candidate);
   const messageKey = input.candidate.sourceProviderSlug === "apple_health_kit"
     ? "linq.apple_health_delivery_stalled"
@@ -91,6 +95,15 @@ export async function materializeHostedSourceDeliveryStallNotice(input: {
   }
   const appended = await runWithPreparedHostedMailboxItemAppendCrypto({
     append: (prepared) => prisma.$transaction(async (tx) => {
+      // Serialize first materialization and retries on the existing episode
+      // owner before checking whether another attempt already queued it.
+      await tx.$queryRaw`
+        SELECT id
+        FROM device_connection_source
+        WHERE connection_id = ${input.candidate.connectionId}
+          AND source_instance_key = ${input.candidate.sourceInstanceKey}
+        FOR UPDATE
+      `;
       const source = await tx.deviceConnectionSource.findUnique({
         select: {
           connection: { select: { status: true, userId: true } },
@@ -153,9 +166,15 @@ export async function materializeHostedSourceDeliveryStallNotice(input: {
       ) {
         return null;
       }
-      const policy = readSourceRecoveryNoticePolicy(source.sourceProviderSlug);
-      if (!policy) {
-        return null;
+      const alreadyQueued = await readHostedMailboxItemByDedupeKey({
+        dedupeKey,
+        prisma: tx,
+        userId: input.userId,
+      });
+      if (alreadyQueued) {
+        // The stored payload is immutable: rebuilding it with this attempt's
+        // timestamp, copy, or route would produce a false dedupe conflict.
+        return { item: alreadyQueued };
       }
       const checkIn = renderUserFacingMessage({
         context: {
@@ -203,6 +222,9 @@ async function signalHostedSourceDeliveryStallNoticeBestEffort(input: {
   item: HostedMailboxItemRecord;
   prisma: PrismaClient;
 }): Promise<void> {
+  if (input.item.kind !== "assistant.notification.requested") {
+    throw new Error("Source recovery notification identity belongs to another mailbox kind.");
+  }
   if (input.item.consumedAt !== null) {
     return;
   }

--- a/apps/web/test/device-sync-source-delivery-stall-notice.test.ts
+++ b/apps/web/test/device-sync-source-delivery-stall-notice.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   getPrisma: vi.fn(),
   hasHostedLinqInboundWithinDays: vi.fn(),
   hasHostedRuntimeActiveAccess: vi.fn(),
+  lockSource: vi.fn(),
   findDeviceConnectionSource: vi.fn(),
   readHostedMailboxItemByDedupeKey: vi.fn(),
   readHostedSourceNoDataOutreachPolicy: vi.fn(),
@@ -59,6 +60,7 @@ const BASE_INPUT = {
 const MAILBOX_ITEM = {
   consumedAt: null,
   id: "mailbox-1",
+  kind: "assistant.notification.requested",
   lane: "system",
   laneSeq: "7",
   userId: "member-1",
@@ -80,6 +82,7 @@ const DIRECT_LINQ_DESTINATION = {
 beforeEach(() => {
   vi.clearAllMocks();
   const tx = {
+    $queryRaw: mocks.lockSource,
     deviceConnectionSource: {
       findUnique: vi.fn().mockResolvedValue({
         id: BASE_INPUT.sourceId,
@@ -96,6 +99,7 @@ beforeEach(() => {
     $transaction: vi.fn((run: (client: typeof tx) => Promise<unknown>) => run(tx)),
   });
   mocks.readHostedMailboxItemByDedupeKey.mockResolvedValue(null);
+  mocks.lockSource.mockResolvedValue([{ id: BASE_INPUT.sourceId }]);
   mocks.findDeviceConnectionSource.mockResolvedValue({
     connection: { status: "active", userId: "member-1" },
     id: BASE_INPUT.sourceId,
@@ -326,13 +330,119 @@ describe("hosted source delivery-stall notice materialization", () => {
 
     await materializeHostedSourceDeliveryStallNotice({
       candidate,
-      now: BASE_INPUT.now,
+      now: "2026-08-25T00:01:00.000Z",
       userId: "member-1",
     });
 
     expect(mocks.runWithPreparedHostedMailboxItemAppendCrypto).toHaveBeenCalledOnce();
-    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).toHaveBeenCalledOnce();
+    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).not.toHaveBeenCalled();
+    expect(mocks.findDeviceConnectionSource).toHaveBeenCalledOnce();
+    expect(mocks.hasHostedRuntimeActiveAccess).toHaveBeenCalledOnce();
     expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledOnce();
+  });
+
+  it.each([null, BASE_INPUT.now])("reuses the item committed after the initial lookup (consumedAt: %s)", async (consumedAt) => {
+    const candidate = resolveHostedSourceDeliveryStallNoticeCandidate(BASE_INPUT);
+    if (!candidate) throw new Error("Expected recovery candidate");
+    mocks.readHostedMailboxItemByDedupeKey
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ ...MAILBOX_ITEM, consumedAt });
+
+    await materializeHostedSourceDeliveryStallNotice({
+      candidate,
+      now: "2026-08-25T00:02:00.000Z",
+      userId: "member-1",
+    });
+
+    expect(mocks.lockSource).toHaveBeenCalledOnce();
+    expect(mocks.lockSource.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.findDeviceConnectionSource.mock.invocationCallOrder[0]!,
+    );
+    expect(mocks.findDeviceConnectionSource.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.readHostedMailboxItemByDedupeKey.mock.invocationCallOrder[1]!,
+    );
+    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).not.toHaveBeenCalled();
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(consumedAt ? 0 : 1);
+  });
+
+  it("rejects a queued episode identity belonging to another mailbox kind", async () => {
+    const candidate = resolveHostedSourceDeliveryStallNoticeCandidate(BASE_INPUT);
+    if (!candidate) throw new Error("Expected recovery candidate");
+    mocks.readHostedMailboxItemByDedupeKey.mockResolvedValue({
+      ...MAILBOX_ITEM,
+      kind: "device-sync.wake",
+    });
+
+    await expect(materializeHostedSourceDeliveryStallNotice({
+      candidate, now: BASE_INPUT.now, userId: "member-1",
+    })).rejects.toThrow("another mailbox kind");
+    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).not.toHaveBeenCalled();
+    expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
+  });
+
+  it("converges overlapping attempts with different timestamps on one stored notification", async () => {
+    const candidate = resolveHostedSourceDeliveryStallNoticeCandidate(BASE_INPUT);
+    if (!candidate) throw new Error("Expected recovery candidate");
+    let queued: typeof MAILBOX_ITEM | null = null;
+    let previousCommit = Promise.resolve();
+    type Tx = {
+      $queryRaw: () => Promise<void>;
+      deviceConnectionSource: { findUnique: typeof mocks.findDeviceConnectionSource };
+    };
+    mocks.getPrisma.mockReturnValue({
+      $transaction: async (run: (tx: Tx) => Promise<unknown>) => {
+        const prior = previousCommit;
+        let release = () => {};
+        previousCommit = new Promise<void>((resolve) => { release = resolve; });
+        try {
+          return await run({
+            $queryRaw: async () => { await prior; },
+            deviceConnectionSource: { findUnique: mocks.findDeviceConnectionSource },
+          });
+        } finally {
+          release();
+        }
+      },
+    });
+    mocks.readHostedMailboxItemByDedupeKey.mockImplementation(async () => queued);
+    mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx.mockImplementation(async () => {
+      queued = MAILBOX_ITEM;
+      return { item: MAILBOX_ITEM };
+    });
+
+    await Promise.all([
+      materializeHostedSourceDeliveryStallNotice({
+        candidate, now: BASE_INPUT.now, userId: "member-1",
+      }),
+      materializeHostedSourceDeliveryStallNotice({
+        candidate, now: "2026-08-25T00:04:00.000Z", userId: "member-1",
+      }),
+    ]);
+
+    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).toHaveBeenCalledOnce();
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(2);
+    expect(mocks.signalHostedMailboxAppendRuntime.mock.calls[1]?.[0]).toEqual(
+      mocks.signalHostedMailboxAppendRuntime.mock.calls[0]?.[0],
+    );
+  });
+
+  it("retries a failed signal using the original pending item", async () => {
+    const candidate = resolveHostedSourceDeliveryStallNoticeCandidate(BASE_INPUT);
+    if (!candidate) throw new Error("Expected recovery candidate");
+    mocks.signalHostedMailboxAppendRuntime.mockRejectedValueOnce(new Error("Unavailable"));
+    await materializeHostedSourceDeliveryStallNotice({
+      candidate, now: BASE_INPUT.now, userId: "member-1",
+    });
+    mocks.readHostedMailboxItemByDedupeKey.mockResolvedValue(MAILBOX_ITEM);
+    await materializeHostedSourceDeliveryStallNotice({
+      candidate, now: "2026-08-25T00:03:00.000Z", userId: "member-1",
+    });
+
+    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).toHaveBeenCalledOnce();
+    expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(2);
+    expect(mocks.signalHostedMailboxAppendRuntime.mock.calls[1]?.[0]).toEqual(
+      mocks.signalHostedMailboxAppendRuntime.mock.calls[0]?.[0],
+    );
   });
 
   it("suppresses members without active access before appending", async () => {
@@ -392,7 +502,7 @@ describe("hosted source delivery-stall notice materialization", () => {
         status: BASE_INPUT.status,
       }),
     },
-  ])("suppresses the notice when $name", async ({ prepare }) => {
+  ])("suppresses a new or pending notice when $name", async ({ prepare }) => {
     const candidate = resolveHostedSourceDeliveryStallNoticeCandidate(BASE_INPUT);
     expect(candidate).not.toBeNull();
     if (!candidate) {
@@ -400,11 +510,14 @@ describe("hosted source delivery-stall notice materialization", () => {
     }
     prepare();
 
-    await materializeHostedSourceDeliveryStallNotice({
-      candidate,
-      now: BASE_INPUT.now,
-      userId: "member-1",
-    });
+    for (const existing of [null, MAILBOX_ITEM]) {
+      mocks.readHostedMailboxItemByDedupeKey.mockResolvedValue(existing);
+      await materializeHostedSourceDeliveryStallNotice({
+        candidate,
+        now: BASE_INPUT.now,
+        userId: "member-1",
+      });
+    }
 
     expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).not.toHaveBeenCalled();
     expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();


### PR DESCRIPTION
## Why

Repeated device-sync applies rebuild an unconsumed wearable recovery notification with a new occurrence timestamp under the same episode key. The strict mailbox hash comparison reports a conflict even though the existing notification remains authoritative.

Serialize materialization on the existing source row, recheck eligibility, and reuse the stored notification. Retries and overlapping callbacks converge on one immutable item and can retry its wake signal.

## Product UX

- Effort: Patch — restore the existing single private check-in promise.
- Result: Ready.
- Walkthrough: Initial eligible episodes still queue the same exact copy. Pending episodes reuse their item. Consumed, recovered, opted-out, inactive-access, and non-direct episodes retain their existing suppression. No new audience or message is introduced.

## Evidence

- Direct: The pending-replay regression fails on the original implementation and passes after the change. The final materializer suite passes 27 tests, including overlapping attempts with different timestamps, a concurrent consumed item, signal failure/retry, identity-kind rejection, and current eligibility checks.
- Coverage: 205 tests passed across the materializer, device-sync runtime authority, prepared mailbox append, and mailbox store before the final isolated concurrency test was added; the expanded materializer suite then passed 27/27. Strict mailbox mismatch behavior stays covered by the unchanged store suite.
- Commands: `pnpm --dir apps/web test:prepared test/device-sync-source-delivery-stall-notice.test.ts test/device-sync-hosted-runtime-authority.test.ts test/hosted-mailbox-prepared-append.test.ts test/hosted-mailbox-store.test.ts`; final materializer rerun; `pnpm --dir apps/web typecheck`; final `typecheck:prepared`; scoped ESLint; `pnpm complexity:diff`; `pnpm docs:drift`; `git diff --check` — pass.
- Boundaries: Concurrency proof uses a serialized transaction fixture. Local tests do not claim a live provider send or a production deployment. Required CI and ReviewGPT run on this head.

## Non-obvious affected surfaces

The source lock uses the same source-before-mailbox ordering as delivery eligibility. Crypto preparation remains before the database transaction and signaling after commit. Stored payloads, mailbox conflict detection, and device-sync apply responses are unchanged.

## Architecture and reuse

- Existing systems reused: Source row authority, episode key, mailbox store, prepared crypto, existing eligibility checks, and post-commit runtime signaling.
- New logic: Lock the source before the transactional reread; return the existing item; reject an unexpected kind before signaling.
- New abstractions: None; the existing materializer owns the complete operation.
- Complexity intentionally avoided: No tables, queues, dedupe exceptions, retry store, protocol changes, or new scheduler.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: The materializer transaction callback remains 23, with no debt or maximum increase.
- Agent judgment: Preserve the explicit eligibility sequence; further extraction would add indirection without simplifying this correction.

## Hot reply path impact

- Path status: Not applicable — this is post-response device-sync recovery materialization.
- Database calls: None added to foreground replies. Each eligible background candidate adds one unique source-row lock and at most one unique mailbox read. At the existing 100-by-64 apply bound this adds at most 12,800 serial statements, one transaction at a time per callback; the transaction timeout remains 10 seconds.
- Network/provider calls: None added. Crypto preparation stays outside transactions.
- Other awaited latency: No new foreground work; existing best-effort signaling remains after commit.
- Before/after proof: Focused pending and overlapping replay tests prove one append and reuse of the same signal target; suppression tests retain live checks.

## Murph initial provider input impact

Not applicable for individual and group runtimes: this change does not alter instructions, tools, schemas, generated guidance, or notification text. It reuses an already-stored item.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old and new Web instances use the same source, mailbox, and envelope shapes. Existing pending items are directly reusable. Cloudflare and warm containers require no changes.
- Safe order: Merge after review and required CI, then let the managed Vercel Git deployment and exact-main admission checks publish Web.
- Rollback floor: No new persisted shape or authority floor.
- Expected exposure: Older Web requests can continue rebuilding payloads during the deployment drain and may log the original warning.
- Reversibility: A forward revert restores the previous behavior without a migration; it also restores the warning.
- Convergence proof: Verify the production alias points to the merged commit or a descendant and inspect natural device-sync apply traffic after deployment.
- Post-deploy checks: Confirm deployment readiness/admission, successful apply requests, and absence of this conflict on observed post-deploy traffic. No synthetic member messages.

## Change-shape breakdown

Classification rule: Application TypeScript is source, test files are tests, and agent docs are documentation. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 25 | 3 |
| Tests / fixtures | 121 | 8 |
| Docs | 63 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **209** | **12** |

## Changelog

- Changelog: not applicable
- Reason: Internal notification retry correction with unchanged copy and delivery policy.

ReviewGPT context sensitivity: sensitive
Classification reason: Hosted notification idempotency, ordering, and concurrency.
ReviewGPT first-reviewed head: 72a3ca885af3d17f17c31e02bbb373e9090d85ab

## Final review

- ReviewGPT: PASS — [full-patch review](https://chatgpt.com/c/6a9db9a3-7300-83ea-8c43-66784886ad46).
- Reviewed head: `72a3ca885af3d17f17c31e02bbb373e9090d85ab`; round 1; Phlebas lane; selected model and response metadata both identify GPT-6 Pro.
- Capture: More than 301 seconds elapsed after submission. The tool confirmed the attached snapshot and exact committed user/assistant turns; response hash matches model-verification metadata. `ROUND_OUTCOME: PASS` and `REVIEW_COMPLETE` are present. The response's textual model self-attestation was unknown, while captured response-model metadata was explicit.
- Scope and disposition: The reviewer checked all five changed files, source-row serialization, eligibility, immutable reuse, consumed-item suppression, crypto preparation, signaling, and downstream delivery authority. No findings to remediate. Parent review accepts the result; local command evidence remains independently owned by the parent.

## Shipped verification

- Merged as `80202dff274f9270a13ae795dad56a4c774b551a` after required PR checks passed. The reviewed source and tests match the merged source and tests.
- Both production domains serve ready Vercel deployment `dpl_8fB6fecedhxbRJJpLNnV9fE2fG4P`, revision `78358acae29e470743a4c12f48d69a5c47d80fe0`, which contains the merged fix unchanged. Readiness was observed at 2026-09-06 19:33 UTC.
- Bounded natural-traffic observation after readiness found seven device-sync apply requests, all HTTP 200, with zero matching mailbox dedupe-conflict warnings. This is observed production evidence, not an assertion that every future retry is exercised.
- Separate post-merge admission status: the hosted checkpoint-ordering and reply-priority suites failed during standby-container smoke setup before their test cases ran. The retry was superseded by a newer main admission run. This is not a green admission result; no checks were bypassed or production aliases manually promoted. Required PR CI and ReviewGPT remain green.
