### PR TITLE
perf: simplify locked Linq direct admission

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-06-linq-admission-ci-proof.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-linq-admission-ci-proof.md
@@ -1,0 +1,25 @@
+# Align Linq admission regression proof
+
+Status: completed
+Created: 2026-09-06
+Updated: 2026-09-06
+
+## Outcome
+
+PR #3008 CI exposed stale assertions in three suites outside the original focused suites:
+an inactive-access proof required the deleted pre-lock read and repeated route
+locks; home-binding proofs required both cleanup updates for empty conflict
+sets. A lookup-version repair fixture now supplies a competing pending owner
+so its single cleanup assertion exercises an actual conflict. Update only tests, preserving access refresh after the owner lock, ordering
+before mailbox append, and the binding's persisted output assertions.
+
+## Verification
+
+Run all three complete affected suites, Web typecheck, diff/privacy checks, and CI.
+The production tree remains byte-identical to ReviewGPT round 1's passed head.
+Under the review runbook's non-substantive test-only rule, no new review round
+is required; the first-reviewed head remains immutable in the PR body.
+
+All 134 tests in the affected suites and Web typecheck pass. Parent review
+confirms that the delta changes only regression proof and this plan.
+Completed: 2026-09-06

--- a/agent-docs/exec-plans/completed/2026-09-06-linq-locked-admission.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-linq-locked-admission.md
@@ -1,0 +1,68 @@
+# Simplify locked Linq admission
+
+Status: completed
+Created: 2026-09-06
+Updated: 2026-09-06
+
+## Outcome
+
+Third patch from the ReviewGPT design: one live member resolution under existing
+transaction owners; no repeated home-row locking or route mutation for a clean
+exact binding. Keep mutable access, metadata comparisons, ownership precedence,
+quota, replay, routing repair, and receipt semantics. No new state or flags.
+
+## Implementation and proof
+
+Consolidate selected-member authority before live discovery, retain one current
+access decision, and remove duplicated routing revalidation work. Reuse the
+existing home policy and unchanged-binding predicate. A pending conflict still
+requires the normal repair owner, with sorted nonblocking member locks and one
+cleanup statement. Empty conflict sets require no cleanup statement.
+
+Verify composed operation counts, maintenance and conflicting-owner cases,
+prepared identity/routing drift, consent/activation/replay, and PostgreSQL races.
+Run Web typecheck, complexity and docs checks, then parent review and a focused
+PR. Final ReviewGPT and exact-head CI remain completion gates.
+
+## Constraints
+
+Identity preparation and root discovery are independent PRs #2998 and #3000.
+Canonical provider classification and outreach selection retain existing policy.
+Never replace selected-member SKIP LOCKED with a blocking acquisition.
+
+## Result
+
+Consolidated prepared control-root/member/identity validation into one admission
+step before live discovery. Removed the second discovery pass, repeated member
+locks, and the pre-lock access read. Existing runtime access remains authoritative.
+Own-message diagnostics no longer query access solely to populate a log field.
+The existing policy has an explicit entry point for callers already owning the
+member lock; standalone callers retain its locking wrapper.
+
+An exact binding uses the existing unchanged predicate and returns its stored
+participant after checking competing pending routes. Maintenance still falls
+through to the existing writer. Empty conflict sets issue no cleanup; nonempty
+sets retain sorted nonblocking member locks and use one identical cleanup update.
+
+The clean composed dispatch fixture fails against baseline source with identity
+discovery 2 versus 1, routing findMany 3 versus 1, raw route reads 3 versus 2,
+selected-member row locks 4 versus 1, chat locks 2 versus 1, and cleanup updates
+2 versus 0. Binding upserts remain zero and the canonical provider GET remains
+one. These named mock-Prisma counts do not represent all physical SQL or an
+end-to-end latency measurement. Preflight and crypto owners are mocked here.
+
+Deleted one mock-only thread race that invented a group route after the chat
+lock was already held. The separate thread-route suite retains the reachable
+group-created-after-preflight and false-direct provider classification proofs.
+Prepared-owner mismatch tests now expect control-root validation before discovery;
+the existing bounded retry still rejects without accepting mailbox work.
+
+PostgreSQL proof passes all 20 tests, including competing pending owners with and
+without a home route, busy-owner rejection, successful repair, and clean replay.
+The prepared planner count fixture and binding maintenance matrix cover the new
+skip path; existing dispatch, home policy, and thread suites cover consent,
+activation, identity/routing drift, duplicates, and ownership conflicts.
+
+Final local checks and parent review are recorded in the PR. ReviewGPT and
+exact-head CI run after push; no merge or deployment is part of this task.
+Completed: 2026-09-06

--- a/apps/web/src/lib/hosted-onboarding/hosted-member-routing-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/hosted-member-routing-linq.ts
@@ -729,6 +729,42 @@ function isHostedMemberHomeLinqBindingUnchanged(input: {
   );
 }
 
+/**
+ * Retains an exact binding after the caller's live member/home/thread resolution
+ * under participant, chat, and member locks. Pending conflicts still use repair.
+ */
+export async function readUnchangedHostedMemberHomeLinqBindingTx(input: {
+  chatId: string;
+  homeLineAssignedAt: Date | null;
+  memberId: string;
+  prisma: Prisma.TransactionClient;
+  recipientPhone: string | null;
+  routingRecord: Pick<HostedMemberRouting, keyof typeof hostedMemberLinqBindingSelect> | null;
+}): Promise<HostedLinqParticipantIdentity | null> {
+  const participant = readHostedMemberHomeLinqParticipantIdentity(input.routingRecord);
+  const recipientPhone = normalizePhoneNumber(input.recipientPhone);
+  const linqChatLookupKey = createHostedLinqChatLookupKey(input.chatId);
+  if (!participant || !linqChatLookupKey || !isHostedMemberHomeLinqBindingUnchanged({
+    clearPending: true,
+    homeLineAssignedAt: input.homeLineAssignedAt,
+    linqChatLookupKey,
+    lockedHomeRoute: input.routingRecord,
+    participantContact: participant,
+    recipientPhone,
+    recipientPhoneLookupKey: createHostedPhoneLookupKey(recipientPhone),
+  })) {
+    return null;
+  }
+  const pendingConflict = await input.prisma.hostedMemberRouting.findFirst({
+    select: { memberId: true },
+    where: {
+      pendingLinqChatLookupKey: { in: createHostedLinqChatLookupKeyReadCandidates(input.chatId) },
+      NOT: { memberId: input.memberId },
+    },
+  });
+  return pendingConflict ? null : participant;
+}
+
 async function writeHostedMemberLinqBindingTx(input: {
   clearPending: boolean;
   homeLineAssignedAt: Date | null;
@@ -1107,6 +1143,9 @@ async function clearHostedMemberLinqChatConflicts(input: {
       .map((route) => route.memberId)
       .filter((memberId) => memberId !== input.memberId),
   )].sort();
+  if (conflictingMemberIds.length === 0) {
+    return;
+  }
   for (const memberId of conflictingMemberIds) {
     if (!(await tryAcquireHostedMemberHomeLinqRouteLockTx({
       memberId,
@@ -1123,31 +1162,6 @@ async function clearHostedMemberLinqChatConflicts(input: {
 
   await input.tx.hostedMemberRouting.updateMany({
     where: {
-      linqChatLookupKey: null,
-      pendingLinqChatLookupKey: {
-        in: [...input.linqChatLookupKeys],
-      },
-      NOT: {
-        memberId: input.memberId,
-      },
-    },
-    data: {
-      pendingLinqChatIdEncrypted: null,
-      pendingLinqChatLookupKey: null,
-      pendingLinqParticipantContactEncrypted: null,
-      pendingLinqParticipantContactKind: null,
-      pendingLinqParticipantContactLookupKey: null,
-      pendingLinqParticipantContactObservedAt: null,
-      pendingLinqRecipientPhoneEncrypted: null,
-      pendingLinqRecipientPhoneLookupKey: null,
-    },
-  });
-
-  await input.tx.hostedMemberRouting.updateMany({
-    where: {
-      linqChatLookupKey: {
-        not: null,
-      },
       pendingLinqChatLookupKey: {
         in: [...input.linqChatLookupKeys],
       },

--- a/apps/web/src/lib/hosted-onboarding/linq-home-routing.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-home-routing.ts
@@ -331,6 +331,13 @@ export async function resolveHostedMemberLinqHomeLineRouteBindingTx(input: {
     memberId: input.memberId,
     prisma: input.prisma,
   });
+  return resolveHostedMemberLinqHomeLineRouteBindingWithLockedMemberTx(input);
+}
+
+/** The caller owns this member's row lock for the current transaction. */
+export async function resolveHostedMemberLinqHomeLineRouteBindingWithLockedMemberTx(
+  input: Parameters<typeof resolveHostedMemberLinqHomeLineRouteBindingTx>[0],
+): Promise<HostedLinqHomeLineRouteBindingResult> {
   const decision = await resolveHostedMemberLinqHomeLineRouteBindingDecision(input);
   if (decision.kind === "done") {
     return decision.result;

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -129,6 +129,7 @@ import {
   type HostedLinqHomeLineRouteBindingResult,
   readHostedLinqHomeLineAuthority,
   resolveHostedMemberLinqHomeLineRouteBindingTx,
+  resolveHostedMemberLinqHomeLineRouteBindingWithLockedMemberTx,
   reserveHostedLinqHomeLineFromPoolTx,
   startOfUtcDay,
 } from "./linq-home-routing";
@@ -136,6 +137,7 @@ import {
   claimHostedLinqProactiveConversationCapacityTx,
   readHostedLinqIncomingLineState,
 } from "./linq-line-store";
+import { readUnchangedHostedMemberHomeLinqBindingTx } from "./hosted-member-routing-linq";
 import {
   resolveHostedLinqSignupWelcomeDailyLimit,
 } from "./linq-routing-policy";
@@ -687,19 +689,15 @@ interface PreparedHostedLinqDirectMailboxPayloadRoot {
   routingState: HostedMemberRoutingStateSnapshot | null;
 }
 
-async function revalidatePreparedHostedLinqDirectMailboxControlRootTx(input: {
-  memberId: string;
-  prepared: PreparedHostedLinqDirectMailboxPayloadRoot | null;
+async function lockPreparedHostedLinqDirectMemberTx(input: {
+  prepared: PreparedHostedLinqDirectMailboxPayloadRoot;
   prisma: Prisma.TransactionClient;
 }): Promise<PreparedHostedLinqDirectMailboxPayloadRoot> {
-  if (!input.prepared || input.prepared.memberId !== input.memberId) {
-    throw hostedLinqDirectMailboxPreparationRequired("member");
-  }
-
+  const memberId = input.prepared.memberId;
   const preparedControlRoot = input.prepared.preparedControlRoot;
   if (
     preparedControlRoot.domain !== "control"
-    || preparedControlRoot.userId !== input.memberId
+    || preparedControlRoot.userId !== memberId
   ) {
     throw hostedLinqDirectMailboxPreparationRequired("control-root");
   }
@@ -714,33 +712,21 @@ async function revalidatePreparedHostedLinqDirectMailboxControlRootTx(input: {
     }
     throw error;
   }
-  return input.prepared;
-}
-
-async function tryLockPreparedHostedLinqDirectMemberRowTx(input: {
-  memberId: string;
-  prisma: Prisma.TransactionClient;
-}): Promise<boolean> {
   const lockedRows = await input.prisma.$queryRaw<Array<{ id: string }>>`
     select "id"
     from "hosted_member"
-    where "id" = ${input.memberId}
+    where "id" = ${memberId}
     for update skip locked
   `;
-  return lockedRows.length === 1;
-}
-
-async function revalidatePreparedHostedLinqDirectIdentityTx(input: {
-  memberId: string;
-  prepared: PreparedHostedLinqDirectMailboxPayloadRoot;
-  prisma: Prisma.TransactionClient;
-}): Promise<void> {
+  if (lockedRows.length !== 1) {
+    throw hostedLinqDirectMailboxPreparationRequired("member");
+  }
   await lockHostedMemberIdentityStateTx({
-    memberId: input.memberId,
+    memberId,
     prisma: input.prisma,
   });
   const identityRecord = await readHostedMemberIdentityRecord({
-    memberId: input.memberId,
+    memberId,
     prisma: input.prisma,
   });
   if (!hostedMemberIdentityRecordsEqual(
@@ -749,11 +735,10 @@ async function revalidatePreparedHostedLinqDirectIdentityTx(input: {
   )) {
     throw hostedLinqDirectMailboxPreparationRequired("member");
   }
+  return input.prepared;
 }
 
 async function revalidatePreparedHostedLinqDirectRoutingTx(input: {
-  chatId: string;
-  contact: HostedLinqParticipantContact;
   memberId: string;
   prepared: PreparedHostedLinqDirectMailboxPayloadRoot | null;
   prisma: Prisma.TransactionClient;
@@ -761,12 +746,6 @@ async function revalidatePreparedHostedLinqDirectRoutingTx(input: {
   if (!input.prepared || input.prepared.memberId !== input.memberId) {
     throw hostedLinqDirectMailboxPreparationRequired("member");
   }
-
-  // The caller already owns the chat, control-root, and member authorities.
-  await acquireHostedMemberHomeLinqRouteLockTx({
-    memberId: input.memberId,
-    prisma: input.prisma,
-  });
 
   const routingRecord = await readHostedMemberRoutingRecord({
     memberId: input.memberId,
@@ -789,56 +768,6 @@ async function revalidatePreparedHostedLinqDirectRoutingTx(input: {
       memberId: input.memberId,
       reason: "routing",
     });
-  }
-
-  const threadIdentityLookupKeys =
-    createHostedExternalThreadIdentityLookupKeyReadCandidates({
-      channel: "linq",
-      threadId: input.chatId,
-    });
-  const threadRoute = threadIdentityLookupKeys.length === 0
-    ? null
-    : await input.prisma.hostedThreadRoute.findFirst({
-        select: {
-          containerMemberId: true,
-        },
-        where: {
-          channel: "linq",
-          threadIdentityLookupKey: {
-            in: threadIdentityLookupKeys,
-          },
-        },
-      });
-  if (threadRoute) {
-    throw hostedLinqDirectMailboxPreparationRequired("thread-route");
-  }
-
-  const identityCandidate = await lookupHostedLinqIdentityCoreCandidate({
-    audience: "direct",
-    contact: input.contact,
-    prisma: input.prisma,
-  });
-  const homeChatCandidate = await lookupHostedLinqHomeChatCoreCandidate({
-    chatId: input.chatId,
-    prisma: input.prisma,
-  });
-  const pendingContactCandidate = identityCandidate || homeChatCandidate
-    ? null
-    : await lookupHostedMemberCoreByPendingLinqParticipantContact({
-        contact: input.contact,
-        prisma: input.prisma,
-      });
-  const revalidatedMemberId =
-    identityCandidate?.memberId
-    ?? homeChatCandidate?.memberId
-    ?? pendingContactCandidate?.id
-    ?? null;
-
-  if (revalidatedMemberId !== input.memberId) {
-    throw hostedLinqDirectMailboxPreparationRequired("member");
-  }
-  if (homeChatCandidate && homeChatCandidate.memberId !== input.memberId) {
-    throw hostedLinqDirectMailboxPreparationRequired("home-chat-owner");
   }
 
   return input.prepared;
@@ -1519,6 +1448,12 @@ export async function planHostedOnboardingLinqWebhook(
     });
   }
 
+  const preparedMember = input.preparedDirectMailboxPayloadRoot;
+  const preparedDirectMailboxControlAuthority = preparedMember
+    ? await lockPreparedHostedLinqDirectMemberTx({ prepared: preparedMember, prisma: input.prisma })
+    : null;
+  let preparedDirectRoutingAuthority: PreparedHostedLinqDirectMailboxPayloadRoot | null = null;
+
   const existingMemberLookup = await lookupHostedLinqIdentityCoreCandidate({
     audience: "direct",
     contact: participantContact,
@@ -1542,6 +1477,10 @@ export async function planHostedOnboardingLinqWebhook(
     ?? existingHomeLinqChatLookup?.core
     ?? existingPendingLinqContactLookup
     ?? null;
+  if (preparedDirectMailboxControlAuthority
+    && preparedDirectMailboxControlAuthority.memberId !== existingMember?.id) {
+    throw hostedLinqDirectMailboxPreparationRequired("member");
+  }
   const existingMemberMatch = resolveHostedLinqExistingMemberMatch({
     existingHomeLinqChatLookupPresent: Boolean(existingHomeLinqChatLookup),
     existingMemberLookup,
@@ -1615,12 +1554,7 @@ export async function planHostedOnboardingLinqWebhook(
   const existingMemberSuspended = existingMember
     ? isHostedMemberSuspended(existingMember.suspendedAt)
     : false;
-  let existingMemberEffectiveActive = existingMember && !existingMemberSuspended
-    ? await readActiveHostedMemberAccess({
-        memberId: existingMember.id,
-        prisma: input.prisma,
-      })
-    : false;
+  let existingMemberEffectiveActive = false;
   let instantStartOwner: HostedLinqInstantStartOwner | null = null;
 
   if (summary.isFromMe) {
@@ -1636,7 +1570,6 @@ export async function planHostedOnboardingLinqWebhook(
     }
 
     return buildHostedLinqIgnoredPlan(input.event, context, {
-      existingMemberActive: existingMemberEffectiveActive,
       existingMemberMatch,
       reason: "own-message",
       routeStage: "ignored-own-message",
@@ -1655,35 +1588,8 @@ export async function planHostedOnboardingLinqWebhook(
     });
   }
 
-  let preparedDirectMailboxControlAuthority:
-    | PreparedHostedLinqDirectMailboxPayloadRoot
-    | null = null;
-  let preparedDirectRoutingAuthority:
-    | PreparedHostedLinqDirectMailboxPayloadRoot
-    | null = null;
   if (existingMember) {
-    if (
-      directMailboxPreparationProvided
-      && input.preparedDirectMailboxPayloadRoot
-    ) {
-      preparedDirectMailboxControlAuthority =
-        await revalidatePreparedHostedLinqDirectMailboxControlRootTx({
-          memberId: existingMember.id,
-          prepared: input.preparedDirectMailboxPayloadRoot,
-          prisma: input.prisma,
-        });
-      if (!await tryLockPreparedHostedLinqDirectMemberRowTx({
-        memberId: existingMember.id,
-        prisma: input.prisma,
-      })) {
-        throw hostedLinqDirectMailboxPreparationRequired("member");
-      }
-      await revalidatePreparedHostedLinqDirectIdentityTx({
-        memberId: existingMember.id,
-        prepared: preparedDirectMailboxControlAuthority,
-        prisma: input.prisma,
-      });
-    } else {
+    if (!preparedDirectMailboxControlAuthority) {
       await lockHostedMemberRow(input.prisma, existingMember.id);
     }
     const exactMemberAccess = await readHostedRuntimeAiAccessDecision({
@@ -1692,6 +1598,7 @@ export async function planHostedOnboardingLinqWebhook(
       now: new Date(occurredAt),
       prisma: input.prisma,
     });
+    existingMemberEffectiveActive = exactMemberAccess.allowed;
     // The committed mailbox row is the canonical classification for this exact
     // member/event pair. Repair its wake before mutable Family, group, quota, or
     // routing state can reinterpret a provider redelivery.
@@ -1787,8 +1694,6 @@ export async function planHostedOnboardingLinqWebhook(
       }
       preparedDirectRoutingAuthority =
         await revalidatePreparedHostedLinqDirectRoutingTx({
-          chatId: summary.chatId,
-          contact: participantContact,
           memberId: existingMember.id,
           prepared: preparedDirectMailboxControlAuthority,
           prisma: input.prisma,
@@ -1984,7 +1889,6 @@ export async function planHostedOnboardingLinqWebhook(
   if (existingMember && existingMemberEffectiveActive) {
     return planHostedLinqActiveMemberDirectWebhook({
       context,
-      directMailboxPreparationProvided,
       existingMember,
       existingMemberEffectiveActive,
       existingMemberMatch,
@@ -2479,7 +2383,6 @@ async function planHostedLinqFirstContactWebhook(planner: {
 
 async function planHostedLinqActiveMemberDirectWebhook(input: {
   context: ReturnType<typeof resolveHostedOnboardingLinqMessageContext>;
-  directMailboxPreparationProvided: boolean;
   existingMember: HostedMemberCoreState;
   existingMemberEffectiveActive: boolean;
   existingMemberMatch: HostedLinqExistingMemberMatch;
@@ -2491,7 +2394,6 @@ async function planHostedLinqActiveMemberDirectWebhook(input: {
 }): Promise<HostedOnboardingLinqDirectPlan> {
   const {
     context,
-    directMailboxPreparationProvided,
     existingMember,
     existingMemberEffectiveActive,
     existingMemberMatch,
@@ -2502,14 +2404,11 @@ async function planHostedLinqActiveMemberDirectWebhook(input: {
   } = input;
   const { messageEvent, occurredAt, recipientPhoneNumber, summary } = context;
   const plannerInput = input.input;
-  const preparedDirectMailbox = directMailboxPreparationProvided
-    ? preparedDirectRoutingAuthority
-    : null;
-  if (directMailboxPreparationProvided && !preparedDirectMailbox) {
-    throw hostedLinqDirectMailboxPreparationRequired("member");
-  }
+  const preparedDirectMailbox = preparedDirectRoutingAuthority;
 
-  const bindingResult = await resolveIncomingHostedLinqHomeLineRouteBindingTx({
+  const bindingResult = await (preparedDirectMailbox
+    ? resolveHostedMemberLinqHomeLineRouteBindingWithLockedMemberTx
+    : resolveIncomingHostedLinqHomeLineRouteBindingTx)({
     acceptManagedInboundLine:
       existingMemberMatch === "phone-identity"
       && isHostedLinqIMessageService(messageEvent.data.service),
@@ -2584,14 +2483,23 @@ async function planHostedLinqActiveMemberDirectWebhook(input: {
     };
   }
 
-  const mailboxParticipantIdentity = await bindHostedMemberHomeLinqChat({
+  const homeBinding = {
     chatId: summary.chatId,
     homeLineAssignedAt: bindingResult.homeLineAssignedAt,
     memberId: existingMember.id,
     participantContact,
     prisma: plannerInput.prisma,
     recipientPhone: bindingResult.recipientPhone,
-  }) ?? participantContact;
+  };
+  const retainedParticipant = preparedDirectMailbox
+    ? await readUnchangedHostedMemberHomeLinqBindingTx({
+        ...homeBinding,
+        routingRecord: preparedDirectMailbox.routingRecord,
+      })
+    : null;
+  const mailboxParticipantIdentity = retainedParticipant
+    ?? await bindHostedMemberHomeLinqChat(homeBinding)
+    ?? participantContact;
 
   if (await hasConflictingHostedLinqInstantFirstTurnForChatTx({
     eventId: plannerInput.event.event_id,

--- a/apps/web/test/hosted-member-routing-linq-binding.test.ts
+++ b/apps/web/test/hosted-member-routing-linq-binding.test.ts
@@ -4,7 +4,10 @@ import {
   createHostedLinqChatLookupKey,
   createHostedPhoneLookupKey,
 } from "../src/lib/hosted-onboarding/contact-privacy";
-import { upsertHostedMemberHomeLinqBindingTx } from "../src/lib/hosted-onboarding/hosted-member-routing-linq";
+import {
+  readUnchangedHostedMemberHomeLinqBindingTx,
+  upsertHostedMemberHomeLinqBindingTx,
+} from "../src/lib/hosted-onboarding/hosted-member-routing-linq";
 
 const mocks = vi.hoisted(() => ({ encrypt: vi.fn() }));
 vi.mock("../src/lib/hosted-onboarding/member-private-codecs", async (importOriginal) => ({
@@ -55,7 +58,15 @@ function createFixture() {
       recipientPhone: "+15550000000",
       ...overrides,
     });
-  return { bind, prisma, routing };
+  const retain = () => readUnchangedHostedMemberHomeLinqBindingTx({
+    chatId: "synthetic-chat",
+    homeLineAssignedAt: new Date(assignedAt),
+    memberId: "synthetic-member",
+    prisma: prisma as never,
+    recipientPhone: "+15550000000",
+    routingRecord: routing,
+  });
+  return { bind, prisma, retain, routing };
 }
 
 beforeEach(() => {
@@ -66,6 +77,23 @@ beforeEach(() => {
 });
 
 describe("established Linq home binding", () => {
+  it("retains a validated clean binding with only the pending-conflict read", async () => {
+    const { prisma, retain } = createFixture();
+    await expect(retain()).resolves.toEqual(participant);
+    expect(prisma.hostedMemberRouting.findFirst).toHaveBeenCalledOnce();
+    expect(prisma.hostedMemberRouting.findUnique).not.toHaveBeenCalled();
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+    expect(prisma.hostedMemberRouting.upsert).not.toHaveBeenCalled();
+    expect(mocks.encrypt).not.toHaveBeenCalled();
+  });
+
+  it("defers a competing pending route to the repair writer", async () => {
+    const { prisma, retain } = createFixture();
+    prisma.hostedMemberRouting.findFirst.mockResolvedValue({ memberId: "other-owner" });
+    await expect(retain()).resolves.toBeNull();
+    expect(prisma.hostedMemberRouting.updateMany).not.toHaveBeenCalled();
+  });
+
   it("keeps the stored participant and ciphertext without rewriting an unchanged route", async () => {
     const { bind, prisma } = createFixture();
     await expect(bind()).resolves.toEqual(participant);
@@ -74,7 +102,7 @@ describe("established Linq home binding", () => {
     expect(prisma.$queryRaw).toHaveBeenCalled();
     expect(prisma.hostedThreadRoute.findFirst).toHaveBeenCalledOnce();
     expect(prisma.hostedMemberRouting.findFirst).toHaveBeenCalledOnce();
-    expect(prisma.hostedMemberRouting.updateMany).toHaveBeenCalledTimes(2);
+    expect(prisma.hostedMemberRouting.updateMany).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -91,8 +119,9 @@ describe("established Linq home binding", () => {
     ["missing ciphertext", { linqChatIdEncrypted: "" }],
     ["missing participant", { linqParticipantContactKind: null, linqParticipantContactLookupKey: null }],
   ])("still writes for %s", async (_name, change) => {
-    const { bind, prisma, routing } = createFixture();
+    const { bind, prisma, retain, routing } = createFixture();
     Object.assign(routing, change);
+    await expect(retain()).resolves.toBeNull();
     await bind();
     expect(mocks.encrypt).toHaveBeenCalledOnce();
     expect(prisma.hostedMemberRouting.upsert).toHaveBeenCalledOnce();
@@ -130,6 +159,25 @@ describe("established Linq home binding", () => {
       code: owner === "thread" ? "HOSTED_LINQ_CHAT_THREAD_ROUTE_CONFLICT" : "HOSTED_LINQ_CHAT_HOME_ROUTE_CONFLICT",
     });
     expect(mocks.encrypt).not.toHaveBeenCalled();
+    expect(prisma.hostedMemberRouting.upsert).not.toHaveBeenCalled();
+  });
+
+  it("repairs pending conflicts with one cleanup after locking the conflicting member", async () => {
+    const { bind, prisma } = createFixture();
+    prisma.hostedMemberRouting.findMany.mockResolvedValue([{ memberId: "other-owner" }]);
+    prisma.$queryRaw.mockResolvedValue([{ id: "other-owner" }]);
+    await expect(bind()).resolves.toEqual(participant);
+    expect(prisma.hostedMemberRouting.updateMany).toHaveBeenCalledOnce();
+    expect(prisma.hostedMemberRouting.upsert).not.toHaveBeenCalled();
+    expect(mocks.encrypt).not.toHaveBeenCalled();
+  });
+
+  it("leaves pending conflicts untouched when their member lock is busy", async () => {
+    const { bind, prisma } = createFixture();
+    prisma.hostedMemberRouting.findMany.mockResolvedValue([{ memberId: "other-owner" }]);
+    prisma.$queryRaw.mockResolvedValue([]);
+    await expect(bind()).rejects.toMatchObject({ code: "HOSTED_LINQ_PENDING_ROUTE_BUSY", retryable: true });
+    expect(prisma.hostedMemberRouting.updateMany).not.toHaveBeenCalled();
     expect(prisma.hostedMemberRouting.upsert).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-dispatch.test.ts
@@ -4392,6 +4392,57 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(mocks.sendHostedLinqChatMessage).not.toHaveBeenCalled();
   });
 
+  it("admits a clean established home with one live discovery and one member/chat lock", async () => {
+    const { prisma, hostedMemberRouting, hostedLinqDeliveryFindMany, restoreRootMock } =
+      await createDirectPreparationTransitionFixture();
+    const record = await hostedMemberRouting.findUnique({ where: { memberId: "member_123" } });
+    if (!record) throw new Error("Expected the existing routing fixture.");
+    await hostedMemberRouting.upsert({ create: {
+      ...record,
+      linqHomeLineAssignedAt: new Date("2026-03-25T00:00:00Z"),
+      linqRecipientPhoneEncrypted: await encryptHostedWebNullableString({
+        field: "hosted-member-routing.home-linq-recipient-phone",
+        memberId: "member_123", value: "+15550000000",
+      }),
+      linqRecipientPhoneLookupKey: createHostedPhoneLookupKey("+15550000000"),
+      pendingLinqChatIdEncrypted: null,
+      pendingLinqChatLookupKey: null,
+      pendingLinqParticipantContactEncrypted: null,
+      pendingLinqParticipantContactKind: null,
+      pendingLinqParticipantContactLookupKey: null,
+      pendingLinqParticipantContactObservedAt: null,
+      pendingLinqRecipientPhoneEncrypted: null,
+      pendingLinqRecipientPhoneLookupKey: null,
+    } });
+    hostedMemberRouting.findUnique.mockClear();
+    hostedMemberRouting.upsert.mockClear();
+    hostedLinqDeliveryFindMany.mockResolvedValue([]);
+    mocks.resolveHostedLinqMailboxPayloadRootPrewarmMemberId.mockResolvedValue("member_123");
+    try {
+      await expect(handleHostedOnboardingLinqWebhook({
+        prisma,
+        rawBody: buildHostedLinqWebhookBody({ eventId: "evt_clean_home_count" }),
+        signature: null, timestamp: null,
+      })).resolves.toMatchObject({ reason: "wake-appended-active-member" });
+      expect(prisma.hostedMemberIdentity!.findMany).toHaveBeenCalledOnce();
+      expect(hostedMemberRouting.findMany).toHaveBeenCalledOnce();
+      expect(hostedMemberRouting.findUnique).toHaveBeenCalledTimes(2);
+      expect(hostedMemberRouting.upsert).not.toHaveBeenCalled();
+      expect(hostedMemberRouting.updateMany).not.toHaveBeenCalled();
+      expect(prisma.$queryRaw.mock.calls.filter(([sql]) =>
+        sql.join(" ").toLowerCase().includes('from "hosted_member"'),
+      )).toHaveLength(1);
+      expect(prisma.$executeRaw.mock.calls.filter((args) =>
+        args.includes("hosted-linq-routing:chat"),
+      )).toHaveLength(1);
+      expect(mocks.getHostedLinqChatSummary).toHaveBeenCalledOnce();
+      expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledOnce();
+      expect(mocks.sendHostedLinqReadReceipt).toHaveBeenCalledOnce();
+    } finally {
+      restoreRootMock();
+    }
+  });
+
   it("re-prepares once when the direct mailbox ingress root changes under lock", async () => {
     mocks.enforceDirectMailboxPreparation = true;
     const prewarmRuntimeShell = vi.fn(async () => ({ accepted: true as const }));
@@ -4839,84 +4890,6 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(mocks.appendHostedMailboxEnvelopeTx).toHaveBeenCalledTimes(1);
   });
 
-  it("retries once and fails closed when a thread route appears under the direct chat lock", async () => {
-    mocks.enforceDirectMailboxPreparation = true;
-    mocks.resolveHostedLinqMailboxPayloadRootPrewarmMemberId.mockResolvedValue(
-      "member_123",
-    );
-    const hostedMemberRouting = createStatefulHostedMemberRoutingMock({
-      linqChatIdEncrypted: await encryptHostedWebNullableString({
-        field: "hosted-member-routing.home-linq-chat-id",
-        memberId: "member_123",
-        value: "chat_123",
-      }),
-      linqChatLookupKey: createHostedLinqChatLookupKey("chat_123"),
-      linqParticipantContactKind: "phone",
-      linqParticipantContactLookupKey: createHostedPhoneLookupKey(
-        "+15551234567",
-      ),
-      linqRecipientPhoneEncrypted: null,
-      linqRecipientPhoneLookupKey: null,
-      memberId: "member_123",
-      pendingLinqChatIdEncrypted: null,
-      pendingLinqRecipientPhoneEncrypted: null,
-      telegramUserIdEncrypted: null,
-      telegramUserLookupKey: null,
-    });
-    const hostedThreadRoute = {
-      findFirst: vi.fn().mockResolvedValue({
-        containerMemberId: "member_thread_container_123",
-      }),
-      findMany: vi.fn().mockResolvedValue([]),
-    };
-    const prisma = asPrismaTransactionClient({
-      hostedLinqLine: buildUnassignableHostedLinqLineFixture(),
-      hostedMember: {
-        findUnique: vi.fn().mockResolvedValue({
-          accountGroupMemberships: [],
-          billingStatus: HostedBillingStatus.active,
-          createdAt: new Date("2026-03-26T00:00:00.000Z"),
-          id: "member_123",
-          invites: [],
-          phoneLookupKey: "+15551234567",
-          suspendedAt: null,
-          updatedAt: new Date("2026-03-26T00:00:00.000Z"),
-        }),
-      },
-      hostedMemberRouting,
-      hostedThreadRoute,
-      hostedWebhookReceipt: buildHostedWebhookReceiptFixture(),
-    });
-    prisma.$transaction = vi.fn(async (
-      callback: (transaction: typeof prisma) => Promise<unknown>,
-    ) => callback(prisma));
-
-    await expect(handleHostedOnboardingLinqWebhook({
-      prisma,
-      rawBody: buildHostedLinqWebhookBody({
-        eventId: "evt_direct_thread_route_drift",
-      }),
-      signature: null,
-      timestamp: null,
-    })).rejects.toMatchObject({
-      code: "HOSTED_THREAD_ROUTE_PREPARATION_REQUIRED",
-      details: {
-        preparationTarget: "direct_linq_mailbox",
-        reason: "thread-route",
-      },
-      retryable: true,
-    });
-
-    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
-    expect(mocks.resolveHostedLinqMailboxPayloadRootPrewarmMemberId)
-      .toHaveBeenCalledTimes(2);
-    expect(hostedThreadRoute.findFirst).toHaveBeenCalledTimes(2);
-    expect(mocks.lockAndReadActiveHostedDomainRootKeyIdTx).toHaveBeenCalledTimes(2);
-    expect(hostedMemberRouting.upsert).not.toHaveBeenCalled();
-    expect(hostedMemberRouting.updateMany).not.toHaveBeenCalled();
-    expect(mocks.appendHostedMailboxEnvelopeTx).not.toHaveBeenCalled();
-  });
-
   it("keeps an exact committed direct event canonical after group context becomes eligible", async () => {
     mocks.enforceDirectMailboxPreparation = true;
     mocks.resolveHostedLinqMailboxPayloadRootPrewarmMemberId.mockResolvedValue(
@@ -5040,7 +5013,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).toHaveBeenCalledTimes(1);
     expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenCalledTimes(1);
     expect(hostedMemberRouting.upsert).toHaveBeenCalledTimes(1);
-    expect(hostedMemberRouting.updateMany).toHaveBeenCalledTimes(2);
+    expect(hostedMemberRouting.updateMany).not.toHaveBeenCalled();
 
     await expect(handleHostedOnboardingLinqWebhook({
       prisma,
@@ -5058,7 +5031,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(mocks.incrementHostedLinqInboundDailyState).toHaveBeenCalledTimes(1);
     expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).toHaveBeenCalledTimes(1);
     expect(hostedMemberRouting.upsert).toHaveBeenCalledTimes(1);
-    expect(hostedMemberRouting.updateMany).toHaveBeenCalledTimes(2);
+    expect(hostedMemberRouting.updateMany).not.toHaveBeenCalled();
     expect(mocks.signalHostedMailboxAppendRuntime).toHaveBeenNthCalledWith(2, {
       abortSignal: expect.any(AbortSignal),
       expectedUserId: "member_123",
@@ -5090,7 +5063,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(hostedInviteCreate).toHaveBeenCalledTimes(1);
     expect(mocks.sendHostedLinqChatMessage).toHaveBeenCalledTimes(1);
     expect(hostedMemberRouting.upsert).toHaveBeenCalledTimes(1);
-    expect(hostedMemberRouting.updateMany).toHaveBeenCalledTimes(2);
+    expect(hostedMemberRouting.updateMany).not.toHaveBeenCalled();
   });
 
   it("re-prepares an explicit-null direct preflight before active group routing", async () => {
@@ -6112,7 +6085,7 @@ describe("handleHostedOnboardingLinqWebhook", () => {
     expect(prisma.$transaction).toHaveBeenCalledTimes(2);
     expect(mocks.resolveHostedLinqMailboxPayloadRootPrewarmMemberId)
       .toHaveBeenCalledTimes(2);
-    expect(mocks.lockAndReadActiveHostedDomainRootKeyIdTx).not.toHaveBeenCalled();
+    expect(mocks.lockAndReadActiveHostedDomainRootKeyIdTx).toHaveBeenCalledOnce();
     expect(hostedMemberRouting.upsert).not.toHaveBeenCalled();
     expect(hostedMemberRouting.updateMany).not.toHaveBeenCalled();
     expect(mocks.appendHostedMailboxEnvelopeTx).not.toHaveBeenCalled();

--- a/apps/web/test/hosted-onboarding-linq-home-routing-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-home-routing-postgres.test.ts
@@ -66,6 +66,8 @@ import { planHostedOnboardingLinqWebhook } from "@/src/lib/hosted-onboarding/web
 import { planHostedOnboardingTelegramWebhook } from "@/src/lib/hosted-onboarding/webhook-provider-telegram";
 import { runHostedLinqMessageEditPreparedTransaction } from "@/src/lib/hosted-onboarding/webhook-service";
 import { createPrismaClient } from "@/src/lib/prisma";
+import { readUnchangedHostedMemberHomeLinqBindingTx } from "@/src/lib/hosted-onboarding/hosted-member-routing-linq";
+import { acquireHostedLinqChatOwnershipLockTx } from "@/src/lib/hosted-routing/linq-chat-ownership-lock";
 
 const handlerPrismaClients = vi.hoisted(() => [] as PrismaClient[]);
 
@@ -175,6 +177,71 @@ async function acquireHostedMailboxSourceLocksForTest(input: {
 describe.skipIf(!runPostgresConcurrencyProof)(
   "hosted Linq home-routing PostgreSQL concurrency",
   () => {
+    it.each([false, true])("repairs a conflicting pending route without disturbing its home (has home: %s)", async (hasHome) => {
+      const client = createPrismaClient({ databaseUrl, poolMax: 1 });
+      const blocker = createPrismaClient({ databaseUrl, poolMax: 1 });
+      const memberId = `member_clean_binding_${randomUUID()}`;
+      const otherMemberId = `member_pending_conflict_${randomUUID()}`;
+      const chatId = `chat_clean_binding_${randomUUID()}`;
+      const homeLineAssignedAt = new Date("2026-08-01T00:00:00Z");
+      const recipientPhone = "+15550000000";
+      const participantContact = createHostedLinqParticipantContact({ kind: "phone", value: "+15551112222" });
+      if (!participantContact) throw new Error("Expected a synthetic contact.");
+      const release = createDeferred();
+      const locked = createDeferred();
+      let blockedTransaction: Promise<void> | null = null;
+      const otherHomeKey = hasHome ? createHostedLinqChatLookupKey(`other-${chatId}`) : null;
+      try {
+        await client.hostedMember.createMany({ data: [{ id: memberId }, { id: otherMemberId }] });
+        const bind = (tx: Prisma.TransactionClient) => upsertHostedMemberHomeLinqBindingTx({
+          clearPending: true, homeLineAssignedAt, linqChatId: chatId, memberId,
+          participantContact, prisma: tx, recipientPhone,
+        });
+        await client.$transaction(bind, transactionOptions);
+        await client.hostedMemberRouting.create({ data: {
+          memberId: otherMemberId,
+          linqChatLookupKey: otherHomeKey,
+          linqChatIdEncrypted: hasHome ? "synthetic-other-home" : null,
+          pendingLinqChatLookupKey: createHostedLinqChatLookupKey(chatId),
+          pendingLinqChatIdEncrypted: "synthetic-pending-chat",
+        } });
+        const admit = () => client.$transaction(async (tx) => {
+          await acquireHostedLinqParticipantPhoneLockTx({ phoneNumber: participantContact.value, tx });
+          await acquireHostedLinqChatOwnershipLockTx({ chatId, tx });
+          await lockHostedMemberRow(tx, memberId);
+          const routingRecord = await tx.hostedMemberRouting.findUnique({ where: { memberId } });
+          const retained = await readUnchangedHostedMemberHomeLinqBindingTx({
+            chatId, homeLineAssignedAt, memberId, prisma: tx, recipientPhone, routingRecord,
+          });
+          return retained ?? bind(tx);
+        }, transactionOptions);
+        blockedTransaction = blocker.$transaction(async (tx) => {
+          await lockHostedMemberRow(tx, otherMemberId);
+          locked.resolve();
+          await release.promise;
+        }, transactionOptions);
+        await locked.promise;
+        await expect(admit()).rejects.toMatchObject({ code: "HOSTED_LINQ_PENDING_ROUTE_BUSY", retryable: true });
+        expect(await client.hostedMemberRouting.findUnique({
+          where: { memberId: otherMemberId }, select: { pendingLinqChatLookupKey: true },
+        })).toEqual({ pendingLinqChatLookupKey: createHostedLinqChatLookupKey(chatId) });
+        release.resolve();
+        await blockedTransaction;
+        const participant = { kind: participantContact.kind, lookupKey: participantContact.lookupKey };
+        await expect(admit()).resolves.toEqual(participant);
+        await expect(admit()).resolves.toEqual(participant);
+        expect(await client.hostedMemberRouting.findUnique({
+          where: { memberId: otherMemberId },
+          select: { linqChatLookupKey: true, pendingLinqChatLookupKey: true, pendingLinqChatIdEncrypted: true },
+        })).toEqual({ linqChatLookupKey: otherHomeKey, pendingLinqChatLookupKey: null, pendingLinqChatIdEncrypted: null });
+      } finally {
+        release.resolve();
+        await blockedTransaction;
+        await client.hostedMember.deleteMany({ where: { id: { in: [memberId, otherMemberId] } } });
+        await disconnectClients([client, blocker]);
+      }
+    });
+
     it("serializes edits and rejects a stale prepared lineage after the winner appends", async () => {
       const observer = createPrismaClient({ databaseUrl, poolMax: 1 });
       const owner = createPrismaClient({ databaseUrl, poolMax: 1 });

--- a/apps/web/test/hosted-onboarding-member-service.test.ts
+++ b/apps/web/test/hosted-onboarding-member-service.test.ts
@@ -746,50 +746,7 @@ describe("upsertHostedMemberHomeLinqBinding", () => {
         },
       },
     });
-    expect(updateMany).toHaveBeenNthCalledWith(1, {
-      data: {
-        pendingLinqChatIdEncrypted: null,
-        pendingLinqChatLookupKey: null,
-        pendingLinqParticipantContactEncrypted: null,
-        pendingLinqParticipantContactKind: null,
-        pendingLinqParticipantContactLookupKey: null,
-        pendingLinqParticipantContactObservedAt: null,
-        pendingLinqRecipientPhoneEncrypted: null,
-        pendingLinqRecipientPhoneLookupKey: null,
-      },
-      where: {
-        NOT: {
-          memberId: "member_123",
-        },
-        linqChatLookupKey: null,
-        pendingLinqChatLookupKey: {
-          in: [expect.stringMatching(/^hbidx:linq-chat:v1:/u)],
-        },
-      },
-    });
-    expect(updateMany).toHaveBeenNthCalledWith(2, {
-      data: {
-        pendingLinqChatIdEncrypted: null,
-        pendingLinqChatLookupKey: null,
-        pendingLinqParticipantContactEncrypted: null,
-        pendingLinqParticipantContactKind: null,
-        pendingLinqParticipantContactLookupKey: null,
-        pendingLinqParticipantContactObservedAt: null,
-        pendingLinqRecipientPhoneEncrypted: null,
-        pendingLinqRecipientPhoneLookupKey: null,
-      },
-      where: {
-        NOT: {
-          memberId: "member_123",
-        },
-        linqChatLookupKey: {
-          not: null,
-        },
-        pendingLinqChatLookupKey: {
-          in: [expect.stringMatching(/^hbidx:linq-chat:v1:/u)],
-        },
-      },
-    });
+    expect(updateMany).not.toHaveBeenCalled();
     expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
     expect(executeRaw).toHaveBeenCalledTimes(1);
     expect(upsert).toHaveBeenCalledWith({

--- a/apps/web/test/hosted-onboarding-member-store.test.ts
+++ b/apps/web/test/hosted-onboarding-member-store.test.ts
@@ -1825,51 +1825,7 @@ describe("hosted-member-store", () => {
         },
       },
     });
-    expect(updateMany).toHaveBeenCalledTimes(2);
-    expect(updateMany).toHaveBeenNthCalledWith(1, {
-      where: {
-        linqChatLookupKey: null,
-        pendingLinqChatLookupKey: {
-          in: [expect.stringMatching(/^hbidx:linq-chat:v1:/u)],
-        },
-        NOT: {
-          memberId: "member_123",
-        },
-      },
-      data: {
-        pendingLinqChatIdEncrypted: null,
-        pendingLinqChatLookupKey: null,
-        pendingLinqParticipantContactEncrypted: null,
-        pendingLinqParticipantContactKind: null,
-        pendingLinqParticipantContactLookupKey: null,
-        pendingLinqParticipantContactObservedAt: null,
-        pendingLinqRecipientPhoneEncrypted: null,
-        pendingLinqRecipientPhoneLookupKey: null,
-      },
-    });
-    expect(updateMany).toHaveBeenNthCalledWith(2, {
-      where: {
-        linqChatLookupKey: {
-          not: null,
-        },
-        pendingLinqChatLookupKey: {
-          in: [expect.stringMatching(/^hbidx:linq-chat:v1:/u)],
-        },
-        NOT: {
-          memberId: "member_123",
-        },
-      },
-      data: {
-        pendingLinqChatIdEncrypted: null,
-        pendingLinqChatLookupKey: null,
-        pendingLinqParticipantContactEncrypted: null,
-        pendingLinqParticipantContactKind: null,
-        pendingLinqParticipantContactLookupKey: null,
-        pendingLinqParticipantContactObservedAt: null,
-        pendingLinqRecipientPhoneEncrypted: null,
-        pendingLinqRecipientPhoneLookupKey: null,
-      },
-    });
+    expect(updateMany).not.toHaveBeenCalled();
     expect(queryRaw).toHaveBeenCalledTimes(1);
     expect(executeRaw).toHaveBeenCalledTimes(1);
     expect(upsert).toHaveBeenCalledWith({
@@ -2471,7 +2427,7 @@ describe("hosted-member-store", () => {
       pendingLinqChatIdEncrypted: null,
       pendingLinqChatLookupKey: null,
     }));
-    expect(updateMany).toHaveBeenCalledTimes(2);
+    expect(updateMany).not.toHaveBeenCalled();
   });
 
   it("clears pending Linq route state when a different pending chat becomes home", async () => {
@@ -2522,7 +2478,7 @@ describe("hosted-member-store", () => {
         memberId: "member_123",
       },
     });
-    expect(updateMany).toHaveBeenCalledTimes(2);
+    expect(updateMany).not.toHaveBeenCalled();
   });
 
   it("rewrites pending Linq chat binding without reading prior route state", async () => {
@@ -2631,7 +2587,7 @@ describe("hosted-member-store", () => {
       },
       hostedMemberRouting: {
         findFirst,
-        findMany: vi.fn().mockResolvedValue([]),
+        findMany: vi.fn().mockResolvedValue([{ memberId: "member_pending_owner" }]),
         findUnique,
         updateMany,
         upsert,
@@ -2655,29 +2611,17 @@ describe("hosted-member-store", () => {
         },
       }),
     }));
-    expect(updateMany).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      where: expect.objectContaining({
-        linqChatLookupKey: null,
+    expect(updateMany).toHaveBeenCalledOnce();
+    expect(updateMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        NOT: { memberId: "member_123" },
         pendingLinqChatLookupKey: {
           in: expect.arrayContaining([
             expect.stringMatching(/^hbidx:linq-chat:v2:/u),
             expect.stringMatching(/^hbidx:linq-chat:v1:/u),
           ]),
         },
-      }),
-    }));
-    expect(updateMany).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      where: expect.objectContaining({
-        linqChatLookupKey: {
-          not: null,
-        },
-        pendingLinqChatLookupKey: {
-          in: expect.arrayContaining([
-            expect.stringMatching(/^hbidx:linq-chat:v2:/u),
-            expect.stringMatching(/^hbidx:linq-chat:v1:/u),
-          ]),
-        },
-      }),
+      },
     }));
     expect(upsert).toHaveBeenCalledWith(expect.objectContaining({
       create: expect.objectContaining({
@@ -2818,7 +2762,7 @@ describe("hosted-member-store", () => {
       code: "P2002",
     });
 
-    expect(updateMany).toHaveBeenCalledTimes(2);
+    expect(updateMany).not.toHaveBeenCalled();
     expect(upsert).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/test/hosted-onboarding-webhook-idempotency.test.ts
+++ b/apps/web/test/hosted-onboarding-webhook-idempotency.test.ts
@@ -1817,25 +1817,24 @@ describe("hosted onboarding Linq webhook hard-cut flows", () => {
       reason: "wake-appended-active-member",
     });
 
-    expect(prisma.hostedMember.findUnique).toHaveBeenCalledTimes(4);
-    const initialAccessReadOrder =
-      prisma.hostedMember.findUnique.mock.invocationCallOrder[1]!;
+    expect(prisma.hostedMember.findUnique).toHaveBeenCalledTimes(3);
     const exactAccessReadOrder =
-      prisma.hostedMember.findUnique.mock.invocationCallOrder[2]!;
+      prisma.hostedMember.findUnique.mock.invocationCallOrder[1]!;
     const refreshedAccessReadOrder =
-      prisma.hostedMember.findUnique.mock.invocationCallOrder[3]!;
-    const preparedRoutingLockOrder =
-      mocks.acquireHostedMemberHomeLinqRouteLockTx.mock.invocationCallOrder[0]!;
+      prisma.hostedMember.findUnique.mock.invocationCallOrder[2]!;
+    const selectedMemberLockIndex = prisma.$queryRaw.mock.calls.findIndex(([sql]) =>
+      sql.join(" ").toLowerCase().includes('from "hosted_member"'),
+    );
+    expect(selectedMemberLockIndex).toBeGreaterThanOrEqual(0);
+    const selectedMemberLockOrder =
+      prisma.$queryRaw.mock.invocationCallOrder[selectedMemberLockIndex]!;
     const reclassificationLockOrder =
-      mocks.acquireHostedMemberHomeLinqRouteLockTx.mock.invocationCallOrder[1]!;
-    expect(initialAccessReadOrder).toBeLessThan(exactAccessReadOrder);
-    expect(exactAccessReadOrder).toBeLessThan(preparedRoutingLockOrder);
-    expect(preparedRoutingLockOrder).toBeLessThan(reclassificationLockOrder);
+      mocks.acquireHostedMemberHomeLinqRouteLockTx.mock.invocationCallOrder[0]!;
+    expect(selectedMemberLockOrder).toBeLessThan(exactAccessReadOrder);
+    expect(exactAccessReadOrder).toBeLessThan(reclassificationLockOrder);
     expect(reclassificationLockOrder).toBeLessThan(refreshedAccessReadOrder);
-    expect(
-      refreshedAccessReadOrder,
-    ).toBeLessThan(
-      mocks.acquireHostedMemberHomeLinqRouteLockTx.mock.invocationCallOrder[2],
+    expect(refreshedAccessReadOrder).toBeLessThan(
+      mocks.appendHostedMailboxEnvelopeTx.mock.invocationCallOrder[0]!,
     );
     expect(mocks.issueHostedInviteTx).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Why and outcome

Established Linq messages repeat member discovery and reacquire the same locks before reaching the mailbox. Resolve live ownership once after locking the prepared member, reuse the existing home policy, and retain an exact clean binding without invoking its mutation writer. Collapse duplicate pending-conflict cleanup updates.

## Product UX

- Effort: Patch.
- Result: Ready.
- Walkthrough: Direct messages preserve current access, consent, Family activation, duplicate-event recovery, group privacy, and read-receipt ordering. No UI or new product policy.

## Evidence

- Final review: [ReviewGPT round 1](https://chatgpt.com/c/6a9dc7e8-2a34-83ea-9b5f-ff541e2dee03) PASS on `abdc01bd21df`, no qualifying findings. Production code is byte-identical at current head `a7337758498d`; the later commit changes only regression tests and its execution plan. Under the review runbook, this does not create another substantive round. Current-head CI is green.
- Combined proof: All three patches (#2998, #3000, #3008) apply without conflicts; the combined checkout passes 908 focused admission/Family/routing/crypto/member tests and Web typecheck.

- Direct: Admission, binding, home policy, and thread suites pass (451 tests before the last two binding assertions; final dispatch/binding rerun passes 227 tests). All 20 real PostgreSQL concurrency tests pass. Web typecheck and final prepared typecheck, complexity guard, docs drift, and parent diff/privacy review pass.
- Coverage: The identical clean-message fixture fails against baseline production code on all six reduced call counts below. The prepared planner runs with mock Prisma/external providers; preflight identity resolution and crypto are mocked. Separate real PostgreSQL tests prove busy pending-owner rejection, repair for owners with and without a home route, preservation of their home, and clean repeat admission.
- CI follow-up: Full CI exposed seven stale assertions across three additional suites. All 134 affected tests now pass with access/lock ordering, persisted binding fields, and readable lookup-version conflict repair preserved; final prepared typecheck passes.
- Commands: `pnpm exec tsx apps/web/scripts/run-hosted-web-vitest.mts apps/web/test/hosted-onboarding-linq-dispatch.test.ts apps/web/test/hosted-member-routing-linq-binding.test.ts apps/web/test/hosted-onboarding-linq-home-routing.test.ts apps/web/test/hosted-onboarding-linq-thread-route.test.ts --reporter=dot --silent`; local PostgreSQL concurrency suite with `MURPH_TEST_POSTGRES_CONCURRENCY=1`; `pnpm --dir apps/web typecheck`; `pnpm complexity:diff`; `pnpm docs:drift`.

## Non-obvious affected surfaces

Prepared identity/routing drift, independently conflicting home owners, current consent, activation, duplicates, and false-direct/group classification retain focused regression coverage. Shared binding cleanup serves other callers: maintenance still uses the original writer and sorted nonblocking member locks. The existing maintenance matrix now also proves the retained-binding path declines pending fields, retained lookup versions, missing ciphertext, and missing participant metadata. Own-message diagnostics no longer read access solely to populate a log field.

One deleted mock test invented a thread route appearing after the chat lock was held by returning inconsistent results from two reads of that table. The dedicated thread-route suite retains reachable group-created-after-preflight and false-direct privacy cases.

## Architecture and reuse

- Existing systems reused: Participant/chat/member locks, prepared-root and raw-metadata validation, runtime access policy, home-line policy, unchanged-binding predicate, and binding repair writer.
- New logic: Skip repeated work only after live authority validation; retain the stored participant for an exact binding with no pending conflict.
- New abstractions: One explicit entry point for the existing home policy when the caller already owns the member lock; one narrow retained-binding reader. Consolidate three private preparation helpers into one.
- Complexity intentionally avoided: No cache, state, schema, flags, queue, service, dependency, or parallel transaction. Production source decreases by 71 lines.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; debt unchanged in all three source files.
- Hotspots: Planner (93), group (89), first contact (76), edit (56), thread preparation (40), Family (31), explicit thread (28), direct preflight (23), active direct (22), and wake builder (21); routing finalization (37), create-data builder (26), writer (22); home materialization (28) and reservation (21).
- Agent judgment: Removed duplicated discovery and private helper layers in this path. Remaining hotspots encode existing product policies; further splitting would redistribute branches without deleting requirements. No broader policy change is justified by this latency fix.

## Hot reply path impact

- Path status: Touched — direct-message admission before durable mailbox append.
- Database calls: Clean path named counts below. One pending-conflict read replaces the full binding writer's redundant reads and locks. Prepared-member root/member/identity validation moves before live discovery; on a stale prepared owner this can perform root validation, one nonblocking member lock, one identity lock, and one identity read before rejecting where the old order could reject earlier. No new transaction or pooled connection.
- Network/provider calls: None added. Canonical chat GET remains one, because webhook false-direct classification has a real group-privacy regression. Receipt and mailbox append remain one in the fixture.
- Other awaited latency: Existing bounded re-preparation/retry, transaction timeout, quota, and handoff behavior remain. Clean binding maintenance falls back to the original writer; conflict repair still locks sorted competing members without waiting. No new timeout or background work.
- Before/after proof: Same fixture against base/head, named Prisma/raw-call counts:

| Operation | Base | Head |
| --- | ---: | ---: |
| Live identity discovery | 2 | 1 |
| Routing findMany (home discovery plus conflict scan) | 3 | 1 |
| Raw route reads | 3 | 2 |
| Explicit selected-member row locks | 4 | 1 |
| Explicit chat locks | 2 | 1 |
| Empty-conflict cleanup updates | 2 | 0 |
| Exact-binding upserts | 0 | 0 |
| Canonical provider GET | 1 | 1 |

These counts exclude mocked preflight/crypto work and are not all physical SQL. Do not sum them with other PRs' counts or infer an end-to-end latency reduction. Nonempty pending cleanup becomes one update rather than two, with one lock per distinct conflicting member as before.

## Murph initial provider input impact

Not applicable for individual and group Murph: no provider input builders, instructions, tools, or schemas changed.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Transaction-local Web refactor preserving persisted formats, lock namespaces, schemas, external protocols, and service boundaries. No migration or mixed-version contract change.

## Change-shape breakdown

Classification rule: production TypeScript is source, test files are tests, execution plan is docs. No binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 87 | 158 |
| Tests / fixtures | 199 | 211 |
| Docs | 93 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **379** | **369** |

## Changelog

- Changelog: not applicable
- Reason: Internal admission simplification preserving product behavior; production latency has not been remeasured.

ReviewGPT context sensitivity: sensitive
Classification reason: Transaction ordering, identity/routing authority, admission privacy, and shared binding repair.
ReviewGPT first-reviewed head: abdc01bd21df384cf7932bf4fb30a49c4ccc89b9

