### PR TITLE
docs(assistant-engine): document focused package test command

### DIFF
--- a/packages/assistant-engine/README.md
+++ b/packages/assistant-engine/README.md
@@ -386,6 +386,19 @@ read before support questions or effects. Normal recursive skill packaging and
 filesystem reads remain the owners. Keep that reference in focused real-Codex
 fixtures when changing support policy.
 
+## Focused tests
+
+From the repository root, invoke Vitest directly to run selected test files:
+
+```sh
+pnpm --dir packages/assistant-engine exec vitest run --config vitest.config.ts --no-coverage test/model-behavior.test.ts
+```
+
+Append additional file paths after the Vitest options. Do not put an extra `--`
+before the file paths: `pnpm --dir packages/assistant-engine test -- <file>`
+forwards that separator to Vitest, which drops the file filter and runs the
+package suite.
+
 ## Real-Codex test fixtures
 
 Synthetic real-Codex journeys that need fixture executables can opt into


### PR DESCRIPTION
## Why and outcome

The Assistant Engine package test script forwards an extra argument separator to Vitest, which removes positional file filters and selects the whole package suite. Document the existing direct Vitest invocation so focused checks select only the named files.

Frog autofix issue: #3001

## Product UX

- Effort: Not applicable — package developer documentation only.
- Result: Not applicable.
- Walkthrough: From the repository root, run the documented command to select one test file; additional paths follow the Vitest options directly.

## Evidence

- Direct: `pnpm --dir packages/assistant-engine exec vitest run --config vitest.config.ts --no-coverage test/model-behavior.test.ts` passed exactly one test file and 84 tests in 4.68 seconds.
- Coverage: The pinned Vitest `parseCLI` returns no file filters with the extra separator and returns the named file without it. The documented command exercises the actual package configuration. No provider execution is needed.
- Readback: The referenced test file exists, the command ran from the repository root, and `git diff --check` passed. All four required GitHub checks passed on the unchanged PR head. The explicitly requested full ReviewGPT result is recorded below.

## Non-obvious affected surfaces

None. Only the package README changes.

## Architecture and reuse

- Existing systems reused: The existing package Vitest configuration, test file, and direct pnpm exec entrypoint.
- New logic: None; this documents existing command behavior.
- New abstractions: None; the existing invocation already supports positional file selection.
- Complexity intentionally avoided: No argument wrapper, package-script change, or new test runner.

## Complexity impact

- Guard: not applicable — no authored JavaScript or TypeScript changes.
- Hotspots: No source functions changed.
- Agent judgment: A package-local example resolves the missing guidance without additional implementation.

## Hot reply path impact

- Path status: Not applicable — developer documentation does not change conversation execution.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: The complete diff changes only the package README.

## Murph initial provider input impact

Not applicable for individual or group Murph. No prompt, tool, schema, provider input, or runtime-consumed guidance changes; no input measurement is required.

## Deployment concerns

- Deployment: not applicable
- Reason: Package developer documentation changes no deployed behavior or configuration.

## Change-shape breakdown

Classification rule: The sole changed Markdown README is documentation. No binary or generated files change.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 0 | 0 |
| Docs | 13 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **13** | **0** |

## Changelog

- Changelog: not applicable
- Reason: Internal package test guidance has no member-visible outcome.

ReviewGPT context sensitivity: routine
Classification reason: Documentation of an existing local test invocation; no runtime or boundary changes.
ReviewGPT first-reviewed head: d5bcf3db80febfc1952d9a61215cb7a9b5a633f8

## Final review

ReviewGPT round 1: PASS on `d5bcf3db80febfc1952d9a61215cb7a9b5a633f8`, with no findings or remediation. The full snapshot review traced package argument forwarding, configuration ownership, the documented file path, and the deterministic test boundary. Independent review execution was unavailable; the focused local command supplied that proof. Native response metadata identifies the requested `gpt-6-pro` model, and exact committed-turn and normalized response hashes match. The first final capture occurred 402 seconds after send. Canonical same-session recovery completed after a transient post-send attachment confirmation failure, preserving the accepted turn and closing its owned target; no nested Codex process was launched. Earlier timing and pre-send surface failures are uncredited tooling attempts, not additional substantive rounds.
