### PR TITLE
Avoid a duplicate binding RPC on fresh runner starts

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-06-standby-binding-reuse.md
+++ b/agent-docs/exec-plans/active/2026-09-06-standby-binding-reuse.md
@@ -1,0 +1,38 @@
+# Reuse same-request fresh slot binding proof
+
+Status: active
+Created: 2026-09-06
+Updated: 2026-09-06
+
+## Goal
+
+Remove the redundant immutable-binding RPC after fresh allocation has already verified the exact claim, member, slot, region and release. Build on PR #2999; prepare the additional improvement as a separately reviewed PR.
+
+## Product UX
+
+Effort: Patch. Outcome: Less setup after a fresh slot is assigned.
+Reaches: Successful fresh binds and exact same-request bind recovery. Retained and direct preparation still fetch current binding evidence.
+Proof: Actual controller/service call counts and delayed-I/O benchmark; member, claim, release, region, retirement and stale-fence rejection coverage.
+
+## Invariants
+
+The receipt stays in the allocating request and is not persisted, cached or sent to a container. Fenced preparation validates the receipt using the existing identity predicate. Controller fence revalidation and the container's live bound-member authorization remain mandatory. A retired slot can never rebind.
+
+## Tasks
+
+1. Prove the duplicate call and trace live launch authorization.
+2. Thread the verified receipt through existing fresh preparation; keep ordinary lookup fallback.
+3. Add focused failure and race coverage, benchmark, typecheck and complexity checks.
+4. Publish release note and stacked PR; resolve ReviewGPT and required CI; verify mergeability.
+
+## Evidence
+
+The existing container `authorizeBoundUser` reads its durable slot state at the runtime boundary; no caller receipt substitutes for that check.
+
+## Local verification
+
+- Final identity, fleet, standby and runtime-callback suites: 186 tests passed, including exact bind-response recovery.
+- Cloudflare build and typecheck passed; complexity is unchanged against PR #2999 (invocation debt 7, maximum 24; controller debt 5, maximum 25).
+- Paired actual-controller benchmark: balanced reads 428.22 ms base / 428.73 ms candidate (no meaningful wall-time change); slow binding read 489.09 ms / 386.90 ms (102.19 ms saved). Both eliminate one immutable-binding RPC. The base fails the zero-extra-read assertion; the candidate passes. These are synthetic I/O timings, not production estimates.
+- Direct and retained starts keep the lookup fallback. Invalid member, claim, region, release, slot and retired receipts are rejected using the existing binding checks.
+- Remaining larger opportunities investigated: restore already streams authenticated decryption and native extraction; ingress crypto caching is security-scoped; startup archive recovery protects representation consistency. No unrelated cache or weaker validation was added to chase unmeasured gains.

--- a/agent-docs/exec-plans/active/2026-09-06-standby-binding-reuse.md
+++ b/agent-docs/exec-plans/active/2026-09-06-standby-binding-reuse.md
@@ -36,3 +36,10 @@ The existing container `authorizeBoundUser` reads its durable slot state at the 
 - Paired actual-controller benchmark: balanced reads 428.22 ms base / 428.73 ms candidate (no meaningful wall-time change); slow binding read 489.09 ms / 386.90 ms (102.19 ms saved). Both eliminate one immutable-binding RPC. The base fails the zero-extra-read assertion; the candidate passes. These are synthetic I/O timings, not production estimates.
 - Direct and retained starts keep the lookup fallback. Invalid member, claim, region, release, slot and retired receipts are rejected using the existing binding checks.
 - Remaining larger opportunities investigated: restore already streams authenticated decryption and native extraction; ingress crypto caching is security-scoped; startup archive recovery protects representation consistency. No unrelated cache or weaker validation was added to chase unmeasured gains.
+
+## PR preparation
+
+- Draft PR #3006 is stacked on #2999. The base PR changes are reconciled by an ordinary merge.
+- All 177 runner-alarm tests pass. The consent-withdrawal budget test now exercises the retained target, which still requires the binding read; timeout, fence clearing and exact retirement assertions are preserved.
+- Nine changelog rendering tests and Web typecheck pass; Cloudflare typecheck passes after the fixture update.
+- The first docs-drift invocation considered only the uncommitted fixture and attribution; updating this plan supplies the matching explanation for that change. ReviewGPT and final CI remain pending.

--- a/agent-docs/exec-plans/completed/2026-09-06-standby-binding-reuse.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-standby-binding-reuse.md
@@ -1,6 +1,6 @@
 # Reuse same-request fresh slot binding proof
 
-Status: active
+Status: completed
 Created: 2026-09-06
 Updated: 2026-09-06
 
@@ -43,3 +43,10 @@ The existing container `authorizeBoundUser` reads its durable slot state at the 
 - All 177 runner-alarm tests pass. The consent-withdrawal budget test now exercises the retained target, which still requires the binding read; timeout, fence clearing and exact retirement assertions are preserved.
 - Nine changelog rendering tests and Web typecheck pass; Cloudflare typecheck passes after the fixture update.
 - The first docs-drift invocation considered only the uncommitted fixture and attribution; updating this plan supplies the matching explanation for that change. ReviewGPT and final CI remain pending.
+
+## Completion evidence
+
+- ReviewGPT round 1: PASS at `7a8bdd385bfbb3ee1a9aa649689722dda9557652`, no qualifying findings. Full snapshot and all seven changed file identities matched. Exact-turn capture and backend model evidence verify `gpt-6-pro` and response hash `054dc49fce76d9e5f51034d8c38e34355e8e005975c811db909b099e35a49084`. The response arrived more than five minutes after send, exceeding the 270-second minimum. Raw artifacts stay ignored.
+- Parent final review confirms the receipt remains request-local, exact validation and live authorization remain mandatory, fallback reads are preserved, and the diff contains no personal identifiers or generated files.
+- This final commit only archives this explanatory plan. The reviewed source and tests are unchanged. Required CI will be verified on the resulting PR head; no merge or deployment is included in this task.
+Completed: 2026-09-06

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -621,6 +621,12 @@ binding workspace facts. It also overlaps immutable slot-binding verification
 with runner-secret and snapshot-restore preparation. Launch still requires the
 exact active write fence, verified member binding, usage admission and container
 readiness. Warm active-runtime wakes do not start these fresh preparation reads.
+Fresh allocation carries its verified immutable binding result into that same
+request's fenced preparation, avoiding a second binding RPC. The receipt is
+validated against the selected slot, member, claim format, region and release;
+it is neither persisted nor sent to the container. Retained/direct preparation
+still reads binding evidence, and the container still checks its live bound
+member at launch. Exact bind-response recovery can reuse its verified result.
 The individual read timings overlap allocation and each other; they are not
 additive slices of `runtimeInvocationPreparationElapsedMs`, which measures the
 remaining fenced preparation call.

--- a/apps/cloudflare/src/user-runner/runtime-invocation.ts
+++ b/apps/cloudflare/src/user-runner/runtime-invocation.ts
@@ -58,6 +58,7 @@ import {
   isHostedStandbyClaimId,
   requireHostedRunnerSlotLifecycle,
   resolveHostedRunnerReleaseId,
+  type HostedStandbySlotBinding,
 } from "../standby-runner-contract.js";
 import {
   createHostedProviderEgressCredential,
@@ -236,12 +237,12 @@ export class RuntimeInvocationService {
   prepareForFreshStart(input: {
     commandBudget?: RuntimeProcessingCommandBudget;
     input: RuntimeInvocationInput;
-  }): (token: RunnerWriteFenceToken) => Promise<PreparedRuntimeInvocation> {
+  }): (token: RunnerWriteFenceToken, verifiedSlotBinding?: HostedStandbySlotBinding) => Promise<PreparedRuntimeInvocation> {
     const preparationInputs = this.prepareInputs(input);
     // Allocation can fail before consuming the reads. Observe rejection while
     // their original request deadlines bound any remaining read-only work.
     void preparationInputs.catch(() => undefined);
-    return (token) => this.prepareWithInputs({ ...input, token }, preparationInputs);
+    return (token, verifiedSlotBinding) => this.prepareWithInputs({ ...input, token }, preparationInputs, verifiedSlotBinding);
   }
 
   private async prepareInputs(input: {
@@ -288,6 +289,7 @@ export class RuntimeInvocationService {
   private async prepareWithInputs(
     input: Parameters<RuntimeInvocationService["prepareWithFence"]>[0],
     preparationInputs: Promise<RuntimeInvocationPreparationInputs>,
+    verifiedSlotBinding?: HostedStandbySlotBinding,
   ): Promise<PreparedRuntimeInvocation> {
     const preparationStartedAtMs = Date.now();
     const preparation = await preparationInputs;
@@ -366,6 +368,7 @@ export class RuntimeInvocationService {
     });
     const workspaceRunnerInvocation = await this.prepareWorkspaceRunnerInvocation({
       stores,
+      verifiedSlotBinding,
       commandBudget: input.commandBudget,
       hostedAssistantCustomInferenceOverride,
       hostedAssistantModelOverride:
@@ -946,6 +949,7 @@ export class RuntimeInvocationService {
     hostedAssistantSubagentModelOverridesAllowed: boolean;
     processingMode?: HostedWorkspaceInvocationProcessingMode | null;
     stores: RunnerUserStores;
+    verifiedSlotBinding?: HostedStandbySlotBinding;
     token: RunnerWriteFenceToken;
     userId: string;
     workspace: HostedWorkspaceState | null;
@@ -1030,6 +1034,7 @@ export class RuntimeInvocationService {
           stepTimeoutMs: this.input.env.webControlTimeoutMs,
         }),
         this.resolveInvocationRunnerContainerName({
+          verifiedSlotBinding: input.verifiedSlotBinding,
           commandBudget: input.commandBudget ?? null,
           runnerContainerName: input.token.runnerContainerName,
           userId: input.userId,
@@ -1159,6 +1164,7 @@ export class RuntimeInvocationService {
   }
 
   private async resolveInvocationRunnerContainerName(input: {
+    verifiedSlotBinding?: HostedStandbySlotBinding;
     commandBudget: RuntimeProcessingCommandBudget | null;
     runnerContainerName: string | null;
     userId: string;
@@ -1175,13 +1181,16 @@ export class RuntimeInvocationService {
       }
       const readBinding = async () =>
         await requireHostedRunnerSlotLifecycle(namespace.getByName(runnerContainerName)).readStandbySlotBinding();
-      const binding = input.commandBudget
+      // Fresh allocation already checked this immutable binding. Reuse only
+      // its request-local receipt; direct and retained starts still read it.
+      // The container independently authorizes its live binding at launch.
+      const binding = input.verifiedSlotBinding ?? (input.commandBudget
         ? await runRuntimeProcessingCommandStep({
             budget: input.commandBudget,
             operation: readBinding,
             stepTimeoutMs: this.input.env.webControlTimeoutMs,
           })
-        : await readBinding();
+        : await readBinding());
       if (
         !hostedRunnerSlotBindingMatchesTarget(binding, runnerContainerName)
         || binding.state !== "bound"

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -156,6 +156,7 @@ type FreshRunnerContainerResolution =
   | {
       kind: "ready";
       runnerContainerName: string;
+      verifiedSlotBinding?: HostedStandbySlotBinding;
       standbyAllocationOutcome: NonNullable<
         RuntimeProcessingOrchestrationDiagnostics["standbyAllocationOutcome"]
       >;
@@ -1136,6 +1137,7 @@ export class RuntimeProcessingController {
     );
     const ready = (): FreshRunnerContainerResolution => ({
       kind: "ready",
+      verifiedSlotBinding: { ...bindingInput, state: "bound" },
       runnerContainerName: slotName,
       standbyAllocationOutcome: input.outcome,
       standbyAllocationReason: input.reason,
@@ -1352,6 +1354,7 @@ export class RuntimeProcessingController {
 
     const preparation = await this.prepareFreshRuntimeStart({
       prepareInvocation,
+      verifiedSlotBinding: resolution.verifiedSlotBinding,
       commandBudget: input.commandBudget,
       input: processingInput,
       runnerContainerName,
@@ -1453,6 +1456,7 @@ export class RuntimeProcessingController {
   }
 
   private async prepareFreshRuntimeStart(input: {
+    verifiedSlotBinding?: HostedStandbySlotBinding;
     prepareInvocation: ReturnType<RuntimeInvocationService["prepareForFreshStart"]>;
     commandBudget: RuntimeProcessingCommandBudget;
     input: RuntimeProcessingInput;
@@ -1476,7 +1480,7 @@ export class RuntimeProcessingController {
         startupConfirmed,
       };
     });
-    const preparationPromise = input.prepareInvocation(token).then(
+    const preparationPromise = input.prepareInvocation(token, input.verifiedSlotBinding).then(
       (prepared) => ({
         kind: "prepared" as const,
         prepared,

--- a/apps/cloudflare/test/hosted-runner-container-identity.test.ts
+++ b/apps/cloudflare/test/hosted-runner-container-identity.test.ts
@@ -115,11 +115,23 @@ vi.mock("@murphai/hosted-execution", async () => {
 const FIXED_NOW = "2026-06-03T00:00:00.000Z";
 const TEST_USER_ID = "member_123";
 describe("hosted runner container identity", () => {
-  it("measures the fresh standby handoff with delayed allocation and preparation reads", async () => {
+  it.each([
+    { name: "balanced reads", bindingReadMs: 100, secretReadMs: 100, recoverBindReply: false },
+    { name: "slow binding read", bindingReadMs: 180, secretReadMs: 40, recoverBindReply: false },
+    { name: "recovered bind reply", bindingReadMs: 100, secretReadMs: 40, recoverBindReply: true },
+  ])("measures the fresh standby handoff with delayed allocation and preparation reads ($name)", async ({ bindingReadMs, secretReadMs, recoverBindReply }) => {
     const durable = createRunnerDurableState();
     const stateStore = new RunnerStateStore(durable.state);
     const slotName = "runner--v-release_1--0123456789abcdef0123456789abcdef";
-    const standby = createAllocatingStandbyHarness({ slotName, stateStore, bindDelayMs: 100, readDelayMs: 100 });
+    const standby = createAllocatingStandbyHarness({ slotName, stateStore, bindDelayMs: recoverBindReply ? 10 : 100, readDelayMs: bindingReadMs });
+    if (recoverBindReply) {
+      const bind = vi.mocked(standby.namespace.getByName(slotName).bindStandbySlot).getMockImplementation();
+      if (!bind) throw new Error("Expected synthetic binding implementation.");
+      standby.bindStandbySlot.mockImplementationOnce(async (input) => {
+        await bind(input);
+        throw new Error("Synthetic bind response lost after commit.");
+      });
+    }
     const namespace = createHostedRunnerContainerNamespaceRouter({ exactUser: standby.namespace, standby: null });
     if (!namespace) throw new Error("Expected synthetic runner namespace.");
     const source = {
@@ -134,7 +146,7 @@ describe("hosted runner container identity", () => {
     const startedAt = performance.now();
     const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
     vi.spyOn(EmptyRunnerSecretsService.prototype, "readRunnerSecrets").mockImplementation(async () => {
-      await delay(100);
+      await delay(secretReadMs);
       return {};
     });
     vi.spyOn(TestRunnerStoreCache.prototype, "ensure").mockImplementation(async () => {
@@ -167,7 +179,7 @@ describe("hosted runner container identity", () => {
           return {
             async claimReadyStandby() {
               spans.claimStarted = performance.now() - startedAt;
-              await delay(100);
+              await delay(recoverBindReply ? 10 : 100);
               spans.claimFinished = performance.now() - startedAt;
               return { outcome: "claimed", slotName };
             },
@@ -184,6 +196,7 @@ describe("hosted runner container identity", () => {
     const elapsedMs = Math.round(performance.now() - startedAt);
     expect(result.kind).toBe("runtime_processing_accepted");
     expect(standby.bindStandbySlot).toHaveBeenCalledOnce();
+    expect(standby.readStandbySlotBinding).toHaveBeenCalledTimes(recoverBindReply ? 1 : 0);
     expect(invoke).toHaveBeenCalledOnce();
     expect(invoke.mock.calls[0]?.[0].prepared.input.orchestration).toMatchObject({
       standbyAllocationOutcome: "claimed",
@@ -241,6 +254,44 @@ describe("hosted runner container identity", () => {
       await prepared;
     }
     expect(started).toHaveLength(2);
+  });
+
+  it.each([
+    ["foreign member", { userId: "member_other" }],
+    ["invalid claim", { claimId: "invalid-claim" }],
+    ["wrong release", { releaseId: "release_other" }],
+    ["wrong region", { region: HOSTED_STANDBY_REGION }],
+    ["wrong slot", { slotName: "runner--v-release_1--11111111111111111111111111111111" }],
+    ["retired", { state: "retired", claimId: null, userId: null }],
+  ] as const)("rejects a same-request binding receipt with %s", async (_name, altered) => {
+    const durable = createRunnerDurableState();
+    const stateStore = new RunnerStateStore(durable.state);
+    const slotName = "runner--v-release_1--0123456789abcdef0123456789abcdef";
+    await stateStore.reserveRunnerContainerStopTarget({ runnerContainerName: slotName, userId: TEST_USER_ID });
+    const token = await stateStore.beginWriteFence({ runnerContainerName: slotName, userId: TEST_USER_ID });
+    const standby = createAllocatingStandbyHarness({ slotName, stateStore });
+    const service = createRuntimeInvocationService({
+      invokedContainerNames: [],
+      runnerContainerNamespace: standby.namespace,
+      runnerRuntimeEnvSource: {
+        CF_VERSION_METADATA: { id: "release_1" },
+        HOSTED_ASSISTANT_PROVIDER: "openai",
+        HOSTED_PROVIDER_EGRESS_CREDENTIAL_SIGNING_SECRET: "synthetic-signing-secret",
+        OPENAI_API_KEY: "test-openai-key",
+      },
+      state: durable.state, stateStore,
+    });
+    const consume = service.prepareForFreshStart({
+      input: { orchestrationAttemptId: "invalid-binding-receipt", userId: TEST_USER_ID },
+    });
+    const verifiedSlotBinding = {
+      claimId: "standby-claim-12345678-1234-4123-8123-123456789abc",
+      releaseId: "release_1", region: readHostedRunnerTargetIdentity(slotName)!.region,
+      slotName, state: "bound" as const, userId: TEST_USER_ID,
+      ...altered,
+    };
+    await expect(consume(token, verifiedSlotBinding)).rejects.toThrow("Hosted standby slot binding did not match the runtime invocation user.");
+    expect(standby.readStandbySlotBinding).not.toHaveBeenCalled();
   });
 
   it("verifies the bound slot while runner secrets are still loading", async () => {

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1003,7 +1003,7 @@ describe("HostedUserRunner execution coordination", () => {
     expect(readRunnerMeta(sql).active_attempt_id).toBeNull();
   });
 
-  it("releases consent withdrawal after standby invocation binding exhausts the command budget", async () => {
+  it("releases consent withdrawal after retained standby invocation binding exhausts the command budget", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     let consentState: "granted" | "revoked" = "granted";
@@ -1030,6 +1030,7 @@ describe("HostedUserRunner execution coordination", () => {
       binding = { ...input, state: "bound" };
       return { ...input, bound: true as const };
     });
+    const resolveRetainedStandbySlot = vi.fn(async () => binding);
     const invocationBindingRead = vi.fn(async () => {
       bindingReadStarted.resolve(undefined);
       return await new Promise<HostedStandbySlotBinding>(() => {});
@@ -1062,9 +1063,7 @@ describe("HostedUserRunner execution coordination", () => {
               state: "bound" as const,
             };
           },
-          async resolveRetainedStandbySlot() {
-            throw new Error("Retained standby resolution was not expected.");
-          },
+          resolveRetainedStandbySlot,
           retireStandbySlot,
           async smokeHealth() {
             return {
@@ -1108,6 +1107,11 @@ describe("HostedUserRunner execution coordination", () => {
       standbyCoordinatorNamespace,
     });
     await harness.runner.bindUser(TEST_USER_ID);
+    // Retained targets still require a fresh binding read during preparation.
+    harness.sql.exec(
+      "UPDATE runner_meta SET active_runner_container_name = ? WHERE singleton = 1",
+      slotName,
+    );
 
     const ensure = harness.runner.ensureRuntimeProcessingForUser({
       commandTimeoutMs:
@@ -1150,8 +1154,9 @@ describe("HostedUserRunner execution coordination", () => {
       processingAllowed: false,
       runnerContainerDestroyOk: true,
     });
-    expect(claimReadyStandby).toHaveBeenCalledOnce();
-    expect(bindStandbySlot).toHaveBeenCalledOnce();
+    expect(claimReadyStandby).not.toHaveBeenCalled();
+    expect(bindStandbySlot).not.toHaveBeenCalled();
+    expect(resolveRetainedStandbySlot).toHaveBeenCalledOnce();
     expect(invocationBindingRead).toHaveBeenCalledOnce();
     expect(cleanupBindingRead).toHaveBeenCalledOnce();
     expect(retireStandbySlot).toHaveBeenCalledOnce();

--- a/apps/web/changelog/entries/2026-09-06/faster-fresh-conversation-starts.json
+++ b/apps/web/changelog/entries/2026-09-06/faster-fresh-conversation-starts.json
@@ -13,7 +13,8 @@
       "performance"
     ],
     "sourcePullRequests": [
-      2999
+      2999,
+      3006
     ]
   }
 }


### PR DESCRIPTION
## Why and outcome

Fresh allocation already verifies the exact immutable slot binding. Reuse that verified result in the same request instead of fetching it again during invocation preparation. Retained and direct preparation still read their binding; the container still authorizes its live bound member at launch.

Stacked on #2999; merge #2999 first. This PR removes one RPC per successful fresh allocation. The local slow-binding fixture improves from 489.09 ms to 386.90 ms; balanced independent reads remain about 429 ms. Production end-to-end savings are not measured.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Successful fresh binds and same-request bind-response recovery avoid repeated setup. Cold fallback benefits too. Retained targets, stale fences, invalid identities and retirement retain their existing checks.

## Evidence

- Direct: 186 focused identity, fleet, standby and container runtime-callback tests pass; Cloudflare build and typecheck pass. All 177 runner-alarm tests, 9 changelog rendering tests, Web typecheck and docs drift pass. Exact bind-response recovery is exercised through the real controller and invocation service. Six malformed/foreign/retired receipt cases reject before launch.
- Coverage: The base makes one redundant binding read and fails the new call-count assertion; the candidate makes none. Bind-response recovery makes only its required recovery read. Existing live container authorization and final controller fence checks remain in the path.
- Benchmark: Same synthetic delays and composed owners at base/head; 102.19 ms saved when binding verification dominates. Balanced reads show no meaningful wall-time difference because another branch determines completion.

ReviewGPT round 1: PASS at `7a8bdd385bfbb3ee1a9aa649689722dda9557652`, zero qualifying findings. Exact-turn/backend evidence confirms `gpt-6-pro`, full snapshot, and more than five minutes after send. The final commit only closes the explanatory plan; reviewed source and tests are identical. Final head `5368b33e5db698e90f1e286e4c87d08187831681`: build, typecheck, Cloudflare, Web and package regression checks passed. GitHub shows the current aggregate CI result. The stacked base merges cleanly.

## Non-obvious affected surfaces

A request-local receipt proves immutable membership, not current lifecycle readiness. It never replaces the container's live bound-member authorization or the controller's current write-fence check. No receipt is persisted or forwarded to a container.

## Architecture and reuse

- Existing systems reused: Fresh allocation's exact binding validation, RuntimeInvocationService's identity predicate, RunnerStateStore fencing, and RunnerContainer live authorization.
- New logic: Carry the allocating request's verified binding through existing preparation and skip its duplicate read.
- New abstractions: None; an optional existing binding value travels through current method arguments.
- Complexity intentionally avoided: No cache, new state owner, durable field, protocol change, queue or new retry policy.

## Complexity impact

- Guard: pass — pnpm complexity:diff --base perf/standby-start-latency
- Hotspots: prepareWithInputs 24, prepareWorkspaceRunnerInvocation 23, ensureExistingRuntimeProcessing 25; all unchanged against the base PR.
- Agent judgment: The small receipt handoff removes a redundant RPC without replacing authority. Further unrelated refactoring is not justified.

## Hot reply path impact

- Path status: Touched — fresh runtime preparation.
- Database calls: No added or moved database query.
- Network/provider calls: One immutable-binding RPC removed after verified fresh allocation. Direct/retained preparation keeps its existing read, original remaining command deadline and failure behavior. Same-request bind recovery retains its required recovery read. No new provider call or retry.
- Other awaited latency: Identity validation remains local; other preparation reads retain #2999's parallel ordering.
- Before/after proof: Actual controller/service call counts plus paired delayed-I/O setup measurement: slow binding 489.09 to 386.90 ms; balanced reads 428.22 to 428.73 ms. No production forecast is claimed.

## Murph initial provider input impact

Not applicable for individual or group runtimes: no instructions, messages, tools, schemas, generated guidance, history or provider-visible fields change. No token measurement was run.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: Content-only source-PR attribution in the existing performance release note; 9 archive rendering tests and Web typecheck passed.
- Coverage: Unchanged archive presentation and member-facing performance copy; no new visual or interaction.

## Deployment concerns

- Deployment: applicable
- Supported skew: Worker-local receipt only. Web, container job, slot persistence and checkpoint shapes remain unchanged.
- Safe order: Merge #2999 then this PR. Worker deployment uses ordinary release ordering; the Web release note can follow separately.
- Rollback floor: Previous Worker code reads the same binding; no migration or compatibility floor changes.
- Expected exposure: Successful fresh allocations skip one read. Retained/direct starts and active runtime wakes retain their existing behavior.
- Reversibility: Reverting this scheduling optimization restores the binding read. Production rollback remains separately authorized.
- Convergence proof: Current owners and lifecycle tests preserve identical durable/wire contracts. No live mixed-version rollout is claimed.
- Post-deploy checks: Compare fresh-start preparation spans and binding RPC counts; check retry, preparation failure and retirement rejection rates.

## Change-shape breakdown

Classification: runtime TS as source, tests as tests, Markdown as docs, authored changelog attribution as other. No generated or binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 18 | 5 |
| Tests / fixtures | 66 | 10 |
| Docs | 58 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 2 | 1 |
| **Total** | **144** | **16** |

## Changelog

- Changelog: updated
- Items: 2026-09-06 · faster-fresh-conversation-starts

ReviewGPT context sensitivity: sensitive
Classification reason: Hosted execution binding authority and request-local concurrency.

ReviewGPT first-reviewed head: 7a8bdd385bfbb3ee1a9aa649689722dda9557652
