### PR TITLE
docs(cloudflare): explain focused test commands

### DIFF
--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -20,6 +20,28 @@ Cloudflare-hosted execution plane for the hosted Murph path.
 - canonical hosted product facts or ledgers outside the encrypted execution workspace, including hosted usage and lifecycle state in `apps/web`
 - gateway state or other product truth outside the encrypted workspace snapshot
 
+## Focused tests
+
+Run these commands from the repository root. To run one Node workspace test,
+pass its repository-relative filename directly to Vitest:
+
+```bash
+pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/workspace-snapshot-local.test.ts
+```
+
+The Containers helper uses a separate configuration and has its own command:
+
+```bash
+pnpm --dir apps/cloudflare test:node:containers-helper
+```
+
+Use `pnpm --dir apps/cloudflare test` for typecheck and both complete Node
+suites, or `pnpm --dir apps/cloudflare test:node` for both suites alone. These
+composite commands do not apply positional file filters to every stage: a
+filename reaches only the final Containers helper command, while the Node
+workspace still runs in full. Use the direct invocation above for focused
+workspace proof.
+
 ## Route Surface
 
 Public routes:


### PR DESCRIPTION
## Why and outcome

Cloudflare's composite test scripts append a positional filename only to the final Containers helper stage, so using them for focused workspace proof runs the full Node workspace first. The package README now gives the existing direct Vitest command for a single workspace file, the separate Containers helper command, and the intended full-suite commands.

Frog autofix issue: #2994

## Product UX

- Effort: Not applicable — internal developer command documentation only.
- Result: Ready.
- Walkthrough: Developers can select one Node workspace file or the separate Containers helper suite; existing full-suite behavior is documented.

## Evidence

- Direct: The exact documented snapshot command passed one file and 29 tests; the exact Containers helper command passed one file and six tests.
- Coverage: Executing both examples verifies their existing configuration and file selection. Package scripts confirm why the composite chain forwards a filename only to its final stage.
- Checks: Frozen workspace install, Frog inventory, command-reference readback, `git diff --check`, and added-line privacy scan passed.
- Exact-head CI: all four required checks passed (Release checks, both CLI host matrices, and hosted Stripe billing).
- Full ReviewGPT: round 1 passed with no qualifying findings on the unchanged head; exact-turn and gpt-6-pro response evidence verified, with at least 489 seconds of review time.

## Non-obvious affected surfaces

None. Only `apps/cloudflare/README.md` changes.

## Architecture and reuse

- Existing systems reused: The Node workspace Vitest config and the dedicated Containers helper package command.
- New logic: None; the change documents existing executable behavior.
- New abstractions: None; existing test entrypoints cover both examples.
- Complexity intentionally avoided: No new dispatcher, argument parser, or combined Vitest configuration.

## Complexity impact

- Guard: Not applicable — no authored JavaScript or TypeScript changes.
- Hotspots: None; this is Markdown documentation.
- Agent judgment: The existing commands provide focused proof without another test runner.

## Hot reply path impact

- Path status: Not applicable — developer documentation does not affect message handling.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: No runtime source changes.

## Murph initial provider input impact

Not applicable for individual or group runtimes: package test documentation is not part of Murph provider input.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

ReviewGPT first-reviewed head: 3f21ac643e3a38af1a923779ec8aa1efcc9ad3c6
ReviewGPT context sensitivity: routine
Classification reason: README-only developer command guidance with no executable or policy changes.

## Deployment concerns

- Deployment: not applicable
- Reason: Package README guidance changes no deployed runtime or infrastructure.

## Change-shape breakdown

Classification rule: The sole changed Markdown file is documentation; no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 0 | 0 |
| Docs | 22 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **22** | **0** |

## Changelog

- Changelog: not applicable
- Reason: Internal developer command documentation only; no member-facing behavior changes.
