### PR TITLE
fix: preserve complete assistant live test titles

### DIFF
--- a/packages/assistant-engine/vitest.config.ts
+++ b/packages/assistant-engine/vitest.config.ts
@@ -5,6 +5,10 @@ export default createMurphPackageVitestConfig({
   name: "assistant-engine",
   coverageExclude: ["src/assistant/system-prompt.ts"],
   test: {
+    // Parameterized live titles must stay intact for exact list/run selection.
+    ...(process.env.MURPH_RUN_REAL_CODEX_E2E === "1"
+      ? { chaiConfig: { truncateThreshold: 0 } }
+      : {}),
     tags: [{
       name: "real-codex-live",
       description: "Opt-in tests that call a real Codex model",

--- a/scripts/assistant-live-title-selection.test.ts
+++ b/scripts/assistant-live-title-selection.test.ts
@@ -1,0 +1,75 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { expect, it } from 'vitest'
+
+import {
+  executeAssistantRealCodexRun,
+  parseAssistantRealCodexRunArgs,
+  type AssistantRealCodexCommandRequest,
+} from './run-assistant-real-codex-e2e.ts'
+
+it('selects complete live titles while preserving ordinary display and ambiguous-name admission', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'murph-live-title-'))
+  const configPath = path.join(root, 'vitest.config.mts')
+  const fixturePath = path.join(root, 'journey.test.mjs')
+  const receiptPath = path.join(root, 'receipt.txt')
+  const packageConfig = fileURLToPath(new URL('../packages/assistant-engine/vitest.config.ts', import.meta.url))
+  const vitestEntry = fileURLToPath(new URL('../node_modules/vitest/vitest.mjs', import.meta.url))
+  const vitestModule = fileURLToPath(import.meta.resolve('vitest'))
+  const prefix = 'selects one synthetic record after a sufficiently long shared title prefix'
+  const selected = `${prefix} alpha`
+  try {
+    await writeFile(configPath, [
+      `import config from ${JSON.stringify(packageConfig)}`,
+      `export default { ...config, root: ${JSON.stringify(root)}, test: { ...config.test, globalSetup: [], include: ['journey.test.mjs'] } }`,
+    ].join('\n'))
+    await writeFile(fixturePath, [
+      `import { it } from ${JSON.stringify(vitestModule)}`,
+      "import { appendFileSync } from 'node:fs'",
+      `it.each([{ testName: ${JSON.stringify(selected)} }, { testName: ${JSON.stringify(`${prefix} beta`)} }])`,
+      `('$testName', { tags: ['real-codex-live'] }, ({ testName }) => appendFileSync(${JSON.stringify(receiptPath)}, testName + '\\n'))`,
+    ].join('\n'))
+    const requests: AssistantRealCodexCommandRequest[] = []
+    const runCommand = (request: AssistantRealCodexCommandRequest) => {
+      requests.push(request)
+      if (request.args[0] === 'login') return { status: 0 }
+      const args = request.args.slice(request.args.indexOf('vitest') + 1)
+        .map((argument) => argument === 'vitest.config.ts' ? configPath
+          : argument === 'test/assistant-codex-real-e2e.test.ts' ? fixturePath : argument)
+      const result = spawnSync(process.execPath, [vitestEntry, ...args], {
+        cwd: root, env: request.env, encoding: 'utf8', timeout: 30_000,
+      })
+      expect(result.error).toBeUndefined()
+      expect(result.status, result.stderr).toBe(0)
+      return { status: result.status, stdout: result.stdout }
+    }
+    const sourceEnv = { ...process.env }
+    delete sourceEnv.MURPH_RUN_REAL_CODEX_E2E
+    // Ordinary package invocations retain Vitest's existing title/display limit.
+    const ordinary = runCommand({
+      args: ['vitest', 'list', '--config', configPath, '--testNamePattern', selected, '--json'],
+      command: 'pnpm', env: sourceEnv, stdio: 'capture',
+    })
+    expect(JSON.parse(ordinary.stdout ?? '')).toEqual([])
+    requests.length = 0
+    const errors: string[] = []
+    const dependencies = {
+      runCommand, sourceEnv, writeStderr: (value: string) => errors.push(value),
+      writeStdout: () => undefined,
+    }
+    expect(executeAssistantRealCodexRun(parseAssistantRealCodexRunArgs([selected]), dependencies)).toBe(0)
+    expect(requests.map((request) => request.stdio)).toEqual(['capture', 'ignore', 'inherit'])
+    expect(await readFile(receiptPath, 'utf8')).toBe(`${selected}\n`)
+    requests.length = 0
+    expect(executeAssistantRealCodexRun(parseAssistantRealCodexRunArgs(['selects one synthetic']), dependencies)).toBe(2)
+    expect(errors.join('')).toContain('matched 2 live journeys')
+    expect(requests.map((request) => request.stdio)).toEqual(['capture'])
+    expect(await readFile(receiptPath, 'utf8')).toBe(`${selected}\n`)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}, 60_000)


### PR DESCRIPTION
## Why and outcome

Vitest abbreviates long parameterized titles before the focused live runner filters them, so a complete journey name can select nothing. Opted-in assistant live runs now preserve the full title consistently for discovery and exact execution. Ordinary test runs retain their current display limit.

Frog autofix issue: #2991

## Product UX

- Effort: Not applicable; internal test selection only.
- Result: Ready.
- Walkthrough: Full unique names select one synthetic journey; ambiguous prefixes stop before login or execution. No member-facing behavior changes.

## Evidence

- Direct: The new real-Vitest synthetic regression failed before the configuration correction with selection status 2, then passed after it. Two long titles share a prefix; the exact requested title writes one receipt, while ambiguous selection leaves that receipt unchanged and never reaches login.
- Coverage: The same regression imports the actual package config and runs the production wrapper's list/run arguments against synthetic fixtures. With the live flag absent, ordinary title truncation remains unchanged. Login alone is stubbed; no Codex process or provider is started.
- `pnpm exec vitest run --config scripts/vitest.config.ts --no-coverage scripts/assistant-live-title-selection.test.ts scripts/run-assistant-real-codex-e2e.test.ts`: 10 tests passed.
- Focused TypeScript 7 check extending `tsconfig.tools.json` for the package config and both test files: passed.
- `pnpm complexity:diff` and `git diff --check`: passed. Final full-snapshot ReviewGPT round 1 passed on this exact head with verified GPT-6 Pro response metadata and at least 484 seconds of captured wait. The earlier under-duration response was rejected and receives no review credit. All four required checks passed on the same head, including the complete release verification run.

## Non-obvious affected surfaces

The native Chai display option also allows longer assertion displays during opted-in live runs. Ordinary runs retain the previous limit; production code and provider inputs are unaffected.

## Architecture and reuse

- Existing systems reused: Vitest's native title-display option, the existing live environment gate, and the focused runner's exact-one admission and anchored execution.
- New logic: One conditional configuration override while the existing live flag is enabled.
- New abstractions: None; existing configuration and selection owners suffice.
- Complexity intentionally avoided: No title parser, approximate matcher, wrapper fallback, dependency patch, or new runtime state.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`.
- Hotspots: None above 20 in changed source.
- Agent judgment: Four configuration lines correct the framework-owned title identity. The synthetic fixture exercises composed behavior without another production helper.

## Hot reply path impact

- Path status: Not applicable; test configuration only.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None on the reply path.
- Before/after proof: Synthetic list/run selection described above; production path unchanged.

## Murph initial provider input impact

Not applicable for individual or group runtimes: no prompt, schema, tool, or provider-input source changed. No input measurement is claimed.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal test configuration and synthetic regression only; no deployed runtime boundary changes.

## Change-shape breakdown

Classification rule: The package Vitest file is config/tooling and the new regression is tests/fixtures. No binaries or generated artifacts.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 75 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 4 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **79** | **0** |

## Changelog

- Changelog: not applicable
- Reason: Internal developer verification tooling only; no member-visible change.

ReviewGPT context sensitivity: routine
Classification reason: Narrow deterministic test harness correction with no production or trust-boundary changes; final review is explicitly requested.

ReviewGPT first-reviewed head: 989f9a75ad825d62e33e70e2a9b927234a0d6d39
