### PR TITLE
docs: bound runtime event inventories and report partial coverage

### DIFF
--- a/docs/hosted-runtime-log-database.md
+++ b/docs/hosted-runtime-log-database.md
@@ -381,6 +381,58 @@ nonces belong to a separate primary-database nonce cron at minute 5; its
 callback statements retain the 5,000-row statement cap and use a dedicated
 400-batch catch-up ceiling.
 
+### Bounded event inventories
+
+For an already-authorized aggregate diagnostic that times out over a day, keep
+its fixed UTC window and event filter, then query six adjacent four-hour slices
+sequentially. Use one connection and a separate statement for each slice, with
+the existing ten-second server and twelve-second client query bounds. Combining
+all slices into one statement would retain the original statement-budget limit.
+Do not increase timeouts or infer an index bottleneck from a timeout alone.
+
+For example, the first slice of the synthetic day `[2030-01-01, 2030-01-02)` is:
+
+```sql
+SELECT
+  TIMESTAMPTZ '2030-01-01T00:00:00Z' AS slice_start,
+  TIMESTAMPTZ '2030-01-01T04:00:00Z' AS slice_end,
+  COUNT(*) AS event_count,
+  MIN(at) AS first_at,
+  MAX(at) AS last_at
+FROM hosted_runtime_log
+WHERE at >= TIMESTAMPTZ '2030-01-01T00:00:00Z'
+  AND at < TIMESTAMPTZ '2030-01-01T04:00:00Z'
+  AND event_code = 'outbox.delivery_finished';
+```
+
+Advance both bounds by four hours for each subsequent statement, ending at the
+original window end. Keep all other predicates and grouping keys identical.
+Bound each pass to six sequential slice queries; if a slice still times out,
+record its interval as unknown and use a later bounded pass for smaller slices.
+Retain only aggregate results and their interval, completion status, and
+observation time; never return subject keys or raw JSON.
+
+A successful zero count is different from an unsuccessful query. Report a
+complete interval inventory only when successful, nonoverlapping slices cover
+the entire original window; otherwise list the missing intervals and label the
+total partial. A retry replaces the result for the same interval. If smaller
+slices replace an interval, require their bounds to cover it exactly and do not
+count both the parent interval and its replacements.
+
+For matching groups, sum event counts and combine `MIN`/`MAX` endpoints. Do not
+sum per-slice `COUNT(DISTINCT subject_key)`: a subject can occur in several
+slices. Keep distinct counts per slice unless a separately bounded whole-window
+query establishes the union. Averages and percentiles are not additive either.
+
+Interval coverage describes retained rows observed by those statements, not one
+consistent database snapshot. Appends and retention can change rows between
+[Read Committed statements](https://www.postgresql.org/docs/current/transaction-iso.html#XACT-READ-COMMITTED).
+Record that limitation with the observation window; do not hold a long snapshot
+transaction merely to combine diagnostic slices. Compare plans with
+`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` on representative synthetic local data
+before proposing an index change; local timing does not establish production
+performance or the cause of a production timeout.
+
 ## Configuration
 
 Runtime traffic:


### PR DESCRIPTION
## Why and outcome

The runtime-log owner documented whole-window aggregates without a bounded fallback or a way to distinguish a complete inventory from partial results. This adds a sequential slice recipe with explicit interval accounting, retry replacement, distinct-count limits, and the observation-snapshot caveat.

Frog autofix issue: #2996

## Product UX

- Effort: Not applicable — internal diagnostic documentation.
- Result: Not applicable
- Walkthrough: Operators retain the existing access and query-budget boundaries; no member-facing flow changes.

## Evidence

- Direct: Applied the unchanged runtime-log init migration in a disposable loopback-only PostgreSQL database. On 100,007 synthetic rows, the whole-day query and six disjoint four-hour slices both returned 506 events, including six in-window boundary rows. The exact documented SQL passed all six interval receipts. Distinct subjects were 5 for the day versus an invalid sum of 30 per-slice distinct counts.
- Coverage: Compared `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` for the existing count query and its slices under the existing 10-second server / 12-second client bounds. The local day plan took 129.211 ms; individual slices took 1.851–16.354 ms. These are local observations, not production or cold-cache performance claims.
- Limits: A larger 1,000,007-row attempt remained incomplete after a four-hour slice hit the statement budget; no complete result is credited to it. Fixture insert batches were reduced after a setup statement exceeded the same budget. Every task-created database was removed. No production data, schema/index change, or timeout increase was used.
- Checks: Exact documented SQL, interval endpoints, count equivalence, non-additive distinct-count counterexample, `git diff --check`, and `pnpm docs:drift` passed. `pnpm docs:gardening` passed with zero issues.

## Non-obvious affected surfaces

None — the change is confined to the existing runtime-log owner document.

## Architecture and reuse

- Existing systems reused: The isolated runtime-log schema, existing aggregate query, retention/time index, and established query bounds.
- New logic: No runtime logic; the document explains bounded manual query composition and completeness reporting.
- New abstractions: None; the existing document remains the owner.
- Complexity intentionally avoided: No query dispatcher, index, migration, persistent inventory state, or additional datastore.

## Complexity impact

- Guard: Not applicable — no authored JavaScript or TypeScript changed.
- Hotspots: None; one Markdown document only.
- Agent judgment: The example and accounting rules cover the documented fallback without adding an implementation owner.

## Hot reply path impact

- Path status: Not applicable — operator documentation does not execute in conversation handling.
- Database calls: None added to runtime.
- Network/provider calls: None added.
- Other awaited latency: None added.
- Before/after proof: The entire diff is Markdown.

## Murph initial provider input impact

- Individual Murph: Not applicable — no provider-input surface changes.
- Group Murph: Not applicable — no provider-input surface changes.
- Measurement method: Not run — runtime prompts, tools, schemas, and history are unchanged.

## Deployment concerns

- Deployment: not applicable
- Reason: Documentation only; no runtime artifact, schema, deployment order, or permission changes.

## Change-shape breakdown

Classification rule: The sole changed Markdown owner document is documentation; no binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 0 | 0 |
| Docs | 52 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **52** | **0** |

## Changelog

- Changelog: not applicable
- Reason: Internal diagnostic documentation with no member-visible change.

ReviewGPT context sensitivity: routine
Classification reason: Documentation of existing read-only aggregate behavior; no source, authorization, schema, or external-effect boundary changes.
ReviewGPT first-reviewed head: f6655acecd6c7d3b518fd845c5baff0475ed47e1
