### PR TITLE
Fix Journal sleep accuracy, refresh recovery and date navigation

### DIFF
--- a/.agents/friction-log/20260906154117-design-catalog-date/friction.md
+++ b/.agents/friction-log/20260906154117-design-catalog-date/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Design catalog date hydration disrupts browser proofs in UTC+14'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The synthetic components catalog should hydrate consistently when the browser time zone differs from the development server, so focused component interaction proofs can start reliably.
+
+## Current Behavior
+
+Opening the components catalog in Pacific/Kiritimati against a UTC server produces a date hydration mismatch in the unrelated group sponsorship study. React replaces the catalog tree while the Journal proof is activating its synthetic region, detaching the element before interaction.
+
+## Possible Solution
+
+Give synthetic catalog date displays a shared explicit time zone or isolate component studies so an unrelated hydration mismatch cannot replace the target study. The Journal proof currently changes the browser zone after catalog hydration to exercise chart labels independently.
+
+## Minimal Reproducible Example
+
+Start the Web smoke server with UTC. Open `/design?tab=components#journal-study` with a Chromium context configured with `timezoneId: "Pacific/Kiritimati"`. Observe the synthetic group sponsorship date rendering on different calendar days between server and browser and the resulting hydration replacement.
+
+## Context
+
+This required a browser-proof workaround during Journal date-label verification. It concerns synthetic catalog rendering; no production member data was used.

--- a/agent-docs/exec-plans/completed/2026-09-06-journal-internals.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-journal-internals.md
@@ -1,0 +1,115 @@
+# Journal correctness and projection efficiency
+
+Status: completed
+Created: 2026-09-06
+Updated: 2026-09-06
+
+## Outcome and architecture
+
+Find and fix reproducible Journal data/refresh defects and remove measured
+unnecessary work. Retain canonical event/metric owners, query-owned projection,
+Browser Vault publication, and the existing website. No new persistence,
+service, dependency, model call or production mutation.
+
+## Investigation
+
+Three independent subagents reviewed projection correctness, refresh recovery,
+and projection cost. After review, the first added regression tests and the
+second implemented the scoped page recovery fix and composed tests. The third
+ran ignored synthetic benchmarks. Parent reviewed their output and owns query
+changes, browser proof, final review and commit. Existing UI commit stays intact.
+
+## Product UX
+
+- Entry and promise: open Journal to see accurate recent health context, navigate
+  dates, and inspect summaries without misattributing records or missing data.
+- Journeys: main sleep plus naps, linked events, sparse/dense wearable history,
+  loading/empty/stale replicas, date boundaries and missing daily chart samples.
+- Proof: synthetic query regressions, composed Browser Vault tests where affected,
+  parent-reviewed before/after timing and rendered evidence for any UI change.
+- Done when: accepted defects fail before and pass after, optimizations preserve
+  output, and focused tests/typechecks/review pass.
+- Exclusions: production inspection/mutations, new capture behavior, auth changes,
+  unrelated historical code, deployment and publishing.
+
+## Decisions and evidence
+
+- Accepted: observation dates could disagree with normalized metric dates and
+  merge adjacent sleep nights through record links. Journal now reuses the
+  canonical date resolver, retaining timestamp-only fallback.
+- Accepted: the duration catalog used `total-sleep` instead of canonical
+  `total-sleep-minutes`; duration-only observations were missing from statistics.
+  The catalog and duplicate suppression now use the canonical key.
+- Accepted: raw observation values could replace normalized duration values.
+  Journal now uses canonical extraction for in-window observations, including
+  aliases, unit conversion and incompatible-unit rejection.
+- Accepted: an explicit main sleep plus one short unlabeled session swallowed
+  the nap. Only choose an unlabeled main when no explicit main exists, retaining
+  the existing long-duplicate rule. Five agent regressions failed before fixes.
+- Accepted: first-import `empty` plus pending import skipped both provider
+  polling and page refresh. Journal now joins its existing bounded refresh
+  window. Existing server handling suppresses a competing runtime wake during
+  import. Repeated unavailable-state retries cannot reset an active deadline.
+  Composed tests proved initial publication, timeout and retry failures first.
+- Accepted: UTC+14 shifted chart weekday labels because a date-only value used
+  the browser zone. Chart labels now use UTC for the date-only formatting.
+- Efficiency: partition in-window metric points in one history scan, clip
+  experiment iteration while preserving original progress, and reuse formatter
+  instances per projection. No persistent cache or new dependency.
+- Avoided: extracting every historical observation initially regressed a
+  20,075-observation fixture from roughly 32 ms to 250–288 ms. Moving extraction
+  after the canonical date filter removed that regression without another index.
+
+### Synthetic performance evidence
+
+Six optimization fixtures retained identical output hashes. Both observation
+histories matched the corrected normalization output. Timings varied with
+machine load; deterministic work counts are the strongest evidence.
+
+| Fixture | Before | After | Deterministic work |
+| --- | ---: | ---: | --- |
+| 1,440 timed notes over 120 days | 263.1 ms | 39.5 ms | 2,640 formatter constructions to 1 |
+| 54,750 historical metric points | 65.25 ms | 25.25 ms | Eleven history scans to one partition pass |
+| Ten-year experiment phase | 5.55 ms | 1.2 ms | 4,042 ISO conversions to 260 |
+| Future phase outside window | 5.15 ms | Below timer precision | 3,656 ISO conversions to 2 |
+
+These are local synthetic projection measurements, not production page-load
+claims. The final five-year observation median was 74.85 ms versus 54.65 ms
+baseline under noisy load; current-window canonical normalization adds real
+correctness work. There is no claim that every input is faster.
+
+## Verification and delivery
+
+- Query Journal, replica, shard, device metric and metric-point tests: 64 passed.
+  The final Journal-only run passed 25 tests after correcting a fixture title.
+- Web provider/context, dashboard and navigation tests: 114 passed.
+- Changelog fragments and production archive rendering: 16 passed.
+- Query and Web typechecks passed. A new fixture initially omitted a required
+  title argument; corrected and rerun.
+- Complexity guard passed with no hotspots above 20; Journal source maximum
+  fell from 19 to 18. Scoped Web ESLint and whitespace checks passed. Root
+  `pnpm exec eslint` is unavailable; lint uses the declared Web entrypoint.
+- Chromium journey passed at 320, 390 and 1280 pixels, including native calendar
+  keyboard activation, selected-week summaries, today, empty refresh status,
+  overflow and chart weekdays after switching to Pacific/Kiritimati.
+- Parent inspected the rendered 320-pixel timeline and phone/desktop chart
+  captures. The chart retains Sunday–Saturday labels in UTC+14. A development
+  issue badge overlays part of the phone chart capture; desktop labels and
+  browser assertions independently verify the corrected dates. Captures remain
+  ignored local proof, with no production data.
+- Product UX: Ready. First-import success
+  reveals entries, timeout exits preparing, stale/legacy retries stay bounded,
+  and existing readable dashboard flows remain covered.
+- Parent reviewed source/test diffs, canonical ownership, auth and refresh
+  boundaries, synthetic evidence and privacy. No new state schema, external
+  call, foreground reply work, AI behavior or dependency.
+- Journal product owner updated. Changelog item:
+  `2026-09-06 / journal-sleep-and-import-recovery`.
+- Logged catalog-only date hydration friction at
+  `.agents/friction-log/20260906154117-design-catalog-date/friction.md`.
+  The chart proof switches zones after catalog hydration to isolate the real
+  Journal component from that unrelated synthetic study.
+- Delivery boundary: scoped local commit. No PR, remote CI, final ReviewGPT or
+  deployment ran; those are future publishing gates, not local proof.
+
+Completed: 2026-09-06

--- a/agent-docs/exec-plans/completed/2026-09-06-journal-ux-fixes.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-journal-ux-fixes.md
@@ -1,0 +1,66 @@
+# Journal date navigation and recovery
+
+Status: completed
+Created: 2026-09-06
+Updated: 2026-09-06
+
+## Outcome and protected boundary
+
+Keep Today aligned with the browser local date, label historical statistics
+accurately, and show background refresh progress for empty timelines. Make calendar
+selection perceivable and comfortable on touch screens. Journal remains a
+read-only view of canonical Browser Vault records; no data or capture changes.
+
+## Evidence and implementation
+
+The component initializes its selected date from a server UTC snapshot and never
+updates that state when the clock changes. Statistics always say Last 7 days,
+even for history. The refresh indicator is gated on a nonempty days collection.
+Calendar day buttons are 30 pixels tall and expose no selected state.
+Derive Today from the existing clock until a historical date is explicitly
+selected. Reuse existing controls and dates; add no dependency or persistence.
+
+## Product UX
+
+- Entry: Journal, existing seven-day timeline and calendar.
+- Reaches: local/UTC date differences, midnight rollover, historical navigation,
+  empty refreshing accounts, phone touch and desktop keyboard users.
+- Proof: focused component regressions and rendered production components in
+  the synthetic design study at phone and desktop sizes.
+- Done when: Today follows local time while history stays put, statistics name
+  their displayed dates, empty refresh remains visible, and calendar selection
+  is visible and exposed to assistive technology.
+- Exclusions: capture, editing, auth, queries, live member data and deployment.
+
+## Verification and completion
+
+- Reproduce clock and empty-refresh failures before implementation.
+- Run focused dashboard tests, Web typecheck, changed-file lint and complexity.
+- Inspect rendered phone and desktop states, then review full diff and privacy.
+- Update Journal owner and changelog; close this plan and create a scoped commit.
+- Final external review is not routed for this frontend-only interaction patch.
+
+## Results
+
+Product UX: Ready.
+
+- Reproduced the stale selected day and missing calendar selected state before
+  the fix. Added a server-render/hydrate regression with different UTC/local
+  dates; it switches to the local date without a recoverable hydration error.
+- Dashboard regressions: 39 passed. Journal navigation regressions: 4 passed.
+  Changelog fragment checks: 7 passed.
+- Web typecheck and changed-file ESLint passed. Complexity diff passed with
+  no hotspots above 20 and unchanged maximum source complexity of 18.
+- Playwright passed with production Journal components and synthetic study
+  data at 320, 390 and 1280 pixels. Checked keyboard selection, mobile drawer,
+  selected-period statistics, Today recovery, refresh status and overflow.
+- Inspected native-resolution phone/calendar/desktop screenshots under ignored
+  local artifacts. Updated the existing study with page padding, a named ready
+  state and an empty refreshing state. Synthetic study controls remain inert.
+- Source diff, data ownership and privacy reviewed. No dependencies, persistence,
+  server behavior, assistant behavior or production settings changed.
+- Browser study emits an unrelated component-catalog hydration warning from
+  input caret styling during capture; Journal interactions and assertions pass.
+- Local scoped commit only. No PR, remote CI, merge or deployment performed.
+
+Completed: 2026-09-06

--- a/agent-docs/exec-plans/completed/2026-09-06-journal-whoop-score-recovery.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-journal-whoop-score-recovery.md
@@ -1,0 +1,59 @@
+# Preserve WHOOP recovery through canonical normalization
+
+Status: completed
+Created: 2026-09-06
+Updated: 2026-09-06
+
+## Outcome and evidence
+
+PR 3002 CI reproduced a missing WHOOP recovery score in the composed development
+persona. Round 1 ReviewGPT passed the earlier candidate; CI correctly remained
+a separate merge gate. Focused persona and Journal regressions reproduced the
+regression locally before correction.
+
+The shared catalog aliases recovery-score to readiness-score, while WHOOP's
+importer emits recovery-score values with a percent unit. Journal's new use of
+canonical normalization therefore lost both the product label and numeric value.
+The generic unit normalizer rejected percent against score. Canonical-only
+fixtures also exposed that provider attribution ignored externalRef.system,
+preventing the existing WHOOP duplicate-score preference.
+
+## Smallest owner corrections
+
+- Normalize percent units to the same numeric score only for canonical
+  sleep-score and readiness-score, both 100-point scales. Keep raw source units
+  and reject incompatible units. No global percent/score equivalence.
+- Reuse the existing exact-unit normalizer for other units. Extract the existing
+  generic fallback without changing its behavior; normalization dispatch
+  complexity decreases from 62 to 55.
+- Preserve an explicit recovery-score presentation key while reading canonical
+  value and date. Reuse externalRef.system for provider attribution after the
+  more specific dataOrigin provider and before a generic source field.
+- Keep canonical data, metric IDs, persistence, refresh ownership, dependencies
+  and UI components unchanged. Document the unit convention with health-metrics.
+
+## Product UX and proof
+
+Ready: WHOOP recovery stays visible, same-value Readiness duplicates stay hidden,
+percentage-based scores retain their value, and invalid units remain rejected.
+The new provider-shaped Journal regression checks canonical aliasing/value,
+Recovery display, duplicate suppression and record count. Existing composed
+personas exercise the final Browser Vault output for WHOOP and Oura.
+
+57 health-metrics tests, 65 query tests, 123 Web tests, all three affected
+typechecks, whitespace and the complexity guard pass. Existing normalization
+hotspots are the metric dispatch (55, improved) and unchanged comparable-point
+selection (21); further decomposition is outside this correction.
+
+The branch design preview returned HTTP 200 and includes the ready and empty
+Journal studies, weekly stats and refresh feedback. Its production UI source is
+unchanged by this query/unit remediation; earlier responsive browser and image
+evidence still covers that rendering. No private data or production secrets
+were accessed.
+
+## Delivery boundary
+
+Parent reviewed the focused diff and privacy. Commit the correction, then run
+ReviewGPT round 2 with the immutable first-reviewed head and re-admit exact-head
+CI. Merge remains gated on their successful results.
+Completed: 2026-09-06

--- a/agent-docs/product-specs/journal.md
+++ b/agent-docs/product-specs/journal.md
@@ -1,6 +1,6 @@
 # Journal
 
-Last verified: 2026-08-31
+Last verified: 2026-09-06
 
 ## Product boundary
 
@@ -139,8 +139,9 @@ bounded refresh. This is not continuous polling while the page remains open.
 ## Web experience
 
 `/journal` shows the seven days ending on the selected day as a calm timeline.
-`Today` ends the window today. Previous and next move the full window by seven
-days, so Monday still includes the prior Tuesday through Sunday. Day bands
+`Today` ends the window on the browser local date and follows date changes while
+the page stays open. An explicitly selected historical window stays in place.
+Previous and next move the full window by seven days, so Monday still includes the prior Tuesday through Sunday. Day bands
 separate the days.
 Main sleep uses `Night`, naps use their time, and context can span a full day.
 Event text is readable without opening a detail view. Source labels stay
@@ -153,8 +154,11 @@ Period sorting anchors order rows without displaying invented clock times.
 
 The right rail shows a small calendar, seven-day sleep and activity statistics,
 and a current Personal Pattern when one is ready. A Pattern is an insight about
-the week, not a health event, so it does not appear on the daily timeline. The
-page supports loading, unavailable, empty, error, and ready states.
+the week, not a health event, so it does not appear on the daily timeline.
+Historical statistics name the selected date range. The calendar marks its
+selected end date separately from today, including for assistive technology. The
+page supports loading, unavailable, empty, error, and ready states. Empty
+timelines retain the background refresh status while showing onboarding.
 
 The web does not provide edit or add controls. A member asks Murph to add,
 correct, or remove an entry. Calendar, email travel, Environment, private chat,

--- a/agent-docs/product-specs/journal.md
+++ b/agent-docs/product-specs/journal.md
@@ -102,7 +102,12 @@ The Journal projection reads canonical events and metric points from the last
 120 days. It includes notes, activities, sleep, meals, observations,
 interventions, context, symptoms, and tests. It groups linked records and
 related sleep metrics into one human event. It does not copy records or write a
-daily summary.
+daily summary. Observation dates, metric keys, and numeric units use the
+canonical metric rules before grouping; raw values never replace normalized
+minutes or other canonical units. Historical observations are filtered by date
+before numeric normalization. Metric selection scans the history once, and
+experiment phases expand only within the visible projection window while
+retaining their original progress day numbers.
 
 An accepted plan can appear when its canonical note exists. A completed
 exercise or workout appears as an activity. A suggestion, reminder, or proposed
@@ -110,8 +115,9 @@ exercise is not an event until the member accepts or completes it.
 
 Journal shows one main sleep for each local date. Main sleep has no clock time.
 Shorter sleep stays visible as a timed nap. When a provider does not label sleep
-type, the longest session becomes main sleep. A long duplicate stays with main
-sleep instead of becoming a nap.
+type and there is no explicitly labeled main sleep, the longest session becomes
+main sleep. With an explicit main sleep, a short unlabeled session stays a nap.
+A long duplicate stays with main sleep instead of becoming a nap.
 
 Repeated activities of the same kind on one day become one display event. The
 event keeps all source sessions and shows their combined time. Personal
@@ -128,13 +134,17 @@ depend on it.
 
 The projection is built during the existing Browser Vault refresh. Opening
 `/journal` shows the available projection and requests one runtime refresh.
-The page has no Refresh control. Automatic refresh does not call AI or start
-a new analysis.
+The ready timeline has no Refresh control; unavailable older projections offer
+a retry. Automatic refresh does not call AI or start a new analysis.
 
 The page waits for a different replica through the existing bounded refresh
 window. A busy runtime can delay publication beyond that window. Existing
 content stays visible after waiting stops. Reopening the page starts another
-bounded refresh. This is not continuous polling while the page remains open.
+bounded refresh. When the first device import is pending and no replica exists,
+Journal observes publication through the same 60-second bounded window. The
+import remains responsible for publication, without a competing runtime wake.
+Repeated retry clicks do not restart an active wait. This is not continuous
+polling while the page remains open.
 
 ## Web experience
 
@@ -155,7 +165,8 @@ Period sorting anchors order rows without displaying invented clock times.
 The right rail shows a small calendar, seven-day sleep and activity statistics,
 and a current Personal Pattern when one is ready. A Pattern is an insight about
 the week, not a health event, so it does not appear on the daily timeline.
-Historical statistics name the selected date range. The calendar marks its
+Historical statistics name the selected date range. Chart weekday labels keep
+their calendar date in every browser time zone. The calendar marks its
 selected end date separately from today, including for assistive technology. The
 page supports loading, unavailable, empty, error, and ready states. Empty
 timelines retain the background refresh status while showing onboarding.

--- a/apps/web/app/(dashboard)/journal/journal-page-client.tsx
+++ b/apps/web/app/(dashboard)/journal/journal-page-client.tsx
@@ -62,6 +62,7 @@ export default function JournalPageClient({
   const requestedOnOpen = useRef(false);
   const refreshJournal = useCallback(
     () => {
+      if (requestedOnOpen.current && refreshPending) return;
       requestedOnOpen.current = true;
       return refresh({
         background: true,
@@ -70,12 +71,17 @@ export default function JournalPageClient({
           (ref === null || !browserVaultReplicaRefsMatch(ref, nextRef)),
       });
     },
-    [ref, refresh],
+    [ref, refresh, refreshPending],
   );
   useEffect(() => {
-    if (requestedOnOpen.current || status !== "ready" || refreshPending) return;
+    const awaitingFirstImport = status === "empty" && deviceSyncImportPending;
+    if (
+      requestedOnOpen.current ||
+      (status !== "ready" && !awaitingFirstImport) ||
+      (refreshPending && !awaitingFirstImport)
+    ) return;
     void refreshJournal();
-  }, [refreshJournal, refreshPending, status]);
+  }, [deviceSyncImportPending, refreshJournal, refreshPending, status]);
   const journal = useMemo(
     () => (client ? selectBrowserVaultJournal(client) : null),
     [client],

--- a/apps/web/app/design/journal-study.tsx
+++ b/apps/web/app/design/journal-study.tsx
@@ -240,8 +240,12 @@ const JOURNAL_STUDY_DATA: JournalView = {
 
 export function JournalStudy() {
   return (
-    <section data-design-study="journal" id="journal-study">
-      <section inert>
+    <section
+      className="mx-auto flex max-w-[1440px] flex-col gap-16 px-5 py-10 sm:px-8 lg:px-12"
+      data-design-study="journal"
+      id="journal-study"
+    >
+      <section aria-label="Journal ready state" inert>
         <JournalViewContent
           asOfDate="2026-06-13"
           insights={[
@@ -265,6 +269,7 @@ export function JournalStudy() {
         <JournalViewContent
           asOfDate="2026-06-13"
           contactOptions={[STUDY_CONTACT_OPTION]}
+          isRefreshing
           journal={{
             days: [],
             eventCount: 0,

--- a/apps/web/changelog/entries/2026-09-06/journal-date-navigation.json
+++ b/apps/web/changelog/entries/2026-09-06/journal-date-navigation.json
@@ -9,7 +9,7 @@
     "summary": "Journal follows your local date while it stays open and labels older weeks with their actual date range.",
     "details": "The calendar has larger touch targets and a clearer selected date. Empty timelines also show when a background update is running.",
     "relevanceTags": ["journal", "usability", "accessibility"],
-    "sourcePullRequests": [],
+    "sourcePullRequests": [3002],
     "tryIt": { "label": "Open Journal", "href": "/journal" }
   }
 }

--- a/apps/web/changelog/entries/2026-09-06/journal-date-navigation.json
+++ b/apps/web/changelog/entries/2026-09-06/journal-date-navigation.json
@@ -1,0 +1,15 @@
+{
+  "publishedOn": "2026-09-06",
+  "order": 100,
+  "item": {
+    "id": "journal-date-navigation",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Journal keeps Today up to date",
+    "summary": "Journal follows your local date while it stays open and labels older weeks with their actual date range.",
+    "details": "The calendar has larger touch targets and a clearer selected date. Empty timelines also show when a background update is running.",
+    "relevanceTags": ["journal", "usability", "accessibility"],
+    "sourcePullRequests": [],
+    "tryIt": { "label": "Open Journal", "href": "/journal" }
+  }
+}

--- a/apps/web/changelog/entries/2026-09-06/journal-sleep-and-import-recovery.json
+++ b/apps/web/changelog/entries/2026-09-06/journal-sleep-and-import-recovery.json
@@ -13,7 +13,7 @@
       "sleep",
       "device-sync"
     ],
-    "sourcePullRequests": [],
+    "sourcePullRequests": [3002],
     "tryIt": {
       "label": "Open Journal",
       "href": "/journal"

--- a/apps/web/changelog/entries/2026-09-06/journal-sleep-and-import-recovery.json
+++ b/apps/web/changelog/entries/2026-09-06/journal-sleep-and-import-recovery.json
@@ -1,0 +1,22 @@
+{
+  "publishedOn": "2026-09-06",
+  "order": 200,
+  "item": {
+    "id": "journal-sleep-and-import-recovery",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "More accurate sleep in Journal",
+    "summary": "Journal keeps sleep on the right date, preserves short naps, and shows sleep durations in consistent units.",
+    "details": "The timeline does less work with long histories. Opening Journal during your first device import now checks for new entries for up to a minute, and chart weekdays stay aligned when you travel.",
+    "relevanceTags": [
+      "journal",
+      "sleep",
+      "device-sync"
+    ],
+    "sourcePullRequests": [],
+    "tryIt": {
+      "label": "Open Journal",
+      "href": "/journal"
+    }
+  }
+}

--- a/apps/web/e2e/journal-navigation.spec.ts
+++ b/apps/web/e2e/journal-navigation.spec.ts
@@ -48,6 +48,15 @@ test("Journal calendar and selected-week summaries work on phone and desktop", a
       if (width < 1024) await page.getByRole("button", { name: "Return to today" }).click();
       else await ready.getByRole("button", { name: "Today", exact: true }).click();
       await expect(stats).toContainText("Last 7 days");
+      // Change zone after catalog hydration, then exercise the production chart in UTC+14.
+      const browserSession = await context.newCDPSession(page);
+      await browserSession.send("Emulation.setTimezoneOverride", { timezoneId: "Pacific/Kiritimati" });
+      await stats.getByRole("button", { name: "Show avg sleep time details" }).click();
+      const chart = page.getByRole("img", { name: "Sleep time trend for this week" });
+      await expect(chart).toBeVisible();
+      await expect(chart.locator("..")).toContainText("Sun");
+      await expect(chart.locator("..")).toContainText("Sat");
+      if (outputDir) await chart.locator("..").screenshot({ path: path.join(outputDir, `journal-sleep-chart-${width}.png`) });
       const empty = page.getByRole("region", { name: "Journal empty state", includeHidden: true });
       await expect(empty.locator('[role="status"]')).toHaveAttribute("aria-label", "Updating latest data");
       expect(await empty.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);

--- a/apps/web/e2e/journal-navigation.spec.ts
+++ b/apps/web/e2e/journal-navigation.spec.ts
@@ -1,0 +1,56 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+
+test("Journal calendar and selected-week summaries work on phone and desktop", async ({ browser }) => {
+  test.setTimeout(300_000);
+  const outputDir = process.env.DESIGN_PROOF_OUTPUT_DIR;
+  if (outputDir) await mkdir(outputDir, { recursive: true });
+  for (const width of [320, 390, 1280]) {
+    const context = await browser.newContext({ viewport: { width, height: 1000 } });
+    try {
+      await context.route("**/*", (route) => {
+        const url = new URL(route.request().url());
+        return ["127.0.0.1", "localhost"].includes(url.hostname) ? route.continue() : route.abort();
+      });
+      const page = await context.newPage();
+      await page.goto("/design?tab=components#journal-study", { timeout: 180_000 });
+      await page.waitForFunction(() => {
+        const element = document.querySelector('[aria-label="Journal ready state"]');
+        return element && Object.keys(element).some((key) => key.startsWith("__reactFiber$"));
+      });
+      const ready = page.getByRole("region", { name: "Journal ready state", includeHidden: true });
+      await expect(ready.getByRole("heading", { name: "Journal", exact: true, includeHidden: true })).toBeVisible();
+      // The public study stays inert; enable only this synthetic production component for interaction proof.
+      await ready.evaluate((element) => element.removeAttribute("inert"));
+      await page.evaluate(async () => {
+        await document.fonts.ready;
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      });
+      expect(await ready.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+      await ready.scrollIntoViewIfNeeded();
+      if (outputDir) await ready.screenshot({ path: path.join(outputDir, `journal-${width}.png`), style: "nextjs-portal, main > .sticky { visibility: hidden; }" });
+      if (width < 1024) await ready.getByRole("button", { name: /Choose a Journal date/ }).click();
+      const calendar = page.getByRole("region", { name: "Journal calendar" }).filter({ visible: true });
+      const date = calendar.getByRole("button", { name: "Thursday, June 11, 2026" });
+      expect((await date.boundingBox())?.height).toBeGreaterThanOrEqual(40);
+      await date.focus();
+      await expect(date).toBeFocused();
+      if (outputDir) await calendar.screenshot({ path: path.join(outputDir, `journal-calendar-${width}.png`), style: "nextjs-portal { visibility: hidden; }" });
+      await date.press("Enter");
+      const stats = ready.getByRole("region", { name: "Seven days at a glance" }).filter({ visible: true });
+      await expect(stats).toContainText("Jun 5–11");
+      await expect(stats).not.toContainText("Last 7 days");
+      await expect(ready.locator('[id^="journal-day-"]').first()).toHaveAttribute("id", "journal-day-2026-06-11");
+      if (width < 1024) await ready.getByRole("button", { name: /Choose a Journal date/ }).click();
+      await expect(calendar.getByRole("button", { name: "Thursday, June 11, 2026" })).toHaveAttribute("aria-pressed", "true");
+      await expect(calendar.getByRole("button", { name: "Saturday, June 13, 2026" })).toHaveAttribute("aria-current", "date");
+      if (width < 1024) await page.getByRole("button", { name: "Return to today" }).click();
+      else await ready.getByRole("button", { name: "Today", exact: true }).click();
+      await expect(stats).toContainText("Last 7 days");
+      const empty = page.getByRole("region", { name: "Journal empty state", includeHidden: true });
+      await expect(empty.locator('[role="status"]')).toHaveAttribute("aria-label", "Updating latest data");
+      expect(await empty.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+    } finally { await context.close(); }
+  }
+});

--- a/apps/web/src/components/journal/journal-view.tsx
+++ b/apps/web/src/components/journal/journal-view.tsx
@@ -92,7 +92,9 @@ export function JournalViewContent({
   const today = asOfDate ?? localToday;
   const latestWindowEnd = today;
   const earliestDate = journal.days.at(-1)?.date ?? latestWindowEnd;
-  const [selectedWindowEnd, setSelectedWindowEnd] = useState(latestWindowEnd);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const selectedWindowEnd = minDate(selectedDate ?? today, today);
+  const selectDate = (date: string) => setSelectedDate(date >= today ? null : date);
   const todayGreeting = useSyncExternalStore(
     subscribeToClock,
     currentGreeting,
@@ -133,54 +135,47 @@ export function JournalViewContent({
       className="flex w-full flex-col gap-8 lg:gap-[2.125rem]"
     >
       <JournalPageHeader headingId={headingId}>
-        {journal.days.length > 0 ? (
-          <div className="flex items-center gap-2">
-            {isRefreshing ? (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <span
-                        aria-label="Updating latest data"
-                        className="inline-flex size-8 items-center justify-center text-muted-foreground"
-                        role="status"
-                      >
-                        <RefreshCw
-                          aria-hidden="true"
-                          className="size-3.5 animate-spin"
-                        />
-                      </span>
-                    }
-                  />
-                  <TooltipContent>Updating latest data</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            ) : null}
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {isRefreshing ? (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <span
+                      aria-label="Updating latest data"
+                      className="inline-flex size-8 items-center justify-center text-muted-foreground"
+                      role="status"
+                    >
+                      <RefreshCw
+                        aria-hidden="true"
+                        className="size-3.5 animate-spin motion-reduce:animate-none"
+                      />
+                    </span>
+                  }
+                />
+                <TooltipContent>Updating latest data</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : null}
+          {journal.days.length > 0 ? (
             <WeekControls
               canGoNext={selectedWindowEnd < latestWindowEnd}
               canGoPrevious={selectedWindowStart > earliestDate}
               earliestDate={earliestDate}
               onNext={() =>
-                setSelectedWindowEnd((current) =>
-                  minDate(
-                    addDays(current, JOURNAL_WINDOW_DAYS),
-                    latestWindowEnd,
-                  ),
-                )
+                selectDate(addDays(selectedWindowEnd, JOURNAL_WINDOW_DAYS))
               }
               onPrevious={() =>
-                setSelectedWindowEnd((current) =>
-                  addDays(current, -JOURNAL_WINDOW_DAYS),
-                )
+                selectDate(addDays(selectedWindowEnd, -JOURNAL_WINDOW_DAYS))
               }
-              onSelectDate={setSelectedWindowEnd}
-              onToday={() => setSelectedWindowEnd(latestWindowEnd)}
+              onSelectDate={selectDate}
+              onToday={() => setSelectedDate(null)}
               selectedWindowEnd={selectedWindowEnd}
               selectedWindowStart={selectedWindowStart}
               today={today}
             />
-          </div>
-        ) : null}
+          ) : null}
+        </div>
       </JournalPageHeader>
 
       {journal.days.length === 0 ? (
@@ -194,6 +189,7 @@ export function JournalViewContent({
                 dates={selectedDates}
                 daysByDate={daysByDate}
                 mode="mobile"
+                today={today}
               />
               <div className="mt-4 flex flex-col lg:mt-0">
                 {visibleDates.map((date) => (
@@ -214,7 +210,7 @@ export function JournalViewContent({
                 <MiniCalendar
                   earliestDate={earliestDate}
                   key={selectedWindowEnd.slice(0, 7)}
-                  onSelectDate={setSelectedWindowEnd}
+                  onSelectDate={selectDate}
                   selectedWindowEnd={selectedWindowEnd}
                   today={today}
                 />
@@ -224,6 +220,7 @@ export function JournalViewContent({
                 dates={selectedDates}
                 daysByDate={daysByDate}
                 mode="desktop"
+                today={today}
               />
               {visibleInsights.length > 0 ? (
                 <WeeklyInsights insights={visibleInsights} />
@@ -554,7 +551,7 @@ function WeekControls({
         aria-label="Previous 7 days"
         disabled={!canGoPrevious}
         onClick={onPrevious}
-        className="size-10 rounded-full lg:size-[38px]"
+        className="size-10 rounded-full"
         size="icon"
         variant="outline"
       >
@@ -564,7 +561,7 @@ function WeekControls({
         <DrawerTrigger asChild>
           <Button
             aria-label={`Choose a Journal date. Showing ${windowLabel}`}
-            className="h-10 max-w-24 rounded-full px-2.5 text-xs lg:hidden"
+            className="h-10 max-w-24 whitespace-normal rounded-full px-2.5 text-xs leading-tight lg:hidden"
             size="sm"
             variant="outline"
           >
@@ -601,7 +598,7 @@ function WeekControls({
         </DrawerContent>
       </Drawer>
       <Button
-        className="hidden h-[38px] rounded-full px-[18px] lg:inline-flex"
+        className="hidden h-10 rounded-full px-[18px] lg:inline-flex"
         onClick={onToday}
         size="sm"
         variant="outline"
@@ -612,7 +609,7 @@ function WeekControls({
         aria-label="Next 7 days"
         disabled={!canGoNext}
         onClick={onNext}
-        className="size-10 rounded-full lg:size-[38px]"
+        className="size-10 rounded-full"
         size="icon"
         variant="outline"
       >
@@ -1273,7 +1270,7 @@ function MiniCalendar({
             aria-label="Previous month"
             className={cn(
               "rounded-full",
-              surface === "drawer" ? "size-11" : "size-9",
+              surface === "drawer" ? "size-11" : "size-10",
             )}
             disabled={!canShowPreviousMonth}
             onClick={() => setMonthDate((current) => shiftMonth(current, -1))}
@@ -1286,7 +1283,7 @@ function MiniCalendar({
             aria-label="Next month"
             className={cn(
               "rounded-full",
-              surface === "drawer" ? "size-11" : "size-9",
+              surface === "drawer" ? "size-11" : "size-10",
             )}
             disabled={!canShowNextMonth}
             onClick={() => setMonthDate((current) => shiftMonth(current, 1))}
@@ -1317,8 +1314,9 @@ function MiniCalendar({
             <button
               aria-current={date === today ? "date" : undefined}
               aria-label={formatDayAccessible(date)}
+              aria-pressed={date === selectedWindowEnd}
               className={cn(
-                "flex h-[30px] w-full items-center justify-center text-[11px] text-foreground transition-colors hover:bg-muted focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                "flex min-h-10 w-full items-center justify-center text-[11px] text-foreground transition-colors hover:bg-muted focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                 !inMonth && "text-muted-foreground",
                 inSelectedWindow && "bg-primary/10",
                 date === selectedWindowStart && "rounded-l-full",
@@ -1333,9 +1331,10 @@ function MiniCalendar({
             >
               <span
                 className={cn(
-                  "flex size-6 items-center justify-center rounded-full",
-                  date === today &&
-                    "bg-primary font-semibold text-primary-foreground",
+                  "flex size-7 items-center justify-center rounded-full",
+                  date === selectedWindowEnd
+                    ? "bg-primary font-semibold text-primary-foreground"
+                    : date === today && "font-semibold ring-1 ring-primary",
                 )}
               >
                 {Number(date.slice(8, 10))}
@@ -1361,11 +1360,13 @@ function WindowStats({
   dates,
   daysByDate,
   mode,
+  today,
 }: {
   className?: string;
   dates: string[];
   daysByDate: Map<string, JournalView["days"][number]>;
   mode: "desktop" | "mobile";
+  today: string;
 }) {
   const stats: WeekStat[] = [];
   const sleepMinutes = buildWeekMetricPoints(
@@ -1410,7 +1411,9 @@ function WindowStats({
   return (
     <section aria-label="Seven days at a glance" className={className}>
       <p className="mb-3 px-1 font-mono text-[10px] uppercase tracking-[0.11em] text-muted-foreground">
-        Last 7 days
+        {dates.at(-1) === today
+          ? "Last 7 days"
+          : formatJournalWindowLabel(dates[0], dates[dates.length - 1], today)}
       </p>
       <div className="grid grid-cols-3 gap-4 px-1">
         {stats.map((stat) => (

--- a/apps/web/src/components/journal/journal-view.tsx
+++ b/apps/web/src/components/journal/journal-view.tsx
@@ -1706,7 +1706,7 @@ function readJournalDayMetric(
 }
 
 function formatShortDay(date: string): string {
-  return new Intl.DateTimeFormat("en-US", { weekday: "short" }).format(
+  return new Intl.DateTimeFormat("en-US", { weekday: "short", timeZone: "UTC" }).format(
     new Date(`${date}T12:00:00Z`),
   );
 }

--- a/apps/web/test/browser-vault-context.test.tsx
+++ b/apps/web/test/browser-vault-context.test.tsx
@@ -1773,6 +1773,153 @@ test("browser-vault provider preserves readable stale data when bounded observat
   await rendered.cleanup();
 });
 
+test.each(["published", "pending"] as const)(
+  "Journal bounds first-import observation when publication remains %s",
+  async (publication) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-30T12:00:00.000Z"));
+    mocks.usePathname.mockReturnValue("/journal");
+    const occurredAt = "2026-04-30T09:15:00.000Z";
+    const replica = createReplica({
+      journal: {
+        days: [{ date: "2026-04-30", events: [{
+          date: "2026-04-30", details: [], id: "stretching-note", kind: "note",
+          metrics: {
+            activityMinutes: 0, deepSleepMinutes: null, hrvMs: null,
+            readinessScore: null, recoveryScore: null, remSleepMinutes: null,
+            respiratoryRate: null, restingHeartRateBpm: null,
+            sleepEfficiencyPercent: null, sleepMinutes: null, sleepScore: null,
+            spo2Percent: null,
+          },
+          occurredAt,
+          records: [{
+            id: "stretching-note", kind: "note", label: "Stretching",
+            occurredAt, source: "manual", summary: "10 min", tags: [], timeZone: "UTC",
+          }],
+          summary: "10 min", timing: "timed", timeZone: "UTC", title: "Stretching",
+        }] }],
+        eventCount: 1, recordCount: 1, weeks: [], windowDays: 120,
+      },
+    });
+    let published = false;
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      requestBodies.push(JSON.parse(String(init?.body)));
+      return jsonResponse(published ? {
+        deviceSyncImportPending: false,
+        encryptedReplica: createReplicaEnvelope(),
+        freshness: "fresh",
+        replicaAad: createReplicaAad(),
+        replicaKeyEnvelope: createReplicaKeyEnvelope(),
+        replicaRef: createReplicaRef({
+          byteLength: new TextEncoder().encode(JSON.stringify(replica)).byteLength,
+        }),
+        refreshPending: false,
+        state: "ready",
+      } : {
+        deviceSyncImportPending: true,
+        encryptedReplica: null,
+        freshness: "stale",
+        memberId: "member_123",
+        replicaAad: null,
+        replicaKeyEnvelope: null,
+        replicaRef: null,
+        refreshPending: true,
+        state: "empty",
+        workspaceVersion: "1",
+      });
+    });
+    installBrowserVaultCryptoMocks();
+    mocks.decryptHostedStoragePayload.mockResolvedValue(
+      new TextEncoder().encode(JSON.stringify(replica)),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const rendered = await renderClientComponent(
+      createAuthenticatedBrowserVaultElement(createElement(JournalPageClient)),
+      { requireButton: false },
+    );
+    try {
+      await waitForText(rendered.container, "Preparing your Journal");
+      published = publication === "published";
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(published ? 1_500 : 60_000);
+      });
+      if (published) {
+        await waitForText(rendered.container, "Stretching");
+        assert.match(rendered.container.textContent ?? "", /10 min/);
+      } else {
+        await waitForText(rendered.container, "Build your health timeline");
+      }
+      assert.equal(rendered.container.textContent?.includes("Preparing your Journal"), false);
+      assert.equal(requestBodies.filter((body) => body.requestRefresh === true).length, 1);
+      assert.ok(requestBodies.some((body) => body.refreshObservationOnly === true));
+      assert.ok(requestBodies.slice(2).every((body) => body.refreshObservationOnly === true));
+      const requestCount = requestBodies.length;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      assert.equal(requestBodies.length, requestCount);
+    } finally {
+      await rendered.cleanup();
+    }
+  },
+);
+
+test("Journal unavailable retry preserves the active refresh deadline", async () => {
+  vi.useFakeTimers();
+  mocks.usePathname.mockReturnValue("/journal");
+  const replica = createReplica();
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+    requestBodies.push(JSON.parse(String(init?.body)));
+    return jsonResponse({
+      encryptedReplica: createReplicaEnvelope(),
+      freshness: "fresh",
+      replicaAad: createReplicaAad(),
+      replicaKeyEnvelope: createReplicaKeyEnvelope(),
+      replicaRef: createReplicaRef({
+        byteLength: new TextEncoder().encode(JSON.stringify(replica)).byteLength,
+      }),
+      refreshPending: false,
+      state: "ready",
+    });
+  });
+  installBrowserVaultCryptoMocks();
+  vi.stubGlobal("fetch", fetchMock);
+  const rendered = await renderClientComponent(
+    createAuthenticatedBrowserVaultElement(createElement(JournalPageClient)),
+    { requireButton: false },
+  );
+  try {
+    await waitForText(rendered.container, "Journal is not ready yet");
+    await waitForCondition(() => requestBodies.length === 2, "automatic Journal request");
+    const retry = [...rendered.container.querySelectorAll("button")]
+      .find((button) => button.textContent === "Refresh Journal");
+    assert.ok(retry);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    const requestCount = requestBodies.length;
+    await act(async () => retry.click());
+    await act(async () => retry.click());
+    assert.equal(requestBodies.length, requestCount);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    const countAtDeadline = requestBodies.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    assert.equal(requestBodies.length, countAtDeadline);
+    assert.equal(requestBodies.filter((body) => body.requestRefresh === true).length, 1);
+    await act(async () => retry.click());
+    assert.equal(requestBodies.filter((body) => body.requestRefresh === true).length, 2);
+  } finally {
+    await rendered.cleanup();
+  }
+});
+
 test("Journal retry admits the recovered session and renders its timeline", async () => {
   vi.useFakeTimers({ toFake: ["Date"] });
   vi.setSystemTime(new Date("2026-04-30T12:00:00.000Z"));

--- a/apps/web/test/journal-navigation.test.tsx
+++ b/apps/web/test/journal-navigation.test.tsx
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { act, createElement } from "react";
+import { test, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+import type { JournalView } from "@murphai/query/browser-overview";
+import { JournalViewContent } from "../src/components/journal/journal-view";
+import { renderClientComponent } from "./render-client-component";
+
+const journal: JournalView = {
+  days: [
+    { date: "2026-08-12", events: [] },
+    { date: "2026-07-01", events: [] },
+  ],
+  eventCount: 0,
+  recordCount: 0,
+  weeks: [],
+  windowDays: 120,
+};
+
+const matchMedia: typeof window.matchMedia = (media) => ({
+  media, matches: false, onchange: null,
+  addEventListener() {}, removeEventListener() {},
+  addListener() {}, removeListener() {}, dispatchEvent: () => false,
+});
+
+test("Journal follows the local day until a historical window is selected", async () => {
+  const view = (asOfDate: string) => createElement(JournalViewContent, { asOfDate, journal });
+  const rendered = await renderClientComponent(view("2026-08-12"), { matchMedia });
+  const firstDay = () => rendered.container.querySelector('[id^="journal-day-"]')?.id;
+  const click = async (label: string) => {
+    const button = rendered.container.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+    assert.ok(button);
+    await act(async () => button.click());
+  };
+  try {
+    await rendered.rerender(view("2026-08-13"));
+    assert.equal(firstDay(), "journal-day-2026-08-13");
+    await click("Previous 7 days");
+    assert.equal(firstDay(), "journal-day-2026-08-06");
+    await rendered.rerender(view("2026-08-14"));
+    assert.equal(firstDay(), "journal-day-2026-08-06");
+    const today = Array.from(rendered.container.querySelectorAll("button")).find((button) => button.textContent === "Today");
+    assert.ok(today);
+    await act(async () => today.click());
+    await rendered.rerender(view("2026-08-15"));
+    assert.equal(firstDay(), "journal-day-2026-08-15");
+    // A local date can also move backward when the browser replaces the UTC snapshot.
+    await rendered.rerender(view("2026-08-14"));
+    assert.equal(firstDay(), "journal-day-2026-08-14");
+    await click("Previous 7 days");
+    await click("Next 7 days");
+    await rendered.rerender(view("2026-08-15"));
+    assert.equal(firstDay(), "journal-day-2026-08-15");
+  } finally { await rendered.cleanup(); }
+});
+
+test("an empty Journal announces its background refresh without hiding onboarding", async () => {
+  const rendered = await renderClientComponent(createElement(JournalViewContent, {
+    asOfDate: "2026-08-12", journal: { ...journal, days: [] }, isRefreshing: true,
+  }), { matchMedia, requireButton: false });
+  try {
+    assert.ok(rendered.container.querySelector('[role="status"][aria-label="Updating latest data"]'));
+    assert.match(rendered.container.textContent ?? "", /Build your health timeline/);
+    assert.equal(rendered.container.querySelector('[aria-label="Previous 7 days"]'), null);
+  } finally { await rendered.cleanup(); }
+});
+
+test("the Journal calendar exposes its selected end date separately from today", async () => {
+  const rendered = await renderClientComponent(createElement(JournalViewContent, { asOfDate: "2026-08-12", journal }), { matchMedia });
+  try {
+    const selected = rendered.container.querySelector<HTMLButtonElement>('button[aria-label="Monday, August 10, 2026"]');
+    assert.ok(selected);
+    await act(async () => selected.click());
+    assert.equal(selected.getAttribute("aria-pressed"), "true");
+    const today = rendered.container.querySelector('button[aria-current="date"]');
+    assert.equal(today?.getAttribute("aria-pressed"), "false");
+    assert.match(rendered.container.textContent ?? "", /Aug 4–10/);
+  } finally { await rendered.cleanup(); }
+});
+
+
+test("Journal replaces the server UTC date with the browser local day during hydration", async () => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(new Date("2026-08-13T01:00:00.000Z"));
+  const localYear = vi.spyOn(Date.prototype, "getFullYear").mockReturnValue(2026);
+  const localMonth = vi.spyOn(Date.prototype, "getMonth").mockReturnValue(7);
+  const localDay = vi.spyOn(Date.prototype, "getDate").mockReturnValue(12);
+  try {
+    const element = createElement(JournalViewContent, { journal });
+    const markup = renderToString(element);
+    assert.match(markup, /journal-day-2026-08-13/);
+    const onRecoverableError = vi.fn();
+    const rendered = await renderClientComponent(element, {
+      matchMedia,
+      hydrateFrom: { markup, onRecoverableError },
+    });
+    try {
+      assert.equal(rendered.container.querySelector('[id^="journal-day-"]')?.id, "journal-day-2026-08-12");
+      assert.equal(onRecoverableError.mock.calls.length, 0);
+      assert.equal(rendered.container.querySelector<HTMLButtonElement>('[aria-label="Next 7 days"]')?.disabled, true);
+    } finally { await rendered.cleanup(); }
+  } finally {
+    localYear.mockRestore();
+    localMonth.mockRestore();
+    localDay.mockRestore();
+    vi.useRealTimers();
+  }
+});

--- a/packages/health-metrics/README.md
+++ b/packages/health-metrics/README.md
@@ -7,3 +7,8 @@ Canonical vault records still store evidence. This package owns only read-side m
 Decision-grade metric-window comparisons use normalized `MetricPoint` values
 and the shared series/window selectors. Wearable day summaries are presentation
 context, not analysis truth.
+
+Sleep and readiness/recovery scores use a 100-point scale. Provider percentages
+normalize to the same numeric score while retaining their source unit; unrelated
+units remain unsupported. Journal may retain a provider's Recovery label even
+when its canonical metric identity is readiness-score.

--- a/packages/health-metrics/src/normalize.ts
+++ b/packages/health-metrics/src/normalize.ts
@@ -121,24 +121,45 @@ function normalizeMetricValueForScope(
     case "sleep-midpoint-variability-minutes":
     case "total-sleep-minutes":
       return normalizeDurationMinutes(input.value, unit, definition.displayName);
-    default: {
-      if (definition.canonicalUnit === null) {
-        const commonCustomValue = normalizeCommonCustomValue(input.value, unit);
-        if (commonCustomValue) return commonCustomValue;
-      }
-      const canonicalUnit = definition.canonicalUnit && (!unit || unitsEquivalent(unit, definition.canonicalUnit))
-        ? definition.canonicalUnit
-        : null;
-      return {
-        canonicalUnit,
-        canonicalValue: canonicalUnit ? input.value : null,
-        unit: unit ?? definition.displayUnit,
-        warnings: canonicalUnit || !definition.canonicalUnit
-          ? []
-          : [unitWarning(definition.displayName, unit, definition.canonicalUnit)],
-      };
-    }
+    case "sleep-score":
+    case "readiness-score":
+      return normalizeHundredPointScore(input.value, unit, definition.displayName);
+    default:
+      return normalizeDeclaredMetricUnit(input.value, unit, definition);
   }
+}
+
+function normalizeDeclaredMetricUnit(
+  value: number,
+  unit: string | null,
+  definition: MetricDefinition,
+): MetricValueNormalization {
+  if (definition.canonicalUnit === null) {
+    const commonCustomValue = normalizeCommonCustomValue(value, unit);
+    if (commonCustomValue) return commonCustomValue;
+  }
+  const canonicalUnit = definition.canonicalUnit && (!unit || unitsEquivalent(unit, definition.canonicalUnit))
+    ? definition.canonicalUnit
+    : null;
+  return {
+    canonicalUnit,
+    canonicalValue: canonicalUnit ? value : null,
+    unit: unit ?? definition.displayUnit,
+    warnings: canonicalUnit || !definition.canonicalUnit
+      ? []
+      : [unitWarning(definition.displayName, unit, definition.canonicalUnit)],
+  };
+}
+
+function normalizeHundredPointScore(
+  value: number,
+  unit: string | null,
+  label: string,
+): MetricValueNormalization {
+  if (unit === "percent") {
+    return { canonicalUnit: "score", canonicalValue: value, unit, warnings: [] };
+  }
+  return normalizeExactUnit(value, unit, "score", label);
 }
 
 export function resolveComparableMetricPointValue(

--- a/packages/health-metrics/test/index.test.ts
+++ b/packages/health-metrics/test/index.test.ts
@@ -9828,3 +9828,20 @@ function seriesPoint(date: string, value: number): MetricSeriesPoint {
     valueLabel: String(value),
   };
 }
+
+
+test("normalizes percentage-based sleep and recovery scores without treating other score units as equivalent", () => {
+  for (const metricKey of ["sleep-score", "readiness-score", "recovery-score"]) {
+    for (const unit of ["%", "percent", "percentage"]) {
+      const normalized = normalizeMetricValue({ metricKey, unit, value: 78 });
+      assert.equal(normalized.canonicalUnit, "score");
+      assert.equal(normalized.canonicalValue, 78);
+      assert.deepEqual(normalized.warnings, []);
+    }
+    assert.equal(normalizeMetricValue({ metricKey, unit: "score", value: 78 }).canonicalValue, 78);
+    const incompatible = normalizeMetricValue({ metricKey, unit: "kg", value: 78 });
+    assert.equal(incompatible.canonicalValue, null);
+    assert.equal(incompatible.warnings.length, 1);
+  }
+  assert.equal(normalizeMetricValue({ metricKey: "sleep-score", unit: "%", value: Number.NaN }).canonicalValue, null);
+});

--- a/packages/query/src/journal-view.ts
+++ b/packages/query/src/journal-view.ts
@@ -8,7 +8,12 @@ import {
   resolveActivityEvidenceLocalDate,
   resolveInterventionSessionLocalDate,
 } from "./experiment-adherence.ts";
-import { selectMetricSeries, type MetricPoint } from "./metrics/index.ts";
+import {
+  extractMetricPointsFromCanonicalEntities,
+  resolveObservationEffectiveDate,
+  selectMetricSeries,
+  type MetricPoint,
+} from "./metrics/index.ts";
 import type { CanonicalEntity } from "./canonical-entities.ts";
 import type { VaultReadModel } from "./read-model.ts";
 import {
@@ -24,7 +29,7 @@ const MAX_RECORDS = 1_500;
 const JOURNAL_METRICS = [
   { key: "sleep-score", label: "Sleep score", group: "sleep" },
   { key: "sleep-efficiency", label: "Sleep efficiency", group: "sleep" },
-  { key: "total-sleep", label: "Total sleep", group: "sleep" },
+  { key: "total-sleep-minutes", label: "Total sleep", group: "sleep" },
   { key: "deep-sleep-minutes", label: "Deep sleep", group: "sleep" },
   { key: "rem-sleep-minutes", label: "REM sleep", group: "sleep" },
   { key: "hrv-rmssd", label: "HRV", group: "sleep" },
@@ -154,11 +159,14 @@ export function buildJournalView(
     dayEvents.push(event);
     daysByDate.set(event.date, dayEvents);
   }
+  const timeFormatters = new Map<string, Intl.DateTimeFormat>();
   const days = [...daysByDate.entries()]
     .sort(([left], [right]) => right.localeCompare(left))
     .map(([date, dayEvents]) => ({
       date,
-      events: dayEvents.sort(compareJournalEvents),
+      events: dayEvents.sort((left, right) =>
+        compareJournalEvents(left, right, timeFormatters),
+      ),
     }));
 
   return {
@@ -182,7 +190,7 @@ function journalCandidateFromEvent(
   if (!date || date < fromDate || date > toDate) return [];
   const occurredAt = normalizeOccurredAt(event.occurredAt ?? undefined, date);
   const presentation = journalEventPresentation(event, vocabulary);
-  const { activityKey, exerciseNames, label, observationMetric } = presentation;
+  const { activityKey, exerciseNames, label, metricValue, observationMetric } = presentation;
   const durationMinutes = readNumber(event.attributes.durationMinutes);
   const sleepType =
     event.kind === "sleep_session"
@@ -208,9 +216,7 @@ function journalCandidateFromEvent(
       kind: event.kind,
       label,
       metricKey: observationMetric?.key ?? null,
-      metricValue: observationMetric
-        ? readNumber(event.attributes.value)
-        : null,
+      metricValue,
       occurredAt,
       relatedIds: [
         ...new Set([
@@ -241,14 +247,21 @@ function journalEventPresentation(
   activityKey: string | null;
   exerciseNames: string[];
   label: string;
+  metricValue: number | null;
   observationMetric: (typeof JOURNAL_METRICS)[number] | null;
 } {
-  const observationMetric = journalObservationMetric(event);
+  const observationPoint = event.kind === "observation"
+    ? extractMetricPointsFromCanonicalEntities([event])[0] ?? null
+    : null;
+  const observationMetric = JOURNAL_METRICS.find(
+    (metric) => metric.key === observationPoint?.metricKey,
+  ) ?? null;
   if (event.kind !== "activity_session") {
     return {
       activityKey: null,
       exerciseNames: [],
       label: observationMetric?.label ?? eventLabel(event),
+      metricValue: observationMetric ? observationPoint?.canonicalValue ?? null : null,
       observationMetric,
     };
   }
@@ -263,6 +276,7 @@ function journalEventPresentation(
     activityKey: concept?.id ?? rawKey,
     exerciseNames: activityExerciseNames(event.attributes),
     label: concept?.label ?? humanizeFactorToken(rawKey),
+    metricValue: null,
     observationMetric,
   };
 }
@@ -344,47 +358,48 @@ function appendExperimentPhaseCandidates(input: {
   title: string;
   toDate: string;
 }): void {
-  let date = input.startDate;
+  let date = input.startDate > input.fromDate ? input.startDate : input.fromDate;
+  const endDate = input.endDate < input.toDate ? input.endDate : input.toDate;
+  if (date > endDate) return;
   const totalDays = daysBetweenInclusive(input.startDate, input.endDate);
-  if (totalDays === null) return;
+  const firstDay = daysBetweenInclusive(input.startDate, date);
+  if (totalDays === null || firstDay === null) return;
 
-  for (let day = 1; date <= input.endDate; day += 1) {
-    if (date >= input.fromDate && date <= input.toDate) {
-      const groupHint = experimentJournalGroupHint(input.title, date);
-      if (!input.explicitDays.has(groupHint)) {
-        const isCompleted = input.completedOn === date;
-        const summary = isCompleted
-          ? "Experiment completed"
-          : input.phase === "baseline"
-          ? `Baseline · day ${day}`
-          : day === 1
-          ? "Experiment started"
-          : `Running experiment · day ${day}`;
-        input.candidates.push({
-          activityKey: null,
-          date,
-          detailItems: [
-            `Status: ${isCompleted ? "Completed" : humanize(input.phase)}`,
-            `Progress: Day ${day} of ${totalDays}`,
-          ],
-          durationMinutes: null,
-          exerciseNames: [],
-          groupHint,
-          id: `${input.experiment.entityId}:${input.phase}:${date}`,
-          kind: "experiment_context",
-          label: input.title,
-          metricKey: null,
-          metricValue: null,
-          occurredAt: `${date}T12:00:00.000Z`,
-          relatedIds: [input.experiment.entityId],
-          sleepType: null,
-          source: "murph",
-          summary,
-          tags: input.experiment.tags.slice(),
-          timing: "all_day",
-          timeZone: null,
-        });
-      }
+  for (let day = firstDay; date <= endDate; day += 1) {
+    const groupHint = experimentJournalGroupHint(input.title, date);
+    if (!input.explicitDays.has(groupHint)) {
+      const isCompleted = input.completedOn === date;
+      const summary = isCompleted
+        ? "Experiment completed"
+        : input.phase === "baseline"
+        ? `Baseline · day ${day}`
+        : day === 1
+        ? "Experiment started"
+        : `Running experiment · day ${day}`;
+      input.candidates.push({
+        activityKey: null,
+        date,
+        detailItems: [
+          `Status: ${isCompleted ? "Completed" : humanize(input.phase)}`,
+          `Progress: Day ${day} of ${totalDays}`,
+        ],
+        durationMinutes: null,
+        exerciseNames: [],
+        groupHint,
+        id: `${input.experiment.entityId}:${input.phase}:${date}`,
+        kind: "experiment_context",
+        label: input.title,
+        metricKey: null,
+        metricValue: null,
+        occurredAt: `${date}T12:00:00.000Z`,
+        relatedIds: [input.experiment.entityId],
+        sleepType: null,
+        source: "murph",
+        summary,
+        tags: input.experiment.tags.slice(),
+        timing: "all_day",
+        timeZone: null,
+      });
     }
     date = addDays(date, 1);
   }
@@ -411,11 +426,19 @@ function journalMetricCandidates(
   fromDate: string,
   toDate: string,
 ): JournalCandidate[] {
+  const pointsByMetric = new Map<string, MetricPoint[]>(
+    JOURNAL_METRICS.map((metric) => [metric.key, []]),
+  );
+  for (const point of points) {
+    if (point.effectiveDate >= fromDate && point.effectiveDate <= toDate) {
+      pointsByMetric.get(point.metricKey)?.push(point);
+    }
+  }
   return JOURNAL_METRICS.flatMap((metric) =>
     selectMetricSeries({
       from: fromDate,
       metricKey: metric.key,
-      points,
+      points: pointsByMetric.get(metric.key) ?? [],
       to: toDate,
     }).rows.flatMap((row) => {
       if (row.value === null || row.confidence === "none") return [];
@@ -492,7 +515,9 @@ function normalizeSleepJournalCandidates(
       (session) => session.sleepType === "unknown",
     );
     const selectedUnknownMain =
-      unknown.slice().sort(compareSleepDuration)[0] ?? null;
+      explicitMain.length === 0
+        ? unknown.slice().sort(compareSleepDuration)[0] ?? null
+        : null;
 
     for (const session of sessions) {
       const isLongUnknownSleep =
@@ -556,7 +581,7 @@ function shouldKeepJournalCandidate(input: {
     return false;
   }
   if (
-    candidate.metricKey === "total-sleep" &&
+    candidate.metricKey === "total-sleep-minutes" &&
     input.hasSleepSession.has(candidate.date)
   ) {
     return false;
@@ -580,15 +605,6 @@ function shouldKeepJournalCandidate(input: {
     );
   }
   return true;
-}
-
-function journalObservationMetric(
-  event: CanonicalEntity,
-): (typeof JOURNAL_METRICS)[number] | null {
-  if (event.kind !== "observation") return null;
-  const metric = readString(event.attributes.metric);
-  if (!metric) return null;
-  return JOURNAL_METRICS.find((candidate) => candidate.key === metric) ?? null;
 }
 
 function groupJournalCandidates(
@@ -685,6 +701,8 @@ function isJournalEventKind(kind: string): boolean {
 }
 
 function resolveEventDate(event: CanonicalEntity): string | null {
+  if (event.kind === "observation")
+    return resolveObservationEffectiveDate(event) ?? event.occurredAt?.slice(0, 10) ?? null;
   if (event.kind === "activity_session")
     return resolveActivityEvidenceLocalDate(event);
   if (event.kind === "intervention_session")
@@ -1149,7 +1167,7 @@ function buildEventPresentation(
   ) {
     const sleepMinutes = maxNumber([
       ...sleepSessions.map((record) => record.durationMinutes),
-      metricValue(records, "total-sleep"),
+      metricValue(records, "total-sleep-minutes"),
     ]);
     const sleepScore = metricValue(records, "sleep-score");
     const summaryParts = [
@@ -1331,15 +1349,22 @@ function compareCandidates(
   );
 }
 
-function compareJournalEvents(left: JournalEvent, right: JournalEvent): number {
+function compareJournalEvents(
+  left: JournalEvent,
+  right: JournalEvent,
+  timeFormatters: Map<string, Intl.DateTimeFormat>,
+): number {
   return (
-    journalEventSortMinute(left) - journalEventSortMinute(right) ||
+    journalEventSortMinute(left, timeFormatters) - journalEventSortMinute(right, timeFormatters) ||
     left.occurredAt.localeCompare(right.occurredAt) ||
     left.id.localeCompare(right.id)
   );
 }
 
-function journalEventSortMinute(event: JournalEvent): number {
+function journalEventSortMinute(
+  event: JournalEvent,
+  timeFormatters: Map<string, Intl.DateTimeFormat>,
+): number {
   if (event.timing === "all_day") return -2;
   if (event.kind === "sleep" && event.timing === "night") return -1;
   // Period anchors order rows only. They are never shown as observed times.
@@ -1348,12 +1373,18 @@ function journalEventSortMinute(event: JournalEvent): number {
   if (event.timing === "evening") return 18 * 60;
   if (event.timing === "night") return 21 * 60;
   if (event.timing === "unknown") return 24 * 60;
-  const parts = new Intl.DateTimeFormat("en-GB", {
-    hour: "2-digit",
-    minute: "2-digit",
-    hourCycle: "h23",
-    timeZone: event.timeZone ?? "UTC",
-  }).formatToParts(new Date(event.occurredAt));
+  const timeZone = event.timeZone ?? "UTC";
+  let formatter = timeFormatters.get(timeZone);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-GB", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+      timeZone,
+    });
+    timeFormatters.set(timeZone, formatter);
+  }
+  const parts = formatter.formatToParts(new Date(event.occurredAt));
   return Number(parts.find((part) => part.type === "hour")?.value ?? 0) * 60
     + Number(parts.find((part) => part.type === "minute")?.value ?? 0);
 }

--- a/packages/query/src/journal-view.ts
+++ b/packages/query/src/journal-view.ts
@@ -253,8 +253,13 @@ function journalEventPresentation(
   const observationPoint = event.kind === "observation"
     ? extractMetricPointsFromCanonicalEntities([event])[0] ?? null
     : null;
+  // Recovery shares canonical units with Readiness but keeps its product label.
+  const observationMetricKey = observationPoint?.metricKey === "readiness-score"
+    && event.attributes.metric === "recovery-score"
+    ? "recovery-score"
+    : observationPoint?.metricKey;
   const observationMetric = JOURNAL_METRICS.find(
-    (metric) => metric.key === observationPoint?.metricKey,
+    (metric) => metric.key === observationMetricKey,
   ) ?? null;
   if (event.kind !== "activity_session") {
     return {
@@ -1067,8 +1072,10 @@ function formatDetailNumber(value: number): string {
 
 function readEventSource(event: CanonicalEntity): string | null {
   const dataOrigin = readRecord(event.attributes.dataOrigin);
+  const externalRef = readRecord(event.attributes.externalRef);
   return (
     readString(dataOrigin?.sourceProviderSlug) ??
+    readString(externalRef?.system) ??
     readString(event.attributes.source) ??
     null
   );

--- a/packages/query/src/metrics/index.ts
+++ b/packages/query/src/metrics/index.ts
@@ -417,9 +417,10 @@ function resolveObservationMetric(entity: CanonicalEntity): string | null {
   return sourceProviderSlug === "apple-health-kit" ? "hrv-sdnn" : metric;
 }
 
-function resolveObservationEffectiveDate(
+export function resolveObservationEffectiveDate(
   entity: CanonicalEntity,
-  observationGrain: string | null,
+  observationGrain: string | null = readString(entity.attributes.observationGrain)
+    ?? inferWearableObservationGrain(entity),
 ): string | null {
   const dayKey = readString(entity.attributes.dayKey);
   if (!isDayGrainObservation(observationGrain)) {

--- a/packages/query/test/journal-view.test.ts
+++ b/packages/query/test/journal-view.test.ts
@@ -1203,3 +1203,24 @@ test("Journal retains timestamp-only observations on their canonical metric day"
   assert.equal(view.days[0]?.events[0]?.metrics.deepSleepMinutes, 90);
   assert.equal(view.recordCount, 1);
 });
+
+test("Journal preserves WHOOP Recovery when canonical normalization uses Readiness", () => {
+  const entities = [event("whoop-recovery", "observation", "2026-08-25T07:30:00.000Z", {
+    metric: "recovery-score", value: 78, unit: "%", source: "device",
+    dayKey: "2026-08-25", observationGrain: "summary",
+    externalRef: { system: "whoop", resourceType: "summary", resourceId: "recovery-day" },
+  }, "Recovery")];
+  const points = extractMetricPointsFromCanonicalEntities(entities);
+  assert.equal(points[0]?.metricKey, "readiness-score");
+  assert.equal(points[0]?.canonicalValue, 78);
+  const view = buildJournalView(
+    createVaultReadModel({ entities, vaultRoot: "test://journal-whoop-recovery" }),
+    points,
+    { asOf: "2026-08-25" },
+  );
+  const sleep = view.days[0]?.events[0];
+  assert.equal(sleep?.metrics.recoveryScore, 78);
+  assert.equal(sleep?.metrics.readinessScore, null);
+  assert.equal(view.recordCount, 1);
+  assert.deepEqual(sleep?.records.map((record) => record.label), ["Recovery score"]);
+});

--- a/packages/query/test/journal-view.test.ts
+++ b/packages/query/test/journal-view.test.ts
@@ -4,7 +4,10 @@ import { test } from "vitest";
 
 import type { CanonicalEntity } from "../src/canonical-entities.ts";
 import { buildJournalView } from "../src/journal-view.ts";
-import type { MetricPoint } from "../src/metrics/index.ts";
+import {
+  extractMetricPointsFromCanonicalEntities,
+  type MetricPoint,
+} from "../src/metrics/index.ts";
 import { createVaultReadModel } from "../src/read-model.ts";
 
 test("Journal groups canonical records into human events without copying source data", () => {
@@ -295,7 +298,7 @@ test("Journal turns dense wearable records into main sleep, naps, and grouped ac
       vaultRoot: "test://journal-wearable-density",
     }),
     [
-      metric("total-sleep", "2026-08-25", 450, "min"),
+      metric("total-sleep-minutes", "2026-08-25", 450, "minutes"),
       metric("sleep-efficiency", "2026-08-25", 89, "percent"),
       metric("hrv-rmssd", "2026-08-25", 68.1429, "ms"),
       metric("readiness-score", "2026-08-25", 71, "score"),
@@ -910,6 +913,136 @@ test("Journal folds a long unknown provider duplicate into explicit main sleep",
   assert.equal(events.find((entry) => entry.kind === "nap")?.summary, "25 min");
 });
 
+test("Journal keeps an unlabeled short nap separate from explicit main sleep", () => {
+  const entities = [
+    event("main", "sleep_session", "2026-08-25T08:00:00.000Z", {
+      durationMinutes: 450,
+      sleepType: "main_sleep",
+    }, "Sleep"),
+    event("short", "sleep_session", "2026-08-25T15:00:00.000Z", {
+      durationMinutes: 25,
+    }, "Sleep"),
+  ];
+  const view = buildJournalView(
+    createVaultReadModel({ entities, vaultRoot: "test://journal-short-unknown-nap" }),
+    extractMetricPointsFromCanonicalEntities(entities),
+    { asOf: "2026-08-25" },
+  );
+
+  const events = view.days[0]?.events ?? [];
+  assert.equal(events.length, 2);
+  assert.equal(events.find((entry) => entry.kind === "sleep")?.metrics.sleepMinutes, 450);
+  const nap = events.find((entry) => entry.kind === "nap");
+  assert.equal(nap?.timing, "timed");
+  assert.equal(nap?.summary, "25 min");
+  assert.deepEqual(nap?.records.map((record) => record.id), ["short"]);
+  assert.equal(view.weeks[0]?.sleepNights, 1);
+  assert.equal(view.weeks[0]?.averageSleepMinutes, 450);
+});
+
+test("Journal counts canonical total sleep observations as a sleep night", () => {
+  const entities = [event("total", "observation", "2026-08-25T08:00:00.000Z", {
+    metric: "total-sleep-minutes",
+    value: 450,
+    unit: "minutes",
+  }, "Total sleep")];
+  const view = buildJournalView(
+    createVaultReadModel({ entities, vaultRoot: "test://journal-total-sleep" }),
+    extractMetricPointsFromCanonicalEntities(entities),
+    { asOf: "2026-08-25" },
+  );
+
+  assert.equal(view.eventCount, 1);
+  assert.equal(view.days[0]?.events[0]?.kind, "sleep");
+  assert.equal(view.days[0]?.events[0]?.summary, "7 h 30");
+  assert.equal(view.days[0]?.events[0]?.metrics.sleepMinutes, 450);
+  assert.equal(view.weeks[0]?.sleepNights, 1);
+  assert.equal(view.weeks[0]?.averageSleepMinutes, 450);
+});
+
+test("Journal hides canonical total sleep already represented by a session", () => {
+  const entities = [
+    event("main", "sleep_session", "2026-08-25T08:00:00.000Z", {
+      durationMinutes: 450,
+      sleepType: "main_sleep",
+    }, "Sleep"),
+    event("total", "observation", "2026-08-25T08:00:00.000Z", {
+      metric: "total-sleep-minutes",
+      value: 475,
+      unit: "minutes",
+    }, "Total sleep"),
+  ];
+  const view = buildJournalView(
+    createVaultReadModel({ entities, vaultRoot: "test://journal-total-sleep-session" }),
+    extractMetricPointsFromCanonicalEntities(entities),
+    { asOf: "2026-08-25" },
+  );
+
+  assert.equal(view.eventCount, 1);
+  assert.deepEqual(view.days[0]?.events[0]?.records.map((record) => record.id), ["main"]);
+  assert.equal(view.days[0]?.events[0]?.metrics.sleepMinutes, 450);
+  assert.equal(view.weeks[0]?.sleepNights, 1);
+  assert.equal(view.weeks[0]?.averageSleepMinutes, 450);
+});
+
+test("Journal keeps observation sleep days from merging adjacent nights", () => {
+  const entities = [
+    event("main_24", "sleep_session", "2026-08-24T08:00:00.000Z", {
+      durationMinutes: 420,
+      sleepType: "main_sleep",
+    }, "Sleep"),
+    event("main_25", "sleep_session", "2026-08-25T08:00:00.000Z", {
+      durationMinutes: 480,
+      sleepType: "main_sleep",
+    }, "Sleep"),
+    event("score", "observation", "2026-08-24T23:00:00.000Z", {
+      metric: "sleep-score",
+      value: 80,
+      unit: "score",
+      dayKey: "2026-08-25",
+      observationGrain: "summary",
+      timeZone: "Asia/Tokyo",
+      source: "device",
+    }, "Sleep score"),
+  ];
+  const view = buildJournalView(
+    createVaultReadModel({ entities, vaultRoot: "test://journal-sleep-observation-day" }),
+    extractMetricPointsFromCanonicalEntities(entities),
+    { asOf: "2026-08-25" },
+  );
+
+  assert.deepEqual(view.days.map((day) => day.date), ["2026-08-25", "2026-08-24"]);
+  assert.equal(view.eventCount, 2);
+  const currentSleep = view.days[0]?.events[0];
+  const priorSleep = view.days[1]?.events[0];
+  assert.equal(currentSleep?.metrics.sleepMinutes, 480);
+  assert.equal(currentSleep?.metrics.sleepScore, 80);
+  assert.equal(priorSleep?.metrics.sleepMinutes, 420);
+  assert.equal(priorSleep?.metrics.sleepScore, null);
+  assert.deepEqual(priorSleep?.records.map((record) => record.id), ["main_24"]);
+  assert.equal(view.weeks[0]?.sleepNights, 2);
+  assert.equal(view.weeks[0]?.averageSleepMinutes, 450);
+});
+
+test("Journal uses normalized sleep observation units", () => {
+  const entities = [event("deep", "observation", "2026-08-25T08:00:00.000Z", {
+    metric: "deep-sleep-minutes",
+    value: 1.5,
+    unit: "hours",
+  }, "Deep sleep")];
+  const points = extractMetricPointsFromCanonicalEntities(entities);
+  assert.equal(points[0]?.canonicalValue, 90);
+  const view = buildJournalView(
+    createVaultReadModel({ entities, vaultRoot: "test://journal-sleep-units" }),
+    points,
+    { asOf: "2026-08-25" },
+  );
+
+  assert.equal(view.eventCount, 1);
+  assert.equal(view.days[0]?.events[0]?.kind, "sleep");
+  assert.equal(view.days[0]?.events[0]?.metrics.deepSleepMinutes, 90);
+});
+
 function event(
   id: string,
   kind: string,
@@ -1021,4 +1154,52 @@ test("Journal keeps an explicitly assigned local day when a timestamp is correct
     { asOf: "2026-05-20" },
   );
   assert.equal(view.days[0]?.date, "2026-05-18");
+});
+
+test("Journal clips experiment expansion without resetting phase progress", () => {
+  const experiment = entity("experiment", "year-plan", {
+    attributes: {
+      runPlan: { interventionStart: "2026-01-01", interventionEnd: "2026-12-31" },
+      status: "active",
+      title: "Consistent schedule",
+    },
+    kind: "experiment_entry",
+    title: "Consistent schedule",
+  });
+  const vault = createVaultReadModel({ entities: [experiment], vaultRoot: "test://journal-phase-window" });
+  const view = buildJournalView(vault, [], { asOf: "2026-08-25", windowDays: 7 });
+  assert.equal(view.days.length, 7);
+  assert.equal(view.days[0]?.events[0]?.summary, "Running experiment · day 237");
+  assert.deepEqual(view.days.at(-1)?.events[0]?.details, [
+    "Status: Active", "Progress: Day 231 of 365",
+  ]);
+  assert.equal(buildJournalView(vault, [], { asOf: "2025-12-31" }).eventCount, 0);
+  assert.equal(buildJournalView(vault, [], { asOf: "2027-12-31" }).eventCount, 0);
+});
+
+test("Journal does not treat an incompatible observation unit as minutes", () => {
+  const entities = [event("incompatible", "observation", "2026-08-25T08:00:00.000Z", {
+    metric: "deep-sleep-minutes", value: 90, unit: "km",
+  }, "Deep sleep")];
+  const view = buildJournalView(
+    createVaultReadModel({ entities, vaultRoot: "test://journal-incompatible-unit" }),
+    extractMetricPointsFromCanonicalEntities(entities),
+    { asOf: "2026-08-25" },
+  );
+  assert.equal(view.days[0]?.events[0]?.metrics.deepSleepMinutes, null);
+});
+
+test("Journal retains timestamp-only observations on their canonical metric day", () => {
+  const observation = event("timestamp-only", "observation", "2026-08-25T08:00:00.000Z", {
+    metric: "deep-sleep-minutes", value: 1.5, unit: "hours", source: "manual",
+  }, "Deep sleep");
+  observation.date = null;
+  const view = buildJournalView(
+    createVaultReadModel({ entities: [observation], vaultRoot: "test://journal-view" }),
+    extractMetricPointsFromCanonicalEntities([observation]),
+    { asOf: "2026-08-25T12:00:00.000Z" },
+  );
+  assert.equal(view.days[0]?.date, "2026-08-25");
+  assert.equal(view.days[0]?.events[0]?.metrics.deepSleepMinutes, 90);
+  assert.equal(view.recordCount, 1);
 });


### PR DESCRIPTION
## Why and outcome

Journal could merge adjacent sleep nights, swallow a short nap, omit duration-only sleep, or display hours as minutes. It could also stay on the first-import loading screen indefinitely. Reuse canonical metric dates and units, preserve naps, and observe first-import publication within the existing bounded refresh window.

The same change makes Today follow the local date, labels historical summaries correctly, improves calendar touch and selected states, preserves empty refresh feedback, and fixes chart weekdays in UTC+14. Projection work is reduced through one metric-history partition pass, clipped experiment expansion, and per-build formatter reuse.

## Product UX

- Effort: Patch
- Result: Ready — local journeys and parent candidate review passed; remote CI and final ReviewGPT gate merge.
- Walkthrough: Recent and historical weeks, midnight rollover, first import success/timeout, stale and legacy replicas, retries, main sleep plus naps, duration normalization, and travel. No capture, editing, auth or persistence changes.

## Evidence

- ReviewGPT: Round 2 PASS on `194cdfff86f7a2f3be11fa60dcd398f2ffbc4775`; exact response SHA and gpt-6-pro attestation verified; 669 seconds from response-wait start to capture. Full sensitive snapshot, ancestry and completion marker confirmed. Parent accepted zero findings. Reviewer independently ran 57 health-metrics cases through a native Node adapter and a differential normalization matrix; Query/Web tests and browser proof remain separately validated locally and in CI.
- Direct: Final correction passed 57 health-metrics tests, 65 query tests and 123 composed Web/context/dashboard/navigation/persona tests; 16 changelog fragment/archive tests also passed. Journal suite now has 26 tests.
- Coverage: Regressions failed before correction for sleep grouping, units, missing naps, publication stalls and retry deadlines. Existing replica/device metric and readable dashboard success paths remain covered.
- Health-metrics, Query and Web typechecks, scoped Web ESLint and whitespace checks passed.
- CI correction: The first Web shard exposed a WHOOP regression. Reproduced it locally, preserved the Recovery display alias, normalized provider percentages for 100-point sleep/readiness scores, and restored provider attribution from externalRef.system. Incompatible units still fail normalization. New focused regressions and the original composed persona test pass; round 2 passed and the previously failing Web shard is now green on the corrected candidate.
- Chromium passed at 320, 390 and 1280 pixels: keyboard calendar selection, Today, historical statistics, empty refresh status, overflow and UTC+14 chart labels. Parent inspected synthetic screenshots.
- Synthetic optimization fixtures retained identical output hashes. Timed notes: 2,640 formatter constructions to one; long phase: 4,042 ISO conversions to 260. Timings were noisy and are not production page-load claims. Current-window observation normalization adds correctness work; no universal speedup is claimed.

## Non-obvious affected surfaces

The query metric module exports its existing observation-date resolver for Journal reuse. Health-metrics now accepts provider percentages for 100-point sleep/readiness scores; its generic normalization fallback is extracted unchanged, and incompatible units stay rejected. Browser Vault schema, provider/context polling owner, session handler and import publication owner remain unchanged. Replica, device metric, context and dashboard regression suites cover those boundaries.

## Architecture and reuse

- Existing systems reused: Canonical records and metric normalization, query-owned Journal projection, encrypted Browser Vault publication, existing bounded refresh, and production Journal components.
- New logic: Correct metric/date/unit selection, nap classification, first-import observation admission, retry deadline guard, date selection derivation and bounded projection work.
- New abstractions: Two private normalization helpers keep score-unit handling and the existing generic fallback explicit; no new public API, state owner or service. Reuse the existing date resolver and local per-build maps.
- Complexity intentionally avoided: No Journal table, persistent cache, new service, dependency, AI call or duplicated refresh owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: Existing normalization dispatch is 55 (down from 62); comparable-point selection remains 21. Journal projection maximum is 19. The catalog dispatch and selection rules remain with their current owner; no unrelated decomposition is justified.
- Agent judgment: Reordering and reuse remove repeated work. Normalization complexity debt drops by seven after extracting its unchanged generic fallback. Further refactoring is not justified by the observed defects.

## Hot reply path impact

- Path status: Not applicable — derived Journal projection and Web interaction only.
- Database calls: None added or moved onto the reply path.
- Network/provider calls: None added or moved onto the reply path.
- Other awaited latency: None added or moved onto the reply path.
- Before/after proof: Existing publication and refresh owners preserved; synthetic projection benchmark and composed refresh tests cover affected work.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no prompts, tool schemas, routing, assembled input or provider-visible guidance changed. No token measurement was needed.

## Design proof

- Design page: [Journal production-component study](https://murph-ghwc1bp4m-cobuildwithus.vercel.app/design?tab=components#journal-study). Preview returned HTTP 200 and renders the ready/empty studies, weekly statistics and refresh feedback. The preview UI source is unchanged by the subsequent score-normalization correction; query output is covered by composed provider persona tests.
- Evidence: Parent-reviewed synthetic production component captures and Chromium interaction assertions on this branch.
- Coverage: Ready and empty-refresh states, calendar, selected-week statistics and chart at 320, 390 and 1280 pixels. Existing catalog hydration friction is separately recorded; proof switches browser zones after catalog hydration.

ReviewGPT first-reviewed head: 593599ca3fbfdd828479ed05b0dbcdbaa46a987a
ReviewGPT context sensitivity: sensitive
Classification reason: Query/Web behavior and refresh admission interact with canonical date and publication owners.

## Deployment concerns

- Deployment: applicable
- Supported skew: Unchanged Journal replica schema is accepted by old and new readers. Old projections can remain readable until refreshed.
- Safe order: Either Web reader or projection producer can roll out first; no migration or coordinated switch required.
- Rollback floor: Existing schema and canonical records remain readable by the previous version.
- Expected exposure: Existing replicas retain earlier grouping until their normal refresh publishes the corrected projection.
- Reversibility: Code can be reverted without changing stored canonical data.
- Convergence proof: Existing replica/shard and composed publication tests pass with unchanged envelope/schema boundaries.
- Post-deploy checks: Open Journal, check selected date and summary range, inspect sleep/naps, and confirm an ordinary refresh replaces the projection.

## Change-shape breakdown

Classification rule: Production TS/TSX is source; tests, E2E and synthetic study are tests/fixtures; Markdown and changelog copy are docs. No binary or generated output is committed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 211 | 142 |
| Tests / fixtures | 548 | 4 |
| Docs | 332 | 11 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **1091** | **157** |

## Changelog

- Changelog: updated
- Items: 2026-09-06 · journal-date-navigation; 2026-09-06 · journal-sleep-and-import-recovery

![Journal synthetic mobile timeline](https://github.com/user-attachments/assets/333b1c27-289e-47c6-8750-e18515ad1009)

![Journal chart preserves Sunday through Saturday in UTC plus 14](https://github.com/user-attachments/assets/72640d6a-f255-4fcc-982c-a11cdd2153c2)



