### PR TITLE
fix: keep environment study previews inline

### DIFF
--- a/.agents/friction-log/20260907011950-voice-activity-orb/friction.md
+++ b/.agents/friction-log/20260907011950-voice-activity-orb/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Voice activity orb SVG precision mismatch warns during hydration'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+A synthetic inline listening preview should hydrate without development-console attribute mismatch warnings.
+
+## Current Behavior
+
+The existing voice activity orb computes SVG circle coordinates with trigonometric functions. Server and Chromium calculations can serialize a sine-derived coordinate with a difference of about two quadrillionths, producing a React attribute hydration warning. The rendered study remains usable and no tree recovery was observed, but browser proof must distinguish this warning from functional failures.
+
+## Possible Solution
+
+Normalize the generated SVG coordinate precision at its existing owner so server and client serialize identical values.
+
+## Minimal Reproducible Example
+
+Render EnvironmentVoiceCapture with presentation="inline" and a synthetic listening preview in the repository smoke Web environment. Open the Health screenshot catalogue in Chromium, wait for hydration, and inspect development-console attribute mismatch diagnostics for VoiceActivityOrb circle coordinates.
+
+## Context
+
+Observed while checking independent Environment and Patterns catalogue rendering at phone and desktop widths. This report concerns the existing SVG coordinate generation; it does not request changes to interview behavior.

--- a/apps/web/app/design/environment-progress-study.tsx
+++ b/apps/web/app/design/environment-progress-study.tsx
@@ -186,6 +186,7 @@ export function EnvironmentProgressStudy() {
           authGate={false}
           contactOptions={DESIGN_CONTACT_OPTIONS}
           initialTopicId="air"
+          presentation="inline"
           preview={{
             state: "idle",
           }}
@@ -199,6 +200,7 @@ export function EnvironmentProgressStudy() {
           authGate={false}
           contactOptions={DESIGN_CONTACT_OPTIONS}
           initialTopicId="workspace:0"
+          presentation="inline"
           preview={{
             capturedFieldKeys: ["workspace.work_mode", "workspace.standing_desk"],
             speaking: true,


### PR DESCRIPTION
## Why and outcome

Opening the Health screenshot catalogue mounted both Environment interview previews as global dialogs, covering unrelated examples and hiding their role names. Both previews now use the existing inline presentation, so the start and listening states stay within their own inert study.

Frog autofix issue: #3011

## Product UX

- Effort: Patch to the synthetic design catalogue.
- Result: Ready for human review; human merge required.
- Walkthrough: Reviewers can inspect Environment and Patterns independently at phone and desktop widths. Preview controls remain inert. Member interview behavior and the shared voice component are unchanged.

## Evidence

- Direct: Real Chromium smoke rendering of `/screenshots/health#personal-patterns` and the Environment start/listening study at 390px and 1440px, with placeholder configuration and non-loopback requests blocked. Baseline reproduced two global dialogs; the fixed candidate has none. Patterns exposes five heading role names after the fix; both inline previews remain visible and contained.
- Coverage: The actual production component is composed with the existing synthetic props. Task-scoped browser proof was preserved outside tracked source and removed after capture; no new permanent test scaffolding is needed for the two existing prop selections.
- Checks: `pnpm --dir apps/web typecheck:prepared` passed; `pnpm complexity:diff` passed; `pnpm test:frontend-design-proof` passed all 12 tests. Requested full ReviewGPT passed on this exact head (full snapshot, concrete model attestation and exact-turn capture verified). All four required exact-head checks and viewport CI passed. The release job passed after one bounded retry of an unrelated GitHub Markdown HTTP403 response; no candidate code change was needed.

## Non-obvious affected surfaces

The modal portal previously hid unrelated Patterns examples. Browser role queries verify their independent discoverability while the catalogue remains inert.

## Architecture and reuse

- Existing systems reused: `EnvironmentVoiceCapture` already owns inline start and listening presentations.
- New logic: None; select the existing presentation at both synthetic preview call sites.
- New abstractions: None; the existing component and study wrapper cover the fix.
- Complexity intentionally avoided: No portal container, dialog mode, modal suppression helper, or component fork.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: None; changed-file debt remains 0 and maximum complexity remains 1.
- Agent judgment: Two existing props are the smallest maintainable composition change.

## Hot reply path impact

- Path status: Not applicable — only synthetic screenshot-study presentation changes.
- Database calls: None added or moved.
- Network/provider waits: None added or moved.
- Latency: Not measured; foreground reply behavior is unchanged.

## Murph initial provider input impact

Not applicable to both individual and group runtimes: no assembled instructions, tool schemas, generated guidance, or other provider-visible input changes. Complete-input measurement was not run because the change is limited to synthetic Web preview composition.

## Design proof

- Design page: The existing `/screenshots/health#environment-progressive-capture` and `/screenshots/health#personal-patterns` catalogue anchors were rendered locally against this exact candidate. The deployed catalogue is not claimed as proof of the unmerged change.
- Evidence: Inspected synthetic phone and desktop captures attached below; direct browser assertions cover the modal and role-name regression.
- Coverage: Start and listening states at 390px and 1440px; no global dialogs, independent Patterns role names, no horizontal preview overflow. This is catalogue presentation proof, not a live member interview.

## Risks

The existing voice-activity SVG produces an attribute-only SSR/client precision warning for sine-derived coordinates in the local smoke browser. The difference is visually negligible; the scoped rendering and accessibility checks pass. This study repair does not modify the shared voice component. A synthetic Frog report records the coordinate-serialization diagnostic for its existing owner.

## Deployment concerns

- Deployment: not applicable
- Reason: This only chooses an existing presentation for synthetic design examples; no API, persistence, runtime protocol, or deploy-order contract changes.

## Change-shape breakdown

- Source: +2 / -0
- Tests/fixtures: +0 / -0
- Docs: +24 / -0
- Config/tooling: +0 / -0
- Generated/other: +0 / -0
- Total: +26 / -0; one authored source file and one Frog report, no binary files.

## Changelog

- Changelog: not applicable
- Reason: Internal design-catalogue repair; no member-visible product behavior changes.

ReviewGPT context sensitivity: routine
Classification reason: Two synthetic preview props reuse existing presentation; no runtime or trust-boundary change.

ReviewGPT first-reviewed head: 9f726214f016fd55698c5430c66db90a4b94c631

![Inline Environment listening preview at phone width](https://github.com/user-attachments/assets/a1352af8-37b0-45e0-a7bd-d4de23b96435)

![Inline Environment listening preview at desktop width](https://github.com/user-attachments/assets/38f55aa4-fcdd-4e3b-8c55-4ad985538063)

![Independent synthetic Patterns study at phone width](https://github.com/user-attachments/assets/c780c24e-ea04-4b9e-adbd-fa7554582ce8)

![Independent synthetic Patterns study at desktop width](https://github.com/user-attachments/assets/576359bc-13b4-4061-aa82-8f944ba8d237)