### PR TITLE
Stage ready runner images before message cutover

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-07-rollout-version-safety.md
+++ b/agent-docs/exec-plans/active/2026-09-07-rollout-version-safety.md
@@ -1,0 +1,66 @@
+# Keep image rollouts off the message path
+
+Status: active
+Created: 2026-09-07
+Updated: 2026-09-07
+
+## Goal
+
+Prepare a matching, ready runtime before selecting it for member messages.
+Keep the serving image untouched during preparation and preserve in-flight owners.
+
+## Success criteria
+
+- Reproduce the previous Worker/new-image ordering failure with synthetic inputs.
+- A slow or failed candidate cannot be selected for member work.
+- Exact image admission remains enforced independently for both targets.
+- Promotion changes the selected release without rolling either container target.
+- A previous target cannot be reused until provider evidence proves it drained.
+- Focused tests, typecheck, required review/CI, protected deployment and live
+  convergence verification pass.
+
+## Scope and constraints
+
+Reuse the existing UserRunner write fence, opaque slot identities, standby
+coordinator, signed deploy smoke, Wrangler and release receipts. Add one
+interchangeable container namespace and an explicit deployment release identity.
+No new retry policy, scheduler, product state owner or model behavior.
+Use synthetic evidence; production credentials remain in the protected workflow.
+
+## Product UX
+
+Effort: Patch. Foreground messages keep the active image throughout candidate
+preparation. Candidate readiness and drain waits belong to deployment only.
+Existing completion and cleanup calls retain their exact container name.
+Status: Hold pending complete verification and deployment.
+
+## Decisions
+
+- Full Wrangler deploys activate Worker code before updating container images.
+  Immediate rollout does not make those operations transactional.
+- Publish the image once and pin its registry digest before any activation.
+- Stage the inactive namespace with the current release still selected.
+  Wrangler per-application `rollout_kind: none` freezes the serving application.
+- Reuse signed smoke and the existing ready-slot inventory before promotion.
+- Promote with rollout disabled for every application; retain the old release
+  until its instances drain. The next deployment reads live release metadata.
+- Preserve consumer-first Worker/container protocol compatibility: preparation
+  runs the new backward-compatible Worker controller against the old active image.
+- Remove the earlier short-retry experiment. No failure delay is added or shortened.
+
+## Tasks
+
+1. Trace the production failure and reproduce readiness rejection. Complete.
+2. Implement immutable publication and stage/smoke/promote ordering. In progress.
+3. Verify cold/warm readiness, exact-owner routing, candidate failure and drain.
+4. Update deployment contracts, run typecheck and required candidate review.
+5. Commit, PR, ReviewGPT/CI, merge, protected deploy and verify live state.
+
+## Verification
+
+Focused Node tests cover both images before/after promotion, retained cleanup
+authority, stage configuration, delayed/failed readiness and receipt parsing.
+Run the existing runner, standby, deployment and artifact regressions, native
+Wrangler bundle/config proof, typecheck, complexity guard and exact-head CI.
+Production rollout timing remains a hosted verification boundary; local tests
+model the provider ordering and exercise the real application owners.

--- a/agent-docs/exec-plans/active/2026-09-07-rollout-version-safety.md
+++ b/agent-docs/exec-plans/active/2026-09-07-rollout-version-safety.md
@@ -32,7 +32,7 @@ Use synthetic evidence; production credentials remain in the protected workflow.
 Effort: Patch. Foreground messages keep the active image throughout candidate
 preparation. Candidate readiness and drain waits belong to deployment only.
 Existing completion and cleanup calls retain their exact container name.
-Status: Hold pending complete verification and deployment.
+Status: Ready for final review; protected deployment remains pending.
 
 ## Decisions
 
@@ -51,8 +51,8 @@ Status: Hold pending complete verification and deployment.
 ## Tasks
 
 1. Trace the production failure and reproduce readiness rejection. Complete.
-2. Implement immutable publication and stage/smoke/promote ordering. In progress.
-3. Verify cold/warm readiness, exact-owner routing, candidate failure and drain.
+2. Implement immutable publication and stage/smoke/promote ordering. Complete.
+3. Verify cold/warm readiness, exact-owner routing, candidate failure and drain. Complete.
 4. Update deployment contracts, run typecheck and required candidate review.
 5. Commit, PR, ReviewGPT/CI, merge, protected deploy and verify live state.
 
@@ -64,3 +64,8 @@ Run the existing runner, standby, deployment and artifact regressions, native
 Wrangler bundle/config proof, typecheck, complexity guard and exact-head CI.
 Production rollout timing remains a hosted verification boundary; local tests
 model the provider ordering and exercise the real application owners.
+
+Local verification: 816 Cloudflare tests and nine changelog rendering tests passed.
+Cloudflare and Web typechecks, native Wrangler immutable-image dry run and the
+complexity guard passed. Zero-target/off inventory still proves the actual
+candidate namespace through the existing prepare/retire lifecycle.

--- a/agent-docs/exec-plans/completed/2026-09-07-rollout-version-safety.md
+++ b/agent-docs/exec-plans/completed/2026-09-07-rollout-version-safety.md
@@ -1,6 +1,6 @@
 # Keep image rollouts off the message path
 
-Status: active
+Status: completed
 Created: 2026-09-07
 Updated: 2026-09-07
 
@@ -32,7 +32,7 @@ Use synthetic evidence; production credentials remain in the protected workflow.
 Effort: Patch. Foreground messages keep the active image throughout candidate
 preparation. Candidate readiness and drain waits belong to deployment only.
 Existing completion and cleanup calls retain their exact container name.
-Status: Ready for final review; protected deployment remains pending.
+Status: completed
 
 ## Decisions
 
@@ -53,8 +53,9 @@ Status: Ready for final review; protected deployment remains pending.
 1. Trace the production failure and reproduce readiness rejection. Complete.
 2. Implement immutable publication and stage/smoke/promote ordering. Complete.
 3. Verify cold/warm readiness, exact-owner routing, candidate failure and drain. Complete.
-4. Update deployment contracts, run typecheck and required candidate review.
-5. Commit, PR, ReviewGPT/CI, merge, protected deploy and verify live state.
+4. Update deployment contracts, run typecheck and required candidate review. Complete.
+5. PR #3030 contains the implementation. Final review passed; exact-head CI,
+   merge, protected deployment and live verification continue as the release handoff.
 
 ## Verification
 
@@ -69,3 +70,18 @@ Local verification: 816 Cloudflare tests and nine changelog rendering tests pass
 Cloudflare and Web typechecks, native Wrangler immutable-image dry run and the
 complexity guard passed. Zero-target/off inventory still proves the actual
 candidate namespace through the existing prepare/retire lifecycle.
+
+## Final review and release handoff
+
+Round one passed at `5f37eb6137c07228d9c0b8c52c9cac08c8c387c5` with no
+qualifying findings and no accepted issues remaining. The Phlebas lane selected
+`gpt-6-pro`; captured model metadata and the response hash agree. One complete
+repository snapshot was attached, and the exact committed turn was captured
+after more than seven minutes. The review identified all 35 changed files and
+examined staging, promotion, drain, routing, retention and receipt owners. This
+is static review evidence; local tests and protected hosted checks own execution.
+
+Only this explanatory plan closure follows the reviewed implementation. PR
+#3030 tracks remaining CI and release evidence. No production deployment is
+claimed by this implementation record.
+Completed: 2026-09-07

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -22,6 +22,36 @@ That rendered surface is then used by:
 
 The rendered deploy helper path is the canonical direct Wrangler deploy contract consumed from the private deployment workflow. The checked-in Wrangler scaffold remains useful for local development, but production deploys must run from private Murph Cloud and use the rendered config so hosted email send bindings stay environment-specific and sender-restricted.
 `deploy:worker:apply` validates the generated Wrangler config, worker secrets payload, and `.deploy/runner-bundle/` manifest before invoking Wrangler. The runner bundle manifest records the assembled workspace closure and source/bundle fingerprints. Production assembly now builds the runner bundle first and renders those exact fingerprints into the Worker config; applying after a stale hosted-local bundle, a smoke-mutated bundle, or a config rendered for another bundle fails before upload.
+The production helper publishes one immutable registry image before activating
+Worker code. It then prepares the inactive `RunnerContainer` or
+`NextRunnerContainer` application while `HOSTED_EXECUTION_RUNNER_DEPLOYMENT`
+keeps the current release selected. The serving application and retained legacy
+application use Wrangler's per-application `rollout_kind: none`; preparation
+cannot replace their running instances. Signed deploy smoke verifies the
+candidate image and fills its existing ready-slot inventory. Only after that
+proof does a second Worker deployment select the candidate, with container
+rollout disabled for every application. No readiness wait or new retry policy
+is added to message processing.
+
+Release identity is independent of the two Worker activations. Each container
+namespace admits its own exact bundle/source fingerprints. Persisted opaque
+slot names retain their original namespace for completion, cancellation and
+cleanup. Before reusing the previous namespace, deployment waits for provider
+instance evidence that it has drained; unknown state stops deployment while
+the active release keeps serving. Both targets have the configured member
+capacity, allowing old in-flight work and new work to overlap; the standby
+inventory remains bounded per release and Cloudflare account limits still apply.
+
+Preparation upgrades the shared Worker controller before changing the selected
+runner. Worker/controller changes therefore still require consumer-first
+compatibility with the serving runner. This procedure does not permit a
+breaking protocol change to skip its compatibility release. A failed candidate
+leaves the old image selected. Do not manually publish a generated config that
+bypasses this helper, or recycle an inactive namespace before drain proof.
+After promotion the helper records the effective config at the canonical
+generated path so private convergence verification checks retained capacities
+and exact image receipts. Rollback remains an explicitly authorized operation.
+
 The deploy helper also rejects generated config or secrets that no longer match the current environment, and rejects runner bundles assembled with `runner:bundle:assemble-only` so smoke-only build shortcuts cannot be uploaded as production artifacts.
 Every protected deploy must set `HOSTED_EXECUTION_DEPLOY_TAG` to the private
 workflow run and attempt identity. The direct deploy emits one ephemeral

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -2402,7 +2402,7 @@ Gradual deploys run managed-container smoke with a longer retry window so Cloudf
 The GitHub deploy workflow enables `HOSTED_EXECUTION_SMOKE_RUNNER_CONTAINER` for every Worker deploy and sets a longer managed-container retry window for gradual rollouts. It enables `HOSTED_EXECUTION_SMOKE_DIRECT_R2_PRESIGNED_PUT` only when `container_rollout=immediate`, and `HOSTED_EXECUTION_SMOKE_LIVE_MODEL_TURN` per the `live_model_turn` input (default on).
 
 When standby mode is `shadow` or `allocate`, the initial signed container smoke
-asks the current-release global coordinator to maintain inventory and reads its
+asks the candidate-release global coordinator to maintain inventory and reads its
 canonical state. It requires the configured number of distinct ready slots and
 no pending preparation. Incomplete inventory returns a retryable failure before
 starting the container probe. The response exposes only counts and release-match
@@ -2412,6 +2412,10 @@ proof when the expected mode is enabled, using `HOSTED_EXECUTION_STANDBY_TARGET`
 check because foreground traffic can consume a previously verified slot. This
 proves a ready inventory snapshot; the migration checks above still own failed
 preparation recovery, drain, foreground allocation and background exclusion.
+
+When ready inventory is disabled or targets zero slots, the initial smoke prepares
+and retires one synthetic unbound slot in the actual candidate namespace. A
+separate smoke application alone is not evidence that the candidate image is ready.
 
 Optional smoke env:
 

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -11,7 +11,7 @@ Cloudflare-hosted execution plane for the hosted Murph path.
   OIDC-authenticated browser/session/status/deletion control requests from
   `apps/web`
 - per-user execution coordination in `USER_RUNNER`
-- native runner-container lifecycle in `RUNNER_CONTAINER`
+- native runner-container lifecycle in `RUNNER_CONTAINER` and `NEXT_RUNNER_CONTAINER`
 - encrypted hosted workspace snapshots, legacy encrypted artifact blobs, encrypted runner-secrets blobs, and the execution-sidecar blobs needed to run hosted jobs in `BUNDLES`
 
 ## What It Does Not Own
@@ -65,7 +65,10 @@ checks.
 
 ### Unified runner fleet and ready inventory
 
-All fresh member execution uses globally eligible `RunnerContainer` instances.
+All fresh member execution uses the selected globally eligible runner target,
+`RunnerContainer` or `NextRunnerContainer`. Deployment prepares the inactive
+target before promotion; both use the same lifecycle implementation. See
+`DEPLOY.md` for preparation, exact-image admission and drain ownership.
 Warm and cold allocations use the same opaque target identity and lifecycle.
 `HOSTED_EXECUTION_STANDBY_TARGET` selects the number of pristine ready slots:
 its default is `2`, and valid values are integers from `0` through `32`. This is

--- a/apps/cloudflare/scripts/container-release-receipt.ts
+++ b/apps/cloudflare/scripts/container-release-receipt.ts
@@ -142,6 +142,7 @@ export function parseWranglerContainerActions(
   );
   const observed: Array<{ action: WranglerContainerActionKind; applicationName: string }> = [];
 
+  let pendingEditApplication: string | null = null;
   for (const line of stripAnsi(output).replaceAll("\r", "\n").split("\n")) {
     const created = matchOutputAction(
       line,
@@ -168,6 +169,13 @@ export function parseWranglerContainerActions(
       ),
     );
 
+    const edit = matchOutputAction(line, new RegExp(`(?:^|[^A-Za-z0-9._-])EDIT ${OUTPUT_APPLICATION_NAME}[^A-Za-z0-9._-]*$`, "u"));
+    if (edit) pendingEditApplication = edit;
+    if (/\bSkipping application rollout\s*$/u.test(line) && pendingEditApplication) {
+      observed.push({ action: "unchanged", applicationName: pendingEditApplication });
+      pendingEditApplication = null;
+    }
+    if (created || modified || unchanged) pendingEditApplication = null;
     if (created) {
       observed.push({ action: "created", applicationName: created });
     }

--- a/apps/cloudflare/scripts/deploy-artifacts.ts
+++ b/apps/cloudflare/scripts/deploy-artifacts.ts
@@ -463,6 +463,11 @@ function assertGeneratedWranglerConfig(config: Record<string, unknown>): void {
   assertGeneratedContainerUsesPreparedImage(runnerContainer);
   assertGeneratedContainerUsesPreparedImage(deploySmokeContainer);
   assertGeneratedContainerUsesPreparedImage(standbyRunnerContainer);
+  const nextRunnerContainer = findGeneratedContainerConfig(containers, "NextRunnerContainer");
+  if (!nextRunnerContainer) {
+    throw new Error("Generated Wrangler config is missing the NextRunnerContainer entry.");
+  }
+  assertGeneratedContainerUsesPreparedImage(nextRunnerContainer);
 }
 
 function findGeneratedContainerConfig(

--- a/apps/cloudflare/scripts/deploy-automation/environment.ts
+++ b/apps/cloudflare/scripts/deploy-automation/environment.ts
@@ -186,7 +186,7 @@ function readHostedRunnerContainerCapacity(
   if (source.CF_STANDBY_CONTAINER_MAX_INSTANCES !== undefined) {
     throw new Error(
       "CF_STANDBY_CONTAINER_MAX_INSTANCES is obsolete. Remove it; set "
-      + "CF_CONTAINER_MAX_INSTANCES to the total member capacity (excluding smoke), "
+      + "CF_CONTAINER_MAX_INSTANCES to the member capacity per active release (excluding smoke), "
       + "and CF_LEGACY_STANDBY_CONTAINER_MAX_INSTANCES to the temporary legacy reservation.",
     );
   }

--- a/apps/cloudflare/scripts/deploy-automation/wrangler-config.ts
+++ b/apps/cloudflare/scripts/deploy-automation/wrangler-config.ts
@@ -100,6 +100,11 @@ export function buildHostedWranglerDeployConfig(
           RUNNER_CONTAINER_ROLLOUT_ACTIVE_GRACE_PERIOD_SECONDS,
       }),
       buildRunnerContainerConfig({
+        className: "NextRunnerContainer",
+        maxInstances: environment.containerMaxInstances - environment.legacyStandbyContainerMaxInstances,
+        rolloutActiveGracePeriodSeconds: RUNNER_CONTAINER_ROLLOUT_ACTIVE_GRACE_PERIOD_SECONDS,
+      }),
+      buildRunnerContainerConfig({
         className: "DeploySmokeRunnerContainer",
         maxInstances: 1,
         rolloutActiveGracePeriodSeconds:
@@ -136,6 +141,10 @@ export function buildHostedWranglerDeployConfig(
         {
           name: "RUNNER_CONTAINER",
           class_name: "RunnerContainer",
+        },
+        {
+          name: "NEXT_RUNNER_CONTAINER",
+          class_name: "NextRunnerContainer",
         },
         {
           name: "RUNNER_CONTAINER_SMOKE",
@@ -185,6 +194,10 @@ export function buildHostedWranglerDeployConfig(
           "StandbyRunnerCoordinatorDurableObject",
           "StandbyRunnerContainer",
         ],
+      },
+      {
+        tag: "v8",
+        new_sqlite_classes: ["NextRunnerContainer"],
       },
     ],
     triggers: {

--- a/apps/cloudflare/scripts/deploy-worker-version.cli.ts
+++ b/apps/cloudflare/scripts/deploy-worker-version.cli.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -14,6 +14,10 @@ import {
 } from "./deploy-automation/shared.ts";
 import { assertHostedDeployEnvironmentAsync } from "./deploy-preflight.js";
 import { resolveDeployWorkerCliPaths } from "./deploy-worker-version-paths.js";
+import { stageHostedRunnerRelease } from "./stage-runner-release.ts";
+import { createRunnerReleaseProvider } from "./runner-release-provider.ts";
+import { runSmokeHostedDeploy } from "./smoke-hosted-deploy.shared.ts";
+import { prepareHostedContainerDeployImage } from "./prepare-container-deploy-image.ts";
 import {
   createCloudflareContainerProvider,
   parseWranglerContainerActions,
@@ -54,9 +58,10 @@ export async function runDeployWorkerVersionCli(
     configPath,
     dependencies: {
       async deployDirect(input) {
-        const containerRolloutArgs = input.containerRolloutMode === "immediate"
-          ? ["--containers-rollout=immediate"]
-          : [];
+        const preparedConfigPath = await prepareHostedContainerDeployImage({
+          accountId: requireConfiguredString(env.CLOUDFLARE_ACCOUNT_ID, "CLOUDFLARE_ACCOUNT_ID"),
+          configPath: input.configPath,
+        });
 
         await applyHostedTransientLifecycleRules({
           deployRoot,
@@ -67,6 +72,23 @@ export async function runDeployWorkerVersionCli(
           accountId: requireConfiguredString(env.CLOUDFLARE_ACCOUNT_ID, "CLOUDFLARE_ACCOUNT_ID"),
           apiToken: requireConfiguredString(env.CLOUDFLARE_API_TOKEN, "CLOUDFLARE_API_TOKEN"),
         });
+        const releaseProvider = createRunnerReleaseProvider({
+          accountId: requireConfiguredString(env.CLOUDFLARE_ACCOUNT_ID, "CLOUDFLARE_ACCOUNT_ID"),
+          apiToken: requireConfiguredString(env.CLOUDFLARE_API_TOKEN, "CLOUDFLARE_API_TOKEN"),
+        });
+        const current = await readCurrentDeployment(input.workerName, input.configPath);
+        const currentVersionId = requireSingleLiveVersion(current);
+        const staged = await stageHostedRunnerRelease({
+          configPath: preparedConfigPath,
+          currentVersion: await releaseProvider.readWorkerVersion(input.workerName, currentVersionId),
+          currentVersionId,
+          listApplications: containerProvider.listApplications,
+        });
+        if (staged.mustDrainCandidate) {
+          if (!staged.candidateApplicationId) throw new Error("Previous runner target is missing.");
+          await releaseProvider.assertDrained(staged.candidateApplicationId);
+        }
+        await assertLiveVersion(input.workerName, input.configPath, currentVersionId);
         const before = await readCloudflareContainerApplicationIdentities(
           renderedContainers,
           containerProvider.listApplications,
@@ -76,8 +98,8 @@ export async function runDeployWorkerVersionCli(
         const deployOutput = await runWranglerLoggedCaptured([
           "deploy",
           "--config",
-          input.configPath,
-          ...containerRolloutArgs,
+          staged.configPath,
+          ...(input.containerRolloutMode === "immediate" ? ["--containers-rollout=immediate"] : []),
           "--message",
           input.deploymentMessage,
           "--name",
@@ -90,6 +112,27 @@ export async function runDeployWorkerVersionCli(
           `${deployOutput.stdout}\n${deployOutput.stderr}`,
           renderedContainers,
         );
+        if (actions.find((action) => action.applicationName === staged.activeApplicationName)?.action !== "unchanged") {
+          throw new Error("Staging unexpectedly changed the active runner application.");
+        }
+        const stageVersionId = parseWranglerWorkerVersionId(`${deployOutput.stdout}\n${deployOutput.stderr}`);
+        await assertLiveVersion(input.workerName, input.configPath, stageVersionId);
+        await runSmokeHostedDeploy({
+          source: {
+            ...env,
+            HOSTED_EXECUTION_SMOKE_RUNNER_CONTAINER: "true",
+            HOSTED_EXECUTION_SMOKE_VERSION_ID: stageVersionId,
+            HOSTED_EXECUTION_SMOKE_RUNNER_MANIFEST_PATH: path.join(runnerBundleDir, ".murph-runner-bundle-manifest.json"),
+          },
+        });
+        await assertLiveVersion(input.workerName, input.configPath, stageVersionId);
+        const promotionOutput = await runWranglerLoggedCaptured([
+          "deploy", "--config", staged.promotionConfigPath,
+          "--message", input.deploymentMessage, "--name", input.workerName,
+          "--tag", input.versionTag,
+          ...(input.includeSecrets ? ["--secrets-file", input.secretsFilePath] : []),
+        ]);
+        await writeFile(input.configPath, await readFile(staged.promotionConfigPath, "utf8"), "utf8");
         return {
           containers: await waitForCloudflareContainerReleaseEntries({
             actions,
@@ -99,7 +142,7 @@ export async function runDeployWorkerVersionCli(
             readRollout: containerProvider.readRollout,
           }),
           workerVersionId: parseWranglerWorkerVersionId(
-            `${deployOutput.stdout}\n${deployOutput.stderr}`,
+            `${promotionOutput.stdout}\n${promotionOutput.stderr}`,
           ),
         };
       },
@@ -185,4 +228,17 @@ async function readCurrentDeployment(
 
 function isWranglerNoDeploymentsError(error: unknown): boolean {
   return error instanceof Error && error.message.includes("has no deployments");
+}
+
+function requireSingleLiveVersion(deployment: DeploymentStatusPayload | null): string {
+  if (deployment?.versions.length !== 1 || deployment.versions[0]?.percentage !== 100) {
+    throw new Error("Staged runner deployment requires one authoritative live Worker version.");
+  }
+  return deployment.versions[0].version_id;
+}
+
+async function assertLiveVersion(workerName: string, configPath: string, expected: string): Promise<void> {
+  if (requireSingleLiveVersion(await readCurrentDeployment(workerName, configPath)) !== expected) {
+    throw new Error("Live Worker changed during runner preparation; promotion stopped.");
+  }
 }

--- a/apps/cloudflare/scripts/prepare-container-deploy-image.ts
+++ b/apps/cloudflare/scripts/prepare-container-deploy-image.ts
@@ -1,0 +1,72 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { isObjectRecord } from "./deploy-automation/shared.ts";
+import { runWranglerLoggedCaptured } from "./wrangler-runner.ts";
+
+/** Publish before `wrangler deploy`, which activates Worker code before building images. */
+export async function prepareHostedContainerDeployImage(input: {
+  accountId: string;
+  configPath: string;
+}): Promise<string> {
+  const source: unknown = JSON.parse(await readFile(input.configPath, "utf8"));
+  if (!isObjectRecord(source) || !Array.isArray(source.containers)
+    || source.containers.length === 0
+    || typeof source.name !== "string" || !/^[a-z0-9-]+$/u.test(source.name)
+    || !/^[a-f0-9]{32}$/u.test(input.accountId)) {
+    throw new Error("Prepared container deployment configuration is invalid.");
+  }
+  const configDir = path.dirname(input.configPath);
+  const containers = source.containers.map((container: unknown) => {
+    if (!isObjectRecord(container)
+      || typeof container.image !== "string"
+      || typeof container.image_build_context !== "string") {
+      throw new Error("Prepared deployment requires local runner image build inputs.");
+    }
+    return container;
+  });
+  const first = containers[0]!;
+  if (containers.some((container) =>
+    container.image !== first.image
+    || container.image_build_context !== first.image_build_context
+  )) {
+    throw new Error("Prepared runner containers must share one validated image build.");
+  }
+  // Keep the generated config beside its source so all relative bindings retain meaning.
+  const releaseId = randomUUID();
+  const imageTag = `${source.name}:prepared-${releaseId}`;
+  try {
+    await promisify(execFile)("docker", [
+      "build", "--platform", "linux/amd64",
+      "--file", path.resolve(configDir, String(first.image)),
+      "--tag", imageTag,
+      path.resolve(configDir, String(first.image_build_context)),
+    ], { maxBuffer: 16 * 1024 * 1024, timeout: 15 * 60_000 });
+  } catch {
+    // Child-process exceptions contain command paths and unbounded build output.
+    throw new Error("Runner image build failed before Worker activation.");
+  }
+  const pushed = await runWranglerLoggedCaptured([
+    "containers", "push", imageTag, "--config", input.configPath,
+  ]);
+  const digests = new Set(
+    [...`${pushed.stdout}\n${pushed.stderr}`.matchAll(/\bdigest:\s+(sha256:[a-f0-9]{64})\s+size:/gu)]
+      .map((match) => match[1]),
+  );
+  if (digests.size !== 1) {
+    throw new Error("Runner image publication did not prove one immutable digest; Worker was not activated.");
+  }
+  const image = `registry.cloudflare.com/${input.accountId}/${source.name}@${[...digests][0]}`;
+  const preparedPath = path.join(configDir, `wrangler.image-${releaseId}.jsonc`);
+  await writeFile(preparedPath, `${JSON.stringify({
+    ...source,
+    containers: containers.map(({ image_build_context: _context, ...container }) => ({
+      ...container,
+      image,
+    })),
+  }, null, 2)}\n`, { encoding: "utf8", flag: "wx" });
+  return preparedPath;
+}

--- a/apps/cloudflare/scripts/runner-release-provider.ts
+++ b/apps/cloudflare/scripts/runner-release-provider.ts
@@ -1,0 +1,61 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { isObjectRecord } from "./deploy-automation/shared.ts";
+
+/** Read-only deployment preconditions. Provider failures never permit a switch. */
+export function createRunnerReleaseProvider(input: {
+  accountId: string;
+  apiToken: string;
+  fetchImpl?: typeof fetch;
+}) {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const read = async (pathname: string): Promise<Record<string, unknown>> => {
+    let value: unknown;
+    try {
+      const response = await fetchImpl(
+        `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(input.accountId)}${pathname}`,
+        {
+          headers: { Authorization: `Bearer ${input.apiToken}` },
+          cache: "no-store",
+          signal: AbortSignal.timeout(30_000),
+        },
+      );
+      if (!response.ok) throw unavailable();
+      value = await response.json();
+    } catch { throw unavailable(); }
+    if (!isObjectRecord(value) || value.success !== true) throw unavailable();
+    return value;
+  };
+  return {
+    async readWorkerVersion(workerName: string, versionId: string): Promise<unknown> {
+      const response = await read(`/workers/scripts/${encodeURIComponent(workerName)}/versions/${encodeURIComponent(versionId)}`);
+      return response.result;
+    },
+    async assertDrained(applicationId: string): Promise<void> {
+      // This waits in CI, while the active target continues serving messages.
+      // Never stop a running member invocation to make a deployment progress.
+      // The application deployment list contains native instances, not the
+      // paginated historical Durable Object identities shown by the dashboard.
+      const deadline = Date.now() + 20 * 60_000;
+      do {
+        const response = await read(`/containers/applications/${encodeURIComponent(applicationId)}/deployments`);
+        if (!Array.isArray(response.result)) throw unavailable();
+        const info = response.result_info;
+        if (isObjectRecord(info) && info.next_page_token) throw unavailable();
+        const drained = response.result.every((instance: unknown) => {
+          if (!isObjectRecord(instance) || !isObjectRecord(instance.current_placement)
+            || !isObjectRecord(instance.current_placement.status)) return false;
+          const status = instance.current_placement.status;
+          return (status.container_status ?? status.health) === "stopped";
+        });
+        if (drained) return;
+        if (Date.now() >= deadline) break;
+        await delay(10_000);
+      } while (true);
+      throw new Error("Previous runner target still has live containers; deployment left the active target serving.");
+    },
+  };
+}
+
+function unavailable(): Error {
+  return new Error("Authoritative runner release state is unavailable; deployment stopped.");
+}

--- a/apps/cloudflare/scripts/stage-runner-release.ts
+++ b/apps/cloudflare/scripts/stage-runner-release.ts
@@ -1,0 +1,133 @@
+import { randomUUID } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  readHostedRunnerDeployment,
+  type HostedRunnerDeployment,
+  type HostedRunnerRelease,
+} from "../src/hosted-runner-release.ts";
+import { isObjectRecord } from "./deploy-automation/shared.ts";
+import type { ListCloudflareContainerApplications } from "./container-release-receipt.ts";
+
+export interface StagedRunnerRelease {
+  activeApplicationName: string;
+  candidateApplicationId: string | null;
+  configPath: string;
+  deployment: HostedRunnerDeployment;
+  mustDrainCandidate: boolean;
+  promotionConfigPath: string;
+}
+
+/** Derive the inactive target from the live version, never from local release history. */
+export async function stageHostedRunnerRelease(input: {
+  configPath: string;
+  currentVersion: unknown;
+  currentVersionId: string;
+  listApplications: ListCloudflareContainerApplications;
+}): Promise<StagedRunnerRelease> {
+  const config: unknown = JSON.parse(await readFile(input.configPath, "utf8"));
+  if (!isObjectRecord(config) || !isObjectRecord(config.vars)
+    || !Array.isArray(config.containers) || typeof config.name !== "string") throw invalid();
+  const vars = config.vars;
+  const liveVars = readReleaseVariables(input.currentVersion);
+  const liveDeployment = readHostedRunnerDeployment(liveVars);
+  const active: HostedRunnerRelease = liveDeployment?.active ?? {
+    bank: "primary",
+    id: input.currentVersionId,
+    bundleFingerprint: requiredString(liveVars.HOSTED_EXECUTION_RUNNER_BUNDLE_FINGERPRINT),
+    sourceFingerprint: requiredString(liveVars.HOSTED_EXECUTION_RUNNER_SOURCE_FINGERPRINT),
+  };
+  const bank = active.bank === "primary" ? "next" : "primary";
+  const candidate: HostedRunnerRelease = {
+    bank,
+    id: `${bank}-${randomUUID()}`,
+    bundleFingerprint: requiredString(config.vars.HOSTED_EXECUTION_RUNNER_BUNDLE_FINGERPRINT),
+    sourceFingerprint: requiredString(config.vars.HOSTED_EXECUTION_RUNNER_SOURCE_FINGERPRINT),
+  };
+  const deployment: HostedRunnerDeployment = { active, candidate, previous: null };
+  const activeClassName = active.bank === "primary" ? "RunnerContainer" : "NextRunnerContainer";
+  const candidateClassName = bank === "primary" ? "RunnerContainer" : "NextRunnerContainer";
+  let activeApplicationName = "";
+  let candidateApplicationId: string | null = null;
+  const containers = await Promise.all(config.containers.map(async (value: unknown) => {
+    if (!isObjectRecord(value)) throw invalid();
+    const className = requiredString(value.class_name);
+    const name = typeof value.name === "string" ? value.name
+      : `${config.name}-${className}`.toLowerCase();
+    if (className === "DeploySmokeRunnerContainer") return value;
+    const result = await input.listApplications(name);
+    if (!Array.isArray(result) || result.length > 1) throw invalid();
+    const live = result[0];
+    if (className === candidateClassName) {
+      if (live !== undefined) {
+        if (!isObjectRecord(live) || live.name !== name) throw invalid();
+        candidateApplicationId = requiredString(live.id);
+      }
+      return value;
+    }
+    if (!isObjectRecord(live) || live.name !== name || !isObjectRecord(live.configuration)) {
+      throw invalid();
+    }
+    if (className === activeClassName) activeApplicationName = name;
+    // Wrangler's per-application rollout control leaves this image and every
+    // running instance untouched, including when the next release changes sizing.
+    return {
+      ...value,
+      image: requiredString(live.configuration.image),
+      max_instances: live.max_instances,
+      rollout_kind: "none",
+    };
+  }));
+  if (!activeApplicationName || !containers.some((item) => item.class_name === candidateClassName)) {
+    throw invalid();
+  }
+  // Validate the same contract the live runtime will read before any activation.
+  readHostedRunnerDeployment({ HOSTED_EXECUTION_RUNNER_DEPLOYMENT: JSON.stringify(deployment) });
+  const configPath = path.join(path.dirname(input.configPath), `wrangler.stage-${candidate.id}.jsonc`);
+  const promotionConfigPath = path.join(path.dirname(input.configPath), `wrangler.promote-${candidate.id}.jsonc`);
+  const render = (release: HostedRunnerDeployment, promote = false) => `${JSON.stringify({
+    ...config,
+    containers: promote ? containers.map((container) => ({ ...container, rollout_kind: "none" })) : containers,
+    vars: { ...vars, HOSTED_EXECUTION_RUNNER_DEPLOYMENT: JSON.stringify(release) },
+  }, null, 2)}\n`;
+  await writeFile(configPath, render(deployment), { encoding: "utf8", flag: "wx" });
+  await writeFile(promotionConfigPath, render({ active: candidate, candidate: null, previous: active }, true), {
+    encoding: "utf8", flag: "wx",
+  });
+  return {
+    activeApplicationName,
+    candidateApplicationId,
+    configPath,
+    deployment,
+    mustDrainCandidate: liveDeployment?.previous?.bank === bank,
+    promotionConfigPath,
+  };
+}
+
+function readReleaseVariables(version: unknown): Record<string, string> {
+  if (!isObjectRecord(version) || !isObjectRecord(version.resources)
+    || !Array.isArray(version.resources.bindings)) throw invalid();
+  const names = new Set([
+    "HOSTED_EXECUTION_RUNNER_DEPLOYMENT",
+    "HOSTED_EXECUTION_RUNNER_BUNDLE_FINGERPRINT",
+    "HOSTED_EXECUTION_RUNNER_SOURCE_FINGERPRINT",
+  ]);
+  const result: Record<string, string> = {};
+  for (const binding of version.resources.bindings) {
+    if (!isObjectRecord(binding) || typeof binding.name !== "string" || !names.has(binding.name)) continue;
+    if (binding.type !== "plain_text" || typeof binding.text !== "string" || binding.name in result) {
+      throw invalid();
+    }
+    result[binding.name] = binding.text;
+  }
+  return result;
+}
+
+function requiredString(value: unknown): string {
+  if (typeof value !== "string" || !value || value.trim() !== value) throw invalid();
+  return value;
+}
+
+function invalid(): Error {
+  return new Error("Cannot stage runner release from authoritative live configuration.");
+}

--- a/apps/cloudflare/src/hosted-local-test-index.ts
+++ b/apps/cloudflare/src/hosted-local-test-index.ts
@@ -4,6 +4,7 @@ export {
 } from "./runner-container.ts";
 export {
   RunnerContainer,
+  NextRunnerContainer,
 } from "./hosted-local-test/runner-container.ts";
 export {
   HostedLocalTestStandbyRunnerContainer as StandbyRunnerContainer,

--- a/apps/cloudflare/src/hosted-local-test/runner-container.ts
+++ b/apps/cloudflare/src/hosted-local-test/runner-container.ts
@@ -195,6 +195,12 @@ export class RunnerContainer extends BaseRunnerContainer {
   }
 }
 
+export class NextRunnerContainer extends RunnerContainer {
+  constructor(state: unknown, env: Readonly<Record<string, unknown>>) {
+    super(state, env, "next");
+  }
+}
+
 // The hosted-local generated wrangler config omits the Workers AI binding for
 // the test-routes profile (dev profiles get the real binding), so the
 // transcribe egress handler would fail closed in E2E. Inject a
@@ -789,3 +795,4 @@ const hostedLocalTestOutboundByHost: typeof HOSTED_RUNNER_OUTBOUND_BY_HOST = {
 };
 
 RunnerContainer.outboundByHost = hostedLocalTestOutboundByHost;
+NextRunnerContainer.outboundByHost = hostedLocalTestOutboundByHost;

--- a/apps/cloudflare/src/hosted-runner-release.ts
+++ b/apps/cloudflare/src/hosted-runner-release.ts
@@ -1,0 +1,80 @@
+/** Two image targets; the deployment selects one only after its readiness proof. */
+export type HostedRunnerBank = "primary" | "next";
+
+export interface HostedRunnerRelease {
+  bank: HostedRunnerBank;
+  bundleFingerprint: string;
+  id: string;
+  sourceFingerprint: string;
+}
+
+export interface HostedRunnerDeployment {
+  active: HostedRunnerRelease;
+  candidate: HostedRunnerRelease | null;
+  previous: HostedRunnerRelease | null;
+}
+
+type Environment = Readonly<Record<string, unknown>>;
+
+export function readHostedRunnerDeployment(source: Environment): HostedRunnerDeployment | null {
+  const raw = source.HOSTED_EXECUTION_RUNNER_DEPLOYMENT;
+  if (raw === undefined) return null;
+  if (typeof raw !== "string") throw invalidDeployment();
+  let value: unknown;
+  try { value = JSON.parse(raw); } catch { throw invalidDeployment(); }
+  if (!isRecord(value) || !isRelease(value.active)
+    || (value.candidate !== null && !isRelease(value.candidate))
+    || (value.previous !== null && !isRelease(value.previous))
+    || (value.candidate !== null && value.previous !== null)) throw invalidDeployment();
+  const other = value.candidate ?? value.previous;
+  if (other && (other.bank === value.active.bank || other.id === value.active.id)) {
+    throw invalidDeployment();
+  }
+  return { active: value.active, candidate: value.candidate, previous: value.previous };
+}
+
+export function readHostedRunnerActiveReleaseId(source: Environment): string | null {
+  const scoped = source.HOSTED_EXECUTION_RUNNER_RELEASE_ID;
+  if (typeof scoped === "string" && /^[A-Za-z0-9_-]{1,128}$/u.test(scoped)) return scoped;
+  return readHostedRunnerDeployment(source)?.active.id ?? null;
+}
+
+export function scopeHostedRunnerReleaseEnvironment<T extends Environment>(
+  source: T,
+  target: HostedRunnerBank | "candidate",
+): T {
+  const deployment = readHostedRunnerDeployment(source);
+  if (!deployment) return source;
+  const release = target === "candidate"
+    ? deployment.candidate ?? deployment.active
+    : [deployment.active, deployment.candidate, deployment.previous]
+      .find((entry) => entry?.bank === target);
+  if (!release) throw new Error("Hosted runner image target has no release identity.");
+  return {
+    ...source,
+    HOSTED_EXECUTION_RUNNER_RELEASE_ID: release.id,
+    HOSTED_EXECUTION_RUNNER_BUNDLE_FINGERPRINT: release.bundleFingerprint,
+    HOSTED_EXECUTION_RUNNER_SOURCE_FINGERPRINT: release.sourceFingerprint,
+  };
+}
+
+export function readHostedRunnerBankFromName(name: string): HostedRunnerBank {
+  return /^runner--v-next-[A-Za-z0-9_-]+--[a-f0-9]{32}$/u.test(name) ? "next" : "primary";
+}
+
+function isRelease(value: unknown): value is HostedRunnerRelease {
+  return isRecord(value)
+    && (value.bank === "primary" || value.bank === "next")
+    && typeof value.id === "string" && /^[A-Za-z0-9_-]{1,128}$/u.test(value.id)
+    && (value.bank === "next" ? value.id.startsWith("next-") : !value.id.startsWith("next-"))
+    && typeof value.bundleFingerprint === "string" && /^[a-f0-9]{64}$/u.test(value.bundleFingerprint)
+    && typeof value.sourceFingerprint === "string" && /^[a-f0-9]{64}$/u.test(value.sourceFingerprint);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function invalidDeployment(): Error {
+  return new Error("Hosted runner deployment identity is invalid.");
+}

--- a/apps/cloudflare/src/index.ts
+++ b/apps/cloudflare/src/index.ts
@@ -1,5 +1,5 @@
 export { ContainerProxy } from "@cloudflare/containers";
-export { DeploySmokeRunnerContainer, RunnerContainer } from "./runner-container.ts";
+export { DeploySmokeRunnerContainer, NextRunnerContainer, RunnerContainer } from "./runner-container.ts";
 export { StandbyRunnerContainer } from "./standby-runner-container.ts";
 export {
   DatabaseHealthDurableObject,

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -1,3 +1,4 @@
+import { readHostedRunnerDeployment, scopeHostedRunnerReleaseEnvironment, type HostedRunnerBank } from "./hosted-runner-release.ts";
 import { Container, type StopParams } from "@cloudflare/containers";
 import type {
   CloudflareHostedControlRuntimeShellPrewarmSource,
@@ -685,7 +686,12 @@ export class RunnerContainer extends Container {
     RunnerWorkspaceInvocationNoPointerAbort | null = null;
   private containerInteractionGeneration = 0;
 
-  constructor(state: unknown, env: RunnerContainerEnvironmentSource) {
+  constructor(
+    state: unknown,
+    source: RunnerContainerEnvironmentSource,
+    target: HostedRunnerBank | "candidate" = "primary",
+  ) {
+    const env = scopeHostedRunnerReleaseEnvironment(source, target);
     super(state as never, env as never);
     this.environment = env;
     this.durableObjectName = readRunnerDurableObjectName(state);
@@ -818,7 +824,8 @@ export class RunnerContainer extends Container {
     const identity = readHostedRunnerTargetIdentity(input.slotName);
     if (
       !identity || identity.region !== input.region
-      || input.currentReleaseId !== resolveHostedRunnerReleaseId(this.environment)
+      || input.currentReleaseId !== (readHostedRunnerDeployment(this.environment)?.active.id
+        ?? resolveHostedRunnerReleaseId(this.environment))
     ) {
       throw new Error("Hosted runner retained-slot identity or release authority is stale.");
     }
@@ -3969,7 +3976,17 @@ function classifyRunnerContainerStop(input: {
   return input.cleanExit ? "unrequested-clean-stop" : "unrequested-nonzero-stop";
 }
 
+export class NextRunnerContainer extends RunnerContainer {
+  constructor(state: unknown, env: RunnerContainerEnvironmentSource) {
+    super(state, env, "next");
+  }
+}
+
 export class DeploySmokeRunnerContainer extends RunnerContainer {
+  constructor(state: unknown, env: RunnerContainerEnvironmentSource) {
+    super(state, env, "candidate");
+  }
+
   private liveModelTurnSmokeFence: {
     expiresAtMs: number;
     model: string;
@@ -4067,6 +4084,7 @@ export class DeploySmokeRunnerContainer extends RunnerContainer {
 }
 
 registerHostedRunnerContainerOutboundInterception(RunnerContainer);
+registerHostedRunnerContainerOutboundInterception(NextRunnerContainer);
 registerHostedRunnerContainerOutboundInterception(DeploySmokeRunnerContainer);
 
 export function registerHostedRunnerContainerOutboundInterception(

--- a/apps/cloudflare/src/runner-slot-binding.ts
+++ b/apps/cloudflare/src/runner-slot-binding.ts
@@ -1,3 +1,4 @@
+import { readHostedRunnerDeployment } from "./hosted-runner-release.ts";
 import {
   isHostedStandbyClaimId,
   readHostedRunnerTargetIdentity,
@@ -251,7 +252,8 @@ export function requireRetainedRunnerRequest(
     userId: string;
   },
 ): RetainedStandbyRequest {
-  const currentReleaseId = resolveHostedRunnerReleaseId(environment);
+  const currentReleaseId = readHostedRunnerDeployment(environment)?.active.id
+    ?? resolveHostedRunnerReleaseId(environment);
   if (input.currentReleaseId !== currentReleaseId) {
     throw new Error("Hosted standby retained-slot release authority is stale.");
   }

--- a/apps/cloudflare/src/standby-runner-contract.ts
+++ b/apps/cloudflare/src/standby-runner-contract.ts
@@ -1,3 +1,4 @@
+import { readHostedRunnerActiveReleaseId, readHostedRunnerBankFromName } from "./hosted-runner-release.ts";
 import type {
   HostedExecutionContainerNamespaceLike,
   HostedExecutionContainerStubLike,
@@ -206,6 +207,8 @@ export function readHostedStandbyTarget(
 export function readHostedStandbyReleaseId(
   source: Readonly<Record<string, unknown>>,
 ): string | null {
+  const configuredReleaseId = readHostedRunnerActiveReleaseId(source);
+  if (configuredReleaseId) return configuredReleaseId;
   const metadata = source.CF_VERSION_METADATA;
   const releaseId = typeof metadata === "object" && metadata !== null && "id" in metadata
     ? metadata.id : undefined;
@@ -221,7 +224,8 @@ export function readHostedStandbyReleaseId(
 export function resolveHostedRunnerReleaseId(
   source: Readonly<Record<string, unknown>>,
 ): string {
-  if (source.CF_VERSION_METADATA === undefined || source.CF_VERSION_METADATA === null) {
+  if (!readHostedRunnerActiveReleaseId(source)
+    && (source.CF_VERSION_METADATA === undefined || source.CF_VERSION_METADATA === null)) {
     return "local";
   }
   const releaseId = readHostedStandbyReleaseId(source);
@@ -336,6 +340,7 @@ function isRunnerBindingRecord(value: unknown): value is Record<string, unknown>
 
 export function createHostedRunnerContainerNamespaceRouter(input: {
   exactUser: HostedExecutionContainerNamespaceLike | null;
+  next?: HostedExecutionContainerNamespaceLike | null;
   standby: HostedStandbyRunnerContainerNamespaceLike | null;
 }): HostedExecutionContainerNamespaceLike | null {
   const runner = input.exactUser;
@@ -345,6 +350,10 @@ export function createHostedRunnerContainerNamespaceRouter(input: {
 
   return {
     getByName(name: string) {
+      if (readHostedRunnerBankFromName(name) === "next") {
+        if (!input.next) throw new Error("Hosted next runner container binding is unavailable.");
+        return input.next.getByName(name);
+      }
       if (isHostedStandbySlotName(name)) {
         if (!input.standby) {
           throw new Error("Hosted standby runner container binding is unavailable.");

--- a/apps/cloudflare/src/worker-contracts.ts
+++ b/apps/cloudflare/src/worker-contracts.ts
@@ -384,6 +384,7 @@ export interface WorkerEnvironmentContract<
   MURPH_ELEVENLABS_MODEL_ID?: string;
   MURPH_ELEVENLABS_VOICE_ID?: string;
   RUNNER_CONTAINER?: WorkerRunnerContainerNamespaceLike;
+  NEXT_RUNNER_CONTAINER?: WorkerRunnerContainerNamespaceLike;
   RUNNER_CONTAINER_SMOKE?: WorkerRunnerContainerNamespaceLike<
     WorkerDeploySmokeRunnerContainerStubLike
   >;

--- a/apps/cloudflare/src/worker-routes/shared.ts
+++ b/apps/cloudflare/src/worker-routes/shared.ts
@@ -104,6 +104,7 @@ export interface UserRunnerDurableObjectStubLike extends WorkerUserRunnerStubLik
 export interface WorkerEnvironmentSource
   extends WorkerEnvironmentContract<UserRunnerDurableObjectStubLike> {
   RUNNER_CONTAINER: HostedExecutionContainerNamespaceLike;
+  NEXT_RUNNER_CONTAINER?: HostedExecutionContainerNamespaceLike;
   RUNNER_CONTAINER_SMOKE: HostedExecutionContainerNamespaceLike;
   STANDBY_COORDINATOR?: HostedStandbyCoordinatorNamespaceLike;
   STANDBY_RUNNER_CONTAINER?: HostedStandbyRunnerContainerNamespaceLike;

--- a/apps/cloudflare/src/worker/hosted-local-test-user-runner-durable-object.ts
+++ b/apps/cloudflare/src/worker/hosted-local-test-user-runner-durable-object.ts
@@ -33,6 +33,7 @@ export class HostedLocalTestUserRunnerDurableObject extends UserRunnerDurableObj
   constructor(state: DurableObjectStateLike, env: WorkerEnvironmentSource) {
     const runnerContainerNamespace = createHostedRunnerContainerNamespaceRouter({
       exactUser: env.RUNNER_CONTAINER,
+      next: env.NEXT_RUNNER_CONTAINER,
       standby: env.STANDBY_RUNNER_CONTAINER ?? null,
     });
     const testRunner = new HostedUserRunnerWithTestControls(

--- a/apps/cloudflare/src/worker/route-handlers/deploy-smoke.ts
+++ b/apps/cloudflare/src/worker/route-handlers/deploy-smoke.ts
@@ -1,4 +1,4 @@
-import { scopeHostedRunnerReleaseEnvironment } from "../../hosted-runner-release.ts";
+import { readHostedRunnerDeployment, scopeHostedRunnerReleaseEnvironment } from "../../hosted-runner-release.ts";
 import {
   deriveHostedExecutionErrorCode,
   emitHostedExecutionStructuredLog,
@@ -44,10 +44,13 @@ import {
 } from "../public-routes.ts";
 import {
   HOSTED_RUNNER_REGION,
+  HOSTED_STANDBY_READY_TIMEOUT_MS,
+  createHostedRunnerSlotName,
   readHostedStandbyMode,
   readHostedStandbyReleaseId,
   readHostedStandbyTarget,
   resolveHostedStandbyCoordinatorName,
+  requireHostedRunnerSlotLifecycle,
 } from "../../standby-runner-contract.ts";
 
 const DEPLOY_DIRECT_R2_PRESIGNED_PUT_SMOKE_BYTES = 160 * 1024 * 1024;
@@ -133,6 +136,9 @@ export async function handleDeployContainerSmokeRoute(
   let primaryError: unknown = null;
 
   try {
+    if (liveModelTurnModel === null && (!standbyInventory || standbyInventory.readyCount === 0)) {
+      await proveDeployRunnerTarget(context.env);
+    }
     result = await container.smokeHealth({
       ...(directR2Smoke ? { directR2PresignedPut: directR2Smoke.containerInput } : {}),
       ...(liveModelTurnModel ? { liveModelTurn: { model: liveModelTurnModel } } : {}),
@@ -193,6 +199,27 @@ export async function handleDeployContainerSmokeRoute(
     ...(standbyInventory ? { standbyInventory } : {}),
     service: "cloudflare-hosted-runner",
   });
+}
+
+/** Even without warm inventory, prove the actual image target before promotion. */
+async function proveDeployRunnerTarget(env: WorkerEnvironmentSource): Promise<void> {
+  const deployment = readHostedRunnerDeployment(env);
+  if (!deployment) return;
+  const release = deployment.candidate ?? deployment.active;
+  const namespace = release.bank === "next" ? env.NEXT_RUNNER_CONTAINER : env.RUNNER_CONTAINER;
+  if (!namespace) throw new Error("Deploy runner target is unavailable.");
+  const slotName = createHostedRunnerSlotName(release.id);
+  const slot = requireHostedRunnerSlotLifecycle(namespace.getByName(slotName));
+  try {
+    await slot.prepareStandbySlot({
+      releaseId: release.id,
+      region: HOSTED_RUNNER_REGION,
+      slotName,
+      timeoutMs: HOSTED_STANDBY_READY_TIMEOUT_MS,
+    });
+  } finally {
+    await slot.retireStandbySlot({});
+  }
 }
 
 async function readDeployStandbyInventory(env: WorkerEnvironmentSource) {

--- a/apps/cloudflare/src/worker/route-handlers/deploy-smoke.ts
+++ b/apps/cloudflare/src/worker/route-handlers/deploy-smoke.ts
@@ -1,3 +1,4 @@
+import { scopeHostedRunnerReleaseEnvironment } from "../../hosted-runner-release.ts";
 import {
   deriveHostedExecutionErrorCode,
   emitHostedExecutionStructuredLog,
@@ -118,7 +119,7 @@ export async function handleDeployContainerSmokeRoute(
   // The initial smoke proves inventory before running the separate live-model
   // phase. A later foreground claim must not invalidate that model-only probe.
   const standbyInventory = liveModelTurnModel === null
-    ? await readDeployStandbyInventory(context.env)
+    ? await readDeployStandbyInventory(scopeHostedRunnerReleaseEnvironment(context.env, "candidate"))
     : null;
   if (standbyInventory && !standbyInventory.ready) {
     return json({ ok: false, error: "Deploy standby inventory is not ready.", standbyInventory }, 503);

--- a/apps/cloudflare/src/worker/route-handlers/test-runner.ts
+++ b/apps/cloudflare/src/worker/route-handlers/test-runner.ts
@@ -189,6 +189,7 @@ async function beginActiveHostedLocalTestRunnerGracefulStop(input: {
   });
   const runnerContainerNamespace = createHostedRunnerContainerNamespaceRouter({
     exactUser: input.context.env.RUNNER_CONTAINER,
+    next: input.context.env.NEXT_RUNNER_CONTAINER,
     standby: input.context.env.STANDBY_RUNNER_CONTAINER ?? null,
   });
   if (!runnerContainerNamespace) {

--- a/apps/cloudflare/src/worker/standby-runner-coordinator-durable-object.ts
+++ b/apps/cloudflare/src/worker/standby-runner-coordinator-durable-object.ts
@@ -1,3 +1,4 @@
+import { readHostedRunnerDeployment, readHostedRunnerBankFromName } from "../hosted-runner-release.ts";
 import { DurableObject } from "cloudflare:workers";
 import {
   deriveHostedExecutionErrorCode,
@@ -41,6 +42,7 @@ type Region = HostedStandbyCoordinatorState["region"];
 
 interface StandbyCoordinatorEnvironment extends Readonly<Record<string, unknown>> {
   RUNNER_CONTAINER?: HostedStandbyRunnerContainerNamespaceLike;
+  NEXT_RUNNER_CONTAINER?: HostedStandbyRunnerContainerNamespaceLike;
   STANDBY_RUNNER_CONTAINER?: HostedStandbyRunnerContainerNamespaceLike;
 }
 
@@ -135,11 +137,17 @@ export class StandbyRunnerCoordinatorDurableObject extends DurableObject {
     await Promise.all([this.startFill(), this.startCleanup()]);
   }
 
+  private currentReleaseId(ownReleaseId: string | null): string | null {
+    const deployment = readHostedRunnerDeployment(this.environment);
+    if (deployment?.candidate?.id === ownReleaseId) return ownReleaseId;
+    return readHostedStandbyReleaseId(this.environment);
+  }
+
   private desiredTarget(): number {
     const target = readHostedStandbyTarget(this.environment);
     const state = this.store.readState();
     return state.releaseId !== null && state.region === HOSTED_RUNNER_REGION
-      && state.releaseId === readHostedStandbyReleaseId(this.environment)
+      && state.releaseId === this.currentReleaseId(state.releaseId)
       && readHostedStandbyMode(this.environment) !== "off" ? target : 0;
   }
 
@@ -314,10 +322,12 @@ export class StandbyRunnerCoordinatorDurableObject extends DurableObject {
       if (!namespace) throw new Error("Legacy standby cleanup binding is unavailable.");
       return namespace.getByName(slotName, { locationHint: HOSTED_STANDBY_LOCATION_HINT });
     }
-    if (!isHostedRunnerSlotName(slotName) || !this.environment.RUNNER_CONTAINER) {
+    const namespace = readHostedRunnerBankFromName(slotName) === "next"
+      ? this.environment.NEXT_RUNNER_CONTAINER : this.environment.RUNNER_CONTAINER;
+    if (!isHostedRunnerSlotName(slotName) || !namespace) {
       throw new Error("Hosted runner container binding is unavailable.");
     }
-    return this.environment.RUNNER_CONTAINER.getByName(slotName);
+    return namespace.getByName(slotName);
   }
 
   private async retireIfOwned(slotName: string): Promise<boolean> {

--- a/apps/cloudflare/src/worker/user-runner-durable-object.ts
+++ b/apps/cloudflare/src/worker/user-runner-durable-object.ts
@@ -250,6 +250,7 @@ function createHostedUserRunner(
 ): HostedUserRunner {
   const runnerContainerNamespace = createHostedRunnerContainerNamespaceRouter({
     exactUser: env.RUNNER_CONTAINER,
+    next: env.NEXT_RUNNER_CONTAINER,
     standby: env.STANDBY_RUNNER_CONTAINER ?? null,
   });
   return new HostedUserRunner(

--- a/apps/cloudflare/test/container-release-receipt.test.ts
+++ b/apps/cloudflare/test/container-release-receipt.test.ts
@@ -75,6 +75,20 @@ describe("container release receipt", () => {
   });
 
   describe("Wrangler action evidence", () => {
+    it("records an explicitly skipped application rollout as unchanged", () => {
+      expect(parseWranglerContainerActions([
+        "╭ EDIT worker-active",
+        "Container configuration diff",
+        "Skipping application rollout",
+        "Modified application worker-smoke",
+        "no changes worker-standby",
+      ].join("\n"), expectedContainers)).toEqual([
+        { ...expectedContainers[0], action: "unchanged" },
+        { ...expectedContainers[1], action: "modified" },
+        { ...expectedContainers[2], action: "unchanged" },
+      ]);
+    });
+
     it("strips terminal controls and returns exactly one sorted action per expected app", () => {
       const output = [
         "\u001B[32m╰ Created application worker-smoke (Application ID: raw-provider-id)\u001B[0m",

--- a/apps/cloudflare/test/container-rollout-config.test.ts
+++ b/apps/cloudflare/test/container-rollout-config.test.ts
@@ -32,7 +32,7 @@ describe("Cloudflare container rollout config", () => {
     { total: "3", legacy: "1", expectedMain: 2, expectedLegacy: 1 },
     { total: "5", legacy: "2", expectedMain: 3, expectedLegacy: 2 },
     { total: "7", legacy: "3", expectedMain: 4, expectedLegacy: 3 },
-  ])("conserves one member budget and legacy identity: %j", ({
+  ])("gives each release the member budget while retaining legacy identity: %j", ({
     total, legacy, expectedMain, expectedLegacy,
   }) => {
     const source = {
@@ -52,11 +52,12 @@ describe("Cloudflare container rollout config", () => {
     }>;
     expect(containers.map(({ class_name, max_instances }) => ({ class_name, max_instances }))).toEqual([
       { class_name: "RunnerContainer", max_instances: expectedMain },
+      { class_name: "NextRunnerContainer", max_instances: expectedMain },
       { class_name: "DeploySmokeRunnerContainer", max_instances: 1 },
       { class_name: "StandbyRunnerContainer", max_instances: expectedLegacy },
     ]);
     expect(containers.reduce((sum, container) => sum + container.max_instances, 0))
-      .toBe(Number(total ?? "1000") + 1);
+      .toBe(Number(total ?? "1000") + expectedMain + 1);
     expect(containers[0]).not.toHaveProperty("constraints");
     expect(config.vars).toMatchObject({
       HOSTED_EXECUTION_STANDBY_MODE: "off",
@@ -113,13 +114,14 @@ describe("Cloudflare container rollout config", () => {
       }>;
     };
 
-    expect(renderedConfig.containers[1]).toMatchObject({
+    const smoke = renderedConfig.containers.find((container) => container.class_name === "DeploySmokeRunnerContainer");
+    expect(smoke).toMatchObject({
       class_name: "DeploySmokeRunnerContainer",
       max_instances: 1,
       rollout_step_percentage: [100],
     });
-    expect(renderedConfig.containers[1]?.rollout_step_percentage).toHaveLength(
-      renderedConfig.containers[1]?.max_instances ?? 0,
+    expect(smoke?.rollout_step_percentage).toHaveLength(
+      smoke?.max_instances ?? 0,
     );
   });
 
@@ -153,10 +155,10 @@ describe("Cloudflare container rollout config", () => {
       rollout_active_grace_period: renderedConfig.containers[1]?.rollout_active_grace_period,
       rollout_step_percentage: renderedConfig.containers[1]?.rollout_step_percentage,
     });
-    expect(checkedInConfig.containers[2]).toMatchObject({
-      rollout_active_grace_period: renderedConfig.containers[2]?.rollout_active_grace_period,
+    expect(checkedInConfig.containers[3]).toMatchObject({
+      rollout_active_grace_period: renderedConfig.containers[3]?.rollout_active_grace_period,
     });
-    expect(renderedConfig.containers[2]).not.toHaveProperty("rollout_step_percentage");
-    expect(checkedInConfig.containers[2]).not.toHaveProperty("rollout_step_percentage");
+    expect(renderedConfig.containers[3]).not.toHaveProperty("rollout_step_percentage");
+    expect(checkedInConfig.containers[3]).not.toHaveProperty("rollout_step_percentage");
   });
 });

--- a/apps/cloudflare/test/deploy-automation.test.ts
+++ b/apps/cloudflare/test/deploy-automation.test.ts
@@ -332,6 +332,16 @@ describe("hosted deploy automation helpers", () => {
         ssh: { enabled: false },
       },
       {
+        class_name: "NextRunnerContainer",
+        image: "../../../Dockerfile.cloudflare-hosted-runner",
+        image_build_context: "..",
+        instance_type: "standard-1",
+        max_instances: 648,
+        rollout_active_grace_period: 300,
+        rollout_step_percentage: [10, 25, 50, 100],
+        ssh: { enabled: false },
+      },
+      {
         class_name: "DeploySmokeRunnerContainer",
         image: "../../../Dockerfile.cloudflare-hosted-runner",
         image_build_context: "..",
@@ -373,6 +383,10 @@ describe("hosted deploy automation helpers", () => {
       {
         class_name: "RunnerContainer",
         name: "RUNNER_CONTAINER",
+      },
+      {
+        class_name: "NextRunnerContainer",
+        name: "NEXT_RUNNER_CONTAINER",
       },
       {
         class_name: "DeploySmokeRunnerContainer",
@@ -425,6 +439,7 @@ describe("hosted deploy automation helpers", () => {
         ],
         tag: "v7",
       },
+      { new_sqlite_classes: ["NextRunnerContainer"], tag: "v8" },
     ]);
     expect(config).toMatchObject({
       triggers: {
@@ -798,6 +813,7 @@ describe("hosted deploy automation helpers", () => {
       expectedDefaultInstanceType,
       expectedDefaultInstanceType,
       expectedDefaultInstanceType,
+      expectedDefaultInstanceType,
     ]);
     expect(checkedInConfig.containers).toHaveLength(generatedConfig.containers.length);
     for (const [index, generatedContainer] of generatedConfig.containers.entries()) {
@@ -984,7 +1000,7 @@ describe("hosted deploy automation helpers", () => {
       "containers_pid_namespace",
       "enable_request_signal",
     ]);
-    expect(config.containers).toHaveLength(3);
+    expect(config.containers).toHaveLength(4);
     for (const container of config.containers) {
       expect(container.ssh).toEqual({ enabled: false });
       expect(container).not.toHaveProperty("authorized_keys");

--- a/apps/cloudflare/test/deploy-worker-version-cli.test.ts
+++ b/apps/cloudflare/test/deploy-worker-version-cli.test.ts
@@ -2,11 +2,24 @@ import path from "node:path";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const fileMocks = vi.hoisted(() => ({ readFile: vi.fn(async () => "{}"), writeFile: vi.fn(async () => {}) }));
+vi.mock("node:fs/promises", async () => ({
+  ...await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises"),
+  ...fileMocks,
+}));
 const wranglerMocks = vi.hoisted(() => ({
   runWranglerJson: vi.fn(),
   runWranglerLogged: vi.fn(),
   runWranglerLoggedCaptured: vi.fn(),
 }));
+const imageMocks = vi.hoisted(() => ({ prepareHostedContainerDeployImage: vi.fn() }));
+vi.mock("../scripts/prepare-container-deploy-image.ts", () => imageMocks);
+const releaseMocks = vi.hoisted(() => ({
+  stageHostedRunnerRelease: vi.fn(), readWorkerVersion: vi.fn(), assertDrained: vi.fn(), runSmokeHostedDeploy: vi.fn(),
+}));
+vi.mock("../scripts/stage-runner-release.ts", () => ({ stageHostedRunnerRelease: releaseMocks.stageHostedRunnerRelease }));
+vi.mock("../scripts/runner-release-provider.ts", () => ({ createRunnerReleaseProvider: () => releaseMocks }));
+vi.mock("../scripts/smoke-hosted-deploy.shared.ts", () => ({ runSmokeHostedDeploy: releaseMocks.runSmokeHostedDeploy }));
 const receiptMocks = vi.hoisted(() => ({
   createCloudflareContainerProvider: vi.fn(),
   parseWranglerContainerActions: vi.fn(),
@@ -36,7 +49,21 @@ import { runDeployWorkerVersionCli } from "../scripts/deploy-worker-version.cli.
 
 describe("runDeployWorkerVersionCli", () => {
   beforeEach(() => {
+    releaseMocks.stageHostedRunnerRelease.mockReset();
+    releaseMocks.stageHostedRunnerRelease.mockImplementation(async ({ configPath }) => ({
+      configPath, promotionConfigPath: `${configPath}.promote`,
+      activeApplicationName: "hosted-worker-runnercontainer", mustDrainCandidate: false,
+    }));
+    releaseMocks.readWorkerVersion.mockReset();
+    releaseMocks.readWorkerVersion.mockResolvedValue({});
+    releaseMocks.assertDrained.mockReset();
+    releaseMocks.assertDrained.mockResolvedValue(undefined);
+    releaseMocks.runSmokeHostedDeploy.mockReset();
+    releaseMocks.runSmokeHostedDeploy.mockResolvedValue(undefined);
+    imageMocks.prepareHostedContainerDeployImage.mockReset();
+    imageMocks.prepareHostedContainerDeployImage.mockImplementation(async ({ configPath }) => configPath);
     wranglerMocks.runWranglerJson.mockReset();
+    wranglerMocks.runWranglerJson.mockResolvedValue(JSON.stringify({ versions: [{ percentage: 100, version_id: "version-direct" }] }));
     wranglerMocks.runWranglerLogged.mockReset();
     wranglerMocks.runWranglerLoggedCaptured.mockReset();
     wranglerMocks.runWranglerLoggedCaptured.mockResolvedValue({ stderr: "", stdout: "deploy" });
@@ -46,7 +73,7 @@ describe("runDeployWorkerVersionCli", () => {
       readRollout: vi.fn(),
     });
     receiptMocks.parseWranglerContainerActions.mockReset();
-    receiptMocks.parseWranglerContainerActions.mockReturnValue([]);
+    receiptMocks.parseWranglerContainerActions.mockReturnValue([{ action: "unchanged", applicationName: "hosted-worker-runnercontainer", className: "RunnerContainer" }]);
     receiptMocks.parseWranglerWorkerVersionId.mockReset();
     receiptMocks.parseWranglerWorkerVersionId.mockReturnValue("version-direct");
     receiptMocks.readCloudflareContainerApplicationIdentities.mockReset();
@@ -55,6 +82,63 @@ describe("runDeployWorkerVersionCli", () => {
     receiptMocks.readRenderedContainerIdentities.mockResolvedValue(renderedContainers);
     receiptMocks.waitForCloudflareContainerReleaseEntries.mockReset();
     receiptMocks.waitForCloudflareContainerReleaseEntries.mockResolvedValue(releasedContainers);
+  });
+
+  it("does not activate a Worker while its image is still publishing or after publication fails", async () => {
+    let rejectPublication!: (error: Error) => void;
+    imageMocks.prepareHostedContainerDeployImage.mockImplementation(() => new Promise<string>((_resolve, reject) => {
+      rejectPublication = reject;
+    }));
+    const deployment = runDeployWorkerVersionCli([], {
+      deployRoot: "/tmp/repo/apps/cloudflare",
+      env: {
+        CF_WORKER_NAME: "hosted-worker",
+        CF_BUNDLES_BUCKET: "hosted-bundles",
+        CLOUDFLARE_ACCOUNT_ID: "account-fixture",
+        CLOUDFLARE_API_TOKEN: "token-fixture",
+      },
+      log: false,
+      runHostedWorkerDeployment: async ({ dependencies }) => {
+        await dependencies.deployDirect({
+          configPath: "/tmp/repo/apps/cloudflare/.deploy/wrangler.generated.jsonc",
+          containerRolloutMode: "immediate",
+          deploymentMessage: "synthetic release",
+          includeSecrets: true,
+          secretsFilePath: "/tmp/worker-secrets.json",
+          versionTag: "synthetic-release",
+          workerName: "hosted-worker",
+        });
+        return createDeploymentResult();
+      },
+    });
+    const failure = deployment.catch((error: unknown) => error);
+    await vi.waitFor(() => expect(imageMocks.prepareHostedContainerDeployImage).toHaveBeenCalledOnce());
+    expect(wranglerMocks.runWranglerLoggedCaptured).not.toHaveBeenCalled();
+    rejectPublication(new Error("synthetic image publication failed"));
+    expect(await failure).toEqual(new Error("synthetic image publication failed"));
+    expect(wranglerMocks.runWranglerLoggedCaptured).not.toHaveBeenCalled();
+    expect(receiptMocks.waitForCloudflareContainerReleaseEntries).not.toHaveBeenCalled();
+  });
+
+  it.each(["pending", "failed"])("does not promote when candidate readiness is %s", async (state) => {
+    let rejectSmoke!: (error: Error) => void;
+    releaseMocks.runSmokeHostedDeploy.mockImplementation(() => new Promise<void>((_resolve, reject) => { rejectSmoke = reject; }));
+    const deployment = runDeployWorkerVersionCli([], {
+      deployRoot: "/tmp/repo/apps/cloudflare", log: false,
+      env: { CF_WORKER_NAME: "hosted-worker", CF_BUNDLES_BUCKET: "hosted-bundles", CLOUDFLARE_ACCOUNT_ID: "fixture", CLOUDFLARE_API_TOKEN: "fixture" },
+      runHostedWorkerDeployment: async ({ dependencies }) => {
+        await dependencies.deployDirect({ configPath: "/tmp/config.jsonc", containerRolloutMode: "immediate", deploymentMessage: "synthetic", includeSecrets: false, secretsFilePath: "/tmp/secrets.json", versionTag: "synthetic", workerName: "hosted-worker" });
+        return createDeploymentResult();
+      },
+    });
+    const failure = deployment.catch((error: unknown) => error);
+    await vi.waitFor(() => expect(releaseMocks.runSmokeHostedDeploy).toHaveBeenCalledOnce());
+    expect(wranglerMocks.runWranglerLoggedCaptured).toHaveBeenCalledTimes(1);
+    expect(wranglerMocks.runWranglerLoggedCaptured.mock.calls[0]![0]).toContain("/tmp/config.jsonc");
+    rejectSmoke(new Error(state === "failed" ? "candidate image never became ready" : "synthetic cancelled preparation"));
+    expect(await failure).toBeInstanceOf(Error);
+    expect(wranglerMocks.runWranglerLoggedCaptured).toHaveBeenCalledTimes(1);
+    expect(receiptMocks.waitForCloudflareContainerReleaseEntries).not.toHaveBeenCalled();
   });
 
   it("passes app-root deploy artifact paths to the deploy entrypoint", async () => {
@@ -136,6 +220,7 @@ describe("runDeployWorkerVersionCli", () => {
   });
 
   it("builds a receipt around the exact direct deploy", async () => {
+    imageMocks.prepareHostedContainerDeployImage.mockResolvedValueOnce("/tmp/wrangler.image-prepared.jsonc");
     const env = {
       CF_BUNDLES_BUCKET: "hosted-bundles",
       CLOUDFLARE_ACCOUNT_ID: "account-fixture",
@@ -151,7 +236,7 @@ describe("runDeployWorkerVersionCli", () => {
       version: 6,
     }];
     const actions = [{
-      action: "modified",
+      action: "unchanged",
       applicationName: "hosted-worker-runnercontainer",
       className: "RunnerContainer",
     }];
@@ -187,7 +272,7 @@ describe("runDeployWorkerVersionCli", () => {
     expect(wranglerMocks.runWranglerLoggedCaptured).toHaveBeenCalledWith([
       "deploy",
       "--config",
-      "/tmp/wrangler.generated.jsonc",
+      "/tmp/wrangler.image-prepared.jsonc",
       "--message",
       "manual direct deploy",
       "--name",
@@ -306,10 +391,10 @@ describe("runDeployWorkerVersionCli", () => {
       "--tag",
       "manual-version",
     ]);
-    expect(trace).toEqual(["r2", "r2", "deploy"]);
+    expect(trace).toEqual(["r2", "r2", "deploy", "deploy"]);
   });
 
-  it("passes the immediate container rollout flag only for explicit hotfix deploys", async () => {
+  it("prepares the inactive image immediately and promotes without a container rollout", async () => {
     await runDeployWorkerVersionCli(
       ["--config", "./.deploy/wrangler.generated.jsonc"],
       {

--- a/apps/cloudflare/test/hosted-runner-release.test.ts
+++ b/apps/cloudflare/test/hosted-runner-release.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  readHostedRunnerDeployment,
+  scopeHostedRunnerReleaseEnvironment,
+} from "../src/hosted-runner-release.ts";
+import {
+  createHostedRunnerContainerNamespaceRouter,
+  createHostedRunnerSlotName,
+  resolveHostedRunnerReleaseId,
+} from "../src/standby-runner-contract.ts";
+import { requireRetainedRunnerRequest } from "../src/runner-slot-binding.ts";
+
+const primary = { bank: "primary", id: "primary-old", bundleFingerprint: "a".repeat(64), sourceFingerprint: "b".repeat(64) };
+const next = { bank: "next", id: "next-new", bundleFingerprint: "c".repeat(64), sourceFingerprint: "d".repeat(64) };
+const source = (promoted: boolean) => ({
+  CF_VERSION_METADATA: { id: promoted ? "worker-promoted" : "worker-preparing" },
+  HOSTED_EXECUTION_RUNNER_DEPLOYMENT: JSON.stringify(promoted
+    ? { active: next, candidate: null, previous: primary }
+    : { active: primary, candidate: next, previous: null }),
+});
+
+describe("staged runner release", () => {
+  it("holds the active release stable during preparation and changes it only on promotion", () => {
+    expect(resolveHostedRunnerReleaseId(source(false))).toBe(primary.id);
+    expect(resolveHostedRunnerReleaseId(source(true))).toBe(next.id);
+    expect(resolveHostedRunnerReleaseId(scopeHostedRunnerReleaseEnvironment(source(false), "candidate")))
+      .toBe(next.id);
+  });
+
+  it("routes retained exact owners independently of the active release", () => {
+    const primaryGet = vi.fn();
+    const nextGet = vi.fn();
+    const router = createHostedRunnerContainerNamespaceRouter({
+      exactUser: { getByName: primaryGet }, next: { getByName: nextGet }, standby: null,
+    })!;
+    const oldName = createHostedRunnerSlotName(primary.id);
+    const newName = createHostedRunnerSlotName(next.id);
+    router.getByName(oldName);
+    router.getByName(newName);
+    router.getByName(oldName);
+    expect(primaryGet.mock.calls).toEqual([[oldName], [oldName]]);
+    expect(nextGet.mock.calls).toEqual([[newName]]);
+  });
+
+  it("authorizes cleanup against the promoted release while preserving the old target identity", () => {
+    const slotName = createHostedRunnerSlotName(primary.id);
+    const env = scopeHostedRunnerReleaseEnvironment(source(true), "primary");
+    const request = { currentReleaseId: next.id, region: "GLOBAL" as const, slotName, userId: "member_test" };
+    const binding = { state: "bound" as const, claimId: "a".repeat(32), releaseId: primary.id, region: "GLOBAL" as const, slotName, userId: "member_test" };
+    expect(requireRetainedRunnerRequest(env, binding, request)).toMatchObject({
+      currentReleaseId: next.id, targetReleaseId: primary.id, slotName,
+    });
+    expect(() => requireRetainedRunnerRequest(env, binding, { ...request, userId: "member_other" }))
+      .toThrow("another member");
+  });
+
+  it("rejects two releases that address the same mutable image target", () => {
+    expect(() => readHostedRunnerDeployment({ HOSTED_EXECUTION_RUNNER_DEPLOYMENT: JSON.stringify({
+      active: primary, candidate: { ...next, bank: "primary", id: "primary-new" }, previous: null,
+    }) })).toThrow("identity is invalid");
+  });
+});

--- a/apps/cloudflare/test/index.test.ts
+++ b/apps/cloudflare/test/index.test.ts
@@ -521,6 +521,61 @@ describe("cloudflare worker routes", () => {
     expect(claimReadyStandby).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { mode: "off", fails: false },
+    { mode: "off", fails: true },
+    { mode: "shadow", fails: false },
+    { mode: "shadow", fails: true },
+  ])("proves the actual candidate with $mode zero inventory (fails=$fails)", async ({ mode, fails }) => {
+    const release = { bank: "next", id: "next-candidate", bundleFingerprint: "b".repeat(64), sourceFingerprint: "c".repeat(64) };
+    const prepareStandbySlot = vi.fn<NonNullable<HostedExecutionContainerStubLike["prepareStandbySlot"]>>(async (input) => {
+      if (fails) throw new Error("Hosted runner container bundle fingerprint mismatch.");
+      return { ...input, prepared: true };
+    });
+    const retireStandbySlot = vi.fn(async () => ({ retired: true as const }));
+    const bindStandbySlot = vi.fn(async () => { throw new Error("Deploy smoke must not bind member work."); });
+    const getByName = vi.fn(() => ({
+      ...createRunnerContainerNamespace().getByName("candidate"),
+      prepareStandbySlot, retireStandbySlot, bindStandbySlot,
+      async readStandbySlotBinding() { throw new Error("Unexpected binding read."); },
+      async readStandbySlotCoordinatorState() { throw new Error("Unexpected coordinator read."); },
+      async resolveRetainedStandbySlot() { throw new Error("Unexpected retention."); },
+    }));
+    const activeGetByName = vi.fn(() => { throw new Error("Deploy smoke must leave the active target alone."); });
+    const claimReadyStandby = vi.fn(async () => ({ outcome: "disabled" as const }));
+    const env = createWorkerEnv(createUserRunnerStub(), {
+      HOSTED_EXECUTION_RUNNER_DEPLOYMENT: JSON.stringify({
+        active: { ...release, bank: "primary", id: "current" }, candidate: release, previous: null,
+      }),
+      HOSTED_EXECUTION_STANDBY_MODE: mode,
+      HOSTED_EXECUTION_STANDBY_TARGET: "0",
+      RUNNER_CONTAINER: { getByName: activeGetByName },
+      NEXT_RUNNER_CONTAINER: { getByName },
+      STANDBY_COORDINATOR: { getByName: () => ({
+        claimReadyStandby,
+        async ensureReadyStandby() { return { accepted: true }; },
+        async readStandbyCoordinatorState() {
+          return { readySlotNames: [], provisioningSlotNames: [], releaseId: release.id, region: HOSTED_RUNNER_REGION };
+        },
+      }) },
+    });
+    const url = new URL("https://runner.example.test/internal/deploy/container-smoke");
+    const response = await worker.fetch(new Request(url, {
+      headers: await createHostedWebCallbackSignatureHeaders({
+        environment: readHostedExecutionEnvironment(asWorkerStringEnvironment(env)).webCallbackSigning,
+        method: "POST", path: url.pathname, payload: "", search: url.search,
+      }),
+      method: "POST",
+    }), env);
+    expect(response.status).toBe(fails ? 500 : 200);
+    expect(getByName).toHaveBeenCalledWith(expect.stringMatching(/^runner--v-next-candidate--[a-f0-9]{32}$/u));
+    expect(prepareStandbySlot).toHaveBeenCalledWith(expect.objectContaining({ releaseId: release.id, region: HOSTED_RUNNER_REGION }));
+    expect(retireStandbySlot).toHaveBeenCalledWith({});
+    expect(activeGetByName).not.toHaveBeenCalled();
+    expect(claimReadyStandby).not.toHaveBeenCalled();
+    expect(bindStandbySlot).not.toHaveBeenCalled();
+  });
+
   it("returns the signed Temporal worker binding admission without caching it", async () => {
     const env = createWorkerEnv();
     const url = new URL(

--- a/apps/cloudflare/test/prepare-container-deploy-image.test.ts
+++ b/apps/cloudflare/test/prepare-container-deploy-image.test.ts
@@ -1,0 +1,88 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ build: vi.fn(), push: vi.fn() }));
+vi.mock("node:child_process", () => ({ execFile: mocks.build }));
+vi.mock("../scripts/wrangler-runner.ts", () => ({ runWranglerLoggedCaptured: mocks.push }));
+import { prepareHostedContainerDeployImage } from "../scripts/prepare-container-deploy-image.ts";
+
+const accountId = "a".repeat(32);
+const digest = `sha256:${"b".repeat(64)}`;
+let directory: string;
+let configPath: string;
+const config = {
+  name: "synthetic-worker",
+  main: "../src/index.ts",
+  vars: { HOSTED_EXECUTION_RUNNER_BUNDLE_FINGERPRINT: "expected-bundle" },
+  containers: ["RunnerContainer", "DeploySmokeRunnerContainer", "StandbyRunnerContainer"].map((className) => ({
+    class_name: className,
+    image: "../../../Dockerfile.cloudflare-hosted-runner",
+    image_build_context: "..",
+    max_instances: className === "StandbyRunnerContainer" ? 0 : 1,
+  })),
+};
+
+describe("container image publication before Worker activation", () => {
+  beforeEach(async () => {
+    directory = await mkdtemp(path.join(tmpdir(), "murph-image-prepublish-"));
+    configPath = path.join(directory, "wrangler.generated.jsonc");
+    await writeFile(configPath, JSON.stringify(config));
+    mocks.build.mockReset();
+    mocks.build.mockImplementation((_command, _args, _options, callback) => callback(null, "", ""));
+    mocks.push.mockReset();
+    mocks.push.mockResolvedValue({ stdout: `prepared: digest: ${digest} size: 1234\n`, stderr: "" });
+  });
+  afterEach(async () => { await rm(directory, { recursive: true, force: true }); });
+
+  it("builds once, publishes once, and pins every fleet to the proven digest without changing other config", async () => {
+    const preparedPath = await prepareHostedContainerDeployImage({ accountId, configPath });
+    const prepared = JSON.parse(await readFile(preparedPath, "utf8"));
+    expect(path.dirname(preparedPath)).toBe(path.dirname(configPath));
+    expect(JSON.parse(await readFile(configPath, "utf8"))).toEqual(config);
+    expect(prepared).toEqual({
+      ...config,
+      containers: config.containers.map(({ image_build_context: _context, ...container }) => ({
+        ...container,
+        image: `registry.cloudflare.com/${accountId}/synthetic-worker@${digest}`,
+      })),
+    });
+    expect(mocks.build).toHaveBeenCalledOnce();
+    expect(mocks.push).toHaveBeenCalledOnce();
+    expect(mocks.build.mock.invocationCallOrder[0]).toBeLessThan(mocks.push.mock.invocationCallOrder[0]!);
+    const args = mocks.build.mock.calls[0]![1] as string[];
+    expect(args).toEqual([
+      "build", "--platform", "linux/amd64", "--file",
+      path.resolve(directory, config.containers[0]!.image),
+      "--tag", expect.stringMatching(/^synthetic-worker:prepared-/u),
+      path.resolve(directory, ".."),
+    ]);
+    expect(mocks.push).toHaveBeenCalledWith(["containers", "push", args[6], "--config", configPath]);
+  });
+
+  it("never publishes if the validated image cannot build", async () => {
+    mocks.build.mockImplementation((_command, _args, _options, callback) => callback(new Error("synthetic build failure")));
+    await expect(prepareHostedContainerDeployImage({ accountId, configPath }))
+      .rejects.toThrow("Runner image build failed before Worker activation.");
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  it.each(["", `digest: ${digest} size: 1\ndigest: sha256:${"c".repeat(64)} size: 1`])(
+    "rejects missing or ambiguous immutable publication evidence", async (stdout) => {
+      mocks.push.mockResolvedValue({ stdout, stderr: "" });
+      await expect(prepareHostedContainerDeployImage({ accountId, configPath }))
+        .rejects.toThrow("did not prove one immutable digest");
+    },
+  );
+
+  it("fails before build when fleet image inputs differ", async () => {
+    await writeFile(configPath, JSON.stringify({ ...config, containers: [
+      config.containers[0], { ...config.containers[1], image: "another-dockerfile" },
+    ] }));
+    await expect(prepareHostedContainerDeployImage({ accountId, configPath }))
+      .rejects.toThrow("share one validated image build");
+    expect(mocks.build).not.toHaveBeenCalled();
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -31,6 +31,7 @@ import {
   resolveHostedExecutionRunnerContainerName,
   RUNNER_CONTAINER_STARTUP_FAILURE_ELAPSED_MAX_MS,
   RunnerContainer,
+  NextRunnerContainer,
   type RunnerContainerStartupFailureStage,
 } from "../src/runner-container.ts";
 import { StandbyRunnerContainer } from "../src/standby-runner-container.ts";
@@ -1988,6 +1989,51 @@ describe("RunnerContainer", () => {
             === "Hosted execution container startup confirmation failed.",
       ),
     ).toHaveLength(0);
+  });
+
+  it("reproduces the old deployment gap: new Worker fingerprints reject an available previous image", async () => {
+    const { container, destroy, containerFetch } = createContainerDouble({
+      env: {
+        HOSTED_EXECUTION_RUNNER_BUNDLE_FINGERPRINT: "c".repeat(64),
+        HOSTED_EXECUTION_RUNNER_SOURCE_FINGERPRINT: "d".repeat(64),
+      },
+      containerFetch: vi.fn(async () => new Response(JSON.stringify({
+        ...createRunnerHealthResult(),
+        runnerBundle: { bundleFingerprint: "a".repeat(64), sourceFingerprint: "b".repeat(64) },
+      }), { headers: { "content-type": "application/json" } })),
+    });
+    await expect(container.ensureReadyForProcessing({ timeoutMs: 15_000, userId: "member_123" }))
+      .rejects.toThrow("bundle fingerprint mismatch");
+    expect(containerFetch).toHaveBeenCalledTimes(2);
+    expect(destroy).toHaveBeenCalled();
+  });
+
+  it.each(["preparing", "promoted"])("keeps both exact images usable without replacement while %s", async (phase) => {
+    const previous = { bank: "primary", id: "primary-previous", bundleFingerprint: "a".repeat(64), sourceFingerprint: "b".repeat(64) };
+    const candidate = { bank: "next", id: "next-candidate", bundleFingerprint: "c".repeat(64), sourceFingerprint: "d".repeat(64) };
+    const deployment = phase === "preparing"
+      ? { active: previous, candidate, previous: null }
+      : { active: candidate, candidate: null, previous };
+    for (const [containerClass, release] of [[RunnerContainer, previous], [NextRunnerContainer, candidate]] as const) {
+      const { container, destroy, startAndWaitForPorts, containerFetch } = createContainerDouble({
+        containerClass,
+        env: {
+          CF_VERSION_METADATA: { id: "worker-new" },
+          HOSTED_EXECUTION_RUNNER_DEPLOYMENT: JSON.stringify(deployment),
+          HOSTED_EXECUTION_RUNNER_BUNDLE_FINGERPRINT: candidate.bundleFingerprint,
+          HOSTED_EXECUTION_RUNNER_SOURCE_FINGERPRINT: candidate.sourceFingerprint,
+        },
+        containerFetch: vi.fn(async () => new Response(JSON.stringify({
+          ...createRunnerHealthResult(),
+          runnerBundle: { bundleFingerprint: release.bundleFingerprint, sourceFingerprint: release.sourceFingerprint },
+        }), { headers: { "content-type": "application/json" } })),
+      });
+      await expect(container.ensureReadyForProcessing({ timeoutMs: 15_000, userId: "member_123" }))
+        .resolves.toMatchObject({ kind: "ready" });
+      expect(startAndWaitForPorts).toHaveBeenCalledOnce();
+      expect(containerFetch).toHaveBeenCalledOnce();
+      expect(destroy).not.toHaveBeenCalled();
+    }
   });
 
   it("replaces one stale rollout image before cold readiness succeeds", async () => {

--- a/apps/cloudflare/test/runner-release-provider.test.ts
+++ b/apps/cloudflare/test/runner-release-provider.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRunnerReleaseProvider } from "../scripts/runner-release-provider.ts";
+
+vi.mock("node:timers/promises", () => ({ setTimeout: async () => {} }));
+
+describe("inactive runner target drain admission", () => {
+  const response = (state: string) => new Response(JSON.stringify({
+    success: true,
+    result: [{ current_placement: { status: { container_status: state } } }],
+  }));
+
+  it("permits reuse only when the provider reports stopped instances", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => response("stopped"));
+    await expect(createRunnerReleaseProvider({ accountId: "fixture", apiToken: "fixture", fetchImpl })
+      .assertDrained("inactive-app")).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it.each(["running", "stopping", "unknown"])("keeps %s instances protected until they stop", async (state) => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(response(state))
+      .mockResolvedValueOnce(response("stopped"));
+    const work = createRunnerReleaseProvider({ accountId: "fixture", apiToken: "fixture", fetchImpl })
+      .assertDrained("inactive-app");
+    await work;
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not infer a drained target from failed or incomplete provider evidence", async () => {
+    for (const body of [{ success: false }, { success: true, result: {} }, {
+      success: true, result: [], result_info: { next_page_token: "next-page" },
+    }]) {
+      const fetchImpl = vi.fn<typeof fetch>(async () => new Response(JSON.stringify(body)));
+      await expect(createRunnerReleaseProvider({ accountId: "fixture", apiToken: "fixture", fetchImpl })
+        .assertDrained("inactive-app")).rejects.toThrow("unavailable");
+      expect(fetchImpl).toHaveBeenCalledOnce();
+    }
+  });
+});

--- a/apps/cloudflare/test/stage-runner-release.test.ts
+++ b/apps/cloudflare/test/stage-runner-release.test.ts
@@ -1,0 +1,79 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { stageHostedRunnerRelease } from "../scripts/stage-runner-release.ts";
+
+let directory: string;
+const primary = { bank: "primary", id: "primary-old", bundleFingerprint: "a".repeat(64), sourceFingerprint: "b".repeat(64) };
+const next = { bank: "next", id: "next-old", bundleFingerprint: "c".repeat(64), sourceFingerprint: "d".repeat(64) };
+const classes = ["RunnerContainer", "NextRunnerContainer", "DeploySmokeRunnerContainer", "StandbyRunnerContainer"];
+const image = `registry.cloudflare.com/${"a".repeat(32)}/synthetic@sha256:${"e".repeat(64)}`;
+const config = {
+  name: "synthetic-worker", main: "../src/index.ts",
+  vars: { HOSTED_EXECUTION_RUNNER_BUNDLE_FINGERPRINT: "e".repeat(64), HOSTED_EXECUTION_RUNNER_SOURCE_FINGERPRINT: "f".repeat(64) },
+  containers: classes.map((class_name) => ({ class_name, image, max_instances: 12, instance_type: "standard-1" })),
+};
+function version(deployment?: unknown) {
+  const vars: Record<string, string> = {
+    HOSTED_EXECUTION_RUNNER_BUNDLE_FINGERPRINT: primary.bundleFingerprint,
+    HOSTED_EXECUTION_RUNNER_SOURCE_FINGERPRINT: primary.sourceFingerprint,
+    ...(deployment ? { HOSTED_EXECUTION_RUNNER_DEPLOYMENT: JSON.stringify(deployment) } : {}),
+  };
+  return { resources: { bindings: Object.entries(vars).map(([name, text]) => ({ name, text, type: "plain_text" })) } };
+}
+const listApplications = async (name: string) => [{
+  id: `id-${name}`, name,
+  configuration: { image: "registry.example.test/previous@sha256:old", vcpu: 2, memory_mib: 4096, disk: { size_mb: 6000 } },
+  max_instances: 10, constraints: { regions: ["ENAM"] }, rollout_active_grace_period: 300,
+}];
+
+describe("runner deployment staging", () => {
+  beforeEach(async () => {
+    directory = await mkdtemp(path.join(tmpdir(), "murph-release-stage-"));
+    await writeFile(path.join(directory, "source.json"), JSON.stringify(config));
+  });
+  afterEach(async () => { await rm(directory, { recursive: true, force: true }); });
+
+  it.each([false, true])("freezes the live application while preparing the opposite target (reversed=%s)", async (reversed) => {
+    const active = reversed ? next : primary;
+    const previous = reversed ? primary : next;
+    const staged = await stageHostedRunnerRelease({
+      configPath: path.join(directory, "source.json"), currentVersionId: "worker-live",
+      currentVersion: version({ active, candidate: null, previous }), listApplications,
+    });
+    const stage = JSON.parse(await readFile(staged.configPath, "utf8"));
+    const promotion = JSON.parse(await readFile(staged.promotionConfigPath, "utf8"));
+    const activeClass = reversed ? "NextRunnerContainer" : "RunnerContainer";
+    const candidateClass = reversed ? "RunnerContainer" : "NextRunnerContainer";
+    expect(stage.containers.find((entry: { class_name: string }) => entry.class_name === activeClass))
+      .toMatchObject({ image: "registry.example.test/previous@sha256:old", max_instances: 10, rollout_kind: "none" });
+    expect(stage.containers.find((entry: { class_name: string }) => entry.class_name === candidateClass))
+      .toMatchObject({ image, max_instances: 12 });
+    const prepared = JSON.parse(stage.vars.HOSTED_EXECUTION_RUNNER_DEPLOYMENT);
+    const promoted = JSON.parse(promotion.vars.HOSTED_EXECUTION_RUNNER_DEPLOYMENT);
+    expect(prepared.active).toEqual(active);
+    expect(promoted).toEqual({ active: prepared.candidate, candidate: null, previous: active });
+    expect(promotion.containers).toEqual(stage.containers.map((entry: Record<string, unknown>) => ({ ...entry, rollout_kind: "none" })));
+    expect(staged.mustDrainCandidate).toBe(true);
+  });
+
+  it("bootstraps from the existing Worker fingerprint without changing its release identity", async () => {
+    const staged = await stageHostedRunnerRelease({
+      configPath: path.join(directory, "source.json"), currentVersionId: "worker-live",
+      currentVersion: version(),
+      listApplications: async (name) => name.endsWith("-nextrunnercontainer") ? [] : listApplications(name),
+    });
+    expect(staged.deployment.active).toEqual({ ...primary, id: "worker-live" });
+    expect(staged.deployment.candidate?.bank).toBe("next");
+    expect(staged.mustDrainCandidate).toBe(false);
+    expect(staged.candidateApplicationId).toBeNull();
+  });
+
+  it("fails closed when the live target's image identity cannot be established", async () => {
+    await expect(stageHostedRunnerRelease({
+      configPath: path.join(directory, "source.json"), currentVersionId: "worker-live",
+      currentVersion: version(), listApplications: async () => [],
+    })).rejects.toThrow("authoritative live configuration");
+  });
+});

--- a/apps/cloudflare/test/standby-runner.test.ts
+++ b/apps/cloudflare/test/standby-runner.test.ts
@@ -344,6 +344,28 @@ describe("RunnerContainer slot lifecycle", () => {
 });
 
 describe("StandbyRunnerCoordinatorDurableObject", () => {
+  it("warms a candidate without making it claimable, then reuses that inventory on promotion", async () => {
+    const h = createCoordinatorHarness({ target: "2" });
+    const active = { bank: "primary", id: RELEASE_ID, bundleFingerprint: "a".repeat(64), sourceFingerprint: "b".repeat(64) };
+    const candidate = { bank: "next", id: "next-candidate", bundleFingerprint: "c".repeat(64), sourceFingerprint: "d".repeat(64) };
+    const nextGet = vi.fn(h.runnerGet);
+    h.environment.NEXT_RUNNER_CONTAINER = { getByName: nextGet };
+    h.environment.HOSTED_EXECUTION_RUNNER_DEPLOYMENT = JSON.stringify({ active, candidate, previous: null });
+    const input = { releaseId: candidate.id, region: HOSTED_RUNNER_REGION };
+    await h.coordinator.ensureReadyStandby(input);
+    await h.flush();
+    expect(nextGet).toHaveBeenCalled();
+    expect(h.coordinator.readStandbyCoordinatorState().readySlotNames).toHaveLength(2);
+    const claim = { ...input, claimId: createHostedStandbyClaimId(), deadlineAtEpochMs: Date.now() + 250 };
+    expect(h.coordinator.claimReadyStandby(claim)).toEqual({ outcome: "stale_release" });
+    const preparedCount = prepareCount(h);
+    h.environment.HOSTED_EXECUTION_RUNNER_DEPLOYMENT = JSON.stringify({ active: candidate, candidate: null, previous: active });
+    expect(h.coordinator.claimReadyStandby(claim)).toMatchObject({ outcome: "claimed" });
+    // Promotion consumes the already-ready slot; it does not await a new startup.
+    expect(prepareCount(h)).toBe(preparedCount);
+    await h.flush();
+  });
+
   it("strictly bounds the configured target and defaults absent or blank values", () => {
     assert.equal(readHostedStandbyTarget({}), 2);
     for (const value of ["", " "]) {

--- a/apps/cloudflare/wrangler.jsonc
+++ b/apps/cloudflare/wrangler.jsonc
@@ -23,6 +23,20 @@
       "ssh": { "enabled": false }
     },
     {
+      "class_name": "NextRunnerContainer",
+      "image": "../../Dockerfile.cloudflare-hosted-runner",
+      "image_build_context": ".",
+      "instance_type": {
+        "vcpu": 2,
+        "memory_mib": 6144,
+        "disk_mb": 6000
+      },
+      "max_instances": 1000,
+      "rollout_active_grace_period": 300,
+      "rollout_step_percentage": [10, 25, 50, 100],
+      "ssh": { "enabled": false }
+    },
+    {
       "class_name": "DeploySmokeRunnerContainer",
       "image": "../../Dockerfile.cloudflare-hosted-runner",
       "image_build_context": ".",
@@ -78,6 +92,10 @@
         "class_name": "RunnerContainer"
       },
       {
+        "name": "NEXT_RUNNER_CONTAINER",
+        "class_name": "NextRunnerContainer"
+      },
+      {
         "name": "RUNNER_CONTAINER_SMOKE",
         "class_name": "DeploySmokeRunnerContainer"
       },
@@ -125,6 +143,10 @@
         "StandbyRunnerCoordinatorDurableObject",
         "StandbyRunnerContainer"
       ]
+    },
+    {
+      "tag": "v8",
+      "new_sqlite_classes": ["NextRunnerContainer"]
     }
   ],
   "triggers": {

--- a/apps/web/changelog/entries/2026-09-07/replies-during-updates.json
+++ b/apps/web/changelog/entries/2026-09-07/replies-during-updates.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-07",
+  "order": 100,
+  "item": {
+    "id": "replies-during-updates",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Less waiting during updates",
+    "summary": "Murph checks that an update is ready before switching new replies to it.",
+    "details": "A slow or failed update leaves the current version handling your messages.",
+    "relevanceTags": ["conversations", "reliability"],
+    "sourcePullRequests": [3030]
+  }
+}

--- a/packages/hosted-local-harness/src/dev-hosted-local/environment.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/environment.ts
@@ -1119,6 +1119,7 @@ export function buildWranglerLocalDevConfig(
     compatibility_flags: ["nodejs_compat", "containers_pid_namespace", "enable_request_signal"],
     containers: [
       buildRunnerContainerConfig({ className: "RunnerContainer", maxInstances: 50 }),
+      buildRunnerContainerConfig({ className: "NextRunnerContainer", maxInstances: 50 }),
       buildRunnerContainerConfig({ className: "DeploySmokeRunnerContainer", maxInstances: 1 }),
       // Keep the legacy binding/application even after its reservation reaches zero.
       buildRunnerContainerConfig({ className: "StandbyRunnerContainer", maxInstances: 0 }),
@@ -1144,6 +1145,10 @@ export function buildWranglerLocalDevConfig(
         {
           name: "RUNNER_CONTAINER",
           class_name: "RunnerContainer",
+        },
+        {
+          name: "NEXT_RUNNER_CONTAINER",
+          class_name: "NextRunnerContainer",
         },
         {
           name: "RUNNER_CONTAINER_SMOKE",
@@ -1191,6 +1196,7 @@ export function buildWranglerLocalDevConfig(
           "StandbyRunnerContainer",
         ],
       },
+      { tag: "v8", new_sqlite_classes: ["NextRunnerContainer"] },
     ],
     triggers: {
       crons: ["*/5 * * * *"],

--- a/packages/hosted-local-harness/src/dev-hosted-local/runtime.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/runtime.ts
@@ -77,6 +77,7 @@ export type HostedRunnerContainerCleanupScope = "all-builds" | "current-build" |
 const HOSTED_RUNNER_LOCAL_DO_CLASS_NAMES = [
   "UserRunnerDurableObject",
   "RunnerContainer",
+  "NextRunnerContainer",
   "DeploySmokeRunnerContainer",
   "StandbyRunnerContainer",
 ] as const;

--- a/packages/hosted-local-harness/test/dev-hosted-local/environment.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/environment.test.ts
@@ -1691,8 +1691,8 @@ describe("buildWranglerLocalDevConfig", () => {
       ssh: { enabled: boolean };
     }[];
     const container = containers[0]!;
-    const smokeContainer = containers[1]!;
-    const standbyContainer = containers[2]!;
+    const smokeContainer = containers[2]!;
+    const standbyContainer = containers[3]!;
 
     expect(config.main).toBe("../src/index.ts");
     expect(config.name).toBe("murph-hosted");
@@ -1706,6 +1706,7 @@ describe("buildWranglerLocalDevConfig", () => {
     expect(config.vars).not.toHaveProperty("HOSTED_EXECUTION_RUNNER_DESTROY_TIMEOUT_MS");
     expect(containers.map((entry) => entry.class_name)).toEqual([
       "RunnerContainer",
+      "NextRunnerContainer",
       "DeploySmokeRunnerContainer",
       "StandbyRunnerContainer",
     ]);
@@ -1841,7 +1842,7 @@ describe("buildWranglerLocalDevConfig", () => {
       image_vars: Record<string, string>;
     }[];
     const container = containers[0]!;
-    const smokeContainer = containers[1]!;
+    const smokeContainer = containers[2]!;
 
     expect(config.main).toBe("../../workspace/apps/cloudflare/src/index.ts");
     expect(container.image).toBe("../../workspace/Dockerfile.cloudflare-hosted-runner");

--- a/packages/hosted-local-harness/test/dev-hosted-local/runtime.cleanup.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/runtime.cleanup.test.ts
@@ -517,6 +517,7 @@ describe("cleanupHostedRunnerContainers", () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "murph-runner-state-test-"));
     const persistDir = path.join(root, "state");
     const runnerStateDir = path.join(persistDir, "v3", "do", "murph-hosted-RunnerContainer");
+    const nextStateDir = path.join(persistDir, "v3", "do", "murph-hosted-NextRunnerContainer");
     const smokeStateDir = path.join(persistDir, "v3", "do", "murph-hosted-DeploySmokeRunnerContainer");
     const standbyStateDir = path.join(persistDir, "v3", "do", "murph-hosted-StandbyRunnerContainer");
     const userRunnerStateDir = path.join(persistDir, "v3", "do", "murph-hosted-UserRunnerDurableObject");
@@ -524,6 +525,7 @@ describe("cleanupHostedRunnerContainers", () => {
 
     try {
       await mkdir(runnerStateDir, { recursive: true });
+      await mkdir(nextStateDir, { recursive: true });
       await mkdir(smokeStateDir, { recursive: true });
       await mkdir(standbyStateDir, { recursive: true });
       await mkdir(userRunnerStateDir, { recursive: true });
@@ -534,6 +536,7 @@ describe("cleanupHostedRunnerContainers", () => {
       });
 
       await expect(access(runnerStateDir)).rejects.toThrow();
+      await expect(access(nextStateDir)).rejects.toThrow();
       await expect(access(smokeStateDir)).rejects.toThrow();
       await expect(access(standbyStateDir)).rejects.toThrow();
       await expect(access(userRunnerStateDir)).rejects.toThrow();


### PR DESCRIPTION
## Why and outcome

Full Worker deployment could select a runner bundle before its container image was available. Exact-image readiness then rejected the serving image and delayed message processing.

Prepare and smoke an inactive container target while retaining the serving target. Promote the ready release with all container rollouts disabled, and wait for native instance drain before reusing the previous target. Existing UserRunner fences and opaque target names retain in-flight ownership. This adds no message-path retry policy or awaited operation.

## Product UX

- Effort: Patch.
- Result: Ready. Deterministic success, delayed preparation, failure and promotion journeys pass.
- Walkthrough: Slow or failed preparation leaves the current image serving; promotion consumes prewarmed inventory; completion and cleanup remain addressed to their original target. Other causes of provider or network latency are unchanged.

## Evidence

- Actual readiness regression reproduces the previous image rejection and proves first-health success for both targets before/after promotion.
- 816 focused Cloudflare tests pass across deployment, runner, standby, artifacts, signed routes and failure cases; nine changelog rendering tests pass.
- Cloudflare and Web typechecks passed.
- Native Wrangler dry run with immutable image references passed, including the new namespace and per-application rollout controls. A Dockerfile-based dry run could not build without the assembled runner bundle; the immutable-image proof matches the prepared deployment path.
- Complexity guard passed with no added complexity debt.
- Final ReviewGPT: PASS at `5f37eb6137c07228d9c0b8c52c9cac08c8c387c5`; concrete gpt-6-pro capture, complete snapshot, over seven minutes, no qualifying findings. Plan closure was followed by a CI-discovered hosted-local parity correction; round two also PASSED at `188c8e4f16185ebc573b571df6735c38ec93bde5`, with an exact-turn gpt-6-pro capture and full 42-file audit after more than five minutes. No findings remain.
- CI follow-up: local harness now declares, exports and cleans up the second target; capacity tests cover both targets. 39 focused Cloudflare and 120 local-harness checks pass; both affected typechecks pass. Complete Cloudflare Node suite passed: 3,232 tests across 165 files, two existing skips, plus six native container-helper tests.
- Hosted rollout and final-head CI remain pending.

## Non-obvious affected surfaces

The standby coordinator can fill candidate inventory but cannot grant a candidate claim until promotion. Retained cleanup uses the active release authority while addressing the old target. Release receipts recognize Wrangler's explicit skipped-rollout output. The canonical generated config records effective retained capacities for private convergence verification.

## Architecture and reuse

- Existing systems reused: UserRunner write fence, opaque slot names, ready inventory, signed deploy smoke, Wrangler and provider release receipts.
- New logic: Publish an immutable image, stage/smoke/promote, and admit target reuse only after native instance drain.
- New abstractions: One release identity record in Worker configuration and one interchangeable container namespace sharing the existing implementation.
- Complexity intentionally avoided: No new scheduler, queue, retry owner, per-message deployment lookup, provider-selection change or custom container-update API.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; no added complexity debt.
- Hotspots: Existing `wakeRuntime`, `ensureContainerReady`, `destroyIfRunning`, `classifyHostedRunnerContainerErrorResponse`, and `invokeHostedExecution` debt did not increase; their lifecycle behavior is preserved. Local harness hotspots `mergeCloudflareLocalEnv` (31) and `buildHostedLocalDevOverrides` (26) also remain unchanged.
- Agent judgment: Explicit target selection is required to avoid mutating the serving image. Existing owners handle readiness, claims, cleanup and effect fencing.

## Hot reply path impact

No network call, database query, provider call, timeout or retry was added to the foreground path. Release selection is local configuration parsing and exact-name namespace routing. Image publication, smoke and drain waits execute in deployment. Existing slot claims and retirement retain their prior ownership boundaries.

## Murph initial provider input impact

Not applicable: individual/group prompt assembly, tools, model choice and provider request construction are unchanged.

## Deployment concerns

- Deployment: applicable
- Supported skew: During preparation the new Worker controller accepts each target's exact image; existing Worker/container consumer-first protocol rules still apply.
- Safe order: Publish image; freeze serving application; stage inactive application; verify candidate image/inventory; promote with all application rollouts disabled.
- Rollback floor: Keep this release-aware controller after selecting the second namespace. Any rollback requires explicit review and authorization.
- Expected exposure: One active target plus bounded candidate inventory and prior in-flight work; no candidate image is selected while preparation waits.
- Reversibility: A failed candidate leaves the existing release selected; prior namespace reuse requires provider drain evidence.
- Convergence proof: Signed smoke, exact Worker version checks and per-application receipts; protected live verification remains required.
- Post-deploy checks: Confirm exact promoted Worker/image receipt, ready inventory, and bounded runtime failure/latency observations.

## Change-shape breakdown

Paths classified by ownership; no binary changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 176 | 9 |
| Tests/fixtures | 530 | 18 |
| Docs | 127 | 3 |
| Config/tooling | 378 | 8 |
| Generated/other | 14 | 0 |
| Total | 1225 | 38 |

## Changelog

- Changelog: updated
- Items: 2026-09-07 · replies-during-updates


ReviewGPT first-reviewed head: 5f37eb6137c07228d9c0b8c52c9cac08c8c387c5
ReviewGPT context sensitivity: sensitive
Reason: Hosted execution ownership and production deployment ordering.

## Production release evidence

The protected production deployment [run 34088205774](https://github.com/cobuildwithus/murph-cloud/actions/runs/34088205774) pinned merged source `9d0ae5ae1b4858a149bfc119ca93b7982517d0c7`. All predeployment gates passed: hosted authorization, provider cache prefix, Linq delivery, scheduled reminders, and Cloudflare verification/runner smoke.

Production promotion is **incomplete**. Cloudflare rejected creation of the inactive application because the requested capacity exceeded account CPU quota. Wrangler reported the serving application rollout as skipped; promotion and the final live-model smoke did not run. The existing serving image was preserved. A quota-aware capacity transition or account quota increase is required before completing deployment. Local and CI proof did not cover this native account admission constraint.
