### PR TITLE
Reduce empty runtime invocations and repeated sync inventory reads

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-06-runtime-callback-volume.md
+++ b/agent-docs/exec-plans/active/2026-09-06-runtime-callback-volume.md
@@ -1,0 +1,73 @@
+# Reduce redundant hosted runtime callbacks
+
+Status: active
+Created: 2026-09-06
+Updated: 2026-09-06
+
+## Outcome and invariants
+
+Reduce empty runtime recurrence and repeated Junction inventory/projection work.
+Accepted messages must remain runnable, schedule truth must converge through the
+existing checkpoint owner, and every canonical device import must retain current
+source authorization. No production data or identities belong in this plan.
+
+## Owners and evidence
+
+The workspace assistant phase derives wake state; the workspace checkpoint owns
+its durable projection. Inspection found stale-wake correction is requested on
+one maintenance exit but is not propagated through all empty exits. Reproduce
+that gap before changing it. This is not yet proof of the precise historical
+production trigger.
+
+DeviceSyncService owns each bounded worker drain. Junction currently reloads and
+projects inventory separately for resource jobs in that drain. Projection adds a
+hosted source read; canonical import authorization is an independent live read.
+
+## Design
+
+Reuse the existing projection-checkpoint request for disproved schedules. Keep
+real pending input and unavailable authority retryable. Add no retry scheduler.
+Give provider execution an explicit pass lifetime so Junction can reuse successful
+inventory/projection work within that bounded lifetime. Keep provider reuse keyed
+to connection/source lifecycle, discard failed work, and retain live import reads.
+No TTL, persisted cache, protocol migration, or production configuration change.
+
+## Tasks
+
+1. Add focused failing regressions for empty wake projection and duplicate inventory.
+2. Apply corrections at the current owners; exercise pending-input, failure,
+   disconnect/reconnect, and new-pass boundaries.
+3. Run affected suites, typechecks, complexity review, and required completion gates.
+4. Update owner documentation and commit the scoped change.
+
+## Verification
+
+Focused assistant phase and runtime checkpoint tests; Junction resource tests and
+service drain lifetime tests; both affected package typechecks. Inspect the final
+diff for architectural simplicity, authority preservation, and private data.
+Production percentage savings require a comparable post-release measurement and
+are not a unit-test or local completion claim.
+
+## Implementation and candidate evidence
+
+- Reproduced an empty assistant phase returning no projection-checkpoint request
+  after disproving a due default wake. The regression failed before the fix and
+  passes with both an empty schedule and a future cron wake. A second corrected
+  invocation does not request another correction. Entrypoint proof confirms the
+  checkpoint removes the obsolete default wake.
+- Added an optional provider pass executor at the existing worker-drain boundary.
+  Junction owns its resource inventory loader; live import authorization is
+  unchanged. Two ordinary resource jobs use one inventory and three source reads,
+  versus two inventories and four source reads with independent job execution.
+- Covered disconnect during provider fetch, reconnect/source epoch, connection
+  generation, failed authorization reads, independent passes, and historical work.
+- Assistant foreground/scheduling suites: 146 tests passed. Device-sync service,
+  resource, and source-reuse suites: 208 tests passed. Focused runner and entrypoint
+  checkpoint proofs passed. Both affected package typechecks passed.
+- Complexity guard passes with unchanged maximum complexity and debt. Existing
+  large functions remain; the added loader isolates inventory lifetime rather
+  than expanding the resource job or worker control flow.
+- Internal-only invocation/callback reduction; no member-visible copy, prompts,
+  tools, or UI change, so no public changelog or model-based reply proof applies.
+- Candidate review completed locally. Required external review and final-head CI
+  remain pending. No production deployment or percentage reduction is claimed.

--- a/agent-docs/exec-plans/completed/2026-09-06-runtime-callback-volume.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-runtime-callback-volume.md
@@ -1,6 +1,6 @@
 # Reduce redundant hosted runtime callbacks
 
-Status: active
+Status: completed
 Created: 2026-09-06
 Updated: 2026-09-06
 
@@ -71,3 +71,13 @@ are not a unit-test or local completion claim.
   tools, or UI change, so no public changelog or model-based reply proof applies.
 - Candidate review completed locally. Required external review and final-head CI
   remain pending. No production deployment or percentage reduction is claimed.
+
+## Final review
+
+ReviewGPT round 1 passed on `aa0740b9b9d89c4f522f5312b2bdab7ed687ea80`.
+The captured response hash and native model metadata were verified. It found no
+qualifying bugs or complexity collapse. Parent final review confirms no remaining
+source edits. This final plan-only commit does not change the reviewed behavior.
+Required PR checks are still running; merge, deployment, fleet convergence, and
+post-release percentage measurement are separate from this implementation.
+Completed: 2026-09-06

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -49,6 +49,11 @@ The live ownership split is:
   notifications remain excluded. Non-idempotent provider work still waits for
   the resulting durable checkpoint.
   Inherited or committed wakes and durability barriers remain checkpoint-first.
+  When the assistant phase disproves a persisted due default wake and finds an
+  empty maintenance frontier, it requests the existing projection-only checkpoint.
+  That checkpoint clears or advances the schedule even without application
+  progress. Future cron work remains projected; newly pending input and unavailable
+  scheduling authority retain their normal execution or retry paths.
   At the idle floor, or on shutdown, the runtime checkpoints remaining dirty
   state before returning success. When Cloudflare reports container activity
   expiry, the shell yields to any active foreground operation; otherwise it runs

--- a/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/workspace-assistant-phase.ts
@@ -5810,6 +5810,27 @@ function resolveDeferredPendingAssistantInputWakeAt(input: {
   ).toISOString();
 }
 
+async function resolveDisprovedDefaultWakeCheckpoint(input: {
+  phaseInput: HostedWorkspaceRuntimeAssistantPhaseInput;
+  readAssistantCronWakeState: () => Promise<HostedAssistantCronWakeState>;
+  requested: boolean;
+}): Promise<HostedWorkspaceRunnerAssistantPhaseResult | null> {
+  if (!input.requested) {
+    return null;
+  }
+  const wake = await resolveHostedBackgroundMaintenanceWakeCandidate({
+    assistantCronWake: resolveHostedAssistantCronWakeCandidate({
+      phaseInput: input.phaseInput,
+      state: await input.readAssistantCronWakeState(),
+    }),
+    input: input.phaseInput,
+  });
+  return withHostedRuntimeWakeCandidate({
+    result: { progressed: false, runtimeProjectionCheckpointRequested: true },
+    wake,
+  });
+}
+
 async function runSystemMailboxMaintenancePhase(input: {
   backgroundRouteActions?: readonly HostedSystemMailboxRouteAction[];
   backgroundWakeKinds?: readonly HostedExecutionSystemWake["kind"][];
@@ -6344,7 +6365,13 @@ async function runSystemMailboxMaintenancePhase(input: {
       deviceSyncMaintenanceRan: false,
       initialProviderCleanupCheckpoint,
       pendingAssistantInputWakeAt,
-      result: mergeMemberPreferencesPrePlanningResult(null),
+      result: mergeMemberPreferencesPrePlanningResult(
+        await resolveDisprovedDefaultWakeCheckpoint({
+          phaseInput,
+          readAssistantCronWakeState,
+          requested: staleDefaultProjectionDisproved,
+        }),
+      ),
     };
   }
   const systemMailboxDeliveryEffects =

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-foreground.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-assistant-phase-foreground.test.ts
@@ -1468,6 +1468,49 @@ describe("runHostedWorkspaceAssistantPhase runtime logs", () => {it("passes fore
     }
   });
 
+  it.each([null, "2026-04-28T00:00:00.000Z"])(
+    "checkpoints a disproved default wake with next cron wake %s",
+    async (nextRunAt) => {
+      mocks.getAssistantCronStatus.mockResolvedValue({
+        dueJobs: 0, enabledJobs: nextRunAt ? 1 : 0, nextRunAt, runningJobs: 0,
+        totalJobs: nextRunAt ? 1 : 0,
+      });
+      const staleWakeAt = "2026-04-26T23:59:00.000Z";
+      const result = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        assistantInputIds: [],
+        conversationImportedCount: 0,
+        importedCount: 0,
+        now: () => "2026-04-27T00:00:00.000Z",
+        workspace: createDueAssistantWorkspace({
+          nextDefaultProcessingWakeAt: staleWakeAt,
+          nextDefaultProcessingWakeReason: "assistant",
+          nextWakeAt: staleWakeAt,
+          nextWakeReason: "assistant",
+          systemMailboxProgressGeneration: "1",
+        }),
+      }));
+
+      expect(result).toMatchObject({
+        progressed: false,
+        runtimeProjectionCheckpointRequested: true,
+      });
+      expect(result.nextWakeAt ?? null).toBe(nextRunAt);
+      expect(mocks.runHostedAssistantAutomationLane).not.toHaveBeenCalled();
+      const nextResult = await runHostedWorkspaceAssistantPhase(createPhaseInput({
+        assistantInputIds: [], conversationImportedCount: 0, importedCount: 0,
+        now: () => "2026-04-27T00:00:00.000Z",
+        workspace: createDueAssistantWorkspace({
+          nextDefaultProcessingWakeAt: nextRunAt,
+          nextDefaultProcessingWakeReason: nextRunAt ? "assistant" : null,
+          nextWakeAt: nextRunAt,
+          nextWakeReason: nextRunAt ? "assistant" : null,
+          systemMailboxProgressGeneration: "1",
+        }),
+      }));
+      expect(nextResult.runtimeProjectionCheckpointRequested).not.toBe(true);
+    },
+  );
+
   it(
     "hands a model-free device frontier off after disproving a stale default projection",
     async () => {

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-scheduling.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-scheduling.test.ts
@@ -123,7 +123,58 @@ import {
   updateHostedSystemMailboxState,
 } from "../src/hosted-runtime/system-mailbox-state.ts";
 
-describe("hosted workspace runtime entrypoint", () => {test("reports mailbox budget exhaustion only after deferring an overflow item", async () => {
+describe("hosted workspace runtime entrypoint", () => {
+  test("persists a disproved default wake without claiming assistant progress", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-empty-default-wake-"));
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const events: string[] = [];
+    const staleWakeAt = "2026-04-01T00:00:00.000Z";
+    let assistantPasses = 0;
+    try {
+      await runHostedWorkspaceRuntimeJobInProcess(
+        createWorkspaceRuntimeJobInput({ request: { idleCheckpointDelayMs: 1 } }),
+        {
+          vaultRoot,
+          platform: createPlatform({
+            mailboxPort: createMailboxPort({ events, items: [] }),
+            workspacePort: createWorkspacePort({
+              checkpointRequests, events,
+              workspace: createWorkspaceState({
+                version: "0", nextWakeAt: staleWakeAt, nextWakeReason: "assistant",
+                nextDefaultProcessingWakeAt: staleWakeAt,
+                nextDefaultProcessingWakeReason: "assistant",
+                systemMailboxProgressGeneration: "1",
+              }),
+            }),
+          }),
+          async importItem() {
+            throw new Error("Empty mailbox must not import an item.");
+          },
+          async runAssistantPhase() {
+            assistantPasses += 1;
+            return assistantPasses === 1
+              ? { progressed: false, runtimeProjectionCheckpointRequested: true }
+              : { progressed: false };
+          },
+          async createCheckpointSnapshot() {
+            return { snapshotRef: createBundleRef({
+              hash: "c".repeat(64), size: 512,
+              key: "users/bundles/member-synthetic/empty-default.bundle.json",
+            }) };
+          },
+        },
+      );
+      assert.ok(checkpointRequests.length > 0);
+      for (const checkpoint of checkpointRequests) {
+        assert.notEqual(checkpoint.nextWakeAt, staleWakeAt);
+        assert.equal(checkpoint.nextDefaultProcessingWakeAt, null);
+        assert.equal(checkpoint.nextDefaultProcessingWakeReason, null);
+      }
+    } finally {
+      await removeTempRoot(vaultRoot);
+    }
+  });
+test("reports mailbox budget exhaustion only after deferring an overflow item", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const events: string[] = [];
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];

--- a/packages/device-syncd/README.md
+++ b/packages/device-syncd/README.md
@@ -465,3 +465,14 @@ Strava settings:
 # from the repo root
 node packages/device-syncd/dist/bin.js
 ```
+
+### Provider execution scope
+
+Each bounded worker drain creates an optional provider pass executor once, then
+releases it when the drain returns. Standalone worker calls get separate scopes.
+Junction reuses successful inventory and source projection across ordinary
+resource jobs in that scope, keyed by account identity, connection generation,
+and source lifecycle. Non-resource work, historical attempts, calendar repair, or any failed job
+discards that reuse; historical attempts and calendar repair load their own inventory. Every
+canonical import retains its live connection-source admission check. The scope
+contains provider inventory only, never cached authorization or durable state.

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -167,6 +167,7 @@ import type {
   DeviceSyncBackfillDiagnosticResult,
   DeviceSyncJobInput,
   DeviceSyncJobRecord,
+  DeviceJobExecutor,
   DeviceSyncProvider,
   DeviceSyncProviderRequestCandidateAliasSource,
   DeviceSyncRestDiagnosticContext,
@@ -1535,6 +1536,7 @@ export function createJunctionDeviceSyncProvider(
   async function executeJob(
     context: ProviderJobContext,
     job: DeviceSyncJobRecord,
+    resourceInventories?: Map<string, readonly JunctionProviderConnection[]>,
   ): Promise<ProviderJobResult> {
     const skippedOptionalResources: JunctionSkippedOptionalResource[] = [];
 
@@ -1567,6 +1569,7 @@ export function createJunctionDeviceSyncProvider(
         job,
         skippedOptionalResources,
         completedWorkoutStreamIdentities,
+        resourceInventories,
       );
     }
 
@@ -2491,11 +2494,59 @@ export function createJunctionDeviceSyncProvider(
     };
   }
 
+  function createResourceInventoryLoader(
+    context: ProviderJobContext,
+    job: DeviceSyncJobRecord,
+    resourceInventories?: Map<string, readonly JunctionProviderConnection[]>,
+  ) {
+    // Historical attempts and calendar repair require their own inventory read.
+    const inventoryKey = resourceInventories
+      && !readJunctionSparseCalendarRefreshDay(job)
+      && job.payload.historicalBackfill !== true
+      ? buildJunctionResourceInventoryKey(context)
+      : null;
+    if (!inventoryKey) {
+      resourceInventories?.clear();
+    }
+    const priorInventory = inventoryKey ? resourceInventories?.get(inventoryKey) : undefined;
+    let listedSourceProviders = priorInventory ?? null;
+    let projectedSourceProviders = priorInventory ?? null;
+    const loadSourceProviders = async (): Promise<readonly JunctionProviderConnection[]> => {
+      if (listedSourceProviders) {
+        return listedSourceProviders;
+      }
+
+      const sourceProviders = await measureJunctionProviderRequest(
+        context,
+        "inventory",
+        () => client.listUserProviders(context.account.externalAccountId, {
+          signal: context.signal ?? null,
+        }),
+      );
+      listedSourceProviders = sourceProviders;
+      return sourceProviders;
+    };
+    const loadAndProjectSourceProviders = async (): Promise<readonly JunctionProviderConnection[]> => {
+      if (projectedSourceProviders) {
+        return projectedSourceProviders;
+      }
+      const sourceProviders = await loadSourceProviders();
+      await projectJunctionSources(context, sourceProviders);
+      projectedSourceProviders = sourceProviders;
+      if (inventoryKey) {
+        resourceInventories?.set(inventoryKey, sourceProviders);
+      }
+      return sourceProviders;
+    };
+    return { loadSourceProviders, loadAndProjectSourceProviders };
+  }
+
   async function executeResourceJob(
     context: ProviderJobContext,
     job: DeviceSyncJobRecord,
     skippedOptionalResources: JunctionSkippedOptionalResource[],
     completedWorkoutStreamIdentities: ReadonlySet<string>,
+    resourceInventories?: Map<string, readonly JunctionProviderConnection[]>,
   ): Promise<ProviderJobResult> {
     const resourceName = normalizeString(job.payload.resource);
 
@@ -2576,32 +2627,8 @@ export function createJunctionDeviceSyncProvider(
     ) {
       return {};
     }
-    let listedSourceProviders: readonly JunctionProviderConnection[] | null = null;
-    let projectedSourceProviders: readonly JunctionProviderConnection[] | null = null;
-    const loadSourceProviders = async (): Promise<readonly JunctionProviderConnection[]> => {
-      if (listedSourceProviders) {
-        return listedSourceProviders;
-      }
-
-      const sourceProviders = await measureJunctionProviderRequest(
-        context,
-        "inventory",
-        () => client.listUserProviders(context.account.externalAccountId, {
-          signal: context.signal ?? null,
-        }),
-      );
-      listedSourceProviders = sourceProviders;
-      return sourceProviders;
-    };
-    const loadAndProjectSourceProviders = async (): Promise<readonly JunctionProviderConnection[]> => {
-      if (projectedSourceProviders) {
-        return projectedSourceProviders;
-      }
-      const sourceProviders = await loadSourceProviders();
-      await projectJunctionSources(context, sourceProviders);
-      projectedSourceProviders = sourceProviders;
-      return sourceProviders;
-    };
+    const { loadSourceProviders, loadAndProjectSourceProviders } =
+      createResourceInventoryLoader(context, job, resourceInventories);
 
     if (calendarRefreshDay) {
       if (
@@ -6107,8 +6134,42 @@ export function createJunctionDeviceSyncProvider(
     jobExecutor: {
       createScheduledJobs,
       executeJob,
+      createPassExecutor(): DeviceJobExecutor {
+        const resourceInventories = new Map<string, readonly JunctionProviderConnection[]>();
+        return {
+          async executeJob(context, job) {
+            if (job.kind !== "resource") {
+              resourceInventories.clear();
+            }
+            try {
+              return await executeJob(context, job, resourceInventories);
+            } catch (error) {
+              resourceInventories.clear();
+              throw error;
+            }
+          },
+        };
+      },
     },
   };
+}
+
+function buildJunctionResourceInventoryKey(context: ProviderJobContext): string {
+  const account = context.account;
+  return JSON.stringify([
+    account.id,
+    account.externalAccountId,
+    account.connectedAt,
+    account.disconnectGeneration,
+    context.connectionSourceAdmissionMode,
+    (account.sources ?? []).map((source) => [
+      source.sourceProviderSlug,
+      source.firstSeenAt,
+      source.lifecycleEpoch,
+      source.status,
+      source.lastErrorCode,
+    ]),
+  ]);
 }
 
 async function fetchJunctionTimeseriesWindow(

--- a/packages/device-syncd/src/service.ts
+++ b/packages/device-syncd/src/service.ts
@@ -888,6 +888,7 @@ class DeviceSyncServiceController {
     const result = await this.runWorkerPassOnce({
       accountId,
       importSession: createDeviceProviderSnapshotImportSession(),
+      providerExecutors: new Map(),
       maxJobRows: Number.POSITIVE_INFINITY,
     });
     return result?.job ?? null;
@@ -896,6 +897,7 @@ class DeviceSyncServiceController {
   private async runWorkerPassOnce(input: {
     accountId?: string;
     importSession: ReturnType<typeof createDeviceProviderSnapshotImportSession>;
+    providerExecutors: Map<string, DeviceJobExecutor>;
     maxJobRows: number;
   }): Promise<{
     job: DeviceSyncJobRecord;
@@ -1181,7 +1183,7 @@ class DeviceSyncServiceController {
 
     const disconnectGeneration = storedAccount.disconnectGeneration;
     const localConnectionRevision = storedAccount.localConnectionRevision;
-    const jobExecutor = resolveProviderJobExecutor(provider);
+    const jobExecutor = resolveProviderJobExecutor(provider, input.providerExecutors);
 
     if (!jobExecutor) {
       failClaimedJob(
@@ -1759,11 +1761,13 @@ class DeviceSyncServiceController {
     const maxJobRows = normalizeProviderJobBatchLimit(limit, this.workerBatchSize);
     let processedJobRows = 0;
     const importSession = createDeviceProviderSnapshotImportSession();
+    const providerExecutors = new Map<string, DeviceJobExecutor>();
 
     while (processedJobRows < maxJobRows) {
       const result = await this.runWorkerPassOnce({
         accountId,
         importSession,
+        providerExecutors,
         maxJobRows: maxJobRows - processedJobRows,
       });
 
@@ -2206,8 +2210,20 @@ function earliestIsoTimestamp(...values: Array<string | null | undefined>): stri
     .sort((left, right) => Date.parse(left) - Date.parse(right))[0] ?? null;
 }
 
-function resolveProviderJobExecutor(provider: DeviceSyncProvider): DeviceJobExecutor | undefined {
-  return provider.jobExecutor;
+function resolveProviderJobExecutor(
+  provider: DeviceSyncProvider,
+  passExecutors?: Map<string, DeviceJobExecutor>,
+): DeviceJobExecutor | undefined {
+  const executor = provider.jobExecutor;
+  if (!executor || !passExecutors) {
+    return executor;
+  }
+  let passExecutor = passExecutors.get(provider.provider);
+  if (!passExecutor) {
+    passExecutor = executor.createPassExecutor?.() ?? executor;
+    passExecutors.set(provider.provider, passExecutor);
+  }
+  return passExecutor;
 }
 
 function isValidProviderJobBatchDescriptor(

--- a/packages/device-syncd/src/types.ts
+++ b/packages/device-syncd/src/types.ts
@@ -1142,6 +1142,9 @@ export interface DeviceWebhookHandler {
 }
 
 export interface DeviceJobExecutor {
+  // Optional execution scope for one bounded worker drain. Never retains live
+  // authorization; a new drain or standalone worker call gets a fresh scope.
+  createPassExecutor?(): DeviceJobExecutor;
   createScheduledJobs?(
     account: StoredDeviceSyncAccount,
     now: string,

--- a/packages/device-syncd/test/junction-timeseries-source-reuse.test.ts
+++ b/packages/device-syncd/test/junction-timeseries-source-reuse.test.ts
@@ -91,3 +91,106 @@ test.each([
   assert.deepEqual(events, [...expectedEvents, ...expectedEvents]);
   assert.deepEqual(snapshots[1], snapshots[0]);
 });
+
+
+test("Junction resource pass shares inventory but reads live import authority for every job", async () => {
+  let inventoryReads = 0;
+  let sourceReads = 0;
+  let imports = 0;
+  let liveSource = createConnectionSource();
+  let disconnectDuringFetch = false;
+  let sourceReadFailure = false;
+  const sourceFailure = new Error("Synthetic live source read failed");
+  const provider = createJunctionProvider(async (input) => {
+    const url = new URL(readUrl(input));
+    if (url.pathname === "/v2/user/providers/junction-user-1") {
+      inventoryReads += 1;
+      return createJsonResponse({ providers: [{
+        slug: "garmin", name: "Garmin", status: "connected",
+        resource_availability: { blood_oxygen: true },
+      }] });
+    }
+    assert.equal(url.pathname, "/v2/timeseries/junction-user-1/blood_oxygen/grouped");
+    if (disconnectDuringFetch) {
+      liveSource = createConnectionSource({ status: "disconnected" });
+    }
+    return createJsonResponse({ groups: { garmin: [{
+      data: [{ timestamp: "2026-04-02T14:00:00.000Z", unit: "%", value: 97 }],
+      source: { provider: "garmin", type: "watch" },
+    }] } });
+  }, { summaryResources: [], timeseriesResources: ["blood_oxygen"] });
+  const context = createJunctionJobContext({
+    now: "2026-04-04T12:00:00.000Z",
+    account: createAccount({ sources: [{ ...liveSource, resourceCount: 1 }] }),
+    connectionSourceAdmissionMode: "listed_only",
+    listConnectionSources: async () => {
+      sourceReads += 1;
+      if (sourceReadFailure) throw sourceFailure;
+      return [liveSource];
+    },
+    importSnapshot: async () => { imports += 1; return { imported: true }; },
+  });
+  const job = createJob("resource", {
+    resource: "blood_oxygen", resourceCategory: "timeseries", sourceProviderSlug: "garmin",
+    windowEnd: "2026-04-03T00:00:00.000Z", windowStart: "2026-04-02T00:00:00.000Z",
+  });
+  assert.ok(provider.jobExecutor);
+  await provider.jobExecutor.executeJob(context, job);
+  await provider.jobExecutor.executeJob(context, job);
+  assert.equal(inventoryReads, 2);
+  assert.equal(sourceReads, 4);
+  assert.equal(imports, 2);
+  inventoryReads = 0;
+  sourceReads = 0;
+  imports = 0;
+
+  const pass = provider.jobExecutor.createPassExecutor?.() ?? provider.jobExecutor;
+  await pass.executeJob(context, job);
+  await pass.executeJob(context, job);
+  assert.equal(inventoryReads, 1);
+  assert.equal(sourceReads, 3); // one projection plus two live import reads
+  assert.equal(imports, 2);
+
+  disconnectDuringFetch = true;
+  await pass.executeJob(context, job);
+  assert.equal(inventoryReads, 1);
+  assert.equal(sourceReads, 4);
+  assert.equal(imports, 2);
+
+  disconnectDuringFetch = false;
+  liveSource = createConnectionSource({ firstSeenAt: "2026-04-04T00:00:00.000Z", lifecycleEpoch: 2 });
+  context.account.sources = [{ ...liveSource, resourceCount: 1 }];
+  await pass.executeJob(context, job);
+  assert.equal(inventoryReads, 2);
+  assert.equal(sourceReads, 6);
+  assert.equal(imports, 3);
+
+  const nextPass = provider.jobExecutor.createPassExecutor?.() ?? provider.jobExecutor;
+  await nextPass.executeJob(context, job);
+  assert.equal(inventoryReads, 3);
+  assert.equal(sourceReads, 8);
+  assert.equal(imports, 4);
+
+  sourceReadFailure = true;
+  await assert.rejects(nextPass.executeJob(context, job), (error) => error === sourceFailure);
+  assert.equal(imports, 4);
+  sourceReadFailure = false;
+  await nextPass.executeJob(context, job);
+  assert.equal(inventoryReads, 4);
+  assert.equal(sourceReads, 11);
+  assert.equal(imports, 5);
+
+  context.account.disconnectGeneration += 1;
+  await nextPass.executeJob(context, job);
+  assert.equal(inventoryReads, 5);
+  assert.equal(imports, 6);
+
+  const historicalJob = { ...job, payload: { ...job.payload, historicalBackfill: true } };
+  await nextPass.executeJob(context, historicalJob);
+  await nextPass.executeJob(context, historicalJob);
+  assert.equal(inventoryReads, 7);
+  assert.equal(imports, 8);
+  await nextPass.executeJob(context, job);
+  assert.equal(inventoryReads, 8);
+  assert.equal(imports, 9);
+});

--- a/packages/device-syncd/test/service.test.ts
+++ b/packages/device-syncd/test/service.test.ts
@@ -6720,6 +6720,50 @@ test("device sync service counts provider batch rows against drainWorker limits"
   close();
 });
 
+test("device sync scopes provider execution to each drain and standalone worker call", async () => {
+  const vaultRoot = await makeTempDirectory("murph-device-syncd-provider-pass");
+  const scopes: number[] = [];
+  let scopeCount = 0;
+  const provider = createFakeProvider();
+  assert.ok(provider.jobExecutor);
+  provider.jobExecutor.createPassExecutor = () => {
+    const scope = ++scopeCount;
+    return { async executeJob() { scopes.push(scope); return {}; } };
+  };
+  const { service, store, close } = createServiceFixture({
+    secret: "secret-for-tests",
+    config: {
+      vaultRoot, publicBaseUrl: "https://sync.example.test/device-sync",
+      stateDatabasePath: path.join(vaultRoot, ".runtime", "device-syncd.sqlite"),
+    },
+    providers: [provider],
+  });
+  const account = store.upsertAccount({
+    provider: "demo", externalAccountId: "demo-pass", displayName: "Demo",
+    scopes: [], tokens: {
+      accessToken: "pass-token",
+      accessTokenEncrypted: encryptStoredAccessToken("demo", "demo-pass", "pass-token"),
+    },
+    connectedAt: "2026-03-17T10:00:00.000Z",
+  });
+  try {
+    for (let index = 0; index < 5; index += 1) {
+      store.enqueueJob({
+        accountId: account.id, provider: "demo", kind: "resource",
+        payload: { resource: `resource-${index}` }, availableAt: "2026-03-17T10:00:00.000Z",
+      });
+    }
+    assert.equal(await service.drainWorker(2, account.id), 2);
+    assert.equal(await service.drainWorker(1, account.id), 1);
+    await service.runWorkerOnce(account.id);
+    await service.runWorkerOnce(account.id);
+    assert.deepEqual(scopes, [1, 1, 2, 3, 4]);
+    assert.equal(scopeCount, 4);
+  } finally {
+    close();
+  }
+});
+
 test("device sync drain shares one bounded import session and reports cumulative progress", async () => {
   const vaultRoot = await makeTempDirectory("murph-device-syncd-import-session");
   const importSessions: unknown[] = [];


### PR DESCRIPTION
## Why and outcome

An empty assistant pass could disprove a persisted due default wake and return without checkpointing that correction, leaving reconciliation free to launch it again. The empty maintenance exit now uses the existing projection checkpoint to clear or advance the wake. Future cron work is preserved, and a corrected invocation does not request another correction.

Junction resource jobs in one worker drain separately loaded and projected the same inventory. An optional provider pass executor now gives Junction a bounded reuse lifetime. Compatible ordinary jobs share successful inventory/projection work while every import retains its live source authorization read. Reconnects, changed source lifecycle, failed jobs, historical/repair work, and new passes invalidate or bypass reuse.

## Product UX

- Effort: Not applicable — internal scheduling and callback reduction.
- Result: Ready for review; production savings remain unmeasured.
- Walkthrough: Empty work remains quiet. Real pending messages, future schedules, and disconnect fences keep their existing owners.

## Evidence

Final ReviewGPT round 1: PASS on `aa0740b9b9d89c4f522f5312b2bdab7ed687ea80`; native model metadata and response hash verified. Final head `8e6a30fcc0cd7ea0e70427699c6109bf1f4c0dcd` adds only the closed execution plan; reviewed source is unchanged. Required CI is tracked on the final head.

- Assistant foreground/scheduling suites: 146 tests passed. Focused runner and entrypoint proofs confirm projection-only work becomes dirty and commits a cleared default wake.
- Device-sync service/resource/source-reuse suites: 208 tests passed. The focused source-reuse regression also covers authority-read failure, source epoch and connection generation changes, and historical bypass.
- Synthetic two-job comparison: independent execution makes two inventory requests and four source reads; pass execution makes one inventory request and three source reads, with identical two imports. Disconnect during provider fetch suppresses the next import.
- Both affected package typechecks and `pnpm complexity:diff` passed.
- Direct commands: `pnpm --filter @murphai/assistant-runtime test test/hosted-runtime-workspace-assistant-phase-foreground.test.ts test/hosted-runtime-workspace-assistant-phase-scheduling.test.ts`; focused runner and entrypoint tests; `pnpm --filter @murphai/device-syncd test test/service.test.ts test/junction-timeseries-source-reuse.test.ts test/junction-provider-resources.test.ts`; each package's `typecheck`.

## Non-obvious affected surfaces

Standalone device-sync workers receive a fresh scope per call. Providers without the optional factory retain their current executor. Batch limits and between-job foreground yielding are covered by service tests.

## Architecture and reuse

- Existing systems reused: workspace wake derivation/checkpoint, bounded worker drain, provider executor, Junction inventory projection, live import admission.
- New logic: persist an already-proven idle schedule correction; reuse successful ordinary-resource inventory within a pass.
- New abstractions: optional `createPassExecutor` on the existing provider executor, with scope owned by the worker drain and data owned by Junction.
- Complexity intentionally avoided: no TTL, durable cache, database/schema change, retry scheduler, queue, or additional authorization owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: existing assistant maintenance, Junction resource execution, and worker execution remain large. Maximum complexity and debt do not increase; inventory loading has one cohesive owner.
- Agent judgment: a wider runtime/provider refactor would expand this correction beyond the reproduced behavior.

## Hot reply path impact

No new foreground I/O. Schedule correction applies only after maintenance disproves the due default wake and finds no pending assistant input. Worker resource imports keep current live checks and the existing yield boundaries. For N compatible resource jobs with imports, projection/source reads fall from 2N to N+1; provider inventory calls fall from N to 1. Existing additional resource-specific authority checks remain.

## Initial provider input

Unchanged — no prompts, tools, schemas, conversation context, or provider-visible assistant input changed. No token measurement or live-model reply proof applies to this deterministic scheduling correction.

## Deployment concerns

- Deployment: applicable
- Supported skew: existing Web/Worker/runtime wire protocols and persisted schemas are unchanged; old and new runners can coexist.
- Safe order: normal runtime release; no paired Web, Temporal, or database deployment is required.
- Rollback floor: the prior runtime remains compatible with all persisted state.
- Expected exposure: hosted default invocations and ordinary Junction resource jobs; other providers retain current behavior.
- Reversibility: ordinary code rollback; no migration or cache cleanup.
- Convergence proof: existing runner release pipeline must confirm the new runtime source SHA across the fleet; local proof does not establish fleet convergence.
- Post-deploy checks: compare equal six-hour windows for empty default invocations, source snapshot callbacks, processed resource jobs, and source-admission errors. Do not claim a percentage reduction before this measurement.

## Changelog

- Changelog: not applicable
- Reason: Internal invocation efficiency with no new member-facing behavior or copy.

ReviewGPT context sensitivity: sensitive
Classification reason: hosted schedule persistence and provider execution lifetime across interacting owners, with live authorization invariants.

## Change-shape breakdown

Authored source, synthetic tests, and owner/plan Markdown by path; no binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 137 | 30 |
| Tests / fixtures | 242 | 1 |
| Docs | 99 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |

ReviewGPT first-reviewed head: aa0740b9b9d89c4f522f5312b2bdab7ed687ea80
