### PR TITLE
perf(device-sync): reuse inventory across summary continuations

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1870,13 +1870,16 @@ Last verified: 2026-09-04
 - Junction historical backfill and non-yieldable full jobs finish inventory,
   summary, profile, and historical scheduling once. A yieldable full reconcile
   instead commits one configured normalization-safe summary unit per full-job
-  continuation, after a live provider inventory read for that attempt, before
-  entering the existing timeseries continuation. The inventory read is one
-  attempt capped at eight seconds, accepts at most 64 provider rows, and its
-  source projection reads the current local source set once before at most 64
-  serial upserts; summary admission adds one fixed local-source read independent
-  of provider cardinality. Ordinary units contain one resource and allow at
-  most three sequential pages with one eight-second request attempt per page.
+  continuation before entering the existing timeseries continuation. Compatible
+  summary continuations reuse inventory and source projection within one worker
+  pass, keyed by connection/source lifecycle and bounded collection policy;
+  failures and history discard reuse. A new inventory read is one attempt capped
+  at eight seconds, accepts at most 64 provider rows, and its source projection
+  reads the current local source set once before at most 64 serial upserts.
+  Every summary admission still reads live sources after the provider fetch,
+  independently of provider cardinality or inventory reuse. Ordinary units contain
+  one resource and allow at most three sequential pages with one eight-second
+  request attempt per page.
   Sleep and sleep-cycle remain one canonical unit so
   stage-owner suppression sees both resources; their one-attempt page timeout
   is five seconds, bounding the paired six-page worst case at 30 seconds. A

--- a/agent-docs/exec-plans/completed/2026-09-07-reduce-sync-snapshot-reads.md
+++ b/agent-docs/exec-plans/completed/2026-09-07-reduce-sync-snapshot-reads.md
@@ -1,0 +1,72 @@
+# Reduce repeated device-sync source snapshots
+
+Status: completed
+Created: 2026-09-07
+
+## Outcome and invariants
+
+Reduce signed Web snapshot reads during Junction reconciliation without caching
+import authority, changing sync cadence, or weakening source disconnect/reconnect
+fences. Target repeated inventory projection across bounded summary continuations.
+A near-half reduction in this path is not a claim about all snapshot traffic.
+
+## Evidence and design
+
+The provider pass executor reuses inventory for resource jobs but clears it for
+every reconciliation job. Each bounded summary continuation reloads inventory and
+reads sources for projection, then reads sources after the summary fetch for
+import admission. Extend the existing loader to compatible reconciliation jobs.
+Keep bounded and ordinary collection scopes distinct, preserve lifecycle keys,
+and discard reuse after failures, history, and unrelated job kinds. Every import
+retains its live post-provider source read. Web remains the source authority;
+the existing worker pass owns the inventory lifetime.
+
+Keep day-level imports, collection limits, foreground yields, retries, and durable
+job formats unchanged. Add no dependency, timer, or persisted cache.
+
+## Proof and completion
+
+1. Reproduce repeated summary inventory and snapshot reads.
+2. Prove unchanged imports with fewer reads and preserve disconnect, reconnect,
+   failure, new-pass, history, and bounded collection behavior.
+3. Run focused provider/service tests, typecheck, complexity and diff checks;
+   update the provider owner documentation and review the candidate.
+4. Commit the implementation. Deployment and equal-load production measurement
+   remain separate from deterministic local proof.
+
+Product UX: internal efficiency only; no public changelog or model-reply proof.
+
+## Result and candidate review
+
+Implemented at the existing provider-pass owner. A complete synthetic summary
+chain produces identical canonical import payloads and continuation results:
+four inventory requests become one, and eight source reads become five (37.5%
+fewer). Every import retains a post-fetch source read. This does not establish a
+50% endpoint-wide reduction. Production savings depend on compatible jobs sharing
+a pass; separate drains and lifecycle changes still fetch fresh inventory.
+
+Focused regression reproduced the duplicate read before the fix. Provider,
+backfill, resource, admission, and service suites passed (252 tests), followed by
+the expanded source-reuse suite (12 tests). Package typecheck and the expanded
+suite passed again after the last test edit. Complexity debt and maximum are unchanged;
+reviewed the existing execution hotspots and kept the change inside the loader.
+
+Parent review traced hosted source reads through the service context, checked
+pass lifetime and collection-policy separation, and inspected the full diff for
+privacy and unrelated changes. No schema, protocol, cadence, retry boundary,
+import authority, or dependency changed. Existing source imports and durable job
+formats remain compatible with prior Web and worker versions. No migration or
+coordinated deployment is needed; production measurement remains outstanding.
+
+Verification commands:
+
+- `pnpm --dir packages/device-syncd exec vitest run --config vitest.config.ts --no-coverage test/junction-timeseries-source-reuse.test.ts test/junction-admission-source-reads.test.ts test/junction-provider-backfill.test.ts test/junction-provider-resources.test.ts test/service.test.ts`
+- `pnpm --dir packages/device-syncd exec vitest run --config vitest.config.ts --no-coverage test/junction-timeseries-source-reuse.test.ts`
+- `pnpm --dir packages/device-syncd typecheck`
+- `pnpm complexity:diff`
+- `git diff --check`
+
+This is a local implementation commit. PR publication, exact-head CI, and the
+applicable final ReviewGPT remain part of subsequent PR completion.
+Updated: 2026-09-07
+Completed: 2026-09-07

--- a/packages/device-syncd/README.md
+++ b/packages/device-syncd/README.md
@@ -471,8 +471,12 @@ node packages/device-syncd/dist/bin.js
 Each bounded worker drain creates an optional provider pass executor once, then
 releases it when the drain returns. Standalone worker calls get separate scopes.
 Junction reuses successful inventory and source projection across ordinary
-resource jobs in that scope, keyed by account identity, connection generation,
-and source lifecycle. Non-resource work, historical attempts, calendar repair, or any failed job
-discards that reuse; historical attempts and calendar repair load their own inventory. Every
-canonical import retains its live connection-source admission check. The scope
-contains provider inventory only, never cached authorization or durable state.
+resource jobs and bounded summary-reconciliation continuations in that scope,
+keyed by account identity, connection generation, and source lifecycle. Bounded
+reconciliation inventory and ordinary resource inventory have separate keys so
+reuse cannot bypass collection limits. Historical attempts, calendar repair,
+unbounded full jobs, timeseries continuations, other job kinds, or any failed job
+discard that reuse. Historical attempts and calendar repair load their own
+inventory. Every canonical import retains its live connection-source admission
+check. The scope contains provider inventory only, never cached authorization
+or durable state.

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -1536,7 +1536,7 @@ export function createJunctionDeviceSyncProvider(
   async function executeJob(
     context: ProviderJobContext,
     job: DeviceSyncJobRecord,
-    resourceInventories?: Map<string, readonly JunctionProviderConnection[]>,
+    passInventories?: Map<string, readonly JunctionProviderConnection[]>,
   ): Promise<ProviderJobResult> {
     const skippedOptionalResources: JunctionSkippedOptionalResource[] = [];
 
@@ -1569,7 +1569,7 @@ export function createJunctionDeviceSyncProvider(
         job,
         skippedOptionalResources,
         completedWorkoutStreamIdentities,
-        resourceInventories,
+        passInventories,
       );
     }
 
@@ -1585,20 +1585,8 @@ export function createJunctionDeviceSyncProvider(
     const window = resolveJobWindow(job, context.now, job.kind === "backfill" ? summaryBackfillDays : reconcileDays);
     const sourceProviderSlug = normalizeProviderSlug(job.payload.sourceProviderSlug);
     const isConnectHistoricalBackfill = isConnectHistoricalBackfillWindow(context.account, window);
-    const listedSourceProviders = await measureJunctionProviderRequest(
-      context,
-      "inventory",
-      () => client.listUserProviders(
-        context.account.externalAccountId,
-        {
-          ...(job.kind === "reconcile" && context.shouldYield
-            ? { collectionWorkLimit: JUNCTION_FULL_JOB_INVENTORY_COLLECTION_WORK_LIMIT }
-            : {}),
-          signal: context.signal ?? null,
-        },
-      ),
-    );
-    await projectJunctionSources(context, listedSourceProviders);
+    const inventory = createJobInventoryLoader(context, job, passInventories);
+    const listedSourceProviders = await inventory.loadAndProjectSourceProviders();
     const sourceProviders = sourceProviderSlug
       ? listedSourceProviders.filter((provider) => areJunctionProviderSlugsDataEquivalent(
           provider.origin.sourceProviderSlug ?? provider.slug,
@@ -2494,21 +2482,23 @@ export function createJunctionDeviceSyncProvider(
     };
   }
 
-  function createResourceInventoryLoader(
+  function createJobInventoryLoader(
     context: ProviderJobContext,
     job: DeviceSyncJobRecord,
-    resourceInventories?: Map<string, readonly JunctionProviderConnection[]>,
+    passInventories?: Map<string, readonly JunctionProviderConnection[]>,
   ) {
+    const boundedReconcile = job.kind === "reconcile" && Boolean(context.shouldYield);
     // Historical attempts and calendar repair require their own inventory read.
-    const inventoryKey = resourceInventories
+    const inventoryKey = passInventories
+      && (job.kind === "resource" || boundedReconcile)
       && !readJunctionSparseCalendarRefreshDay(job)
       && job.payload.historicalBackfill !== true
-      ? buildJunctionResourceInventoryKey(context)
+      ? buildJunctionJobInventoryKey(context, boundedReconcile)
       : null;
     if (!inventoryKey) {
-      resourceInventories?.clear();
+      passInventories?.clear();
     }
-    const priorInventory = inventoryKey ? resourceInventories?.get(inventoryKey) : undefined;
+    const priorInventory = inventoryKey ? passInventories?.get(inventoryKey) : undefined;
     let listedSourceProviders = priorInventory ?? null;
     let projectedSourceProviders = priorInventory ?? null;
     const loadSourceProviders = async (): Promise<readonly JunctionProviderConnection[]> => {
@@ -2520,6 +2510,9 @@ export function createJunctionDeviceSyncProvider(
         context,
         "inventory",
         () => client.listUserProviders(context.account.externalAccountId, {
+          ...(boundedReconcile
+            ? { collectionWorkLimit: JUNCTION_FULL_JOB_INVENTORY_COLLECTION_WORK_LIMIT }
+            : {}),
           signal: context.signal ?? null,
         }),
       );
@@ -2534,7 +2527,7 @@ export function createJunctionDeviceSyncProvider(
       await projectJunctionSources(context, sourceProviders);
       projectedSourceProviders = sourceProviders;
       if (inventoryKey) {
-        resourceInventories?.set(inventoryKey, sourceProviders);
+        passInventories?.set(inventoryKey, sourceProviders);
       }
       return sourceProviders;
     };
@@ -2546,7 +2539,7 @@ export function createJunctionDeviceSyncProvider(
     job: DeviceSyncJobRecord,
     skippedOptionalResources: JunctionSkippedOptionalResource[],
     completedWorkoutStreamIdentities: ReadonlySet<string>,
-    resourceInventories?: Map<string, readonly JunctionProviderConnection[]>,
+    passInventories?: Map<string, readonly JunctionProviderConnection[]>,
   ): Promise<ProviderJobResult> {
     const resourceName = normalizeString(job.payload.resource);
 
@@ -2628,7 +2621,7 @@ export function createJunctionDeviceSyncProvider(
       return {};
     }
     const { loadSourceProviders, loadAndProjectSourceProviders } =
-      createResourceInventoryLoader(context, job, resourceInventories);
+      createJobInventoryLoader(context, job, passInventories);
 
     if (calendarRefreshDay) {
       if (
@@ -6135,16 +6128,19 @@ export function createJunctionDeviceSyncProvider(
       createScheduledJobs,
       executeJob,
       createPassExecutor(): DeviceJobExecutor {
-        const resourceInventories = new Map<string, readonly JunctionProviderConnection[]>();
+        const passInventories = new Map<string, readonly JunctionProviderConnection[]>();
         return {
           async executeJob(context, job) {
-            if (job.kind !== "resource") {
-              resourceInventories.clear();
+            if (
+              (job.kind !== "resource" && job.kind !== "reconcile")
+              || isFullJobTimeseriesContinuation(job)
+            ) {
+              passInventories.clear();
             }
             try {
-              return await executeJob(context, job, resourceInventories);
+              return await executeJob(context, job, passInventories);
             } catch (error) {
-              resourceInventories.clear();
+              passInventories.clear();
               throw error;
             }
           },
@@ -6154,7 +6150,10 @@ export function createJunctionDeviceSyncProvider(
   };
 }
 
-function buildJunctionResourceInventoryKey(context: ProviderJobContext): string {
+function buildJunctionJobInventoryKey(
+  context: ProviderJobContext,
+  boundedReconcile: boolean,
+): string {
   const account = context.account;
   return JSON.stringify([
     account.id,
@@ -6162,6 +6161,7 @@ function buildJunctionResourceInventoryKey(context: ProviderJobContext): string 
     account.connectedAt,
     account.disconnectGeneration,
     context.connectionSourceAdmissionMode,
+    boundedReconcile,
     (account.sources ?? []).map((source) => [
       source.sourceProviderSlug,
       source.firstSeenAt,

--- a/packages/device-syncd/test/junction-timeseries-source-reuse.test.ts
+++ b/packages/device-syncd/test/junction-timeseries-source-reuse.test.ts
@@ -4,6 +4,7 @@ import {
   createAccount,
   createConnectionSource,
   createJob,
+  createJobFromInput,
   createJunctionJobContext,
   createJunctionProvider,
   executeJunctionJob,
@@ -93,7 +94,7 @@ test.each([
 });
 
 
-test("Junction resource pass shares inventory but reads live import authority for every job", async () => {
+test.each(["resource", "reconcile"] as const)("Junction %s pass shares inventory but reads live import authority for every job", async (kind) => {
   let inventoryReads = 0;
   let sourceReads = 0;
   let imports = 0;
@@ -110,15 +111,23 @@ test("Junction resource pass shares inventory but reads live import authority fo
         resource_availability: { blood_oxygen: true },
       }] });
     }
-    assert.equal(url.pathname, "/v2/timeseries/junction-user-1/blood_oxygen/grouped");
+    assert.equal(url.pathname, kind === "resource"
+      ? "/v2/timeseries/junction-user-1/blood_oxygen/grouped"
+      : "/v2/summary/activity/junction-user-1");
     if (disconnectDuringFetch) {
       liveSource = createConnectionSource({ status: "disconnected" });
+    }
+    if (kind === "reconcile") {
+      return createJsonResponse({ data: [{
+        id: "activity-1", source: { provider: "garmin", type: "watch" },
+        calendar_date: "2026-04-02", steps: 5000,
+      }] });
     }
     return createJsonResponse({ groups: { garmin: [{
       data: [{ timestamp: "2026-04-02T14:00:00.000Z", unit: "%", value: 97 }],
       source: { provider: "garmin", type: "watch" },
     }] } });
-  }, { summaryResources: [], timeseriesResources: ["blood_oxygen"] });
+  }, { summaryResources: ["activity"], timeseriesResources: ["blood_oxygen"] });
   const context = createJunctionJobContext({
     now: "2026-04-04T12:00:00.000Z",
     account: createAccount({ sources: [{ ...liveSource, resourceCount: 1 }] }),
@@ -128,9 +137,16 @@ test("Junction resource pass shares inventory but reads live import authority fo
       if (sourceReadFailure) throw sourceFailure;
       return [liveSource];
     },
-    importSnapshot: async () => { imports += 1; return { imported: true }; },
+    importSnapshot: async (snapshot) => {
+      // Summary jobs still submit an empty, fenced snapshot after disconnect.
+      if (kind === "resource" || JSON.stringify(snapshot).includes('"steps":5000')) {
+        imports += 1;
+      }
+      return { imported: true };
+    },
   });
-  const job = createJob("resource", {
+  if (kind === "reconcile") context.shouldYield = () => false;
+  const job = createJob(kind, {
     resource: "blood_oxygen", resourceCategory: "timeseries", sourceProviderSlug: "garmin",
     windowEnd: "2026-04-03T00:00:00.000Z", windowStart: "2026-04-02T00:00:00.000Z",
   });
@@ -193,4 +209,118 @@ test("Junction resource pass shares inventory but reads live import authority fo
   await nextPass.executeJob(context, job);
   assert.equal(inventoryReads, 8);
   assert.equal(imports, 9);
+});
+
+
+test("Junction summary continuations preserve imports and progress with one inventory per pass", async () => {
+  let inventoryReads = 0;
+  let sourceReads = 0;
+  const imported: unknown[] = [];
+  const provider = createJunctionProvider(async (input) => {
+    const pathname = new URL(readUrl(input)).pathname;
+    if (pathname === "/v2/user/providers/junction-user-1") {
+      inventoryReads += 1;
+      return createJsonResponse({ providers: [{
+        id: "provider-garmin-1", slug: "garmin", status: "connected",
+        resource_availability: { activity: true, sleep: true, sleep_cycle: true, body: true },
+      }] });
+    }
+    const resource = pathname.match(/^\/v2\/summary\/([^/]+)\/junction-user-1$/u)?.[1];
+    assert.ok(resource);
+    return createJsonResponse({ data: [{
+      id: `${resource}-1`, connectionId: "provider-garmin-1",
+      calendar_date: "2026-04-02", steps: 5000,
+    }] });
+  }, { summaryResources: ["activity", "sleep", "sleep_cycle", "body"], timeseriesResources: [] });
+  const source = createConnectionSource();
+  const context = createJunctionJobContext({
+    account: createAccount({ sources: [{ ...source, resourceCount: 1 }] }),
+    connectionSourceAdmissionMode: "listed_only",
+    listConnectionSources: async () => { sourceReads += 1; return [source]; },
+    importSnapshot: async (snapshot) => { imported.push(snapshot); return { imported: true }; },
+    shouldYield: () => false,
+  });
+  const jobExecutor = provider.jobExecutor;
+  assert.ok(jobExecutor?.createPassExecutor);
+  const pass = jobExecutor.createPassExecutor();
+  const run = async (shareInventory: boolean) => {
+    const executor = shareInventory ? pass : jobExecutor;
+    let job = createJob("reconcile", {
+      windowStart: "2026-03-27T00:00:00.000Z", windowEnd: "2026-04-03T00:00:00.000Z",
+    });
+    const results = [];
+    for (let index = 0; index < 4; index += 1) {
+      const result = await executor.executeJob(context, job);
+      results.push(result);
+      const continuation = result.scheduledJobs?.[0];
+      if (!continuation) {
+        assert.equal(index, 3);
+        break;
+      }
+      job = createJobFromInput(continuation, index);
+    }
+    return results;
+  };
+  const baselineResults = await run(false);
+  const baselineImports = [...imported];
+  assert.equal(inventoryReads, 4);
+  assert.equal(sourceReads, 8);
+  assert.equal(imported.length, 4);
+  assert.ok(JSON.stringify(imported).includes('"steps":5000'));
+  imported.length = 0;
+  inventoryReads = 0;
+  sourceReads = 0;
+  assert.deepEqual(await run(true), baselineResults);
+  assert.deepEqual(imported, baselineImports);
+  assert.equal(inventoryReads, 1);
+  assert.equal(sourceReads, 5);
+});
+
+
+test("Junction pass keeps bounded inventory separate and refreshes after history or full work", async () => {
+  let inventoryReads = 0;
+  const provider = createJunctionProvider(async (input) => {
+    const pathname = new URL(readUrl(input)).pathname;
+    if (pathname === "/v2/user/providers/junction-user-1") {
+      inventoryReads += 1;
+      return createJsonResponse({ providers: [{
+        slug: "garmin", status: "connected", resource_availability: { blood_oxygen: true },
+      }] });
+    }
+    if (pathname === "/v2/summary/activity/junction-user-1") return createJsonResponse({ data: [] });
+    assert.equal(pathname, "/v2/timeseries/junction-user-1/blood_oxygen/grouped");
+    return createJsonResponse({ groups: {} });
+  }, { summaryResources: ["activity"], timeseriesResources: ["blood_oxygen"] });
+  const context = createJunctionJobContext({
+    account: createAccount({ sources: [{ ...createConnectionSource(), resourceCount: 1 }] }),
+    shouldYield: () => false,
+  });
+  assert.ok(provider.jobExecutor?.createPassExecutor);
+  const pass = provider.jobExecutor.createPassExecutor();
+  const window = { windowStart: "2026-04-02T00:00:00.000Z", windowEnd: "2026-04-03T00:00:00.000Z" };
+  const resource = createJob("resource", {
+    ...window, resource: "blood_oxygen", resourceCategory: "timeseries", sourceProviderSlug: "garmin",
+  });
+  const reconcile = createJob("reconcile", window);
+  await pass.executeJob(context, resource);
+  assert.equal(inventoryReads, 1);
+  await pass.executeJob(context, reconcile);
+  assert.equal(inventoryReads, 2); // Ordinary inventory cannot bypass bounded collection.
+  await pass.executeJob(context, reconcile);
+  await pass.executeJob(context, resource);
+  assert.equal(inventoryReads, 2);
+  await pass.executeJob({ ...context, shouldYield: undefined }, reconcile);
+  assert.equal(inventoryReads, 3);
+  await pass.executeJob(context, reconcile);
+  assert.equal(inventoryReads, 4);
+  await pass.executeJob(context, createJob("backfill", window));
+  await pass.executeJob(context, createJob("backfill", window));
+  assert.equal(inventoryReads, 6);
+  await pass.executeJob(context, reconcile);
+  assert.equal(inventoryReads, 7);
+  await pass.executeJob(context, createJob("reconcile", {
+    ...window, timeseriesCursor: window.windowStart, timeseriesResourceCursor: "blood_oxygen",
+  }));
+  await pass.executeJob(context, reconcile);
+  assert.equal(inventoryReads, 8);
 });


### PR DESCRIPTION
## Why and outcome

Bounded Junction summary continuations reload provider inventory and project sources for every job, even when consecutive jobs run in the same worker pass. Extend the existing resource-job inventory loader to reuse successful inventory for compatible summary continuations.

A complete synthetic summary chain now makes one inventory request instead of four and five control-plane source reads instead of eight (37.5% fewer), with identical import payloads and continuation results. Every import still reads live sources after fetching provider data. This is a path-specific reduction, not a claim of halving total production snapshot traffic.

## Product UX

- Effort: Not applicable — internal device-sync efficiency; no new member flow or sync cadence change.
- Result: Not applicable — existing disconnect, reconnect, foreground-yield, and retry behavior is preserved.
- Walkthrough: Covered connected and disconnected sources, reconnect generations, failed reads, new passes, historical jobs, and bounded versus ordinary inventory collection.

## Evidence

- Direct: The new reconciliation case failed before the fix with two inventory requests instead of one. A complete continuation chain compares exact import payloads and scheduled results before and after reuse, and asserts inventory requests 4 → 1 and source reads 8 → 5.
- Coverage: Provider admission, backfill, resources, source reuse, and service suites passed (252 tests); the subsequently expanded source-reuse suite passed all 12 tests. The latter and package typecheck passed after the final TypeScript edit. Service tests cover pass lifetime, foreground yielding, and continuation restart/watermarks.
- Commands: `pnpm --dir packages/device-syncd exec vitest run --config vitest.config.ts --no-coverage test/junction-timeseries-source-reuse.test.ts test/junction-admission-source-reads.test.ts test/junction-provider-backfill.test.ts test/junction-provider-resources.test.ts test/service.test.ts`; final focused rerun of `test/junction-timeseries-source-reuse.test.ts`; `pnpm --dir packages/device-syncd typecheck`; `pnpm complexity:diff`; `git diff --check`.
- Final ReviewGPT: [Round 1 full-patch review](https://chatgpt.com/c/6a9f3401-9ac4-83e9-8c34-c864ba72c9cd) returned `ROUND_OUTCOME: PASS` and `REVIEW_COMPLETE` for `a728eed14a25bf1be2b93042d807b4c8a6b8c395`, with no qualifying findings. Hercules lane; requested and captured response model both `gpt-6-pro`; capture followed more than five minutes of response waiting. Exact-turn signatures and response hash matched the capture/model evidence. The review checked all five changed files, lifecycle/collection-policy separation, live source admission, worker-pass lifetime, hosted wiring, and continuation behavior. Accepted as a substantive static review; it did not independently run dependencies/tests, which are covered by local proof and CI.
- CI: all 33 current checks passed on `a728eed14a25bf1be2b93042d807b4c8a6b8c395`, including the required release, CLI host, and billing gates. [Release workflow](https://github.com/cobuildwithus/murph/actions/runs/34165108849) completed successfully. Production invocation reduction remains unmeasured.

## Non-obvious affected surfaces

Resource jobs retain their existing reuse and live admission behavior. Bounded reconciliation has a distinct inventory key, so ordinary inventory cannot bypass its request limits. History, full jobs without yielding, timeseries continuations, and failures discard reuse; lifecycle changes and new passes fetch fresh inventory. Focused regression tests cover these boundaries.

## Architecture and reuse

- Existing systems reused: Junction's existing provider pass executor, inventory loader, lifecycle key, source projection, and live import admission.
- New logic: Allow bounded summary reconciliation to reuse inventory within the current pass, with collection policy included in the key.
- New abstractions: None; broaden and rename the existing loader/key to reflect both job types.
- Complexity intentionally avoided: No persistent cache, timer, dependency, protocol, database schema, batching owner, or sync cadence change.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; changed-source debt 406 → 406, maximum 145 → 145.
- Hotspots: Reviewed all 18 existing reported hotspots. The affected `executeJob` (106) delegates its duplicate inventory fetch/projection to the existing loader; `executeResourceJob` (145) retains behavior. Unchanged hotspots include full timeseries continuation, source projection, precise and aggregate imports, history follow-up and coverage, Fitbit coverage, record identity, workout streams, blocked availability, webhook windows, resource imports, ECG candidates, optional-resource classification, webhook source fallback, and the anonymous snapshot-normalization callback.
- Agent judgment: Further extraction from these unrelated provider policies would broaden this targeted optimization. The production diff adds and removes 31 lines with no new owner.

## Hot reply path impact

- Path status: Not applicable — this changes background device-sync inventory reuse, not current-message acceptance through reply handoff.
- Database calls: None added or moved onto the reply path.
- Network/provider calls: None added or moved onto the reply path.
- Other awaited latency: None added or moved onto the reply path; foreground yield boundaries remain intact.
- Before/after proof: Device-sync source reads 8 → 5 and provider inventory requests 4 → 1 in the complete summary-chain regression; existing service foreground-yield tests pass.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no assembled instructions, tools, schemas, generated guidance, history, or provider-visible input changed. Input measurement was not run because this is device-provider inventory reuse only.

ReviewGPT first-reviewed head: a728eed14a25bf1be2b93042d807b4c8a6b8c395
ReviewGPT context sensitivity: sensitive
Classification reason: Hosted device-sync execution and source-admission-adjacent reuse.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing Web/Worker and Worker/warm-container combinations remain supported; snapshot/import APIs and durable job formats are unchanged.
- Safe order: Ordinary worker rollout; no consumer-first prerequisite or coordinated Web deployment.
- Rollback floor: Existing pre-change worker version; no new persisted state or migration.
- Expected exposure: Compatible bounded summary jobs sharing a worker pass. Savings vary with pass composition; total production invocation reduction is not yet established.
- Reversibility: Reverting restores repeated inventory reads without altering persisted data.
- Convergence proof: The cache exists only in one provider pass and is discarded when that pass ends. Old and new executors consume the same durable payloads and produce identical tested continuation/import payloads. Existing source-reuse and service restart tests pass; no live mixed-version deployment was exercised.
- Post-deploy checks: Compare source-read and provider-inventory counts per reconciliation job across equal-load windows; confirm import counts, failures, source disconnect fences, and continuation completion remain stable.

## Change-shape breakdown

Classification rule: Production TypeScript is source; the provider test file is tests; owner documentation and the completed execution plan are docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 31 | 31 |
| Tests / fixtures | 135 | 5 |
| Docs | 91 | 12 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **257** | **48** |

## Changelog

- Changelog: not applicable
- Reason: Internal background sync request reduction with no new member-visible behavior or sync cadence promise.

## Production rollout status

Merged as `bd7bdae088e77241f2829b30bf5ef238db880ed8`. All predeploy runtime gates passed in [the initial protected run](https://github.com/cobuildwithus/murph-cloud/actions/runs/34184484389); its production preflight rejected the workflow's gradual default, which was corrected to immediate.

Production remains blocked. [The immediate deployment and its single failed-job retry](https://github.com/cobuildwithus/murph-cloud/actions/runs/34185777075) used frozen public source `9156e126c412b14db5b11206158eed5fff00b539`, which includes this merge. The intervening change affects deployment tooling only and had green required CI; unchanged runtime E2E gates were reused. Production authentication, preflight, bundle preparation, and bundle validation passed.

Both deployment attempts failed in `createRunnerReleaseProvider.admitApplication` while requesting creation of the inactive native runner application, before Worker upload/activation. Endpoint smoke was skipped and live convergence was not established. The generic provider wrapper suppresses the underlying HTTP status and provider error code, so the actual rejection/transport cause remains unconfirmed. This optimization is not confirmed live. The next diagnostic needs safe HTTP-status/provider-code evidence from the protected deployment boundary; do not bypass native admission or claim a production invocation reduction.
