### PR TITLE
Diagnose missing Postgres connection-state telemetry

### DIFF
--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -311,6 +311,13 @@ without inventing a named state or discarding other states. This follows
 An absent primary family stays unknown; PgBouncer pool labels still require a
 nonempty value.
 
+Missing Postgres-state warnings include one `postgresStateSeries` entry per
+successfully parsed scrape, in collection order. Each entry counts series for
+the configured branch, split into primary, replica, and missing or unrecognized
+roles. Zero branch series distinguishes provider omission from unusable primary
+provenance. These diagnostics contain no label values or raw metrics, add no
+provider calls, and do not change paging or persisted samples.
+
 Discovery selects exactly one target by organization, database name, and branch
 name. The configured branch ID then filters the selected Prometheus payload's
 metric series. Both selectors are required because one organization can have

--- a/apps/cloudflare/src/database-health/metrics.ts
+++ b/apps/cloudflare/src/database-health/metrics.ts
@@ -73,6 +73,12 @@ export interface DatabaseMetricObservationSnapshot {
 
 export interface DatabaseMetricObservation {
   missingMetrics: readonly DatabaseHealthRequiredMetricName[];
+  postgresStateSeries: {
+    branch: number;
+    primary: number;
+    replica: number;
+    unrecognizedRole: number;
+  };
   snapshot: DatabaseMetricObservationSnapshot;
 }
 
@@ -329,6 +335,7 @@ export function parsePlanetScaleDatabaseMetricObservation(
   );
   return {
     missingMetrics,
+    postgresStateSeries: summarizePostgresStateSeries(points),
     snapshot: {
       clientWaitSeconds: clientWaitPoints.length === 0
         ? null
@@ -627,6 +634,25 @@ function parsePrometheusLabels(value: string): Readonly<Record<string, string>> 
     offset += 1;
   }
   return labels;
+}
+
+function summarizePostgresStateSeries(
+  points: readonly PrometheusMetricPoint[],
+): DatabaseMetricObservation["postgresStateSeries"] {
+  const counts = { branch: 0, primary: 0, replica: 0, unrecognizedRole: 0 };
+  for (const point of points) {
+    if (point.name !== "planetscale_postgres_connection_state") {
+      continue;
+    }
+    counts.branch += 1;
+    const role = point.labels[ROLE_LABEL];
+    if (role === "primary" || role === "replica") {
+      counts[role] += 1;
+    } else {
+      counts.unrecognizedRole += 1;
+    }
+  }
+  return counts;
 }
 
 function isPrimaryMetricPoint(point: PrometheusMetricPoint): boolean {

--- a/apps/cloudflare/src/database-health/monitor.ts
+++ b/apps/cloudflare/src/database-health/monitor.ts
@@ -235,6 +235,7 @@ type DatabaseHealthCollectedSample =
 
 interface DatabaseMetricCollection {
   attempts: number;
+  postgresStateSeries: readonly DatabaseMetricObservation["postgresStateSeries"][];
   connectionErrorCounterBaseline: Record<string, number>;
   connectionErrorDeltas: DatabaseConnectionErrorDeltas | null;
   connectionErrorEvidence: DatabaseConnectionErrorCollectionEvidence;
@@ -343,6 +344,7 @@ export class DatabaseHealthMonitor {
     try {
       const {
         attempts,
+        postgresStateSeries,
         connectionErrorCounterBaseline,
         connectionErrorDeltas,
         connectionErrorEvidence,
@@ -374,6 +376,9 @@ export class DatabaseHealthMonitor {
         }
         console.warn("Database health metrics collection failed.", {
           attempts,
+          ...(monitoringMissingMetrics.includes("planetscale_postgres_connection_state")
+            ? { postgresStateSeries }
+            : {}),
           connectionErrorEvidence,
           failureCode: "required_metrics_missing",
           failures,
@@ -1519,6 +1524,9 @@ function buildDatabaseMetricCollection(input: {
   });
   return {
     attempts: input.attempts,
+    postgresStateSeries: input.parsedObservations.map(
+      (observation) => observation.postgresStateSeries,
+    ),
     connectionErrorCounterBaseline: connectionErrorState.baseline,
     connectionErrorDeltas: connectionErrorState.deltas,
     connectionErrorEvidence: {
@@ -1661,6 +1669,7 @@ function composeRecoveredConnectionErrorObservation(input: {
   }
   return {
     missingMetrics: [],
+    postgresStateSeries: input.observation.postgresStateSeries,
     snapshot: {
       ...input.observation.snapshot,
       connectionErrorCounters: confirmationCounters,

--- a/apps/cloudflare/test/database-health-metrics.test.ts
+++ b/apps/cloudflare/test/database-health-metrics.test.ts
@@ -110,6 +110,13 @@ describe("PlanetScale database health metrics", () => {
       expect(observation.missingMetrics).toEqual(["planetscale_postgres_connection_state"]);
       expect(observation.snapshot.postgresConnections).toBeNull();
       expect(observation.snapshot.postgresConnectionStates).toBeNull();
+      const isOtherBranch = shape === "absent" || shape === "wrong branch";
+      expect(observation.postgresStateSeries).toEqual({
+        branch: isOtherBranch ? 0 : 2,
+        primary: 0,
+        replica: shape === "replica" ? 2 : 0,
+        unrecognizedRole: shape === "missing role" ? 2 : 0,
+      });
     },
   );
 

--- a/apps/cloudflare/test/database-health-monitor.test.ts
+++ b/apps/cloudflare/test/database-health-monitor.test.ts
@@ -1264,6 +1264,44 @@ describe("database health monitor", () => {
     });
   });
 
+  it("reports branch-scoped state provenance for both partial scrapes", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let scrapeAttempt = 0;
+    const harness = createMonitorHarness({
+      readMetricsBody() {
+        scrapeAttempt += 1;
+        return buildMetricsBody({ branchId: BRANCH_ID })
+          .split("\n")
+          .map((line) => {
+            if (!line.startsWith("planetscale_postgres_connection_state{")) {
+              return line;
+            }
+            return scrapeAttempt === 1
+              ? line.replace(BRANCH_ID, "branch_other")
+              : line.replace('planetscale_role="primary"', 'planetscale_role="replica"');
+          })
+          .join("\n");
+      },
+    });
+
+    await expect(harness.runScheduledCheck(FIVE_MINUTES_MS)).resolves.toMatchObject({
+      sampleStatus: "failed",
+    });
+    expect(warning).toHaveBeenCalledWith(
+      "Database health metrics collection failed.",
+      expect.objectContaining({
+        attempts: 2,
+        missingMetrics: ["planetscale_postgres_connection_state"],
+        postgresStateSeries: [
+          { branch: 0, primary: 0, replica: 0, unrecognizedRole: 0 },
+          { branch: 2, primary: 0, replica: 2, unrecognizedRole: 0 },
+        ],
+      }),
+    );
+    expect(harness.planetScaleRequests).toHaveLength(4);
+    expect(harness.primaryLinqRequests).toEqual([]);
+  });
+
   it("keeps a persistently missing Postgres-state family incomplete after confirmation", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const partialMetricsBody = buildMetricsBody({


### PR DESCRIPTION
## Why and outcome

A missing Postgres connection-state warning currently cannot distinguish absent branch series from replica-only series or missing primary role metadata. Add branch-scoped series counts for each successfully parsed collection attempt to the existing warning, allowing operator diagnosis without raw scrape data. This is a diagnostic correction; it does not claim to resolve provider omissions or change paging thresholds.

## Product UX

Not applicable: internal operator diagnostics only. Existing alert messages and member behavior are unchanged.

## Evidence

- Four focused database-health Node suites: 135 tests passed.
- `pnpm --dir apps/cloudflare typecheck`: passed.
- `pnpm complexity:diff` and `git diff --check`: passed.
- Parser cases distinguish absent, wrong-branch, replica, and missing-role series. The monitor regression preserves both parsed attempts in order while retaining the four-request bound and existing alert admission.
- ReviewGPT round 1 passed on the exact PR head; verified gpt-6-pro response metadata and capture hash. No qualifying findings.
- [Protected production deployment](https://github.com/cobuildwithus/murph-cloud/actions/runs/34083704721) passed all gates, live smoke, and deployment-state verification on attempt 2. The cache gate required a retry after its test-environment startup hook timed out; no source changes were needed.
- Deployed public source: `02a50de720ed9d4cb5c53e2a0b65ec29c0a95b58`, which includes the merge. Active Worker `7ee5be1b-e330-4d5d-b3fe-bd197335d848` serves 100% of traffic. The existing production migration required immediate rollout.
- Live missing-state classification remains pending a warning carrying the new diagnostics; deployment success alone does not establish the upstream cause.

## Non-obvious affected surfaces

The connection-error recovery composition retains the original gauge observation's series summary. Diagnostics remain in memory until the existing warning; persisted samples and alert obligations retain their existing shapes.

## Architecture and reuse

- Existing systems reused: Current parser, collection sequence, and structured failure warning.
- New logic: Count selected-branch state series by role and retain one summary per parsed attempt.
- New abstractions: One small pure summary helper; no service, dependency, or state owner.
- Complexity intentionally avoided: No provider calls, raw label logging, retry changes, storage changes, or new diagnostic endpoint.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; no added complexity debt.
- Hotspots: Existing parser (38), evaluator (28), alert admission (47), and discovery URL resolver (25) retain their previous complexity.
- Agent judgment: No broader refactoring is justified for this bounded diagnostic change.

## Hot reply path impact

Not applicable: database-health collection runs in an independent platform cron. No member-path database, network, or awaited work changes.

## Murph initial provider input impact

Not applicable to individual or group runtimes: no provider-visible instructions, tool schemas, or input assembly changes.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing Worker logs remain readable; the new warning adds optional counts only. Web and runner containers do not consume this field.
- Safe order: Merge reviewed source, then use the protected Murph Cloud production deployment workflow.
- Rollback floor: No new floor or migration.
- Expected exposure: Old versions lack detailed counts until the new Worker owns the scheduled check.
- Reversibility: A forward revert removes the optional diagnostics without state repair.
- Convergence proof: Verify the deployed public revision and active Worker version, then observe the scheduled collector.
- Post-deploy checks: Inspect only bounded database-health warning metadata and distinguish absent branch series from unusable role provenance. No induced production failure.

## Change-shape breakdown

Runtime TypeScript is source; Vitest files are tests; README is documentation. No generated or binary changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 35 | 0 |
| Tests / fixtures | 45 | 0 |
| Docs | 7 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| Total | 87 | 0 |

## Changelog

- Changelog: not applicable
- Reason: Internal monitoring diagnostics only.

ReviewGPT context sensitivity: sensitive
Classification reason: Adds narrowly scoped metadata at an existing production monitoring log boundary.
ReviewGPT first-reviewed head: 5dffad518ad26b95733c4de93445ec2a6f091c0c
