### PR TITLE
perf: consume prepared crypto candidates without rediscovery

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-06-linq-root-discovery.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-linq-root-discovery.md
@@ -1,0 +1,45 @@
+# Consume prepared domain-root candidates once
+
+Status: completed
+Created: 2026-09-06
+Updated: 2026-09-06
+
+## Goal and design
+
+Second independent PR from the ReviewGPT admission design review: consume the
+candidate map Linq already prepared instead of repeating active-domain discovery
+for control and ingress. Standalone callers retain discovery; prepareMissing:
+false still prohibits provisioning. No new state, flags, cache, or owner.
+
+## Invariants and proof
+
+Keep exact scoped-root identity, user/domain validation, winner drift checks,
+candidate reuse, caller zeroization, failure draining, and KMS outside transactions.
+Use the real crypto owner with synthetic KMS and SQL statement recording to prove
+one discovery instead of three, then cover supplied/empty maps and standalone
+preparation. Run crypto and Linq tests, Web typecheck, complexity and docs checks.
+Parent review precedes publication; final ReviewGPT runs alongside exact-head CI.
+
+## Scope
+
+Only domain-root preparation and its Linq caller. Identity decryption is PR #2998;
+locked admission consolidation is the next independent patch. Provider chat
+classification and outreach history selection retain current behavior.
+
+## Result and verification
+
+Supplied candidates replace nested discovery; standalone discovery and explicit
+no-provisioning behavior remain. Exact candidate/root validation is unchanged.
+The existing Linq mock now uses the renamed prepared-candidate input.
+
+Real crypto-owner composition records discovery 3 -> 1 and existing-root total
+preparation SQL statements 5 -> 3. The same new count tests fail against baseline
+source. KMS decryptions remain two; revalidation adds none; returned plaintext
+copies are zeroized. Empty supplied candidates cannot authorize a missing root.
+Focused crypto/Linq suites: 264 tests pass. Web typecheck and complexity guard
+pass; source complexity debt stays unchanged. No production latency claim.
+
+Parent review: this is one input-contract refinement and removal of redundant
+work, with no new owner, persistent state, framework, or dependency. The shared
+helper retains its ordinary callers. Final ReviewGPT and CI follow publication.
+Completed: 2026-09-06

--- a/apps/web/src/lib/hosted-crypto/domain-root-store.ts
+++ b/apps/web/src/lib/hosted-crypto/domain-root-store.ts
@@ -152,9 +152,10 @@ export class HostedDomainRootPreparationMismatchError extends Error {
 export async function prepareHostedDomainRootForWeb(input: {
   domain: HostedCryptoDomain;
   prepareMissing?: boolean;
+  /** Already-discovered candidates; exact active-root authority is still revalidated. */
+  preparedCandidates?: PreparedHostedCryptoDomainRootCandidates;
   prisma?: HostedCryptoClient;
   reason: string;
-  reusableCandidates?: PreparedHostedCryptoDomainRootCandidates;
   signal?: AbortSignal;
   userId: string;
 }): Promise<PreparedHostedDomainRootForWeb> {
@@ -171,12 +172,9 @@ export async function prepareHostedDomainRootForWeb(input: {
   }
   const preparedCandidates = input.prepareMissing === false
     ? new Map<HostedCryptoDomain, HostedDomainRootKeyEnvelopeV1>()
-    : await prepareHostedCryptoDomainRootCandidates({
+    : input.preparedCandidates ?? await prepareHostedCryptoDomainRootCandidates({
         domains: [input.domain],
         prisma: input.prisma,
-        ...(input.reusableCandidates
-          ? { reusableCandidates: input.reusableCandidates }
-          : {}),
         userId: input.userId,
       });
   const candidate = preparedCandidates.get(input.domain);

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -2987,7 +2987,7 @@ async function prepareHostedLinqDirectMailboxPayloadRoot(input: {
       reason: domain === "control"
         ? "hosted-linq.direct-routing"
         : "hosted-linq.direct-mailbox",
-      reusableCandidates: preparedCryptoDomainRoots,
+      preparedCandidates: preparedCryptoDomainRoots,
       userId: memberId,
     });
   const [ingressRootResult, controlRoutingResult] = await Promise.allSettled([

--- a/apps/web/test/hosted-crypto-domain-root-store.test.ts
+++ b/apps/web/test/hosted-crypto-domain-root-store.test.ts
@@ -2407,6 +2407,67 @@ test.each(["create", "replace", "consent_revoked", "suspended", "root_race"] as 
   },
 );
 
+test.each([true, false])("discovers a control/ingress preparation batch once (existing roots: %s)", async (existing) => {
+  const steps: string[] = [];
+  const { tx, decryptMetrics } = await createHostedWebCryptoTransactionFixture(
+    () => createStepRecordingTransaction(steps),
+  );
+  const {
+    prepareHostedCryptoDomainRootCandidates,
+    prepareHostedDomainRootForWeb,
+    provisionActiveHostedDomainRootEnvelopeForUserOnly,
+    revalidatePreparedHostedDomainRootForWebTx,
+  } = await import("../src/lib/hosted-crypto/domain-root-store");
+  const { runWithHostedDomainRootUnwrapCache } = await import(
+    "../src/lib/hosted-crypto/domain-root-unwrap-cache"
+  );
+  const userId = "member-test-batch-discovery";
+  const domains = ["control", "ingress"] as const;
+  if (existing) {
+    for (const domain of domains) {
+      await provisionActiveHostedDomainRootEnvelopeForUserOnly({
+        domain, prisma: tx.prisma, reason: "test.seed", userId,
+      });
+    }
+  }
+  steps.length = 0;
+  await runWithHostedDomainRootUnwrapCache(async () => {
+    const preparedCandidates = await prepareHostedCryptoDomainRootCandidates({
+      domains, maxConcurrency: 2, prisma: tx.prisma, userId,
+    });
+    const preparedRoots = await Promise.all(domains.map((domain) =>
+      prepareHostedDomainRootForWeb({
+        domain, preparedCandidates, prisma: tx.prisma, reason: "test.batch", userId,
+      }),
+    ));
+    expect(steps).toEqual(existing
+      ? ["db.read-active-domains", "db.read-active-envelope", "db.read-active-envelope"]
+      : ["db.read-active-domains"]);
+    expect(decryptMetrics.calls).toHaveLength(2);
+    for (const prepared of preparedRoots) {
+      await revalidatePreparedHostedDomainRootForWebTx({ prepared, tx: tx.prisma });
+    }
+    expect(decryptMetrics.calls).toHaveLength(2);
+    expect(tx.persistedEnvelopes).toHaveLength(2);
+  });
+  expect(decryptMetrics.returnedPlaintexts.every((bytes) => bytes.every((byte) => byte === 0))).toBe(true);
+});
+
+test("an empty supplied candidate map does not authorize a missing active root", async () => {
+  const { tx, signCalls, decryptMetrics } = await createHostedWebCryptoTransactionFixture();
+  const { prepareHostedDomainRootForWeb } = await import("../src/lib/hosted-crypto/domain-root-store");
+  const { runWithHostedDomainRootUnwrapCache } = await import("../src/lib/hosted-crypto/domain-root-unwrap-cache");
+  await runWithHostedDomainRootUnwrapCache(async () => {
+    await expect(prepareHostedDomainRootForWeb({
+      domain: "control", preparedCandidates: new Map(), prisma: tx.prisma,
+      reason: "test.missing-active", userId: "member-test-missing-active",
+    })).rejects.toMatchObject({ name: "HostedDomainRootEnvelopeUnavailableError" });
+  });
+  expect(signCalls).toHaveLength(0);
+  expect(decryptMetrics.calls).toHaveLength(0);
+  expect(tx.persistedEnvelopes).toHaveLength(0);
+});
+
 test("the prepared Web root token commits and reuses only its exact scoped root", async () => {
   const { tx } = await createHostedWebCryptoTransactionFixture();
   const {
@@ -3630,10 +3691,7 @@ function createStepRecordingKmsClient(input: {
   };
 }
 
-function createStepRecordingTransaction(steps: string[]): {
-  persistedEnvelopes: HostedDomainRootKeyEnvelopeV1[];
-  prisma: Prisma.TransactionClient;
-} {
+function createStepRecordingTransaction(steps: string[]): HostedCryptoTestTransaction {
   const tx = createCapturingTransaction();
   const base = {
     $executeRaw: async (...args: Parameters<Prisma.TransactionClient["$executeRaw"]>) => {
@@ -3651,7 +3709,7 @@ function createStepRecordingTransaction(steps: string[]): {
   // plus the interactive-transaction root here.
   const recorded = base as Prisma.TransactionClient;
   return {
-    persistedEnvelopes: tx.persistedEnvelopes,
+    ...tx,
     prisma: Object.assign(recorded, {
       async $transaction<T>(
         run: (transaction: Prisma.TransactionClient) => Promise<T>,

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -559,19 +559,19 @@ vi.mock("@/src/lib/hosted-crypto/domain-root-store", async (importOriginal) => {
   });
   const prepareRoot = vi.fn(async (input: {
     domain: "control" | "ingress";
-    reusableCandidates?: ReadonlyMap<string, {
+    preparedCandidates?: ReadonlyMap<string, {
       domain: "control" | "ingress";
       rootKeyId: string;
       userId: string;
     }>;
     userId: string;
   }) => {
-    const candidate = input.reusableCandidates?.get(input.domain);
+    const candidate = input.preparedCandidates?.get(input.domain);
     let rootKeyId: string;
     if (candidate) {
       await prewarmPrepared({
         domain: input.domain,
-        prepared: input.reusableCandidates ?? new Map(),
+        prepared: input.preparedCandidates ?? new Map(),
         userId: input.userId,
       });
       rootKeyId = candidate.rootKeyId;


### PR DESCRIPTION
## Why and outcome

Linq already discovers missing domain roots once, but per-domain preparation repeated that discovery for control and ingress. Consume the supplied candidate map directly and retain discovery for standalone callers.

## Product UX

- Effort: Patch.
- Result: Ready.
- Walkthrough: Existing direct admission, Family activation, retry, and receipt behavior are preserved.

## Evidence

- Final review: [ReviewGPT round 1](https://chatgpt.com/c/6a9dc288-38a8-83ea-8a5b-a2a83f1ac00a) PASS on `9dc236d5081d`, no qualifying findings. Exact-head CI is green.

- Direct: Crypto and Linq dispatch suites pass (264 tests); the final crypto suite passes all 58 tests. Web typecheck, complexity guard, docs drift, and diff/privacy checks pass.
- Coverage: Real crypto-owner composition with synthetic KMS and recorded raw SQL proves batch discovery 3 → 1, existing-root preparation statements 5 → 3, two decryptions, no extra decryption during commit, and zeroized returned plaintext. Both count cases fail on baseline production source. An empty supplied map cannot authorize a missing active root.
- Commands: `pnpm exec tsx apps/web/scripts/run-hosted-web-vitest.mts apps/web/test/hosted-crypto-domain-root-store.test.ts apps/web/test/hosted-onboarding-linq-dispatch.test.ts --reporter=dot --silent`; `pnpm --dir apps/web typecheck`; `pnpm complexity:diff`; `pnpm docs:drift`.

## Non-obvious affected surfaces

The shared preparation helper serves standalone identity/device/mailbox callers. Omitted candidates retain discovery, and prepareMissing: false still prohibits provisioning. Exact candidate user/domain identity, root winner validation, scoped cache identity, retry, and zeroization remain with their existing owners and tests.

## Architecture and reuse

- Existing systems reused: Candidate preparation, per-domain preparation, scoped root cache, transactional revalidation.
- New logic: Consume already-prepared candidates instead of rediscovering them.
- New abstractions: None; rename the existing candidate input to describe its new responsibility.
- Complexity intentionally avoided: No extra cache, authority flags, service, state, schema, or dependency.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; debt unchanged.
- Hotspots: No crypto-store hotspots above threshold. Existing service hotspots (147, 31, 27, 24, 22) are unchanged by the caller's argument rename.
- Agent judgment: The patch deletes redundant discovery inside the existing helper; no broader extraction is justified.

## Hot reply path impact

- Path status: Touched — crypto preparation preceding admission.
- Database calls: None added; two repeated discovery queries removed from the ordinary control/ingress batch.
- Network/provider calls: None added; two root decryptions remain in the fixture.
- Other awaited latency: None added. Candidate signing still finishes before bounded unwrap preparation.
- Before/after proof: Identical real-owner fixtures against base/head record discovery 3 → 1; preparation statements 5 → 3 with existing roots. No production latency claim.

## Murph initial provider input impact

Not applicable for individual and group Murph: no provider input builders, instructions, tools, or schemas changed.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Web-local function input and preparation changes with no persistent format, schema, wire protocol, deployment configuration, or cross-service compatibility change.

## Change-shape breakdown

Classification rule: production TypeScript is source, test files are tests, execution plan is docs. No binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 6 |
| Tests / fixtures | 66 | 8 |
| Docs | 45 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **115** | **14** |

## Changelog

- Changelog: not applicable
- Reason: Internal query reduction preserving product behavior; no measured member-visible latency claim.

ReviewGPT context sensitivity: sensitive
Classification reason: Shared cryptographic root preparation and transactional revalidation.
ReviewGPT first-reviewed head: 9dc236d5081dcc5a05f5ed704b098af523f1ba37

