### PR TITLE
fix: rebuild retained legacy runner images

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-08-runner-native-admission.md
+++ b/agent-docs/exec-plans/active/2026-09-08-runner-native-admission.md
@@ -34,3 +34,11 @@ The actual rejection reason is unavailable in the existing logs. Correct diagnos
 Eight diagnostic regressions failed before the correction; the initial 55 provider, staging and deployment tests then passed. Cloudflare typecheck and complexity guard passed (no hotspots). Added exact-message privacy assertions and bounded-code coverage before the final focused replay. Request shapes, capacity, no-retry behavior, and admission-before-activation are preserved. Parent review found no additional state or activation-path changes.
 
 Pending: final focused replay, exact-head CI, ReviewGPT and protected production evidence. Production success requires signed smoke and exact release convergence.
+
+## Protected follow-up evidence
+
+The diagnostic correction merged in PR #3041 with 56 tests, typecheck, all required CI and a validated full ReviewGPT PASS. The protected full release then failed earlier in image reuse: a Worker-only release record retains legacy active provenance and a mutable image tag, but the reuse reader checks only the legacy candidate before validating the selected active image as immutable. No new Worker activation occurred.
+
+The smallest correction applies the existing legacy-provenance guard to the selected candidate-or-active release. It must build normally for legacy retained releases in either bank, preserve the serving image and namespace, and retain exact immutable reuse for admitted releases. The original native POST rejection still requires a subsequent protected attempt after this earlier failure is resolved.
+
+The retained-primary regression reproduced the exact production stack before correction. Both bank-direction scenarios pass after correction, including fresh publication, candidate staging, unchanged serving image and serving exclusion. All 65 focused image/provider/staging/CLI tests, Cloudflare typecheck, whitespace and complexity checks pass. Parent review confirms the correction reuses the existing provenance guard and adds no state or capacity change.

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -58,6 +58,10 @@ The legacy staging pointer predates immutable admission receipts. Its inactive
 application is reconciled through the existing drain/admission path, including
 when a native create committed but its response or subsequent Worker publication
 was lost. Its image is never reused as a verified artifact without provenance.
+A Worker-only release may retain a legacy active record with a mutable image tag.
+The reuse reader applies its legacy-provenance check to whichever release it
+selects, candidate or active, before inspecting the image. Such records require
+a normal immutable image build; they never authorize reuse of a legacy tag.
 No deployment-convergence restart retry is added to message processing.
 
 For a compatible Worker coordination change, the protected workflow may explicitly

--- a/apps/cloudflare/scripts/stage-runner-release.ts
+++ b/apps/cloudflare/scripts/stage-runner-release.ts
@@ -31,7 +31,7 @@ export async function readReusableHostedRunnerImage(input: {
   listApplications: ListCloudflareContainerApplications;
 }): Promise<string | null> {
   const deployment = readHostedRunnerDeployment(readReleaseVariables(input.currentVersion));
-  if (!deployment || isLegacyCandidate(deployment.candidate)) return null;
+  if (!deployment || isLegacyRelease(deployment.candidate ?? deployment.active)) return null;
   const release = deployment.candidate ?? deployment.active;
   const className = release.bank === "primary" ? "RunnerContainer" : "NextRunnerContainer";
   const config = input.config;
@@ -166,7 +166,7 @@ function selectDeployment(input: {
     // A legacy staging pointer is not an immutable admission receipt. Native
     // creation may have committed before its response or Worker publication was lost.
     // Reconcile that inactive namespace through the existing drain/admission path.
-    if (input.candidateExists && !isLegacyCandidate(candidate)) throw new Error("A different candidate release is pending; reconcile it before preparing another image.");
+    if (input.candidateExists && !isLegacyRelease(candidate)) throw new Error("A different candidate release is pending; reconcile it before preparing another image.");
     candidate = null;
   }
   candidate ??= {
@@ -217,7 +217,7 @@ function readLogsEnabled(config: Record<string, unknown>): boolean {
     ? config.observability.logs.enabled === true : config.observability.enabled === true);
 }
 
-function isLegacyCandidate(release: HostedRunnerRelease | null): boolean {
+function isLegacyRelease(release: HostedRunnerRelease | null): boolean {
   return release !== null && release.executionIdentity === undefined && release.releaseSha === undefined;
 }
 

--- a/apps/cloudflare/test/prepare-container-deploy-image.test.ts
+++ b/apps/cloudflare/test/prepare-container-deploy-image.test.ts
@@ -91,6 +91,37 @@ describe("container image publication before Worker activation", () => {
     expect(mocks.push).not.toHaveBeenCalled();
   });
 
+  it.each(["primary", "next"] as const)("builds a full release after Worker-only retention of a legacy %s image", async (bank) => {
+    const classes = ["RunnerContainer", "NextRunnerContainer", "DeploySmokeRunnerContainer", "StandbyRunnerContainer"];
+    const rendered = { ...config,
+      vars: { HOSTED_EXECUTION_RUNNER_BUNDLE_FINGERPRINT: "b".repeat(64), HOSTED_EXECUTION_RUNNER_SOURCE_FINGERPRINT: "c".repeat(64) },
+      containers: classes.map((class_name) => ({ ...config.containers[0], class_name, instance_type: "standard-1", ssh: { enabled: false }, rollout_active_grace_period: 300 })),
+    };
+    await writeFile(configPath, JSON.stringify(rendered));
+    const active = { bank, id: `${bank}-legacy-retained`, bundleFingerprint: "d".repeat(64), sourceFingerprint: "e".repeat(64) };
+    const currentVersion = { resources: { bindings: [
+      { type: "plain_text", name: "HOSTED_EXECUTION_RUNNER_DEPLOYMENT", text: JSON.stringify({ active, candidate: null, previous: null }) },
+      ...classes.map((class_name) => ({ type: "durable_object_namespace", class_name, namespace_id: `namespace-${class_name}` })),
+    ] } };
+    const oldImage = "registry.example.test/runner:legacy-tag";
+    const listApplications = vi.fn(async (name: string) => [{ id: name, name, max_instances: 1, configuration: { image: oldImage } }]);
+    const releaseSha = "1".repeat(40);
+    const preparedPath = await prepareHostedContainerDeployImage({ accountId, configPath, release: { currentVersion, releaseSha, listApplications } });
+    expect(mocks.build).toHaveBeenCalledOnce();
+    expect(mocks.push).toHaveBeenCalledOnce();
+    expect(listApplications).not.toHaveBeenCalled(); // Legacy provenance cannot authorize image reuse.
+    const staged = await stageHostedRunnerRelease({ configPath: preparedPath, currentVersionId: "worker-retained", currentVersion, releaseSha, listApplications });
+    expect(staged.deployment.active).toEqual(active);
+    expect(staged.deployment.candidate?.bank).toBe(bank === "primary" ? "next" : "primary");
+    expect(staged.deployment.candidate?.releaseSha).toBe(releaseSha);
+    expect(staged.workerOnly).toBe(false);
+    const servingClass = bank === "primary" ? "RunnerContainer" : "NextRunnerContainer";
+    expect(staged.applications.map((entry) => entry.className)).not.toContain(servingClass);
+    const stagedConfig = JSON.parse(await readFile(staged.configPath, "utf8"));
+    expect(stagedConfig.containers.find((entry: { class_name: string }) => entry.class_name === servingClass).image).toBe(oldImage);
+    expect(staged.applications.every((entry) => entry.specification.configuration.image.endsWith(`@${digest}`))).toBe(true);
+  });
+
   it("resumes the admitted image across a real manifest rebuild with different timestamps", async () => {
     const releaseSha = "1".repeat(40);
     const bundleDir = await mkdtemp(path.join(directory, "bundle-"));


### PR DESCRIPTION
## Why and outcome

After a Worker-only deployment retains a legacy active release, a full runner deployment fails while validating the old mutable image tag as an immutable reuse candidate. Apply the existing legacy-provenance guard to the selected candidate-or-active release before inspecting its image. Legacy retained releases now build a fresh immutable image through the normal publication path.

## Product UX

- Effort: Not applicable — internal release preparation.
- Result: Ready to merge; production verification pending.
- Walkthrough: Full releases resume after legacy Worker-only retention. Serving images remain unchanged during preparation, and admitted immutable releases retain their existing reuse behavior.

## Evidence

- Direct: The retained-primary regression reproduces the exact protected deployment stack before correction. Both bank-direction scenarios pass afterward, including actual image preparation and staging owners with synthetic Docker/provider boundaries.
- Coverage: All 65 focused image publication, release provider, staging and deployment CLI tests pass. Existing immutable reuse across manifest rebuilds, conflicting candidates, namespace checks and admission-before-activation remain covered.
- Cloudflare typecheck, whitespace and complexity checks pass. ReviewGPT round 1 passed on the exact head with matching GPT-6 Pro response-model and exact-turn capture evidence, with no findings. All required exact-head CI is green.

## Non-obvious affected surfaces

Renamed the existing legacy predicate to reflect its use for either release role. Candidate reconciliation behavior is unchanged. The prior diagnostic correction remains in the base; the original native application POST rejection still needs protected evidence once this earlier failure is removed.

## Architecture and reuse

- Existing systems reused: Legacy provenance predicate, selected release identity, normal immutable image publication and staged deployment.
- New logic: Apply the existing guard to candidate-or-active selection.
- New abstractions: None; rename the existing predicate to match its scope.
- Complexity intentionally avoided: No tag conversion, compatibility state, retry, quota adjustment or alternate release path.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`.
- Hotspots: None; changed-file maximum remains 19 with zero debt.
- Agent judgment: One selection correction is sufficient; no new mechanism is warranted.

## Hot reply path impact

- Path status: Not applicable — deployment scripts only.
- Database calls: None.
- Network/provider calls: None on the reply path.
- Other awaited latency: None on the reply path.
- Before/after proof: Legacy provenance skips the unnecessary provider image lookup and proceeds through normal build/publication.

## Murph initial provider input impact

Not applicable: individual and group prompts, tools, model configuration and provider-visible inputs are unchanged. Input measurement was not run.

## Deployment concerns

- Deployment: applicable
- Supported skew: Legacy active release records remain readable; their mutable tags cannot authorize reuse. Admitted immutable release behavior is unchanged.
- Safe order: Merge the preparation correction, then retry the protected full runner release.
- Rollback floor: Existing runtime and namespace floors remain; no rollback is authorized.
- Expected exposure: Full deployments selecting a legacy release; serving image and capacity stay unchanged during preparation.
- Reversibility: The guard correction is independently reversible through the reviewed release path.
- Convergence proof: Fresh publication and staging are covered in both banks; native admission, signed smoke and exact release receipts remain mandatory.
- Post-deploy checks: Verify the full release reaches native admission and then exact runner convergence. The earlier native POST rejection remains an explicit pending investigation.

## Change-shape breakdown

Classification: deployment TS is source, test paths are tests, plan/owner Markdown is docs. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 3 | 3 |
| Tests / fixtures | 31 | 0 |
| Docs | 12 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| Total | 46 | 3 |

## Changelog

- Changelog: not applicable
- Reason: Internal release preparation; no member-visible runtime change.

ReviewGPT context sensitivity: sensitive
Classification reason: Production deployment ordering and legacy release compatibility.
ReviewGPT first-reviewed head: c5b151ca2ea7d69aa0540e546782e1758a8f5ad0
