### PR TITLE
Expose saved personal patterns to the iOS companion

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-06-ios-home-patterns.md
+++ b/agent-docs/exec-plans/completed/2026-09-06-ios-home-patterns.md
@@ -1,0 +1,30 @@
+# Patterns on iOS Home
+
+## Outcome and ownership
+
+Members read the existing Personal Patterns report on iOS Home, including comparison evidence. The query and Browser Vault remain canonical; native renders a bounded in-memory report. No native calculation or persistence. Existing setup, Health sync, consent recovery, Meals, and Settings remain available.
+
+## Implementation
+
+- Add a bearer-authenticated companion reader using existing member/consent authority and Browser Vault decoding. Return only the saved report and freshness. No refresh wake or database write.
+- Render factors, outcomes, grades, and evidence details natively after initial setup on Home.
+- Fence native reads at the session epoch and clear private presentation on teardown.
+
+## Journeys and proof
+
+Established member with results; sparse/empty report; missing replica; loading and retry; stale report; consent/access loss and delayed completion after sign-out; first-run setup; light/dark and large text. Focused route/decoder tests, native session/API/model tests, Swift simulator build/tests and screenshots, parent review. Backend must deploy before native release; older backend returns a retryable unavailable state. Product UX remains Hold until composed proof is available.
+
+## Progress
+
+- Implemented backend reader and native Home matrix/evidence sheet in isolated branches.
+- Backend: 24 Browser Vault decoder tests and 5 route tests pass; Web typecheck, focused ESLint, complexity guard, and diff whitespace pass.
+- Native: simulator build/typecheck, 43 API/session tests, 3 presentation model tests, and 2 simulator UI journeys pass. SwiftFormat lint passes.
+- Independent local review found one null-grade/no-clear-pattern presentation issue; corrected and independently verified with a focused regression test.
+- Simulator journeys cover populated Home, comparison sheet, empty state, and retry. Final dark/accessibility-large captures inspected; matrix, evidence, empty, and retry states remain usable.
+- Product UX: local native flows are Ready. Production-authenticated native-to-backend integration and release remain unverified; deploy the additive backend reader before the native consumer. No schema migration or Worker rollout is required.
+- Changelog decision: this local implementation has not shipped. Do not claim App Store availability. Native release wording: “Explore your personal patterns from Home. See how your activities relate to sleep and recovery, with the evidence behind each result.”
+- Complexity: shared decoder extraction reduces the existing loader complexity by one; remaining loader hotspots are unchanged owners. No native calculation, persistence, dependencies, or extra tab.
+
+Status: completed
+Updated: 2026-09-06
+Completed: 2026-09-06

--- a/agent-docs/product-specs/personal-patterns.md
+++ b/agent-docs/product-specs/personal-patterns.md
@@ -147,6 +147,19 @@ comparison dates needed to inspect the result.
 An empty report says that Murph needs more comparable data. The page does not
 start a calculation. It reads the latest Browser Vault report.
 
+## Native Home projection
+
+The iOS Home screen reads the saved report through bearer-authenticated
+`GET /api/device-sync/companion/patterns`. This reader checks current active
+member access and launch consent before opening the Browser Vault core shard
+and again before disclosing the report. It reuses Browser Vault member binding,
+key unwrap, bounded decoding, and schema validation. The response contains only
+`report` and `freshness`, uses `Cache-Control: no-store`, and never includes raw
+source records. Missing reports return `report: null`; the reader does not wake
+a runtime or start a calculation. Native retains presentation only in memory.
+Deploy this additive reader before the native release. Existing Web consumers
+remain unchanged; an older backend leaves the native section retryable.
+
 ## Proactive messages
 
 The managed Personal Patterns automation checks each day at 13:00 local time.

--- a/apps/web/app/api/device-sync/companion/patterns/route.ts
+++ b/apps/web/app/api/device-sync/companion/patterns/route.ts
@@ -1,0 +1,61 @@
+import { isCloudflareHostedControlBrowserVaultReplicaNotFoundError } from "@murphai/cloudflare-hosted-control/client";
+import { assessBrowserVaultReplicaFreshness } from "@murphai/hosted-execution";
+import { parseHostedBrowserVaultReplicaRef } from "@murphai/hosted-execution/parsers";
+import { generateHostedUserRecipientKeyPair } from "@murphai/runtime-state";
+
+import { assertBrowserVaultMemberAuthority } from "@/src/lib/browser-vault/authority";
+import { decodeReadyBrowserVaultSession, parseBrowserVaultSessionResponse } from "@/src/lib/browser-vault/loader";
+import { readHostedExecutionControlClientIfConfigured } from "@/src/lib/hosted-execution/control";
+import { requireActivePrivyMemberAuthFromBearerToken } from "@/src/lib/hosted-onboarding/request-auth";
+import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
+import { jsonOk, withJsonError } from "@/src/lib/hosted-onboarding/http";
+import { readHostedWorkspace } from "@/src/lib/hosted-workspace/store";
+import { getPrisma } from "@/src/lib/prisma";
+
+// Read the same saved query result as /patterns. No runtime wake, calculation,
+// persistence, or raw source records in the native response.
+export const GET = withJsonError(async (request: Request) => {
+  const prisma = getPrisma();
+  const auth = await requireActivePrivyMemberAuthFromBearerToken(request, prisma);
+  await assertBrowserVaultMemberAuthority({ memberId: auth.member.id, prisma });
+  const workspace = await readHostedWorkspace({ userId: auth.member.id });
+  const replicaRef = parseHostedBrowserVaultReplicaRef(
+    workspace?.browserVaultReplicaRef ?? null,
+    "Companion Patterns replica ref",
+  );
+  if (!replicaRef) return jsonOk({ report: null, freshness: "stale" });
+  const control = readHostedExecutionControlClientIfConfigured();
+  if (!control) {
+    throw hostedOnboardingError({ code: "HOSTED_EXECUTION_CONTROL_NOT_CONFIGURED", message: "Patterns is temporarily unavailable.", httpStatus: 503 });
+  }
+  const keys = await generateHostedUserRecipientKeyPair();
+  try {
+    const session = parseBrowserVaultSessionResponse({
+      ...await control.createBrowserVaultSession({
+        browserPublicKeyJwk: keys.publicKeyJwk,
+        replicaRef,
+        requestedShards: ["core"],
+        userId: auth.member.id,
+      }),
+      freshness: assessBrowserVaultReplicaFreshness({ now: new Date().toISOString(), replicaRef }).freshness,
+      refreshPending: false,
+      deviceSyncImportPending: false,
+      workspaceVersion: workspace?.version ?? null,
+    });
+    if (session.state !== "ready") return jsonOk({ report: null, freshness: "stale" });
+    const loaded = await decodeReadyBrowserVaultSession({
+      session,
+      privateKeyJwk: keys.privateKeyJwk,
+      expectedMemberId: auth.member.id,
+      signal: request.signal,
+    });
+    // Recheck live access after the external read and before disclosing health data.
+    await assertBrowserVaultMemberAuthority({ memberId: auth.member.id, prisma });
+    return jsonOk({ report: loaded.client.replica.personalPatterns ?? null, freshness: session.freshness });
+  } catch (error) {
+    if (isCloudflareHostedControlBrowserVaultReplicaNotFoundError(error)) {
+      return jsonOk({ report: null, freshness: "stale" });
+    }
+    throw error;
+  }
+});

--- a/apps/web/src/lib/browser-vault/loader.ts
+++ b/apps/web/src/lib/browser-vault/loader.ts
@@ -7,6 +7,7 @@ import {
   unwrapHostedBrowserSessionKey,
   type HostedBrowserSessionKeyEnvelope,
   type HostedCipherEnvelope,
+  type HostedUserRecipientPrivateKeyJwk,
 } from "@murphai/runtime-state";
 import {
   BROWSER_VAULT_CORE_SHARD_SCHEMA,
@@ -268,6 +269,36 @@ export async function loadBrowserVaultReplica({
     };
   }
 
+  return decodeReadyBrowserVaultSession({
+    session, privateKeyJwk, expectedMemberId: responseMemberId,
+    knownReplicaRef, knownReplicaShards, requestedMetricBuckets, requestedShards, signal,
+  });
+}
+
+/** Shared authenticated replica decoding for browser and companion readers. */
+export async function decodeReadyBrowserVaultSession({
+  session,
+  privateKeyJwk,
+  expectedMemberId,
+  knownReplicaRef = null,
+  knownReplicaShards = null,
+  requestedMetricBuckets = [],
+  requestedShards = ["core"],
+  signal,
+}: {
+  session: Extract<BrowserVaultSessionResponse, { state: "ready" }>;
+  privateKeyJwk: HostedUserRecipientPrivateKeyJwk;
+  expectedMemberId: string;
+  knownReplicaRef?: HostedBrowserVaultReplicaRef | null;
+  knownReplicaShards?: BrowserVaultReplicaShardSelection | null;
+  requestedMetricBuckets?: readonly BrowserVaultMetricBucketId[];
+  requestedShards?: readonly BrowserVaultReplicaShard[];
+  signal?: AbortSignal;
+}): Promise<Extract<BrowserVaultSessionLoadResult, { state: "ready" }>> {
+  const responseMemberId = getReadySessionMemberId(session);
+  if (responseMemberId !== expectedMemberId) {
+    throw new Error("Browser vault session member did not match the authorized member.");
+  }
   const replicaKey = await unwrapHostedBrowserSessionKey({
     envelope: session.replicaKeyEnvelope,
     recipientPrivateKeyJwk: privateKeyJwk,

--- a/apps/web/test/browser-vault-loader.test.ts
+++ b/apps/web/test/browser-vault-loader.test.ts
@@ -32,6 +32,7 @@ vi.mock("@murphai/runtime-state", async () => {
 
 import {
   createBrowserVaultRouteQueryClient,
+  decodeReadyBrowserVaultSession,
   isBrowserVaultAbortError,
   isBrowserVaultUnauthorizedError,
   loadBrowserVaultReplica,
@@ -48,6 +49,18 @@ beforeEach(() => {
   });
   runtimeMocks.unwrapHostedBrowserSessionKey.mockReset();
   runtimeMocks.unwrapHostedBrowserSessionKey.mockResolvedValue(new Uint8Array([1, 2, 3]));
+});
+
+test("companion decode rejects another member before private key unwrap", async () => {
+  const fixture = createShardedReadyFixture(["core"]);
+  const session = parseBrowserVaultSessionResponse(await fixture.response.json());
+  assert.equal(session.state, "ready");
+  if (session.state !== "ready") return;
+  const keys = await import("@murphai/runtime-state").then((runtime) => runtime.generateHostedUserRecipientKeyPair());
+  await assert.rejects(decodeReadyBrowserVaultSession({
+    session, privateKeyJwk: keys.privateKeyJwk, expectedMemberId: "different_member",
+  }), /did not match the authorized member/u);
+  assert.equal(runtimeMocks.unwrapHostedBrowserSessionKey.mock.calls.length, 0);
 });
 
 test("route query construction ignores loaded capabilities outside the route demand", async () => {

--- a/apps/web/test/device-sync-companion-patterns-route.test.ts
+++ b/apps/web/test/device-sync-companion-patterns-route.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
+
+vi.mock("server-only", () => ({}));
+const mocks = vi.hoisted(() => ({ auth: vi.fn(), authority: vi.fn(), workspace: vi.fn(), control: vi.fn(), decode: vi.fn() }));
+vi.mock("@/src/lib/prisma", () => ({ getPrisma: () => ({}) }));
+vi.mock("@/src/lib/hosted-onboarding/request-auth", () => ({ requireActivePrivyMemberAuthFromBearerToken: mocks.auth }));
+vi.mock("@/src/lib/browser-vault/authority", () => ({ assertBrowserVaultMemberAuthority: mocks.authority }));
+vi.mock("@/src/lib/hosted-workspace/store", () => ({ readHostedWorkspace: mocks.workspace }));
+vi.mock("@/src/lib/hosted-execution/control", () => ({ readHostedExecutionControlClientIfConfigured: () => ({ createBrowserVaultSession: mocks.control }) }));
+vi.mock("@/src/lib/browser-vault/loader", () => ({
+  parseBrowserVaultSessionResponse: (value: unknown) => value,
+  decodeReadyBrowserVaultSession: mocks.decode,
+}));
+import { GET } from "../app/api/device-sync/companion/patterns/route";
+
+const replicaRef = {
+  byteLength: 128, dataVersion: "d".repeat(64), generatedAt: "2026-04-20T08:00:00.000Z",
+  keyId: "browser-vault-replica:d", objectKey: "users/browser-vault-replicas/opaque/replica.json",
+  replicaSchema: "murph.browser-vault-replica", runtimeRootKeyId: "udrk:runtime:test-root",
+  schema: "murph.hosted-browser-vault-replica-ref.v1", sourceBundleHash: "a".repeat(64),
+};
+const request = () => new Request("https://app.example.test/api/device-sync/companion/patterns?memberId=someone-else");
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.auth.mockResolvedValue({ member: { id: "member_native" } });
+  mocks.authority.mockResolvedValue(undefined);
+  mocks.workspace.mockResolvedValue({ browserVaultReplicaRef: replicaRef, version: "v1" });
+  mocks.control.mockResolvedValue({ state: "ready" });
+  mocks.decode.mockResolvedValue({ client: { replica: { personalPatterns: { factors: [], cells: [] }, privateNotes: ["must not leave reader"] } } });
+});
+
+it("returns only the saved report with no-store and derives identity from bearer auth", async () => {
+  const response = await GET(request());
+  expect(response.status).toBe(200);
+  expect(response.headers.get("cache-control")).toContain("no-store");
+  expect(await response.json()).toEqual({ report: { factors: [], cells: [] }, freshness: "stale" });
+  expect(mocks.control).toHaveBeenCalledWith(expect.objectContaining({ userId: "member_native", requestedShards: ["core"] }));
+  expect(mocks.decode).toHaveBeenCalledWith(expect.objectContaining({ expectedMemberId: "member_native" }));
+  expect(mocks.authority).toHaveBeenCalledTimes(2);
+});
+
+it("does not fetch ciphertext without current member consent", async () => {
+  mocks.authority.mockRejectedValue(hostedOnboardingError({ code: "HOSTED_CONSENT_REQUIRED", message: "Consent required.", httpStatus: 403 }));
+  expect((await GET(request())).status).toBe(403);
+  expect(mocks.workspace).not.toHaveBeenCalled();
+  expect(mocks.control).not.toHaveBeenCalled();
+});
+
+it("does not disclose a report after access is revoked during the external read", async () => {
+  mocks.authority.mockResolvedValueOnce(undefined).mockRejectedValueOnce(hostedOnboardingError({ code: "HOSTED_CONSENT_REQUIRED", message: "Consent required.", httpStatus: 403 }));
+  const response = await GET(request());
+  expect(response.status).toBe(403);
+  expect(await response.text()).not.toContain("factors");
+});
+
+it("returns unavailable without starting a runtime or calculation when no replica exists", async () => {
+  mocks.workspace.mockResolvedValue(null);
+  const response = await GET(request());
+  expect(await response.json()).toEqual({ report: null, freshness: "stale" });
+  expect(mocks.control).not.toHaveBeenCalled();
+});
+
+it("stops before workspace access when authentication fails", async () => {
+  mocks.auth.mockRejectedValue(hostedOnboardingError({ code: "UNAUTHORIZED", message: "Sign in required.", httpStatus: 401 }));
+  expect((await GET(request())).status).toBe(401);
+  expect(mocks.authority).not.toHaveBeenCalled();
+  expect(mocks.workspace).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Why and outcome

Let the iOS Home screen read the member's saved Personal Patterns report through Privy bearer authentication. Return only the report and freshness from the existing Browser Vault core projection.

Native consumer: https://github.com/cobuildwithus/murph-ios/pull/147 at `e204dcb787f8c2c5d53c9d0bfe865eb510ac1417`. Its latest evidence presentation update passed local model and light/dark simulator checks, both hosted checks, and independently validated ReviewGPT round 5 with no qualifying findings. Both PRs are unmerged and unreleased. Deploy this reader before releasing the native consumer.

## Product UX

- Effort: Feature support for native Home; no hosted Web UI changes.
- Result: Ready for review; live production native-to-backend integration remains unverified.
- Walkthrough: Current member and consent checks precede workspace access; authority is rechecked after the external read. Missing replicas return an empty stale report; revoked access returns the existing typed failure.

## Evidence

- Direct: `pnpm --dir apps/web test:prepared browser-vault-loader.test.ts device-sync-companion-patterns-route.test.ts` passed 29 tests; Web typecheck and focused ESLint passed during implementation.
- Coverage: Bearer-owned identity, consent denial before ciphertext access, revocation during external reads, missing replicas, authentication failure, shared decoder member validation, and no-store responses. Native separately covers decoding and session teardown; real production Privy-to-replica integration is not claimed.

## Non-obvious affected surfaces

The browser loader now calls the extracted ready-session decoder. Its existing 24 decoder tests pass. The extraction preserves shard, decryption, and member-binding validation.

## Architecture and reuse

- Existing systems reused: Active Privy member auth, Browser Vault authority, hosted workspace replica reference, control client, freshness assessment, and JSON error/cache policy.
- New logic: A read-only companion route selects the saved core report and rechecks current authority before disclosure.
- New abstractions: Extract the existing ready-session decoding block for both browser and native readers; no new state owner.
- Complexity intentionally avoided: No runtime wake, report calculation, database write, schema migration, persistent cache, or raw-source response.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`; route maximum 11; loader debt decreases from 26 to 25.
- Hotspots: Existing `loadBrowserVaultReplica` 43 and `loadShardedBrowserVaultReplica` 22; extraction reduces the former by one and leaves the latter unchanged.
- Agent judgment: Keep the established decoder and its invariants together; further splitting is not needed for this route.

## Hot reply path impact

- Path status: Not applicable; explicit companion GET outside message acceptance and reply handling.
- Database calls: None added to the reply path.
- Network/provider calls: None added to the reply path.
- Other awaited latency: None added to the reply path.
- Before/after proof: Only the companion route and shared replica decoder change.

## Murph initial provider input impact

Not applicable to individual or group Murph: no prompt, tool, routing, or provider-request changes. No input-token measurement claimed.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing native builds do not call this additive endpoint. New native builds against an older Web backend show a retryable unavailable state.
- Safe order: Deploy this reader before the native consumer in iOS PR #147.
- Rollback floor: No persisted shape changes; older Web removes the endpoint and causes native unavailable/retry behavior.
- Expected exposure: Requests during Web rollout may reach an old instance until convergence; there is no Worker/container protocol change.
- Reversibility: The endpoint is read-only and introduces no migration or write to undo.
- Convergence proof: Not deployed in this task; independently verify the Web version before native release.
- Post-deploy checks: Verify authenticated access, consent rejection, report freshness and no-store; inspect bounded endpoint error counts.

## Change-shape breakdown

Classification: route and loader are source; Vitest files are tests; owner spec and completed plan are docs. No binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 92 | 0 |
| Tests / fixtures | 82 | 0 |
| Docs | 43 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **217** | **0** |

## Changelog

- Changelog: not applicable
- Reason: Additive backend support for an unreleased native consumer; native release notes will announce availability when shipped.

ReviewGPT first-reviewed head: 428f51a12afb8a81a7fb432e7cb9da4aa8e0ba7e
ReviewGPT context sensitivity: sensitive
Classification reason: Authenticated health-data reader and shared decryption boundary.


## Final review

ReviewGPT round 1: PASS on `428f51a12afb8a81a7fb432e7cb9da4aa8e0ba7e`; no findings accepted or rejected and no remediation. The full snapshot review traced member/consent authority, report-only disclosure, and shared decoder invariants. Exact response hash and committed-turn identity match; selected and response model both `gpt-6-pro` on Eragon. Capture exceeded the required 270-second minimum. Review artifact was substantive for this bounded route/decoder extraction; tests were inspected by review, with execution supplied by local proof and CI.
