### PR TITLE
Deploy compatible Worker fixes while retaining runner capacity

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-07-worker-only-deploy.md
+++ b/agent-docs/exec-plans/completed/2026-09-07-worker-only-deploy.md
@@ -1,0 +1,54 @@
+# Preserve runner capacity during Worker-only deployment
+
+Status: completed
+Created: 2026-09-07
+Updated: 2026-09-07
+
+## Goal and invariants
+
+Implement the public selector for compatible Worker coordination releases without
+reserving another member fleet. Preserve every serving runner image, capacity, release identity and
+in-flight invocation. Keep protected private deployment and exact live receipts.
+
+## Evidence and ownership
+
+The current deployment admits an inactive full-capacity fleet before Worker
+activation. Account quota can reject this even for a Worker coordination patch.
+The existing native admission owner already supports publication without a
+container mutation when execution artifacts match. Extend that boundary with an
+explicit Worker-only mode that retains the serving artifact across source changes.
+Private Murph Cloud remains the deployment input and hosted credential owner.
+
+## Design
+
+- Derive the selected release and retained applications from live provider state.
+- Admit only the existing bounded smoke application for the newly built artifact.
+- Keep the selected runner and any existing prior namespace available; a pending
+  candidate becomes retained history so later reuse still requires drain proof.
+- Omit an absent inactive application from effective config and receipt.
+- Run signed smoke, including actual selected-runner readiness, before declaring
+  convergence. Preserve normal predeploy checks and private exact-state verification.
+- Use only with compatible Worker/retained-runner contracts. New optional allocation
+  diagnostics can be omitted by the retained runner while Worker logs remain useful.
+- No quota changes, member capacity reduction, rollback, or new state owner.
+
+## Implementation outcome
+
+The public selector, effective application set, retained history and receipt
+plumbing are implemented. A separate private workflow change exposes the option.
+This plan closes the public implementation phase; external review, exact-head CI,
+private integration and production deployment remain tracked in the PR and owning
+session. No production rollout or live latency improvement is claimed here.
+
+## Verification
+
+Synthetic tests must prove unchanged selected identity and member capacity,
+missing inactive application handling, preserved old namespace routing, bounded
+smoke-only admission, single Worker activation, and truthful receipt coverage.
+Validation passed: 111 tests across staging, deployment CLI/settings, image
+preparation, native release provider and receipt suites; Cloudflare typecheck;
+`pnpm complexity:diff` (no debt, changed-file maximum decreased from 20 to 19);
+`git diff --check`. Parent review confirmed member applications cannot enter
+native admission in explicit retention mode and receipts use the staged set.
+Required external review, exact-head CI and production proof remain outstanding.
+Completed: 2026-09-07

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -53,6 +53,21 @@ when a native create committed but its response or subsequent Worker publication
 was lost. Its image is never reused as a verified artifact without provenance.
 No deployment-convergence restart retry is added to message processing.
 
+For a compatible Worker coordination change, the protected workflow may explicitly
+select `container_rollout=worker-only`. This retains the serving release's exact
+identity and all existing member application images and capacities, even when the
+new source has different bundle fingerprints. Only the existing one-slot deploy
+smoke application is admitted with the newly built artifact. Signed smoke still
+proves the selected serving namespace and its inventory, then exercises the new
+smoke artifact. There is one Worker activation and no member fleet promotion.
+An existing pending candidate becomes retained history; an absent inactive
+application is omitted from the effective config and exact-state receipt.
+Worker-only mode requires the predeploy gates and does not deploy runner changes.
+The selected runner's old parser may omit new optional diagnostics; Worker-side
+logs remain available. Use a full release for changes that require a new runner.
+This mode does not change account quota or the overlap requirement of full image
+releases. Land the public selector before enabling its private workflow input.
+
 A bound, still-warm previous session retains its exact namespace, member, claim,
 and write fence through promotion. Fresh member allocation selects only the
 active release. Previous inventory cannot prepare, bind new members, or restart

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -63,6 +63,8 @@ smoke artifact. There is one Worker activation and no member fleet promotion.
 An existing pending candidate becomes retained history; an absent inactive
 application is omitted from the effective config and exact-state receipt.
 Worker-only mode requires the predeploy gates and does not deploy runner changes.
+Production preflight accepts this explicit retained-image mode; production image
+changes still require immediate rollout and the existing state-isolation floors.
 The selected runner's old parser may omit new optional diagnostics; Worker-side
 logs remain available. Use a full release for changes that require a new runner.
 This mode does not change account quota or the overlap requirement of full image

--- a/apps/cloudflare/scripts/deploy-preflight.ts
+++ b/apps/cloudflare/scripts/deploy-preflight.ts
@@ -406,9 +406,9 @@ export function listHostedDeployEnvironmentInvariantErrors(
     );
   }
 
-  if (hostedExecutionContainerRollout !== STATE_ISOLATION_CONTAINER_ROLLOUT) {
+  if (![STATE_ISOLATION_CONTAINER_ROLLOUT, "worker-only"].includes(hostedExecutionContainerRollout)) {
     errors.push(
-      `production state-isolation deploys must use HOSTED_EXECUTION_CONTAINER_ROLLOUT=${STATE_ISOLATION_CONTAINER_ROLLOUT}; rollback floor is the audience-key, selector-scope, and runner-schema-v16 media-effect bundle.`,
+      `production runner image changes must use HOSTED_EXECUTION_CONTAINER_ROLLOUT=${STATE_ISOLATION_CONTAINER_ROLLOUT}; compatible Worker-only deploys may use worker-only; rollback floor is the audience-key, selector-scope, and runner-schema-v16 media-effect bundle.`,
     );
   }
 

--- a/apps/cloudflare/scripts/deploy-worker-version.cli.ts
+++ b/apps/cloudflare/scripts/deploy-worker-version.cli.ts
@@ -59,7 +59,7 @@ export async function runDeployWorkerVersionCli(
     configPath,
     dependencies: {
       async deployDirect(input) {
-        const renderedContainers = await readRenderedContainerIdentities(input.configPath);
+        const retainServingRunner = input.containerRolloutMode === "worker-only";
         const containerProvider = createCloudflareContainerProvider({
           accountId: requireConfiguredString(env.CLOUDFLARE_ACCOUNT_ID, "CLOUDFLARE_ACCOUNT_ID"),
           apiToken: requireConfiguredString(env.CLOUDFLARE_API_TOKEN, "CLOUDFLARE_API_TOKEN"),
@@ -75,15 +75,16 @@ export async function runDeployWorkerVersionCli(
         const preparedConfigPath = await prepareHostedContainerDeployImage({
           accountId: requireConfiguredString(env.CLOUDFLARE_ACCOUNT_ID, "CLOUDFLARE_ACCOUNT_ID"),
           configPath: input.configPath,
-          release: { currentVersion, releaseSha, listApplications: containerProvider.listApplications },
+          ...(retainServingRunner ? {} : { release: { currentVersion, releaseSha, listApplications: containerProvider.listApplications } }),
         });
         await applyHostedTransientLifecycleRules({ deployRoot, source: env });
         const staged = await stageHostedRunnerRelease({
           configPath: preparedConfigPath,
-          currentVersion, releaseSha,
+          currentVersion, releaseSha, retainServingRunner,
           currentVersionId,
           listApplications: containerProvider.listApplications,
         });
+        const renderedContainers = await readRenderedContainerIdentities(staged.configPath);
         await assertLiveVersion(input.workerName, input.configPath, currentVersionId);
         const before = await readCloudflareContainerApplicationIdentities(
           renderedContainers, containerProvider.listApplications, "before", containerProvider.readRollout,

--- a/apps/cloudflare/scripts/deploy-worker-version.shared.ts
+++ b/apps/cloudflare/scripts/deploy-worker-version.shared.ts
@@ -11,7 +11,7 @@ import type {
 
 type EnvSource = Readonly<Record<string, string | undefined>>;
 
-export type ContainerRolloutMode = "gradual" | "immediate";
+export type ContainerRolloutMode = "gradual" | "immediate" | "worker-only";
 
 export interface DeploymentStatusPayload {
   created_on: string;
@@ -225,11 +225,11 @@ function readContainerRolloutMode(
     return defaultMode;
   }
 
-  if (normalized === "gradual" || normalized === "immediate") {
+  if (normalized === "gradual" || normalized === "immediate" || normalized === "worker-only") {
     return normalized;
   }
 
-  throw new Error("HOSTED_EXECUTION_CONTAINER_ROLLOUT must be 'gradual' or 'immediate'.");
+  throw new Error("HOSTED_EXECUTION_CONTAINER_ROLLOUT must be 'gradual', 'immediate', or 'worker-only'.");
 }
 
 async function requireCurrentDeployment(

--- a/apps/cloudflare/scripts/stage-runner-release.ts
+++ b/apps/cloudflare/scripts/stage-runner-release.ts
@@ -65,6 +65,7 @@ export async function stageHostedRunnerRelease(input: {
   configPath: string;
   currentVersion: unknown;
   currentVersionId: string;
+  retainServingRunner?: boolean;
   releaseSha: string;
   listApplications: ListCloudflareContainerApplications;
 }): Promise<StagedRunnerRelease> {
@@ -93,14 +94,17 @@ export async function stageHostedRunnerRelease(input: {
   const target = entries.find((entry) => entry.className === candidateClass);
   const smoke = entries.find((entry) => entry.className === "DeploySmokeRunnerContainer");
   if (!serving || !target || !smoke || !isObjectRecord(serving.live)) throw invalid();
+  if (input.retainServingRunner) assertBoundedSmoke(smoke.live, smoke.specification);
   const bundleFingerprint = requiredString(vars.HOSTED_EXECUTION_RUNNER_BUNDLE_FINGERPRINT);
   const sourceFingerprint = requiredString(vars.HOSTED_EXECUTION_RUNNER_SOURCE_FINGERPRINT);
   const executionIdentity = runnerApplicationExecutionIdentity(target.specification);
-  const { deployment, candidate, workerOnly, resumeAdmittedCandidate } = selectDeployment({
+  const { deployment, promoted, workerOnly, resumeAdmittedCandidate } = input.retainServingRunner
+    ? retainDeployment(active, liveDeployment, target.live !== undefined)
+    : selectDeployment({
     active, liveDeployment, executionIdentity, bundleFingerprint, sourceFingerprint, releaseSha: input.releaseSha,
     servingMatches: runnerApplicationMatches(serving.live, serving.specification), candidateExists: target.live !== undefined,
   });
-  const applications = workerOnly ? [] : [target, smoke]
+  const applications = (input.retainServingRunner ? [smoke] : workerOnly ? [] : [target, smoke])
     .filter((entry) => !(resumeAdmittedCandidate && isObjectRecord(entry.live)
       && !entry.live.active_rollout_id && runnerApplicationMatches(entry.live, entry.specification)))
     .map((entry): RunnerApplicationPreparation => ({
@@ -108,8 +112,10 @@ export async function stageHostedRunnerRelease(input: {
     className: entry.className, name: entry.name,
     namespaceId: readNamespaceId(input.currentVersion, entry.className), specification: entry.specification,
   }));
-  const effectiveContainers = entries.map((entry) => {
-    if (entry.className === candidateClass || entry.className === "DeploySmokeRunnerContainer") return entry.rendered;
+  const effectiveContainers = entries
+    .filter((entry) => !input.retainServingRunner || entry.live || entry.className === "DeploySmokeRunnerContainer")
+    .map((entry) => {
+    if ((!input.retainServingRunner && entry.className === candidateClass) || entry.className === "DeploySmokeRunnerContainer") return entry.rendered;
     if (!isObjectRecord(entry.live) || !isObjectRecord(entry.live.configuration)
       || !Number.isSafeInteger(entry.live.max_instances) || Number(entry.live.max_instances) < 0) throw invalid();
     return { ...entry.rendered, image: requiredString(entry.live.configuration.image), max_instances: entry.live.max_instances };
@@ -122,8 +128,22 @@ export async function stageHostedRunnerRelease(input: {
     ...config, containers: effectiveContainers, vars: { ...vars, HOSTED_EXECUTION_RUNNER_DEPLOYMENT: JSON.stringify(release) },
   }, null, 2)}\n`;
   await writeFile(configPath, render(deployment), { encoding: "utf8", flag: "wx" });
-  await writeFile(promotionConfigPath, render(workerOnly ? deployment : { active: candidate, candidate: null, previous: active }), { encoding: "utf8", flag: "wx" });
+  await writeFile(promotionConfigPath, render(promoted), { encoding: "utf8", flag: "wx" });
   return { activeApplicationName: serving.name, applications, configPath, deployment, promotionConfigPath, workerOnly };
+}
+
+function assertBoundedSmoke(live: unknown, specification: RunnerApplicationSpecification): void {
+  if (!isObjectRecord(live) || live.max_instances !== 1 || specification.max_instances !== 1) throw invalid();
+}
+
+function retainDeployment(active: HostedRunnerRelease, live: HostedRunnerDeployment | null, candidateExists: boolean) {
+  if (live?.previous && !candidateExists) throw invalid();
+  // Retain an existing pending namespace as history so its next reuse proves drain.
+  const deployment: HostedRunnerDeployment = {
+    active, candidate: null,
+    previous: live?.previous ?? (candidateExists ? live?.candidate ?? null : null),
+  };
+  return { deployment, promoted: deployment, workerOnly: true, resumeAdmittedCandidate: false };
 }
 
 function selectDeployment(input: {
@@ -157,9 +177,9 @@ function selectDeployment(input: {
   const deployment: HostedRunnerDeployment = workerOnly
     ? liveDeployment ?? { active, candidate: null, previous: null }
     : { active, candidate, previous: null };
-  const resumeAdmittedCandidate = liveDeployment?.candidate !== null && liveDeployment?.candidate !== undefined
-    && sameExecution(liveDeployment.candidate);
-  return { deployment, candidate, workerOnly, resumeAdmittedCandidate };
+  const resumeAdmittedCandidate = liveDeployment?.candidate ? sameExecution(liveDeployment.candidate) : false;
+  const promoted: HostedRunnerDeployment = workerOnly ? deployment : { active: candidate, candidate: null, previous: active };
+  return { deployment, promoted, workerOnly, resumeAdmittedCandidate };
 }
 
 function readVersionBindings(version: unknown): unknown[] {

--- a/apps/cloudflare/test/deploy-preflight.test.ts
+++ b/apps/cloudflare/test/deploy-preflight.test.ts
@@ -5,7 +5,8 @@ import {
   HOSTED_AUTHORITY_STANDBY_KEYRING_ERROR,
   HOSTED_CLOUDFLARE_PRIVATE_STANDBY_KEYRING_ERROR,
 } from "@murphai/runtime-state";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { runHostedWorkerDeployment } from "../scripts/deploy-worker-version.shared.js";
 
 import {
   assertHostedDeployEnvironment,
@@ -21,7 +22,7 @@ type EnvSource = Readonly<Record<string, string | undefined>>;
 const HOSTED_ASSISTANT_MODEL_PRICING_ERROR =
   "HOSTED_ASSISTANT_MODEL must be one of gpt-6-astra, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna for hosted AI usage allowance pricing.";
 const HOSTED_STATE_ISOLATION_ROLLOUT_ERROR =
-  "production state-isolation deploys must use HOSTED_EXECUTION_CONTAINER_ROLLOUT=immediate; rollback floor is the audience-key, selector-scope, and runner-schema-v16 media-effect bundle.";
+  "production runner image changes must use HOSTED_EXECUTION_CONTAINER_ROLLOUT=immediate; compatible Worker-only deploys may use worker-only; rollback floor is the audience-key, selector-scope, and runner-schema-v16 media-effect bundle.";
 
 function createRequiredWorkerDeployEnv(overrides: Record<string, string | undefined> = {}): EnvSource {
   return {
@@ -1100,9 +1101,29 @@ describe("deploy preflight helpers", () => {
     }), { deployWorker: true })).not.toThrow();
   });
 
-  it("allows production deploy DNS records only when they resolve to public addresses", async () => {
+  it("reaches Worker-only deployment through the real production preflight", async () => {
+    const deployDirect = vi.fn(async () => ({ containers: [], workerVersionId: "synthetic-version" }));
+    await runHostedWorkerDeployment({
+      env: createRequiredWorkerDeployEnv({ HOSTED_EXECUTION_CONTAINER_ROLLOUT: "worker-only" }),
+      workerName: "hosted-runner", configPath: "/tmp/synthetic-config.json",
+      resultPath: "/tmp/synthetic-result.json", runnerBundleDir: "/tmp/synthetic-bundle",
+      secretsFilePath: "/tmp/synthetic-secrets.json",
+      dependencies: {
+        deployDirect,
+        validateDeployEnvironment: ({ source, deployWorker }) => assertHostedDeployEnvironmentAsync(source, { deployWorker }, {
+          readR2BucketInfo: readValidR2BucketInfo, resolveHostnameAddresses: async () => ["8.8.8.8"],
+        }),
+        validatePreparedArtifacts: async () => {}, mkdir: async () => {}, writeFile: async () => {},
+        readCurrentDeployment: async () => ({ created_on: "2026-01-01T00:00:00Z", versions: [{ percentage: 100, version_id: "synthetic-version" }] }),
+      },
+    });
+    expect(deployDirect).toHaveBeenCalledOnce();
+    expect(deployDirect).toHaveBeenCalledWith(expect.objectContaining({ containerRolloutMode: "worker-only" }));
+  });
+
+  it.each(["immediate", "worker-only"])("accepts %s with valid production DNS and bucket evidence", async (mode) => {
     await expect(assertHostedDeployEnvironmentAsync(
-      createRequiredWorkerDeployEnv(),
+      createRequiredWorkerDeployEnv({ HOSTED_EXECUTION_CONTAINER_ROLLOUT: mode }),
       { deployWorker: true },
       {
         readR2BucketInfo: readValidR2BucketInfo,

--- a/apps/cloudflare/test/deploy-worker-version-cli.test.ts
+++ b/apps/cloudflare/test/deploy-worker-version-cli.test.ts
@@ -177,6 +177,29 @@ describe("runDeployWorkerVersionCli", () => {
     expect(receiptMocks.buildContainerReleaseEntries).toHaveBeenCalledOnce();
   });
 
+  it("forwards explicit retention and records only the effective application set", async () => {
+    releaseMocks.stageHostedRunnerRelease.mockImplementation(async ({ configPath, retainServingRunner }) => {
+      expect(retainServingRunner).toBe(true);
+      return { configPath: `${configPath}.retained`, promotionConfigPath: `${configPath}.retained`,
+        activeApplicationName: "serving", workerOnly: true, applications: [] };
+    });
+    await runDeployWorkerVersionCli([], {
+      deployRoot: "/tmp/synthetic-deploy", log: false,
+      env: { CF_BUNDLES_BUCKET: "synthetic-bundles", CF_WORKER_NAME: "hosted-worker", CLOUDFLARE_ACCOUNT_ID: "account-fixture", CLOUDFLARE_API_TOKEN: "token-fixture" },
+      runHostedWorkerDeployment: async ({ dependencies }) => {
+        await dependencies.deployDirect({ configPath: "/tmp/generated.jsonc", containerRolloutMode: "worker-only",
+          deploymentMessage: "synthetic", includeSecrets: false, secretsFilePath: "/tmp/secrets.json",
+          versionTag: "synthetic", workerName: "hosted-worker" });
+        return createDeploymentResult();
+      },
+    });
+    expect(imageMocks.prepareHostedContainerDeployImage.mock.calls[0]![0]).not.toHaveProperty("release");
+    expect(receiptMocks.readRenderedContainerIdentities).toHaveBeenCalledWith("/tmp/generated.jsonc.retained");
+    expect(releaseMocks.runSmokeHostedDeploy).toHaveBeenCalledOnce();
+    expect(wranglerMocks.runWranglerLoggedCaptured).toHaveBeenCalledOnce();
+    expect(fileMocks.writeFile).toHaveBeenCalledWith("/tmp/generated.jsonc", "{}", "utf8");
+  });
+
   it("passes app-root deploy artifact paths to the deploy entrypoint", async () => {
     const repoRoot = path.join("/tmp", "repo");
     const deployRoot = path.join(repoRoot, "apps", "cloudflare");
@@ -319,7 +342,7 @@ describe("runDeployWorkerVersionCli", () => {
       "/tmp/worker-secrets.json",
     ]);
     expect(receiptMocks.readRenderedContainerIdentities).toHaveBeenCalledWith(
-      "/tmp/wrangler.generated.jsonc",
+      "/tmp/wrangler.image-prepared.jsonc",
     );
     expect(receiptMocks.createCloudflareContainerProvider).toHaveBeenCalledWith({
       accountId: "account-fixture",

--- a/apps/cloudflare/test/deploy-worker-version.test.ts
+++ b/apps/cloudflare/test/deploy-worker-version.test.ts
@@ -339,7 +339,7 @@ describe("runHostedWorkerDeployment", () => {
     });
   });
 
-  it("supports explicit immediate container rollout for hotfix deploys", async () => {
+  it.each(["immediate", "worker-only"])("supports explicit %s deployment", async (mode) => {
     const finalDeployment: DeploymentStatusPayload = {
       created_on: "2026-03-27T00:10:00.000Z",
       versions: [
@@ -360,7 +360,7 @@ describe("runHostedWorkerDeployment", () => {
       dependencies,
       env: {
         CF_WORKER_NAME: "hosted-worker",
-        HOSTED_EXECUTION_CONTAINER_ROLLOUT: "immediate",
+        HOSTED_EXECUTION_CONTAINER_ROLLOUT: mode,
       },
       resultPath: "/tmp/deployment-result.json",
       runnerBundleDir: "/tmp/runner-bundle",
@@ -369,7 +369,7 @@ describe("runHostedWorkerDeployment", () => {
     });
 
     expect(dependencies.deployDirect).toHaveBeenCalledWith({
-      containerRolloutMode: "immediate",
+      containerRolloutMode: mode,
       configPath: "/tmp/wrangler.generated.jsonc",
       deploymentMessage: expect.stringContaining("direct deploy"),
       includeSecrets: true,
@@ -393,7 +393,7 @@ describe("runHostedWorkerDeployment", () => {
       runnerBundleDir: "/tmp/runner-bundle",
       secretsFilePath: "/tmp/worker-secrets.json",
       workerName: "hosted-worker",
-    })).rejects.toThrow("HOSTED_EXECUTION_CONTAINER_ROLLOUT must be 'gradual' or 'immediate'.");
+    })).rejects.toThrow("HOSTED_EXECUTION_CONTAINER_ROLLOUT must be 'gradual', 'immediate', or 'worker-only'.");
 
     expect(dependencies.deployDirect).not.toHaveBeenCalled();
     expect(dependencies.validateDeployEnvironment).not.toHaveBeenCalled();

--- a/apps/cloudflare/test/stage-runner-release.test.ts
+++ b/apps/cloudflare/test/stage-runner-release.test.ts
@@ -96,6 +96,56 @@ describe("runner deployment staging", () => {
     expect(resumed.workerOnly).toBe(false);
   });
 
+  it.each([false, true])("retains the serving fleet across artifact changes (reversed=%s)", async (reversed) => {
+    const active = reversed ? next : primary;
+    const previous = reversed ? primary : next;
+    const retainedConfig = { ...config, containers: config.containers.map((entry) => ({
+      ...entry, max_instances: entry.class_name === "DeploySmokeRunnerContainer" ? 1 : 12,
+    })) };
+    await writeFile(path.join(directory, "source.json"), JSON.stringify(retainedConfig));
+    const staged = await stageHostedRunnerRelease({
+      releaseSha: "2".repeat(40), retainServingRunner: true,
+      configPath: path.join(directory, "source.json"), currentVersionId: "worker-live",
+      currentVersion: version({ active, candidate: null, previous }),
+      listApplications: async (name) => (await listApplications(name)).map((entry) => ({
+        ...entry, max_instances: name.endsWith("-deploysmokerunnercontainer") ? 1 : 10,
+      })),
+    });
+    const effective = JSON.parse(await readFile(staged.promotionConfigPath, "utf8"));
+    expect(staged.workerOnly).toBe(true);
+    expect(staged.deployment).toEqual({ active, candidate: null, previous });
+    expect(staged.applications.map((entry) => entry.className)).toEqual(["DeploySmokeRunnerContainer"]);
+    expect(staged.applications[0]?.specification.max_instances).toBe(1);
+    expect(effective.containers.filter((entry: { class_name: string }) => entry.class_name !== "DeploySmokeRunnerContainer"))
+      .toEqual(expect.arrayContaining([expect.objectContaining({ max_instances: 10, image: "registry.example.test/previous@sha256:old" })]));
+    expect(effective.containers.filter((entry: { class_name: string }) => entry.class_name !== "DeploySmokeRunnerContainer")
+      .every((entry: { max_instances: number; image: string }) => entry.max_instances === 10 && entry.image !== image)).toBe(true);
+  });
+
+  it.each([false, true])("retains only existing pending candidate authority (exists=%s)", async (exists) => {
+    await writeFile(path.join(directory, "source.json"), JSON.stringify({ ...config,
+      containers: config.containers.map((entry) => ({ ...entry, max_instances: entry.class_name === "DeploySmokeRunnerContainer" ? 1 : 12 })),
+    }));
+    const staged = await stageHostedRunnerRelease({
+      releaseSha: "2".repeat(40), retainServingRunner: true,
+      configPath: path.join(directory, "source.json"), currentVersionId: "worker-live",
+      currentVersion: version({ active: primary, candidate: next, previous: null }),
+      listApplications: async (name) => !exists && name.endsWith("-nextrunnercontainer") ? []
+        : (await listApplications(name)).map((entry) => ({ ...entry, max_instances: name.endsWith("-deploysmokerunnercontainer") ? 1 : 10 })),
+    });
+    expect(staged.deployment).toEqual({ active: primary, candidate: null, previous: exists ? next : null });
+    const effective = JSON.parse(await readFile(staged.configPath, "utf8"));
+    expect(effective.containers.some((entry: { class_name: string }) => entry.class_name === "NextRunnerContainer")).toBe(exists);
+    expect(staged.applications.map((entry) => entry.className)).toEqual(["DeploySmokeRunnerContainer"]);
+  });
+
+  it("refuses a Worker-only release that would expand the smoke application", async () => {
+    await expect(stageHostedRunnerRelease({ releaseSha: "2".repeat(40), retainServingRunner: true,
+      configPath: path.join(directory, "source.json"), currentVersionId: "worker-live",
+      currentVersion: version({ active: primary, candidate: null, previous: null }), listApplications,
+    })).rejects.toThrow("authoritative live configuration");
+  });
+
   it("requires preexisting namespace bindings before a native candidate can be created", async () => {
     const currentVersion = version();
     currentVersion.resources.bindings = currentVersion.resources.bindings.filter((binding) => !("class_name" in binding && binding.class_name === "NextRunnerContainer"));


### PR DESCRIPTION
## Why and outcome

Compatible Worker coordination fixes currently require admission of another full member fleet. Add explicit `container_rollout=worker-only` to retain the selected runner release, every existing member image and capacity, and publish the Worker after admitting only the existing one-slot smoke application.

## Product UX

- Effort: Not applicable — protected deployment controls only.
- Result: Ready for review; production deployment remains pending.
- Walkthrough: Active and reversed banks retain their identities and capacities. Existing pending namespaces remain routable as previous history. A missing inactive application is omitted from the effective config and receipt. A missing or expanded smoke application fails before Worker activation.

## Evidence

- Direct: 111 tests across staging, CLI/settings, image preparation, native release provider and receipt suites passed. Cloudflare typecheck passed.
- Coverage: Explicit retained releases across different artifacts, both bank directions, pending candidate present/absent, bounded smoke admission, mode forwarding, single Worker activation and staged receipt coverage. Existing admission-before-activation and unchanged-image proofs remain green.
- Round 1 found a production preflight mismatch. Accepted: the real production validator rejected the new mode before allocation. The correction admits explicit retention while preserving immediate-only image changes and every other environment gate. Two new regressions failed before the correction; 106 preflight/deployment-setting tests, Cloudflare typecheck and complexity checks pass afterward. Round 2 passed on `9b564f9af08d03dc4f574825dafc0e368abb1ac3` with no remaining qualifying findings, exact-turn capture and matching GPT-6 Pro response-model evidence. Required exact-head CI remains pending; the unrelated repository scheduler test failed once in CI and passed focused local replay unchanged.

## Non-obvious affected surfaces

Receipt discovery now reads the effective staged config so an intentionally absent inactive application is not falsely required. Signed smoke still proves the selected serving namespace through its existing readiness/inventory contract and exercises the newly built dedicated smoke artifact. New optional runner diagnostics may be omitted by an old runner; Worker-side logs remain available.

## Architecture and reuse

- Existing systems reused: Native application admission, live release identity, version upload/activation, signed smoke and exact release receipts.
- New logic: Explicit retention selection and effective application coverage.
- New abstractions: Two local helpers validate the one-slot smoke boundary and derive retained release history; no persistent state or new dependency.
- Complexity intentionally avoided: No quota mutation, capacity splitting, scheduler, release coordinator or message-path retry.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`.
- Hotspots: Existing preflight environment validator (57) and private-IP classifier (21) remain unchanged; staging maximum decreases from 20 to 19.
- Agent judgment: Keep retention and ordinary image selection separate while sharing admission and verification.

## Hot reply path impact

- Path status: Not applicable — deployment scripts only.
- Database calls: None.
- Network/provider calls: None on the reply path.
- Other awaited latency: None on the reply path.
- Before/after proof: Deployment tests prove serving member applications never enter native admission in explicit retention mode.

## Murph initial provider input impact

Not applicable: no individual/group prompts, tools, routing, model settings or provider-visible inputs change. Input measurement was not run.

## Deployment concerns

- Deployment: applicable
- Supported skew: Only compatible Worker/retained-runner combinations. This mode explicitly does not ship runner image changes.
- Safe order: Land this public selector before enabling the option in the protected private workflow; then dispatch with all predeploy gates enabled.
- Rollback floor: Existing exact namespace, release and invocation ownership; no migrations. No rollback authorization is added.
- Expected exposure: Explicit Worker-only deployments retain member capacity and update the existing one-slot smoke app.
- Reversibility: Select a normal full image release for later runner changes; image admission still requires quota and drain evidence.
- Convergence proof: Signed smoke, one exact live Worker version and unchanged member application receipts; the private observer checks effective capacities and images.
- Post-deploy checks: Verify a live message's typing delay and the allocation diagnostics from the separately merged latency patch. Production rollout remains pending.

## Change-shape breakdown

Classification: runtime deployment TS is source, test paths are tests, owner/plan content is docs.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 37 | 16 |
| Tests / fixtures | 103 | 9 |
| Docs | 71 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |

## Changelog

- Changelog: not applicable
- Reason: Internal deployment control; the member-visible latency improvement already has its own entry.

ReviewGPT context sensitivity: sensitive
ReviewGPT first-reviewed head: 714c8b5cd7ece18e52b7a62bdb87e994dcf6dbc3
