### PR TITLE
fix(web): stabilize synthetic sponsorship reset dates

### DIFF
--- a/apps/web/app/design/components-content.tsx
+++ b/apps/web/app/design/components-content.tsx
@@ -1820,6 +1820,7 @@ export function ComponentsContent() {
               inert
             >
               <GroupSponsorshipManagementCard
+                periodEndTimeZone="UTC"
                 endpoint={`${DESIGN_SIGNED_GROUP_FUNDING_ENDPOINT}/sponsorship`}
                 initialSelectedMonthlyCapMinor={5_000}
                 management={{

--- a/apps/web/app/design/group-usage-funding-study.tsx
+++ b/apps/web/app/design/group-usage-funding-study.tsx
@@ -478,6 +478,7 @@ function GroupUsageFundingStudy() {
         >
           <div inert>
             <GroupSponsorshipManagementCard
+              periodEndTimeZone="UTC"
               endpoint={endpoint}
               initialSelectedMonthlyCapMinor={5_000}
               management={{
@@ -498,6 +499,7 @@ function GroupUsageFundingStudy() {
           state="monthly-paused"
         >
           <GroupSponsorshipManagementCard
+            periodEndTimeZone="UTC"
             endpoint={endpoint}
             inert
             management={{
@@ -517,6 +519,7 @@ function GroupUsageFundingStudy() {
           state="monthly-recovery"
         >
           <GroupSponsorshipManagementCard
+            periodEndTimeZone="UTC"
             endpoint={endpoint}
             management={{
               authorizationId: "hgsa_design_recovery",
@@ -535,6 +538,7 @@ function GroupUsageFundingStudy() {
           state="monthly-cancel-only"
         >
           <GroupSponsorshipManagementCard
+            periodEndTimeZone="UTC"
             cancelOnly
             endpoint="/api/groups/fund/design/sponsorship"
             management={{

--- a/apps/web/src/components/hosted-groups/group-sponsorship-management-card.tsx
+++ b/apps/web/src/components/hosted-groups/group-sponsorship-management-card.tsx
@@ -60,12 +60,14 @@ export function GroupSponsorshipManagementCard({
   inert = false,
   initialSelectedMonthlyCapMinor,
   management: initialManagement,
+  periodEndTimeZone,
 }: {
   cancelOnly?: boolean;
   endpoint: string;
   inert?: boolean;
   initialSelectedMonthlyCapMinor?: MonthlyCapMinor;
   management: GroupSponsorshipManagementProjection;
+  periodEndTimeZone?: string;
 }) {
   const [management, setManagement] = useState(initialManagement);
   const [selectedMonthlyCapMinor, setSelectedMonthlyCapMinor] = useState(
@@ -357,7 +359,7 @@ export function GroupSponsorshipManagementCard({
             Resets
           </dt>
           <dd className="mt-2 text-sm font-medium">
-            {formatPeriodEnd(management.periodEnd)}
+            {formatPeriodEnd(management.periodEnd, periodEndTimeZone)}
           </dd>
         </div>
       </dl>
@@ -764,13 +766,14 @@ function formatMoney(minor: number): string {
   }).format(minor / 100);
 }
 
-function formatPeriodEnd(value: string): string {
+function formatPeriodEnd(value: string, timeZone?: string): string {
   const date = new Date(value);
   return Number.isFinite(date.getTime())
     ? new Intl.DateTimeFormat("en-US", {
         day: "numeric",
         month: "short",
         year: "numeric",
+        timeZone,
       }).format(date)
     : value;
 }

--- a/apps/web/test/group-sponsorship-management-card.test.tsx
+++ b/apps/web/test/group-sponsorship-management-card.test.tsx
@@ -859,3 +859,35 @@ test.each([
     }
   },
 );
+
+test.each([
+  { periodEndTimeZone: "UTC", expected: "Aug 30, 2026" },
+  { periodEndTimeZone: "Pacific/Kiritimati", expected: "Aug 31, 2026" },
+  {
+    periodEndTimeZone: undefined,
+    expected: `Aug ${new Date("2026-08-30T16:00:00.000Z").getDate()}, 2026`,
+  },
+])("renders reset dates in $periodEndTimeZone, retaining the ambient default", async ({
+  periodEndTimeZone,
+  expected,
+}) => {
+  const { GroupSponsorshipManagementCard } = await import(
+    "@/src/components/hosted-groups/group-sponsorship-management-card"
+  );
+  const rendered = await renderClientComponent(createElement(
+    GroupSponsorshipManagementCard,
+    {
+      endpoint: "/api/groups/fund/example/sponsorship",
+      inert: true,
+      management: { ...baseManagement, periodEnd: "2026-08-30T16:00:00.000Z" },
+      periodEndTimeZone,
+    },
+  ));
+  try {
+    const resetLabel = [...rendered.container.querySelectorAll("dt")]
+      .find((element) => element.textContent === "Resets");
+    assert.equal(resetLabel?.nextElementSibling?.textContent, expected);
+  } finally {
+    await rendered.cleanup();
+  }
+});


### PR DESCRIPTION
## Why and outcome

The synthetic sponsorship reset date changes from August 30 to August 31 when a UTC server hydrates in Pacific/Kiritimati, causing a React hydration failure that disrupts unrelated catalog studies. The existing card formatter now accepts an optional display timezone; all five synthetic catalog callers explicitly use UTC. Production callers retain their ambient timezone default.

Frog autofix issue: #3012

## Product UX

- Effort: Patch.
- Result: Ready for human review; human merge required.
- Walkthrough: The components catalog and four composed group-funding states keep the same reset date across server and browser timezones. Inert boundaries, sponsorship actions, amounts, and production date defaults are unchanged.

## Evidence

- Direct: The exact hydration-gated browser replay fails on original source (August 31 instead of August 30) and passes on the corrected tree with a UTC smoke server and Pacific/Kiritimati Chromium at 390 and 1440 pixels. It waits for React attachment on every reset node, then two frames, before checking final dates and date-specific hydration errors.
- Coverage: The existing sponsorship card suite passes 21 tests in UTC and 21 in Pacific/Kiritimati, including explicit timezone and ambient-default regressions plus existing action/recovery coverage. `pnpm --dir apps/web typecheck` passes. Frozen workspace install and diff hygiene pass.

- Full ReviewGPT round 1: PASS on `98fbe51b6e10d5b0aaef2ec5bd9fd0892358eaf4`; no qualifying findings. Exact model, response hash, turn chain, and minimum review duration verified. All four required CI contexts pass on that exact head.

## Non-obvious affected surfaces

The shared production sponsorship card gains an optional formatting argument only. Its existing mutation and recovery tests pass in both timezones; callers without the prop keep local date behavior. The independent seven-day health study changes in PR #2629 do not overlap this catalog caller.

## Architecture and reuse

- Existing systems reused: `GroupSponsorshipManagementCard`, its `formatPeriodEnd` helper, and native `Intl.DateTimeFormat`.
- New logic: Pass an optional display timezone into the existing formatter and UTC from synthetic examples.
- New abstractions: None; no new formatting owner or state.
- Complexity intentionally avoided: No client-only rendering, hydration suppression, invalid date fixtures, or change to the production timezone contract.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff --base HEAD --json`; zero complexity/debt deltas.
- Hotspots: Existing card (37), submit (21), and confirmation dialog (27) are unchanged in branching. The formatter remains 2.
- Agent judgment: The small formatting seam does not justify restructuring unrelated billing actions.

## Hot reply path impact

- Path status: Not applicable — catalog and Web presentation only.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: No assistant execution or provider path changed.

## Murph initial provider input impact

Not applicable for individual or group Murph: this changes no prompts, tools, schemas, or provider-visible input. No input measurement was needed.

## Design proof

- Design page: [Sponsorship management component](https://www.withmurph.ai/design?tab=components#group-sponsorship-management-component), [group funding states](https://www.withmurph.ai/screenshots/groups#group-usage-funding).
- Evidence: Two inspected synthetic candidate screenshots are attached below. These production anchors locate the existing representation; the corrected cross-timezone behavior is proved in the isolated candidate checkout and is not yet deployed.
- Coverage: Active management on phone and desktop, all four composed management states, UTC server versus Pacific/Kiritimati browser, actual hydration, expected dates, and preserved inert boundaries.

ReviewGPT first-reviewed head: 98fbe51b6e10d5b0aaef2ec5bd9fd0892358eaf4
ReviewGPT context sensitivity: sensitive
Classification reason: Shared sponsorship presentation owner; no billing authority or mutation behavior changes.

## Deployment concerns

- Deployment: not applicable
- Reason: One optional Web presentation prop with unchanged defaults; no schema, protocol, data migration, or cross-plane compatibility boundary. Human merge is required.

## Change-shape breakdown

Classification rule: TSX component/study code is source; the card regression is tests. No binary or generated files are committed. The one-off browser proof and images are evidence artifacts.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 10 | 2 |
| Tests / fixtures | 32 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **42** | **2** |

## Changelog

- Changelog: not applicable
- Reason: Internal synthetic catalog hydration repair; existing member-facing date semantics are preserved.

![Synthetic sponsorship preview after hydration at 390 pixels in Pacific/Kiritimati](https://github.com/user-attachments/assets/c614da92-ce55-4c33-bf36-6f3f2ccab823)

![Synthetic sponsorship preview after hydration at 1440 pixels in Pacific/Kiritimati](https://github.com/user-attachments/assets/660d16e3-db5a-487b-9900-a2dea9941466)
