### PR TITLE
perf(cloudflare): avoid ciphertext copies during workspace restore

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-06-restore-latency.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-restore-latency.md
@@ -1,0 +1,71 @@
+# Reduce workspace restore latency without changing its integrity boundary
+
+Status: completed
+Created: 2026-09-06
+Updated: 2026-09-06
+
+## Goal
+
+- Reduce cold workspace restore work with a small, measured change to the existing owner.
+
+## Success criteria
+
+- Paired synthetic restores preserve every file and demonstrate whether latency improves.
+- Authentication, both digests, byte limits, failure recovery, and cancellation remain enforced before durable replacement.
+- Focused tests and Cloudflare typecheck pass; discard unhelpful experiments.
+
+## Scope
+
+- In scope: existing download/decrypt/extract pipeline and independent preparation ordering.
+- Out of scope: Rust, new dependencies or archive formats, production mutations, speculative extraction, new caches or workers.
+
+## Constraints
+
+- Keep full authentication before extraction and await owned work before cleanup.
+- Do not duplicate ownership or weaken durable workspace recovery to improve a timing.
+- Use synthetic fixtures only; report local benchmark limits explicitly.
+
+## Risks and mitigations
+
+1. Boundary-sensitive ciphertext splitting could mishandle the GCM tag.
+   Mitigation: test arbitrary chunks, truncated/oversized streams, and tampering with preserved old roots.
+2. Host contention can create apparent speedups.
+   Mitigation: alternate paired revisions, verify byte readback, and report CPU alongside wall time.
+
+## Tasks
+
+1. Trace existing parallelism and redundant work; capture an unmodified benchmark module.
+2. Benchmark a bounded experiment at the existing restore owner; retain only justified changes.
+3. Run relevant correctness tests and typecheck; review the full diff and complexity.
+4. Record measurement and shipping limits; close this plan and commit the scoped result.
+
+## Decisions
+
+- Heavy-runtime hydration already overlaps restore. Native zstd already pipes directly to native tar.
+- Investigate eliminating ciphertext copies in the download loop using the ref's already-validated byte count; do not add concurrency unless an independent cost is demonstrated.
+- Retained the bounded ciphertext/tag split: it removes two per-chunk copies with no concurrency and two fewer source lines overall. Existing restore and archive-format owners remain unchanged.
+- No public changelog claim: this is an internal allocation reduction; a consistent production reply-latency improvement has not been established. The changelog skill's internal-refactor route applies.
+
+## Product UX
+
+- Outcome: reduce cold restore delay without changing restored content or recovery.
+- Reaches: personal and group cold restores; warm reuse and reply content remain unchanged.
+- Proof: real encrypted synthetic restores plus malformed-stream and interruption cases; no claim of measured production reply speedup.
+
+## Verification
+
+- Existing paired workspace-restore benchmark, with baseline bundled before edits.
+- Focused snapshot-local, interruption, and runtime-platform tests; Cloudflare typecheck and complexity diff.
+- Expected outcome: identical restored file hashes and preserved fail-closed behavior, with a candid before/after latency result.
+
+## Results
+
+- Seven paired Linux AMD64-emulated runs per fixture, two vCPUs and 6 GiB, preserved all 1,000 file hashes. Median restore wall time improved by 146 ms at 20 MiB and 292 ms at 50 MiB; Node CPU fell about 19% and 15%. Wall time improved in only four of seven pairs at each size. Full methods, paired differences, and limitations are in the existing benchmark owner.
+- A consistent 300 ms production saving is not proven. No production mutation or deployment was performed, and no new snapshot format or concurrent work was introduced.
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/workspace-snapshot-local.test.ts apps/cloudflare/test/workspace-snapshot-interruption.test.ts apps/cloudflare/test/runner-platform.test.ts apps/cloudflare/test/hosted-response-body.test.ts`: 244 tests passed across four files.
+- `pnpm --dir apps/cloudflare typecheck`: passed.
+- `pnpm complexity:diff`: passed; maximum source complexity remains 16 with no hotspots above 20.
+- Product UX walkthrough: Ready for the scoped internal optimization. Successful synthetic cold restores retain every byte; corrupted, interrupted, truncated, and oversized restores preserve the old root. Warm reuse, provider input, and delivery behavior are untouched. Production reply timing remains unmeasured.
+- Parent review: same total-byte guard precedes consumption; no incoming view survives an await; the fixed tag buffer is zeroed in finally; authenticated extraction and old-root recovery remain with their existing owners. No new authority, network call, retry, process, or state owner.
+- No PR, push, or deployment requested. Final external review and exact-head CI remain prerequisites for a later shipping lane.
+Completed: 2026-09-06

--- a/apps/cloudflare/scripts/benchmark-workspace-restore.md
+++ b/apps/cloudflare/scripts/benchmark-workspace-restore.md
@@ -113,6 +113,52 @@ concurrent runtime hydration, or the provider turn.
   decoder/extractor failures, cancellation, and retry exhaustion must never
   replace existing durable files.
 
+## Ciphertext-copy reduction experiment
+
+Baseline source: `78358acae29e470743a4c12f48d69a5c47d80fe0`. The candidate uses
+the ref's existing encrypted byte count to locate the final 16-byte GCM tag.
+Incoming byte views are consumed synchronously, and only tag bytes are copied
+into a fixed buffer. This removes the incoming chunk copy and repeated
+tail-plus-chunk concatenation. The decrypted archive remains buffered until
+GCM authentication, both SHA-256 checks, and byte-count validation succeed;
+native zstd/tar extraction, replacement, cleanup, and retry ownership stay intact.
+There is no new concurrency, dependency, persisted state, or archive format.
+
+The existing paired harness ran seven measured pairs plus one warmup per
+variant for each fixture, alternating order. Both fixtures had 1,000 files and
+64 KiB server chunks, without network pacing. Every restored file passed its
+SHA-256 readback. Baseline and candidate ran sequentially in the same Linux
+container, using the writable container layer, two vCPUs, 6 GiB memory, and
+the pinned Node 24.14.1 runner image
+`sha256:9c10ca59555b728711a62e7aff83d0ceed4d06ab13048e81e5652868ea171f0b`.
+The host was ARM, so these AMD64 runs were emulated; they are relative local
+experiments, not native AMD64 or production latency measurements.
+
+| Median metric | Baseline | Candidate | Difference |
+| --- | ---: | ---: | ---: |
+| 20 MiB fixture restore wall time | 1,171.64 ms | 1,025.50 ms | -146.14 ms |
+| 20 MiB fixture Node CPU | 1,796.77 ms | 1,459.33 ms | -337.44 ms |
+| 50 MiB fixture restore wall time | 2,147.80 ms | 1,856.23 ms | -291.57 ms |
+| 50 MiB fixture Node CPU | 3,164.34 ms | 2,699.63 ms | -464.71 ms |
+
+The actual encrypted/unpacked byte counts were 21,033,206/52,430,000 and
+52,519,845/131,073,000. Node CPU excludes the native child processes and
+includes the loopback HTTP server. Candidate wall time improved in only four
+of seven pairs for each fixture; Node CPU improved in six and five pairs,
+respectively. Median paired wall-time differences were -76.72 ms and
+-281.50 ms. Unchanged extraction also varied, so do not attribute the entire
+wall-time difference to the removed copies or claim a guaranteed latency gain.
+A preceding native macOS run was similarly noisy and is excluded from the
+performance claim. The small implementation removes measurable CPU work, but
+a consistent 300 ms production reduction has not been established.
+
+Focused snapshot, response-body, and platform tests cover split tags, single
+chunks, single-byte chunks, reused nonzero-offset byte views, empty chunks,
+truncated/oversized streams, ciphertext/tag tampering, interruption, and decoder
+or extractor failures. The Cloudflare typecheck also passed. Before making a
+production timing claim, repeat on native AMD64 and compare natural cold
+restores with equivalent snapshot sizes and runtime load.
+
 ## Measurement record
 
 Baseline source: `18b498bc49435c49adb99588754a8a2bf72c4ce6`.

--- a/apps/cloudflare/src/workspace-snapshot-local.ts
+++ b/apps/cloudflare/src/workspace-snapshot-local.ts
@@ -617,48 +617,46 @@ async function decryptHostedWorkspaceSnapshotEncryptedStream(input: {
   };
 }): Promise<void> {
   let encryptedByteCount = 0;
-  let encryptedTail = Buffer.alloc(0);
+  const ciphertextByteSize = input.expectedEncryptedByteSize - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES;
+  const authTag = Buffer.alloc(HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES);
+  let authTagByteCount = 0;
   try {
     for await (const rawChunk of input.encryptedStream) {
       const chunk = Buffer.isBuffer(rawChunk)
         ? rawChunk
-        : Buffer.from(rawChunk);
+        : Buffer.from(rawChunk.buffer, rawChunk.byteOffset, rawChunk.byteLength);
       if (chunk.byteLength === 0) {
         continue;
       }
+      const ciphertextBytes = Math.min(chunk.byteLength, Math.max(0, ciphertextByteSize - encryptedByteCount));
       encryptedByteCount += chunk.byteLength;
       if (encryptedByteCount > input.expectedEncryptedByteSize) {
         throw new Error("Hosted workspace snapshot encrypted stream exceeded its ref byte count.");
       }
       input.encryptedObjectHash.update(chunk);
 
-      const encrypted = encryptedTail.byteLength > 0
-        ? Buffer.concat([encryptedTail, chunk])
-        : chunk;
-      if (encrypted.byteLength <= HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES) {
-        encryptedTail = Buffer.from(encrypted);
-        continue;
+      // The ref fixes the ciphertext/tag boundary independently of stream
+      // chunks. Consume ciphertext synchronously without copying or retaining
+      // the caller's buffer; authentication still completes before extraction.
+      if (ciphertextBytes > 0) {
+        input.plaintextArchiveCollector.append(
+          input.decipher.update(chunk.subarray(0, ciphertextBytes)),
+        );
       }
-
-      const ciphertextEnd =
-        encrypted.byteLength - HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES;
-      encryptedTail = Buffer.from(encrypted.subarray(ciphertextEnd));
-      input.plaintextArchiveCollector.append(
-        input.decipher.update(encrypted.subarray(0, ciphertextEnd)),
-      );
+      authTagByteCount += chunk.copy(authTag, authTagByteCount, ciphertextBytes);
     }
 
     if (encryptedByteCount !== input.expectedEncryptedByteSize) {
       throw new Error("Hosted workspace snapshot encrypted stream byte count does not match its ref.");
     }
-    if (encryptedTail.byteLength !== HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES) {
+    if (authTagByteCount !== HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES) {
       throw new Error("Hosted workspace snapshot auth tag is incomplete.");
     }
 
-    input.decipher.setAuthTag(encryptedTail);
+    input.decipher.setAuthTag(authTag);
     input.plaintextArchiveCollector.append(input.decipher.final());
   } finally {
-    encryptedTail.fill(0);
+    authTag.fill(0);
   }
 }
 

--- a/apps/cloudflare/test/workspace-snapshot-local.test.ts
+++ b/apps/cloudflare/test/workspace-snapshot-local.test.ts
@@ -1001,7 +1001,8 @@ while :; do sleep 0.01; done
     }
   });
 
-  it("restores encrypted snapshots from an encrypted byte stream", async () => {
+  it.each(["split-tag", "single-chunk", "reused-views", "single-bytes"] as const)(
+    "restores encrypted snapshots from an encrypted byte stream (%s)", async (chunkMode) => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "workspace-snapshot-local-stream-test-"));
     const sourceDurableRoot = path.join(tempRoot, "source", "durable");
     const sourceVaultRoot = path.join(sourceDurableRoot, "vault");
@@ -1049,7 +1050,11 @@ while :; do sleep 0.01; done
       const restoreTimings = await restoreEncryptedWorkspaceSnapshotFromEncryptedStream({
         dataKey: encodeHostedWorkspaceSnapshotV2DataKey(dataKey),
         durableRoot: restoredDurableRoot,
-        encryptedStream: streamEncryptedChunks(splitEncryptedSnapshotAcrossAuthTagBoundary(encryptedBytes)),
+        encryptedStream: chunkMode === "reused-views" || chunkMode === "single-bytes"
+          ? streamReusedEncryptedViews(encryptedBytes, chunkMode === "single-bytes" ? 1 : 17)
+          : streamEncryptedChunks(chunkMode === "single-chunk"
+            ? [encryptedBytes]
+            : splitEncryptedSnapshotAcrossAuthTagBoundary(encryptedBytes)),
         ref,
       });
 
@@ -1105,7 +1110,8 @@ while :; do sleep 0.01; done
     }
   });
 
-  it("rejects encrypted stream auth failures without replacing durable state", async () => {
+  it.each(["auth-tag", "truncated", "oversized", "ciphertext"] as const)(
+    "rejects invalid encrypted streams without replacing durable state (%s)", async (failure) => {
     const tempRoot = await mkdtemp(path.join(tmpdir(), "workspace-snapshot-local-stream-auth-test-"));
     const sourceDurableRoot = path.join(tempRoot, "source", "durable");
     const sourceVaultRoot = path.join(sourceDurableRoot, "vault");
@@ -1145,8 +1151,14 @@ while :; do sleep 0.01; done
         outputDir: path.join(tempRoot, "scratch"),
       });
       const encryptedBytes = await readFile(encrypted.encryptedFilePath);
-      const tamperedEncryptedBytes = Buffer.from(encryptedBytes);
-      tamperedEncryptedBytes[tamperedEncryptedBytes.byteLength - 1] ^= 0xff;
+      const tamperedEncryptedBytes = failure === "truncated"
+        ? encryptedBytes.subarray(0, encryptedBytes.byteLength - 1)
+        : failure === "oversized"
+          ? Buffer.concat([encryptedBytes, Buffer.from([0])])
+          : Buffer.from(encryptedBytes);
+      if (failure === "auth-tag" || failure === "ciphertext") {
+        tamperedEncryptedBytes[failure === "auth-tag" ? tamperedEncryptedBytes.byteLength - 1 : 0] ^= 0xff;
+      }
       const ref = createHostedWorkspaceSnapshotTestRef({
         aad,
         encrypted,
@@ -1645,6 +1657,18 @@ async function* streamEncryptedChunks(chunks: readonly Uint8Array[]): AsyncItera
   for (const chunk of chunks) {
     yield chunk;
   }
+}
+
+async function* streamReusedEncryptedViews(bytes: Uint8Array, chunkSize: number): AsyncIterable<Uint8Array> {
+  const storage = new Uint8Array(chunkSize + 6);
+  for (let offset = 0; offset < bytes.byteLength; offset += chunkSize) {
+    storage.fill(0xff);
+    const chunk = bytes.subarray(offset, offset + chunkSize);
+    storage.set(chunk, 3);
+    yield storage.subarray(3, 3 + chunk.byteLength);
+    yield new Uint8Array(0);
+  }
+  storage.fill(0xff);
 }
 
 const TEST_HOSTED_WORKSPACE_SNAPSHOT_AUTH_TAG_BYTES = 16;


### PR DESCRIPTION
## Why and outcome

Workspace snapshot decryption copied each incoming byte view and repeatedly concatenated it with the trailing authentication-tag bytes. Use the snapshot ref's existing exact byte count to consume ciphertext synchronously and copy only the final 16-byte GCM tag into a fixed buffer.

The reader restores the same files and retains full authentication, both hashes, and byte-count checks before extraction. Seven paired, AMD64-emulated Linux runs per fixture showed lower median Node CPU and restore wall time; the results do not establish a consistent 300 ms production saving.

## Product UX

- Effort: Patch; reduce internal cold-restore allocation overhead.
- Result: Ready for the scoped optimization; production reply-latency gains remain unmeasured.
- Walkthrough: Personal and group cold restores retain byte-identical content. Corrupt, truncated, oversized, interrupted, and failed decoder/extractor paths preserve the existing workspace. Warm reuse, provider input, and delivery behavior are unchanged.

## Evidence

- CI: All required checks passed on the reviewed head. [Release verification](https://github.com/cobuildwithus/murph/actions/runs/34056278188) includes Cloudflare verification, build/typecheck, coverage, and the production runner budget. The first latency attempt exceeded the device-import CPU budget on unchanged import code; a targeted retry with identical source and thresholds passed all six comparisons (new-import CPU: base 438.204 ms, candidate 437.035 ms, limit 547.755 ms). No code or budget changes were made for the retry.
- Direct: The existing production-port benchmark restored real encrypted synthetic snapshots through loopback HTTP, native zstd/tar, directory replacement, and cleanup. Every restored file passed SHA-256 readback in all 32 Linux restores, including warmups.
- Coverage: `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/workspace-snapshot-local.test.ts apps/cloudflare/test/workspace-snapshot-interruption.test.ts apps/cloudflare/test/runner-platform.test.ts apps/cloudflare/test/hosted-response-body.test.ts` passed 244 tests across four files. Includes single-byte chunks, split tags, empty chunks, and reused nonzero-offset byte views.
- Typecheck: `pnpm --dir apps/cloudflare typecheck` passed.
- ReviewGPT: Round 1 **PASS** on `5ba17d8f7ab4792e3ce94e6a90698a5d6febe3f6`; no Critical, High, or material Complexity Collapse findings. GPT-6 Pro model attestation and exact response hash verified; Hercules lane, more than 363 seconds observed response wait. Parent accepted the full-patch review as substantive and matching the target; zero accepted or rejected findings. [Review conversation](https://chatgpt.com/c/6a9dc4d1-a888-83e9-a130-01026e2fa705). Reviewer independent tests used Node 22; the author proof and CI cover Node 24.
- Benchmarks: Two vCPUs, 6 GiB, 1,000 files, seven alternating pairs per fixture in the pinned Linux runner image. At 20 MiB, median restore wall time was 1,171.64 to 1,025.50 ms and Node CPU 1,796.77 to 1,459.33 ms. At 50 MiB, wall time was 2,147.80 to 1,856.23 ms and Node CPU 3,164.34 to 2,699.63 ms. Wall time improved in only four of seven pairs at each size; unchanged extraction varied too. Node CPU excludes native children. See `apps/cloudflare/scripts/benchmark-workspace-restore.md` for methods and limitations.

## Non-obvious affected surfaces

The snapshot restore helper also accepts arbitrary asynchronous byte streams. Added coverage proves synchronous consumption of mutable reused views and preservation of old durable state on malformed streams.

## Architecture and reuse

- Existing systems reused: The existing snapshot ref, byte-count guard, Node crypto, fixed plaintext collector, native extraction, and restore/retry owners.
- New logic: Derive the ciphertext/tag boundary from the already-known encrypted size; retain only the fixed tag bytes between chunks.
- New abstractions: None in production; one test generator exercises reused byte views.
- Complexity intentionally avoided: No Rust, dependency, thread, concurrency, format change, cache, or new state owner.

## Complexity impact

- Guard: Pass; `pnpm complexity:diff`.
- Hotspots: None above 20; maximum changed-file source complexity remains 16.
- Agent judgment: The existing owner is sufficient. Production source has two fewer lines overall; further parallelism would add ownership complexity without demonstrated benefit.

## Hot reply path impact

- Path status: Touched only when the current invocation needs a cold v2 workspace restore.
- Database calls: None added or moved.
- Network/provider calls: None added or moved; the existing snapshot GET and at-most-two-attempt retry owner remain unchanged.
- Other awaited latency: None added or moved. The same download/decrypt, authenticated extraction, directory replacement, and cleanup sequence remains. No changes to the 15-second pending-read inactivity budget, overall deadline, cancellation, retry classification, or warm-workspace shortcut.
- Before/after proof: The paired production-port benchmark verifies one object GET per successful restore, identical file hashes, and the measurements above. The change removes synchronous copies; no guaranteed production latency reduction is claimed.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: the change only consumes encrypted snapshot bytes differently and preserves the restored contents. No prompt, tool, schema, history, configuration, or generated guidance surface changes.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run; no provider-input surface changed.

ReviewGPT context sensitivity: sensitive
Classification reason: The patch touches authenticated hosted workspace restoration, even though the archive format and integrity contract are unchanged.
ReviewGPT first-reviewed head: 5ba17d8f7ab4792e3ce94e6a90698a5d6febe3f6

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing and updated runners read the same v2 snapshot format; writers and references are unchanged.
- Safe order: Normal runner rollout; no Web/Worker coordination or migration is needed for this reader-local change.
- Rollback floor: The existing pre-change reader accepts the same snapshots; no new persisted format or state is produced.
- Expected exposure: Cold v2 restores on runners containing this reader during and after rollout. Warm reuse retains its current path.
- Reversibility: Reverting the reader implementation preserves format compatibility; any production rollback remains separately authorized.
- Convergence proof: Tests and paired benchmarks consume the same encrypted fixture with both readers and compare every restored file hash.
- Post-deploy checks: Compare natural cold restore timing for equivalent snapshot sizes and runtime load; check restore integrity failures and retries. Native AMD64 or hosted measurements are required before asserting a consistent production saving.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source, test TypeScript is tests, and benchmark/plan Markdown is docs. No binary or generated files are included.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 16 | 18 |
| Tests / fixtures | 29 | 5 |
| Docs | 117 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **162** | **23** |

## Changelog

- Changelog: not applicable
- Reason: Internal allocation reduction with unchanged restore behavior; a consistent member-visible production latency improvement has not been established, so this PR makes no public speed claim.
