### PR TITLE
fix(runtime): checkpoint device sync queues after provider fanout

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1432,7 +1432,10 @@ Last verified: 2026-09-04
   execution and dirty-admission budgets do not cap recovery: one completed job
   can create multiple accepted follow-ups. The existing workspace snapshot byte
   envelope bounds publication; recovery never truncates accepted work to a pass
-  budget or adds another persisted queue. The same wake
+  budget or adds another persisted queue. Dirty admission uses the same complete
+  account stream to count capacity and relink already-owned jobs anywhere in the
+  queue. Its dedupe map retains only identities from the bounded current dirty
+  page; a full queue blocks new jobs, never acknowledgement of existing jobs. The same wake
   carries the provider's advanced cadence, but Web does not receive that
   cadence until the post-record checkpoint has made the exact completion state
   durable. Before exposing that completion record, the pass requires Web to

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1424,7 +1424,15 @@ Last verified: 2026-09-04
   mailbox item stays pending while that account has queued or running work and
   is narrowed before checkpoint publication from the actual job rows to each
   manifest-safe payload/window, dedupe identity, priority, next retry time, and
-  remaining attempt limit, including worker-created child jobs. The same wake
+  remaining attempt limit, including worker-created child jobs. Recovery streams
+  all queued/running rows for that account through one SQLite statement; it
+  performs no credential decryption, external calls, concurrent reads, or writes
+  while that cursor is open. Only the required manifest-safe retry hints are
+  accumulated. Completed jobs and other accounts are excluded. The 100-job
+  execution and dirty-admission budgets do not cap recovery: one completed job
+  can create multiple accepted follow-ups. The existing workspace snapshot byte
+  envelope bounds publication; recovery never truncates accepted work to a pass
+  budget or adds another persisted queue. The same wake
   carries the provider's advanced cadence, but Web does not receive that
   cadence until the post-record checkpoint has made the exact completion state
   durable. Before exposing that completion record, the pass requires Web to

--- a/agent-docs/exec-plans/active/2026-09-07-device-sync-recovery-capacity.md
+++ b/agent-docs/exec-plans/active/2026-09-07-device-sync-recovery-capacity.md
@@ -1,0 +1,32 @@
+# Preserve provider follow-ups through hosted recovery
+
+Status: active
+Created: 2026-09-07
+Updated: 2026-09-07
+
+## Goal and evidence
+
+A hosted pass executes at most 100 jobs, but a completed provider job can enqueue multiple follow-ups. Recovery currently rejects more than 100 pending rows, preventing checkpoint publication after legitimate queue growth. Prove the failure with synthetic service execution and cold reconstruction, then fix the existing queue export boundary.
+
+## Design and scope
+
+Keep execution and dirty admission bounded at 100. Recovery must preserve every already accepted job, including exact payload, identity, timing, and remaining attempts. Reuse the local queue and existing mailbox continuation; add no durable state or scheduling mechanism. Stream account-scoped pending rows through the existing SQLite query and retain only the required retry hints. Reuse the existing workspace snapshot byte envelope. One synchronous statement, no decryption, writes, external calls, or concurrent work during export.
+
+## Work and verification
+
+1. Reproduce 100 accepted jobs becoming 101 through provider completion.
+2. Correct recovery export and prove cold reconstruction, retry timing, bounded drain, account isolation, and terminal-row exclusion.
+3. Run relevant tests, typechecks, complexity and parent review. Update the reliability owner and changelog decision.
+4. Commit, open a draft PR, run exact-head CI and required ReviewGPT, then merge and deploy within existing authorization. Inspect production recovery without copying private evidence into artifacts.
+
+## Product UX
+
+Connected-device sync must retain accepted work across runtime replacement and allow newer data to progress. No prompt, tool, reply, UI, credential, or provider request contract changes are planned. Recovery is Ready only after the composed restart proof passes.
+
+## Candidate evidence and parent review
+
+- The synthetic provider completed one of 100 accepted jobs and created two future follow-ups. Baseline recovery threw the per-pass durable-limit error with 101 pending jobs. The corrected recovery preserves all 101 through mailbox recording, disk readback, wire parsing, and fresh-service reconstruction. No job runs before its retry; subsequent drains execute 100 then 1.
+- All 359 relevant tests passed: 123 runtime sync, 176 mailbox/entrypoint/preemption, and 60 device store. The existing maximum dirty-input proof now asserts one bounded admission read plus one account-scoped recovery iterator. Iterator coverage includes 200 pending rows, running work, terminal exclusion, independent accounts, and interrupted iteration.
+- Both package typechecks and diff whitespace checks passed. Complexity guard passed; runtime-source debt decreases 145 to 143, maximum stays 75. The changed recovery hotspot decreases 29 to 27; the other pre-existing hotspots remain unchanged.
+- Parent review confirmed one existing query owner, unchanged execution/admission limits, identical manifest shaping, and no credential or provider-input changes. Product UX: Ready for the scoped connected-device restart recovery journey.
+- Remaining release gates: changelog fragment, final pushed-head CI and ReviewGPT, merge, managed deployment, and read-only production outcome inspection.

--- a/agent-docs/exec-plans/completed/2026-09-07-device-sync-recovery-capacity.md
+++ b/agent-docs/exec-plans/completed/2026-09-07-device-sync-recovery-capacity.md
@@ -1,6 +1,6 @@
 # Preserve provider follow-ups through hosted recovery
 
-Status: active
+Status: completed
 Created: 2026-09-07
 Updated: 2026-09-07
 
@@ -26,7 +26,8 @@ Connected-device sync must retain accepted work across runtime replacement and a
 ## Candidate evidence and parent review
 
 - The synthetic provider completed one of 100 accepted jobs and created two future follow-ups. Baseline recovery threw the per-pass durable-limit error with 101 pending jobs. The corrected recovery preserves all 101 through mailbox recording, disk readback, wire parsing, and fresh-service reconstruction. No job runs before its retry; subsequent drains execute 100 then 1.
-- All 359 relevant tests passed: 123 runtime sync, 176 mailbox/entrypoint/preemption, and 60 device store. The existing maximum dirty-input proof now asserts one bounded admission read plus one account-scoped recovery iterator. Iterator coverage includes 200 pending rows, running work, terminal exclusion, independent accounts, and interrupted iteration.
+- All 360 relevant tests passed: 124 runtime sync, 176 mailbox/entrypoint/preemption, and 60 device store. The existing maximum dirty-input proof now asserts one account-scoped admission iterator plus one recovery iterator. Iterator coverage includes 200 pending rows, running work, terminal exclusion, independent accounts, and interrupted iteration.
 - Both package typechecks and diff whitespace checks passed. Complexity guard passed; runtime-source debt decreases 145 to 143, maximum stays 75. The changed recovery hotspot decreases 29 to 27; the other pre-existing hotspots remain unchanged.
 - Parent review confirmed one existing query owner, unchanged execution/admission limits, identical manifest shaping, and no credential or provider-input changes. Product UX: Ready for the scoped connected-device restart recovery journey.
-- Remaining release gates: changelog fragment, final pushed-head CI and ReviewGPT, merge, managed deployment, and read-only production outcome inspection.
+- PR #3025 carries the content-only connected-device-large-sync-recovery changelog entry. The final parent audit also reproduced lost dirty relinking with 150 retained follow-ups ahead of 100 dirty-owned jobs (0 matched versus 100 required). Admission now reuses the complete account iterator while keeping its identity map bounded to the current dirty page and new admission capped at 100. The PR retains the final pushed-head CI/ReviewGPT and managed deployment gates, followed by read-only production outcome inspection.
+Completed: 2026-09-07

--- a/apps/web/changelog/entries/2026-09-07/connected-device-large-sync-recovery.json
+++ b/apps/web/changelog/entries/2026-09-07/connected-device-large-sync-recovery.json
@@ -1,0 +1,19 @@
+{
+  "publishedOn": "2026-09-07",
+  "order": 100,
+  "item": {
+    "id": "connected-device-large-sync-recovery",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "More reliable recovery for larger device syncs",
+    "summary": "Connected-device sync now preserves all pending work when a sync creates additional follow-up tasks.",
+    "details": "If the runtime restarts, those tasks resume with their original retry timing.",
+    "relevanceTags": [
+      "wearables",
+      "reliability"
+    ],
+    "sourcePullRequests": [
+      3025
+    ]
+  }
+}

--- a/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
@@ -1071,42 +1071,31 @@ export function resolveHostedDeviceSyncWakeRecovery(input: {
     return null;
   }
 
-  const pendingJobs = store.listPendingJobsForAccount(
-    localAccountId,
-    HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT + 1,
-  );
-  if (pendingJobs.length > HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT) {
-    throw new Error(
-      "Hosted device-sync retained work exceeds the per-pass durable job limit.",
-    );
+  // A provider job can create multiple follow-ups. The execution/admission
+  // budget must never truncate or reject work already accepted by the queue.
+  let retryAt: string | null = null;
+  const retryHints: HostedExecutionDeviceSyncJobHint[] = [];
+  for (const job of store.iteratePendingJobsForAccount(localAccountId)) {
+    const dedupeKey = job.dedupeKey
+      ?? `hosted-device-sync-job:${createHash("sha256").update(job.id).digest("hex")}`;
+    const payload = shapeHostedDeviceSyncJobHintPayload(account.provider, job);
+    const jobRetryAt = job.status === "running"
+      ? job.leaseExpiresAt ?? job.availableAt
+      : job.availableAt;
+    const remainingAttempts = Math.max(1, job.maxAttempts - job.attempts);
+    retryAt = retryAt === null || Date.parse(jobRetryAt) < Date.parse(retryAt)
+      ? jobRetryAt
+      : retryAt;
+    retryHints.push({
+      availableAt: jobRetryAt,
+      dedupeKey,
+      kind: job.kind,
+      maxAttempts: remainingAttempts,
+      ...(Object.keys(payload).length > 0 ? { payload } : {}),
+      priority: job.priority,
+    });
   }
-  if (pendingJobs.length > 0) {
-    let retryAt: string | null = null;
-    const retryHints: HostedExecutionDeviceSyncJobHint[] = [];
-    for (const job of pendingJobs) {
-      const dedupeKey = job.dedupeKey
-        ?? `hosted-device-sync-job:${createHash("sha256").update(job.id).digest("hex")}`;
-      const payload = shapeHostedDeviceSyncJobHintPayload(account.provider, job);
-      const jobRetryAt = job.status === "running"
-        ? job.leaseExpiresAt ?? job.availableAt
-        : job.availableAt;
-      const remainingAttempts = Math.max(1, job.maxAttempts - job.attempts);
-      retryAt = retryAt === null || Date.parse(jobRetryAt) < Date.parse(retryAt)
-        ? jobRetryAt
-        : retryAt;
-      retryHints.push({
-        availableAt: jobRetryAt,
-        dedupeKey,
-        kind: job.kind,
-        maxAttempts: remainingAttempts,
-        ...(Object.keys(payload).length > 0 ? { payload } : {}),
-        priority: job.priority,
-      });
-    }
-    if (!retryAt) {
-      return null;
-    }
-
+  if (retryAt) {
     return {
       retryAt,
       wake: {

--- a/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-device-sync-runtime.ts
@@ -1367,17 +1367,16 @@ function admitHostedDirtyDeviceSyncJobsForAccount(input: {
   provider: string;
   store: HostedRuntimeDeviceSyncStore;
 }): HostedDirtyDeviceSyncAdmissionResult {
-  const pendingJobs = input.store.listPendingJobsForAccount(
-    input.accountId,
-    HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT + 1,
-  );
-  let availableSlots = Math.max(
-    0,
-    HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT - pendingJobs.length,
-  );
+  let availableSlots = HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT;
+  const requestedDedupeKeys = new Set(input.jobs.map((job) => job.input.dedupeKey));
   const jobIdsByDedupeKey = new Map<string, string>();
-  for (const job of pendingJobs) {
-    if (job.provider === input.provider && job.dedupeKey) {
+  for (const job of input.store.iteratePendingJobsForAccount(input.accountId)) {
+    availableSlots = Math.max(0, availableSlots - 1);
+    if (
+      job.provider === input.provider
+      && job.dedupeKey
+      && requestedDedupeKeys.has(job.dedupeKey)
+    ) {
       jobIdsByDedupeKey.set(job.dedupeKey, job.id);
     }
   }

--- a/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+++ b/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
@@ -5816,8 +5816,7 @@ describe("hosted device-sync runtime", () => {
           provider: "strava",
         });
         const store = getStore(service);
-        const listPendingJobsForAccount = vi.spyOn(store, "listPendingJobsForAccount");
-      const iteratePendingJobsForAccount = vi.spyOn(getStore(service), "iteratePendingJobsForAccount");
+        const iteratePendingJobsForAccount = vi.spyOn(store, "iteratePendingJobsForAccount");
         const wake = buildDirtyDeviceSyncWake(
           connectionId,
           `2026-04-04T10:0${pass}:00.000Z`,
@@ -5870,12 +5869,12 @@ describe("hosted device-sync runtime", () => {
         assert.equal(state.pendingDirtyPayloadJobs.length, 100);
         assert.equal(readJobsForAccount(service, localAccountId).length, 100);
         assert.equal(state.dirtyWorkRemaining, pass < 4);
-        assert.equal(listPendingJobsForAccount.mock.calls.length, 1);
+        assert.equal(iteratePendingJobsForAccount.mock.calls.length, 1);
 
         assert.equal(await service.drainWorker(100, localAccountId), 100);
         promoteHostedCompletedDirtyPayloadAcks({ service, state });
         assert.equal(state.pendingDirtyPayloadJobs.length, 0);
-        assert.equal(listPendingJobsForAccount.mock.calls.length, 1);
+        assert.equal(iteratePendingJobsForAccount.mock.calls.length, 1);
         const [ack] = state.pendingDirtyAcks;
         assert.ok(ack);
         assert.equal(ack.processedDirtyPayloadIds?.length, 100);
@@ -5889,8 +5888,7 @@ describe("hosted device-sync runtime", () => {
         const recoveryRequestedAtMs = Date.now();
         const recovery = resolveHostedDeviceSyncWakeRecovery({ service, state, wake });
         const recoveryResolvedAtMs = Date.now();
-        assert.equal(listPendingJobsForAccount.mock.calls.length, 1);
-        assert.deepEqual(iteratePendingJobsForAccount.mock.calls, [[localAccountId]]);
+        assert.deepEqual(iteratePendingJobsForAccount.mock.calls, [[localAccountId], [localAccountId]]);
         assert.equal(recovery?.wake.hint?.jobs?.length ?? 0, 0);
         assert.equal(
           recovery?.wake.hint?.reason ?? null,
@@ -5912,7 +5910,7 @@ describe("hosted device-sync runtime", () => {
     assert.equal(pendingIndexes.size, 0);
   });
 
-  test("a cold-restored full dirty page relinks every retained job before completion", async () => {
+  test.each([0, 150])("a cold-restored full dirty page relinks every retained job with %i follow-ups", async (followUpCount) => {
     const firstWorkspace = await createHostedRuntimeWorkspace(
       "hosted-device-sync-runtime-dirty-relink-first-",
     );
@@ -5978,6 +5976,16 @@ describe("hosted device-sync runtime", () => {
       },
       async fetchDirtyStates(input = {}) {
         assert.equal(input.connectionId, connectionId);
+        if (firstClosed && followUpCount > 0) {
+          // Make the partial-query boundary deterministic after cold hydration.
+          const database = openSqliteRuntimeDatabase(getStore(restoredService).databasePath);
+          try {
+            database.prepare("update device_job set created_at = ? where dedupe_key like 'relink-follow-up-%'")
+              .run("2026-01-01T00:00:00.000Z");
+          } finally {
+            database.close();
+          }
+        }
         return {
           hasMore: false,
           items: [dirtyState],
@@ -6010,20 +6018,31 @@ describe("hosted device-sync runtime", () => {
       const firstJobIds = new Set(firstJobs.map((job) => job.id));
       assert.equal(firstState.pendingDirtyPayloadJobs.length, 100);
 
+      for (let index = 0; index < followUpCount; index += 1) {
+        getStore(firstService).enqueueJob({
+          accountId: firstAccountId,
+          availableAt: "2099-04-04T10:00:00.000Z",
+          dedupeKey: `relink-follow-up-${index}`,
+          kind: "reconcile",
+          payload: {},
+          provider: "strava",
+        });
+      }
+
       const recovery = resolveHostedDeviceSyncWakeRecovery({
         service: firstService,
         state: firstState,
         wake: initialWake,
       });
       assert.ok(recovery);
-      assert.equal(recovery.wake.hint?.jobs?.length, 100);
+      assert.equal(recovery.wake.hint?.jobs?.length, 100 + followUpCount);
 
       closeHostedRuntimeDeviceSyncService(firstService);
       firstClosed = true;
 
       const restoredStore = getStore(restoredService);
       const enqueueJob = vi.spyOn(restoredStore, "enqueueJob");
-      const listPendingJobsForAccount = vi.spyOn(restoredStore, "listPendingJobsForAccount");
+      const iteratePendingJobsForAccount = vi.spyOn(restoredStore, "iteratePendingJobsForAccount");
       const restoredState = await syncHostedDeviceSyncControlPlaneState({
         deviceSyncPort: port,
         secret: DEVICE_SYNC_SECRET,
@@ -6033,13 +6052,13 @@ describe("hosted device-sync runtime", () => {
       const restoredAccountId = restoredState.hostedToLocalAccountIds.get(connectionId);
       assert.ok(restoredAccountId);
       const restoredJobs = readJobsForAccount(restoredService, restoredAccountId);
-      assert.equal(restoredJobs.length, 100);
+      assert.equal(restoredJobs.length, 100 + followUpCount);
       assert.equal(restoredState.pendingDirtyPayloadJobs.length, 100);
-      assert.equal(listPendingJobsForAccount.mock.calls.length, 1);
-      assert.equal(enqueueJob.mock.calls.length, 100);
+      assert.equal(iteratePendingJobsForAccount.mock.calls.length, 1);
+      assert.equal(enqueueJob.mock.calls.length, 100 + followUpCount);
       assert.equal(
         new Set(enqueueJob.mock.calls.map(([input]) => input.dedupeKey)).size,
-        100,
+        100 + followUpCount,
       );
       assert.ok(restoredJobs.every((job) => !firstJobIds.has(job.id)));
       assert.equal(await restoredService.drainWorker(100, restoredAccountId), 100);
@@ -6053,7 +6072,7 @@ describe("hosted device-sync runtime", () => {
         new Set(restoredState.pendingDirtyAcks[0]?.processedDirtyPayloadIds),
         new Set(dirtyResources.map((resource) => resource.dirtyPayloadId)),
       );
-      assert.equal(readJobsForAccount(restoredService, restoredAccountId).length, 100);
+      assert.equal(readJobsForAccount(restoredService, restoredAccountId).length, 100 + followUpCount);
     } finally {
       if (!firstClosed) {
         closeHostedRuntimeDeviceSyncService(firstService);
@@ -6177,7 +6196,7 @@ describe("hosted device-sync runtime", () => {
 
       const restoredStore = getStore(restoredService);
       const enqueueJob = vi.spyOn(restoredStore, "enqueueJob");
-      const listPendingJobsForAccount = vi.spyOn(restoredStore, "listPendingJobsForAccount");
+      const iteratePendingJobsForAccount = vi.spyOn(restoredStore, "iteratePendingJobsForAccount");
       const restoredState = await syncHostedDeviceSyncControlPlaneState({
         deviceSyncPort: port,
         secret: DEVICE_SYNC_SECRET,
@@ -6190,7 +6209,7 @@ describe("hosted device-sync runtime", () => {
       assert.equal(restoredJobs.length, 100);
       assert.equal(restoredState.pendingDirtyPayloadJobs.length, 101);
       assert.equal(restoredState.dirtyWorkRemaining, true);
-      assert.equal(listPendingJobsForAccount.mock.calls.length, 1);
+      assert.equal(iteratePendingJobsForAccount.mock.calls.length, 1);
       assert.equal(enqueueJob.mock.calls.length, 100);
       assert.equal(
         new Set(enqueueJob.mock.calls.map(([input]) => input.dedupeKey)).size,

--- a/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+++ b/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
@@ -5817,6 +5817,7 @@ describe("hosted device-sync runtime", () => {
         });
         const store = getStore(service);
         const listPendingJobsForAccount = vi.spyOn(store, "listPendingJobsForAccount");
+      const iteratePendingJobsForAccount = vi.spyOn(getStore(service), "iteratePendingJobsForAccount");
         const wake = buildDirtyDeviceSyncWake(
           connectionId,
           `2026-04-04T10:0${pass}:00.000Z`,
@@ -5888,7 +5889,8 @@ describe("hosted device-sync runtime", () => {
         const recoveryRequestedAtMs = Date.now();
         const recovery = resolveHostedDeviceSyncWakeRecovery({ service, state, wake });
         const recoveryResolvedAtMs = Date.now();
-        assert.equal(listPendingJobsForAccount.mock.calls.length, 2);
+        assert.equal(listPendingJobsForAccount.mock.calls.length, 1);
+        assert.deepEqual(iteratePendingJobsForAccount.mock.calls, [[localAccountId]]);
         assert.equal(recovery?.wake.hint?.jobs?.length ?? 0, 0);
         assert.equal(
           recovery?.wake.hint?.reason ?? null,
@@ -6226,6 +6228,128 @@ describe("hosted device-sync runtime", () => {
       if (!firstClosed) {
         closeHostedRuntimeDeviceSyncService(firstService);
       }
+      closeHostedRuntimeDeviceSyncService(restoredService);
+      await firstWorkspace.cleanup();
+      await restoredWorkspace.cleanup();
+    }
+  });
+
+  test("retains provider fanout beyond one pass through cold reconstruction", async () => {
+    const firstWorkspace = await createHostedRuntimeWorkspace("hosted-device-sync-fanout-first-");
+    const restoredWorkspace = await createHostedRuntimeWorkspace("hosted-device-sync-fanout-restored-");
+    const occurredAt = "2026-04-04T10:00:00.000Z";
+    const retryAt = "2026-04-04T10:10:00.000Z";
+    const connectionId = "hosted_fanout_connection";
+    const children = ["child-a", "child-b"].map((dedupeKey) => ({
+      availableAt: retryAt,
+      dedupeKey,
+      kind: "reconcile",
+      maxAttempts: 3,
+      priority: 40,
+    }));
+    const executeJob = vi.fn(async () => ({ scheduledJobs: children }));
+    const firstService = createDeviceSyncServiceForVault(firstWorkspace.vaultRoot, [
+      createFakeProvider({ jobExecutor: { executeJob } }),
+    ]);
+    const restoredExecuteJob = vi.fn(async () => ({}));
+    const restoredService = createDeviceSyncServiceForVault(restoredWorkspace.vaultRoot, [
+      createFakeProvider({ jobExecutor: { executeJob: restoredExecuteJob } }),
+    ]);
+    const jobs = Array.from({ length: HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT }, (_, index) => ({
+      availableAt: index === 0 ? occurredAt : retryAt,
+      dedupeKey: `fanout-parent-${index}`,
+      kind: "reconcile",
+      maxAttempts: 3,
+      priority: 30,
+    }));
+    const wake = buildDeviceSyncWake({
+      connectionId,
+      hint: { jobs },
+      occurredAt,
+      reason: "webhook_hint",
+    });
+    const port: HostedRuntimeDeviceSyncPort = {
+      ...createNoDirtyStateDeviceSyncPortMethods(),
+      async applyUpdates() { throw new Error("No control-plane write expected"); },
+      async createConnectLink() { throw new Error("No connection request expected"); },
+      async fetchSnapshot() {
+        return buildRuntimeSnapshot({ connectionId, externalAccountId: "fanout-account" });
+      },
+    };
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(occurredAt));
+    try {
+      const state = await syncHostedDeviceSyncControlPlaneState({
+        deviceSyncPort: port, secret: DEVICE_SYNC_SECRET, service: firstService, wake,
+      });
+      const accountId = state.hostedToLocalAccountIds.get(connectionId);
+      assert.ok(accountId);
+      assert.equal(await firstService.drainWorker(HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT, accountId), 1);
+      assert.equal(executeJob.mock.calls.length, 1);
+      const recovery = resolveHostedDeviceSyncWakeRecovery({ service: firstService, state, wake });
+      assert.ok(recovery);
+      assert.equal(recovery.retryAt, retryAt);
+      assert.deepEqual(
+        [...(recovery.wake.hint?.jobs ?? [])].sort((a, b) => a.dedupeKey!.localeCompare(b.dedupeKey!)),
+        [...jobs.slice(1), ...children].sort((a, b) => a.dedupeKey.localeCompare(b.dedupeKey)),
+      );
+      assert.deepEqual(parseHostedExecutionWake(JSON.parse(JSON.stringify(recovery.wake))), recovery.wake);
+      const item: HostedSystemMailboxPendingItem = {
+        attemptCount: 1,
+        itemId: "fanout-mailbox-owner",
+        lastAttemptAt: occurredAt,
+        lastErrorCode: null,
+        lastErrorMessage: null,
+        mailboxDedupeKey: wake.eventId,
+        mailboxLaneSeq: "1",
+        nextAttemptAt: null,
+        occurredAt,
+        postCheckpointRecord: {
+          kind: "device-sync.dirty-processed-batch",
+          nextWakeAt: retryAt,
+          records: [],
+          retainedWake: recovery.wake,
+          retainMailboxItemUntil: retryAt,
+        },
+        preferenceCausalSeq: null,
+        requestId: null,
+        routeAction: "run-device-sync-wake",
+        status: "recording",
+        wake,
+      };
+      await updateHostedSystemMailboxState(firstWorkspace.vaultRoot, () => ({ pending: [item] }));
+      await recordHostedSystemMailboxItemAfterCheckpoint({
+        item,
+        runtime: createDeviceSyncPostCheckpointRuntime(port),
+        vaultRoot: firstWorkspace.vaultRoot,
+      });
+      const [retainedItem] = (await readHostedSystemMailboxState(firstWorkspace.vaultRoot)).pending;
+      assert.equal(retainedItem?.status, "pending");
+      assert.equal(retainedItem.postCheckpointRecord, null);
+      assert.equal(retainedItem.nextAttemptAt, retryAt);
+      const restoredWake = retainedItem.wake;
+      assert.deepEqual(restoredWake, recovery.wake);
+      const restoredState = await syncHostedDeviceSyncControlPlaneState({
+        deviceSyncPort: port, secret: DEVICE_SYNC_SECRET, service: restoredService, wake: restoredWake,
+      });
+      const restoredAccountId = restoredState.hostedToLocalAccountIds.get(connectionId);
+      assert.ok(restoredAccountId);
+      assert.equal(await restoredService.drainWorker(HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT, restoredAccountId), 0);
+      vi.setSystemTime(new Date(retryAt));
+      assert.equal(await restoredService.drainWorker(HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT, restoredAccountId), 100);
+      assert.equal(restoredExecuteJob.mock.calls.length, 100);
+      const nextRecovery = resolveHostedDeviceSyncWakeRecovery({
+        service: restoredService, state: restoredState, wake: restoredWake,
+      });
+      assert.equal(nextRecovery?.wake.hint?.jobs?.length, 1);
+      assert.equal(await restoredService.drainWorker(HOSTED_DEVICE_SYNC_PASS_JOB_LIMIT, restoredAccountId), 1);
+      assert.equal(restoredExecuteJob.mock.calls.length, 101);
+      assert.equal(resolveHostedDeviceSyncWakeRecovery({
+        service: restoredService, state: restoredState, wake: restoredWake,
+      }), null);
+    } finally {
+      vi.useRealTimers();
+      closeHostedRuntimeDeviceSyncService(firstService);
       closeHostedRuntimeDeviceSyncService(restoredService);
       await firstWorkspace.cleanup();
       await restoredWorkspace.cleanup();

--- a/packages/device-syncd/src/store.ts
+++ b/packages/device-syncd/src/store.ts
@@ -53,7 +53,7 @@ import {
   findActiveDeviceSyncJobDedupeKeys,
   getDeviceSyncJobById,
   listDueDeviceSyncJobBatchCandidates,
-  listPendingDeviceSyncJobsForAccount,
+  iteratePendingDeviceSyncJobsForAccount,
   markPendingDeviceSyncJobsDeadForAccount,
   markPendingDeviceSyncJobsDeadForAccountIfCurrent,
   readNextDeviceSyncJobWakeAt,
@@ -643,11 +643,16 @@ export class SqliteDeviceSyncStore {
   }
 
   listPendingJobsForAccount(accountId: string, limit: number): DeviceSyncJobRecord[] {
-    return listPendingDeviceSyncJobsForAccount({
+    return [...iteratePendingDeviceSyncJobsForAccount({
       accountId,
       database: this.database,
       limit,
-    });
+    })];
+  }
+
+  // Export every accepted job for recovery, independently of worker pass size.
+  iteratePendingJobsForAccount(accountId: string): Generator<DeviceSyncJobRecord> {
+    return iteratePendingDeviceSyncJobsForAccount({ accountId, database: this.database });
   }
 
   findActiveJobDedupeKeys(input: {

--- a/packages/device-syncd/src/store/jobs.ts
+++ b/packages/device-syncd/src/store/jobs.ts
@@ -241,11 +241,11 @@ export function getDeviceSyncJobById(database: DatabaseSync, jobId: string): Dev
   return mapJobRow(row);
 }
 
-export function listPendingDeviceSyncJobsForAccount(input: {
+export function* iteratePendingDeviceSyncJobsForAccount(input: {
   accountId: string;
   database: DatabaseSync;
-  limit: number;
-}): DeviceSyncJobRecord[] {
+  limit?: number;
+}): Generator<DeviceSyncJobRecord> {
   const rows = input.database.prepare(`
     select *
     from device_job
@@ -253,14 +253,16 @@ export function listPendingDeviceSyncJobsForAccount(input: {
       and status in ('queued', 'running')
     order by created_at asc, id asc
     limit ?
-  `).all(
+  `).iterate(
     input.accountId,
-    input.limit,
-  ).map((row) => decodeStoredJobRow(row));
-  return rows.flatMap((row) => {
-    const job = mapJobRow(row);
-    return job ? [job] : [];
-  });
+    input.limit ?? -1,
+  );
+  for (const row of rows) {
+    const job = mapJobRow(decodeStoredJobRow(row));
+    if (job) {
+      yield job;
+    }
+  }
 }
 
 export function findActiveDeviceSyncJobDedupeKeys(input: {

--- a/packages/device-syncd/test/store.test.ts
+++ b/packages/device-syncd/test/store.test.ts
@@ -5984,3 +5984,53 @@ function normalizeWebhookTraceRow(
 ): ReturnType<typeof readWebhookTraceRowForTesting> {
   return row ? { ...row } : null;
 }
+
+
+test("pending recovery streams every accepted job and releases an interrupted read", async () => {
+  const tempDir = await makeTempDirectory("murph-device-syncd-pending-recovery");
+  const store = new SqliteDeviceSyncStore(path.join(tempDir, "state.sqlite"));
+  try {
+    const accounts = ["recovery", "unrelated"].map((externalAccountId) => store.upsertAccount({
+      connectedAt: "2026-04-04T09:00:00.000Z",
+      displayName: "Synthetic device",
+      externalAccountId,
+      provider: "demo",
+      scopes: [],
+      status: "active",
+      tokens: { accessToken: "synthetic", accessTokenEncrypted: "enc:synthetic" },
+    }));
+    const [account, unrelated] = accounts;
+    assert.ok(account);
+    assert.ok(unrelated);
+    const pending = Array.from({ length: 201 }, (_, index) => store.enqueueJob({
+      accountId: account.id,
+      availableAt: "2026-04-04T10:00:00.000Z",
+      dedupeKey: `recovery-${index}`,
+      kind: "reconcile",
+      payload: {},
+      provider: "demo",
+    }));
+    store.enqueueJob({ accountId: unrelated.id, kind: "reconcile", payload: {}, provider: "demo" });
+    const completed = store.claimDueJob("recovery-worker", "2026-04-04T10:00:00.000Z", 60_000, account.id);
+    assert.ok(completed);
+    store.completeJob(completed.id, "2026-04-04T10:00:00.000Z");
+    const running = store.claimDueJob("recovery-worker", "2026-04-04T10:00:00.000Z", 60_000, account.id);
+    assert.ok(running);
+    const exported = [...store.iteratePendingJobsForAccount(account.id)];
+    assert.deepEqual(
+      exported.map((job) => job.id).sort(),
+      pending.filter((job) => job.id !== completed.id).map((job) => job.id).sort(),
+    );
+    assert.equal(exported.find((job) => job.id === running.id)?.status, "running");
+    assert.equal(store.listPendingJobsForAccount(account.id, 100).length, 100);
+    for (const job of store.iteratePendingJobsForAccount(account.id)) {
+      assert.equal(job.accountId, account.id);
+      break;
+    }
+    store.completeJob(running.id, "2026-04-04T10:00:00.000Z");
+    assert.equal([...store.iteratePendingJobsForAccount(account.id)].length, 199);
+  } finally {
+    store.close();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Why and outcome

A device-sync pass can start with 100 accepted jobs and grow beyond 100 when a provider job creates follow-ups. Recovery incorrectly rejected that remaining queue as larger than one execution pass, preventing a checkpoint and repeatedly replaying the same work.

Stream all pending jobs for the admitted account into its existing mailbox continuation. Use that same complete stream when relinking dirty acknowledgements, retaining only matches from the current dirty page. Preserve exact retry payloads, identities, timing, and remaining attempts. Execution and new dirty-work admission still use the existing 100-job budgets.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Connected-device work survives a runtime restart after provider follow-ups expand the queue. Future retries wait until due; the restored worker drains at most 100 jobs per pass. Other accounts, completed jobs, provider scheduling, foreground priority, and connection authority retain existing behavior.

## Evidence

- Definitive local reproduction: a real device-sync service completed one of 100 accepted jobs and enqueued two follow-ups. Baseline recovery threw its durable-limit error with 101 pending jobs.
- Corrected proof preserves all 101 through mailbox recording, disk readback, wire parsing, and fresh-service reconstruction. Zero jobs run before retry time; subsequent drains execute 100 then 1.
- 360 tests passed: 124 hosted device-sync runtime, 176 mailbox/real workspace entrypoint/preemption, and 60 device-store tests. Includes account isolation, running jobs, terminal exclusion, interrupted iteration, and maximum dirty-input read counts.
- `pnpm --dir packages/device-syncd typecheck` and `pnpm --dir packages/assistant-runtime typecheck` passed.
- A second deterministic restart regression places 150 future follow-ups before 100 dirty-owned jobs. The partial read loses all 100 acknowledgement links; complete streaming restores every link without admitting another job.
- `git diff --check` passed. ReviewGPT round 1 full-snapshot audit: PASS on `698b2063b0de3a7af7cef322e16c00c6e382196c`; model and response hash verified. No qualifying Critical/High bugs or material Complexity Collapse findings. All 33 exact-head CI checks passed before merge. Production deployment completed successfully, including deployed endpoint smoke, a live model turn, and live Cloudflare state verification.

## Non-obvious affected surfaces

The bounded diagnostic list, dirty-admission matching, and recovery export share the same query and decoder. Admission streams the entire pending account queue to count capacity and retains only dedupe identities requested by the current bounded dirty page. Its 100-job new-admission budget is unchanged. The maximum dirty-input test asserts one admission read and one scoped recovery read.

## Architecture and reuse

- Existing systems reused: SQLite job owner, manifest-safe retry shaping, mailbox continuation and post-checkpoint recorder, wire parser, and cold hydration.
- New logic: Stream the existing pending query and remove the execution-budget rejection from recovery.
- New abstractions: One iterator method on the existing store; the bounded list wraps the same iterator. No new state owner or storage format.
- Complexity intentionally avoided: No queue, schema, timer, retry policy, arbitrary larger job cap, truncation, or provider-specific recovery branch.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; runtime-source debt 145 to 143, maximum 75 unchanged. Store and job-query debt remain zero.
- Hotspots: Changed resolveHostedDeviceSyncWakeRecovery decreases 29 to 27. Six pre-existing hotspots in the runtime file remain unchanged; their surrounding authority and data shaping were inspected.
- Agent judgment: Removing the incorrect rejection and streaming through the existing query keeps one owner. Further splitting the recovery serializer would add indirection without simplifying its contract.

## Hot reply path impact

- Path status: Not applicable — background device-sync recovery; foreground preemption is unchanged.
- Database calls: No added call; recovery uses one account read and one pending-job query. Admission also keeps one pending-job query and a dedupe map bounded to its current dirty page. Recovery's query streams only that account's queued/running rows, with zero credential decryptions, external calls, writes, or concurrent cursors. The existing workspace snapshot byte envelope remains the publication bound.
- Network/provider calls: None added.
- Other awaited latency: None added.
- Before/after proof: Maximum dirty-input read-count proof and foreground preemption suite pass.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no assistant-provider input surface changed.

## Design proof

- Design page: [Changelog archive presentation](https://www.withmurph.ai/screenshots/ops#changelog-archive).
- Evidence: Content-only changelog copy reviewed; `pnpm --dir apps/web test -- changelog-page.test.tsx` passed all 9 tests.
- Coverage: Existing archive presentation is unchanged.

## Deployment concerns

- Deployment: applicable
- Supported skew: No mailbox or provider protocol change. Existing readers parse the larger job array; old runtimes retain the original recovery failure if more than 100 jobs remain.
- Safe order: Normal protected Cloudflare hosted deployment with immediate container rollout and all standard predeploy/smoke gates. No Web ordering dependency or migration.
- Rollback floor: This fix is required to checkpoint queues larger than one pass. Older code can read those hints but can reproduce the stall; a rollback requires separate explicit authorization.
- Expected exposure: Progress resumes on the next admitted connection pass. Future provider backoff remains respected.
- Reversibility: Code-only; no deletion or durable-state migration.
- Convergence proof: Legacy-shaped input grows through provider completion, round-trips through the existing parser and mailbox, and reconstructs in a fresh service.
- Post-deploy checks: Verify deployed source, smoke checks, successful recovery checkpointing, mailbox progress, and retained future retry timing through read-only aggregates.

## Change-shape breakdown

Runtime TypeScript is Source, test files are Tests, owner documentation and execution plan are Docs, and authored changelog JSON is Generated / other. No binaries or generated output.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 53 | 58 |
| Tests / fixtures | 207 | 14 |
| Docs | 45 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 19 | 0 |
| **Total** | **324** | **73** |

## Changelog

- Changelog: updated
- Items: 2026-09-07 · connected-device-large-sync-recovery

ReviewGPT context sensitivity: sensitive
Classification reason: Hosted queue recovery, checkpoint durability, and shared device-store query behavior.

ReviewGPT first-reviewed head: 698b2063b0de3a7af7cef322e16c00c6e382196c
