### PR TITLE
fix: use native rollout readiness for deploy smoke

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-08-smoke-native-rollout.md
+++ b/agent-docs/exec-plans/completed/2026-09-08-smoke-native-rollout.md
@@ -1,0 +1,49 @@
+# Preserve member drain checks while rolling the dedicated smoke application
+
+Status: completed
+Created: 2026-09-08
+Updated: 2026-09-08
+
+## Goal
+
+- Unblock compatible Worker releases while preserving serving member capacity and namespace safety.
+
+## Success criteria
+
+- Dedicated smoke proceeds through native admission and readiness without member drain admission.
+- Both member runner banks still stop before mutation when drain evidence is unavailable.
+- Complete the local correction and focused verification; track final review, exact-head CI, merge and protected deployment in the PR/session handoff.
+
+## Scope
+
+- In scope: deployment-loop smoke classification, regression tests and deployment owner documentation.
+- Out of scope: member drain implementation, serving images/capacities, quota changes and runtime behavior.
+
+## Constraints
+
+- Keep the existing class identity as the discriminator; add no state or dependency.
+- Retain native readiness, signed smoke and exact release receipts before reporting convergence.
+
+## Risks and mitigations
+
+1. Accidentally allowing member namespace reuse without drain proof.
+   Mitigation: exclude only the exact dedicated smoke class and test both member banks with rejected drain evidence.
+
+## Tasks
+
+1. Reproduce the smoke failure through the real deployment loop with an unavailable drain provider.
+2. Restrict drain admission to member applications; retain smoke native rollout and readiness checks.
+3. Complete local verification and parent review, then hand the stable candidate to PR review and CI before the protected deployment retry.
+
+## Decisions
+
+- Native rollout owns replacement of the isolated smoke application; member drain admission protects member invocations and is not required for smoke replacement.
+- Keep the broader member drain provider unchanged and fail closed; its API availability is a separate full-image deployment concern.
+
+## Verification
+
+- Both smoke regressions failed before correction; both member-bank protection regressions passed.
+- All 89 CLI/provider/staging/receipt tests pass after correction. Cloudflare typecheck, complexity guard and diff whitespace checks pass.
+- Parent review confirms only the dedicated smoke class bypasses member drain; native readiness and signed smoke remain required.
+- Local implementation phase is complete. Final ReviewGPT, exact-head CI, merge and protected production convergence remain pending in the owning PR/session.
+Completed: 2026-09-08

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -27,6 +27,9 @@ its inactive native application and dedicated smoke application through the
 Cloudflare Containers API. Quota admission and native rollout convergence must
 complete before uploading or activating any Worker version. The serving and
 retained legacy applications are excluded from native mutations.
+Member applications require drain evidence before namespace reuse. The dedicated
+smoke application carries no member invocation, so it proceeds directly through
+native rollout and readiness checks without member drain admission.
 
 The controller is published with `wrangler versions upload` and activated at
 100% with `wrangler versions deploy`. Signed smoke proves the actual candidate

--- a/apps/cloudflare/scripts/deploy-worker-version.cli.ts
+++ b/apps/cloudflare/scripts/deploy-worker-version.cli.ts
@@ -94,7 +94,10 @@ export async function runDeployWorkerVersionCli(
         for (const application of staged.applications) {
           const entry = actions.find((entry) => entry.applicationName === application.name);
           if (!entry || application.name === staged.activeApplicationName) throw new Error("Invalid inactive runner application plan.");
-          if (application.applicationId) await releaseProvider.assertDrained(application.applicationId);
+          // Member drain protects retained invocations; dedicated smoke uses native rollout readiness.
+          if (application.applicationId && application.className !== "DeploySmokeRunnerContainer") {
+            await releaseProvider.assertDrained(application.applicationId);
+          }
           const action = await releaseProvider.admitApplication(application);
           entry.action = action;
           await releaseProvider.assertApplicationReady({ ...application, listApplications: containerProvider.listApplications });

--- a/apps/cloudflare/test/deploy-worker-version-cli.test.ts
+++ b/apps/cloudflare/test/deploy-worker-version-cli.test.ts
@@ -165,6 +165,33 @@ describe("runDeployWorkerVersionCli", () => {
     expect(wranglerMocks.runWranglerLoggedCaptured).not.toHaveBeenCalled();
   });
 
+  it.each(["immediate", "worker-only"] as const)("rolls dedicated smoke without member drain admission in %s mode", async (mode) => {
+    const smoke = { name: "hosted-worker-smoke", className: "DeploySmokeRunnerContainer", applicationId: "smoke-app", namespaceId: "smoke-namespace", specification: {} };
+    receiptMocks.readRenderedContainerIdentities.mockResolvedValue([{ applicationName: smoke.name, className: smoke.className }]);
+    releaseMocks.stageHostedRunnerRelease.mockImplementation(async ({ configPath }) => ({
+      configPath, promotionConfigPath: `${configPath}.promote`, activeApplicationName: "serving", workerOnly: mode === "worker-only", applications: [smoke],
+    }));
+    releaseMocks.assertDrained.mockRejectedValue(new Error("synthetic member drain endpoint unavailable"));
+    await syntheticDeployment(mode);
+    expect(releaseMocks.assertDrained).not.toHaveBeenCalled();
+    expect(releaseMocks.admitApplication).toHaveBeenCalledWith(smoke);
+    expect(releaseMocks.assertApplicationReady).toHaveBeenCalledOnce();
+    expect(releaseMocks.assertApplicationReady.mock.invocationCallOrder[0]).toBeLessThan(wranglerMocks.runWranglerLoggedCaptured.mock.invocationCallOrder[0]!);
+    expect(releaseMocks.runSmokeHostedDeploy).toHaveBeenCalledOnce();
+  });
+
+  it.each(["RunnerContainer", "NextRunnerContainer"])("still blocks reuse of %s when member drain evidence is unavailable", async (className) => {
+    releaseMocks.stageHostedRunnerRelease.mockImplementation(async ({ configPath }) => ({
+      configPath, promotionConfigPath: `${configPath}.promote`, activeApplicationName: "serving", workerOnly: false,
+      applications: [{ name: renderedContainers[0]!.applicationName, className, applicationId: "member-app", namespaceId: "member-namespace", specification: {} }],
+    }));
+    releaseMocks.assertDrained.mockRejectedValue(new Error("synthetic member drain endpoint unavailable"));
+    await expect(syntheticDeployment()).rejects.toThrow("member drain endpoint unavailable");
+    expect(releaseMocks.assertDrained).toHaveBeenCalledWith("member-app");
+    expect(releaseMocks.admitApplication).not.toHaveBeenCalled();
+    expect(wranglerMocks.runWranglerLoggedCaptured).not.toHaveBeenCalled();
+  });
+
   it("publishes an unchanged execution release once, with no container mutation", async () => {
     releaseMocks.stageHostedRunnerRelease.mockImplementation(async ({ configPath }) => ({
       configPath, promotionConfigPath: `${configPath}.promote`, activeApplicationName: "serving", workerOnly: true, applications: [],
@@ -546,12 +573,12 @@ const releasedContainers = [
   },
 ] as const;
 
-async function syntheticDeployment() {
+async function syntheticDeployment(containerRolloutMode: "immediate" | "worker-only" = "immediate") {
   return runDeployWorkerVersionCli([], {
     deployRoot: "/tmp/repo/apps/cloudflare", log: false,
     env: { CF_WORKER_NAME: "hosted-worker", CF_BUNDLES_BUCKET: "hosted-bundles", CLOUDFLARE_ACCOUNT_ID: "fixture", CLOUDFLARE_API_TOKEN: "fixture" },
     runHostedWorkerDeployment: async ({ dependencies }) => {
-      await dependencies.deployDirect({ configPath: "/tmp/config.jsonc", containerRolloutMode: "immediate", deploymentMessage: "synthetic", includeSecrets: false, secretsFilePath: "/tmp/secrets.json", versionTag: "synthetic", workerName: "hosted-worker" });
+      await dependencies.deployDirect({ configPath: "/tmp/config.jsonc", containerRolloutMode, deploymentMessage: "synthetic", includeSecrets: false, secretsFilePath: "/tmp/secrets.json", versionTag: "synthetic", workerName: "hosted-worker" });
       return createDeploymentResult();
     },
   });


### PR DESCRIPTION
## Why and outcome

Worker-only deployment stops before activation when the dedicated smoke application enters member drain admission and that provider request is unavailable. Restrict member drain admission to member applications. The isolated deploy-smoke application proceeds through its existing native rollout and readiness checks.

## Product UX

- Effort: Not applicable — internal deployment control only.
- Result: Merged and deployed through the protected production workflow.
- Walkthrough: Smoke replacement keeps native readiness and signed smoke. Both member banks still reject unavailable drain evidence before mutation or Worker upload.

## Evidence

- Direct: Two smoke regressions failed before correction in immediate and worker-only modes. After correction, all 89 deployment CLI, provider, staging and receipt tests pass.
- Coverage: Both member classes remain protected against unavailable drain evidence. Smoke admission/readiness still precede Worker upload, and signed smoke remains required.
- Cloudflare typecheck, diff whitespace and complexity checks pass. Final ReviewGPT passed on `bb1318f23ec2415e915b1b611b1c20eebe3758e7` with matching GPT-6 Pro model/turn evidence and no findings; required exact-head CI passed.

## Non-obvious affected surfaces

The exact `DeploySmokeRunnerContainer` class is excluded from member drain admission. Member namespace reuse, native admission, readiness, release receipts and live-version race checks retain their owners. The broader member drain provider is unchanged and still fails closed when its evidence is unavailable.

## Architecture and reuse

- Existing systems reused: Staged application class identity, native rollout readiness, signed smoke and exact release receipts.
- New logic: Exclude only the dedicated smoke class from member drain admission.
- New abstractions: None; the existing staged application class provides the complete discriminator.
- Complexity intentionally avoided: No alternative inventory reader, pagination lifecycle, state owner, dependency or deployment bypass.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`.
- Hotspots: None; changed file maximum rises from 7 to 8, with zero debt.
- Agent judgment: One explicit class check preserves the member safety boundary.

## Hot reply path impact

- Path status: Not applicable — deployment scripts only.
- Database calls: None.
- Network/provider calls: None on the reply path.
- Other awaited latency: None on the reply path.
- Before/after proof: The deployment regression reproduces the blocked smoke admission and passes after correction.

## Murph initial provider input impact

Not applicable: no prompts, tools, routing, model configuration or provider-visible inputs change. Input measurement was not run.

## Deployment concerns

- Deployment: applicable
- Supported skew: Compatible Worker with retained member runner images; no runtime contract changes.
- Safe order: Merge the public helper, then dispatch the already-landed protected private worker-only mode with all predeploy gates enabled.
- Rollback floor: Existing floors and release ownership remain; no rollback is authorized.
- Expected exposure: Only the dedicated smoke application changes its preparation path; serving images and capacities remain retained.
- Reversibility: The preparation condition is independently reversible through the normal reviewed deployment path.
- Convergence proof: Native readiness, signed smoke and exact live-state receipt remain required.
- Post-deploy checks: Protected production deployment completed successfully after a transient version-propagation retry. Exact live-state checks confirm unchanged serving image/capacity; runtime diagnostics and authorized live-message verification completed.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 1 |
| Tests / fixtures | 29 | 2 |
| Docs | 52 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |

## Changelog

- Changelog: not applicable
- Reason: Internal deployment correction; the member-visible latency fix has its own entry.

ReviewGPT context sensitivity: sensitive
ReviewGPT first-reviewed head: bb1318f23ec2415e915b1b611b1c20eebe3758e7
