### PR TITLE
Fix Linq retry receipt races and add recovery diagnostics

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,6 +9,11 @@ receipt owner with one attempt timestamp and a blinded original identity.
 It reuses current route/access and egress policy, retrieves the original
 provider message transiently, and resends only that failed message. It creates
 no assistant turn, outbox owner, scheduler, or durable message-body copy.
+Receipt ingestion and acceptance serialize on transient, hashed message locks
+before delivery mutations, so their transactions cannot miss each other's
+committed identity. Legacy receipts recheck promoted child ownership under the
+parent lock. Existing Web diagnostics explain recovery decisions without
+retaining provider content.
 `agent-docs/RELIABILITY.md` specifies the supported content, ordering, limits,
 and conservative behavior after an ambiguous retry.
 

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -43,7 +43,8 @@ Last verified: 2026-09-04
   Web structured logs use `hosted-onboarding.linq.terminal-retry` for every
   failed-event evaluation and exceptional acceptance reconciliation. They
   report the trigger, stage, finite outcome/reason, elapsed time, event suffix,
-  message correlation digest and whether the permanent claim was consumed.
+  message correlation digest and whether this evaluation consumed the permanent
+  claim.
   Provider failures expose only bounded HTTP status and a closed error class;
   bodies, attachment URLs, sender/chat identities and provider prose stay out.
   Normal successful acceptance checks stay quiet. An accepted replacement is

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -8,6 +8,14 @@ Last verified: 2026-09-04
   reason `Message send failed` may resend each failed provider message once.
   The existing delivery-message row owns the permanent attempt timestamp and
   original lookup key; a parent delivery lock serializes competing claims.
+  Terminal receipt ingestion and runtime acceptance first serialize their
+  transactions by a stable hashed provider-message identity. Replacement
+  acceptance uses the same lock before the parent lock. Acceptance takes at
+  most ten message locks in sorted order; signup-welcome callbacks take them
+  before route/member materialization. This prevents concurrent transactions
+  from each missing the other's uncommitted receipt or accepted identity.
+  Legacy parent-only receipt writes take the parent lock, recheck promoted
+  message ownership and fence the active key before mutating the parent.
   Acceptance replaces the existing active message key (and matching parent
   scalar key), preserving the established receipt-reader contract. Receipt
   updates recheck that active key after acquiring the parent lock.
@@ -32,7 +40,16 @@ Last verified: 2026-09-04
   accepted runtime handoff. An unavailable provider response or interrupted
   post-dispatch recording may leave failure evidence unresolved; the consumed
   claim deliberately prevents a further resend.
-  The post-response acceptance check performs one exact failed-delivery lookup
+  Web structured logs use `hosted-onboarding.linq.terminal-retry` for every
+  failed-event evaluation and exceptional acceptance reconciliation. They
+  report the trigger, stage, finite outcome/reason, elapsed time, event suffix,
+  message correlation digest and whether the permanent claim was consumed.
+  Provider failures expose only bounded HTTP status and a closed error class;
+  bodies, attachment URLs, sender/chat identities and provider prose stay out.
+  Normal successful acceptance checks stay quiet. An accepted replacement is
+  explicitly delivery-unconfirmed; canonical delivery/message receipts prove
+  recovery. Logging failure cannot change the send or release its claim.
+  The post-response acceptance check performs one exact delivery lookup
   per provider ID (at most ten, sequentially), with no provider work on normal
   success. Recovery reads at most eleven child rows to reject an oversized
   delivery, reuses bounded canonical access reads, and opens at most one

--- a/agent-docs/exec-plans/active/2026-09-08-linq-terminal-recovery.md
+++ b/agent-docs/exec-plans/active/2026-09-08-linq-terminal-recovery.md
@@ -1,0 +1,72 @@
+# Diagnosable terminal Linq recovery
+
+Status: active
+Created: 2026-09-08
+Updated: 2026-09-08
+
+## Goal
+
+- Recover eligible terminal Linq failures once and report every recovery outcome
+  without private content. Original receipts must not regress replacements.
+
+## Success criteria
+
+- Reproduce receipt/retry overlap with real PostgreSQL and prove the correction.
+- Diagnose guard skips, provider errors, accepted replacements and consumed claims.
+- Pass focused tests, Web typecheck, parent review and routed final review.
+
+## Scope
+
+- In scope: Web-owned retry, receipt ordering, structured diagnostics and tests.
+- Out of scope: production resend/deploy, new scheduler, stored message bodies.
+
+## Constraints
+
+- Keep existing delivery/message state owners, one-attempt fence and bounded work.
+- Preserve routing, consent, access, supported content and ambiguous-send rules.
+- Product UX Patch: eligible direct/group messages recover once; denial and
+  unsupported content remain safe. Proof covers the final receipt state.
+
+## Risks and mitigations
+
+1. Concurrent receipt writes can regress or miss accepted identities.
+   Mitigation: deterministic interleaving proof and shared receipt ownership.
+2. Diagnostic error data can contain private provider content.
+   Mitigation: finite codes, stages and shape facts; no prose or payload logging.
+
+## Tasks
+
+1. Audit retry/receipt ordering and official provider contracts.
+2. Reproduce confirmed races before the smallest correction.
+3. Add bounded diagnostics at the existing Web logging seam.
+4. Run focused unit, HTTP, PostgreSQL and typecheck proof; review the full diff.
+5. Update owner docs, make changelog decision and prepare scoped commit/PR.
+
+## Decisions
+
+- Web remains the sole retry and receipt owner; no schema or dependency added.
+- Historical private incident details are excluded from repository artifacts.
+
+## Verification
+
+- Focused terminal-retry, delivery, HTTP and webhook tests; PostgreSQL concurrency
+  suite on an isolated loopback database; Web typecheck; complexity diff.
+- One resend at most, replacement receipt convergence, explicit safe diagnostics,
+  normal successful acceptance checks quiet, no logger-induced delivery changes.
+
+## Progress
+
+- Confirmed two ordering bugs: receipt/acceptance transactions could miss each
+  other's uncommitted state; a legacy receipt could overwrite a replacement
+  after reading the old parent identity before promotion.
+- Three real-PostgreSQL interleavings fail on the original source and pass with
+  shared message locks plus the parent-locked ownership recheck.
+- Added safe retry outcome diagnostics, retained all eligibility restrictions
+  and the permanent one-attempt fence, and updated durable owner docs.
+- Focused transport/webhook/concurrency proof: 314 tests passed in six files.
+  The subsequent unit/changelog proof passed 20 tests; Web typecheck passed.
+- Complexity diff passes with no new debt; existing store/route hotspots were
+  inspected. Independent read-only audit and parent diff review found no
+  remaining serious patch issues.
+- Remaining: scoped commits, final external PR review, exact-head CI and
+  mergeability proof. Production deployment and live resend are out of scope.

--- a/agent-docs/exec-plans/completed/2026-09-08-linq-terminal-recovery.md
+++ b/agent-docs/exec-plans/completed/2026-09-08-linq-terminal-recovery.md
@@ -1,6 +1,6 @@
 # Diagnosable terminal Linq recovery
 
-Status: active
+Status: completed
 Created: 2026-09-08
 Updated: 2026-09-08
 
@@ -68,5 +68,13 @@ Updated: 2026-09-08
 - Complexity diff passes with no new debt; existing store/route hotspots were
   inspected. Independent read-only audit and parent diff review found no
   remaining serious patch issues.
-- Remaining: scoped commits, final external PR review, exact-head CI and
-  mergeability proof. Production deployment and live resend are out of scope.
+- PR #3044 contains the scoped fix and changelog. Final external review passed
+  on `deb1f3c3396cfe206ab9ae83468f095ff306101e` with no qualifying findings;
+  response digest and GPT-6 Pro model metadata were validated locally.
+- All required CI checks, all four Web test shards, Web build and release
+  typecheck passed on the reviewed head. Final metadata-only commit CI remains
+  the PR completion gate. Merge-tree proof against current main is clean.
+- Parent final review found no remaining serious issues. The final owner-doc
+  wording clarifies that attemptClaimed describes the current evaluation.
+  Production deployment and live resend remain out of scope.
+Completed: 2026-09-08

--- a/apps/web/app/api/internal/hosted-runtime/linq-egress/delivery/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/linq-egress/delivery/route.ts
@@ -1,4 +1,5 @@
 import { after } from "next/server";
+import { lockHostedLinqMessageReceiptsTx } from "@/src/lib/hosted-onboarding/linq-message-receipt-lock";
 
 import {
   requireHostedCloudflareCallbackRequest,
@@ -162,6 +163,7 @@ export const POST = withJsonError(async (request: Request) => {
           throwHostedSignupWelcomeDeliveryAuthorityInvalid();
         }
 
+        await lockHostedLinqMessageReceiptsTx({ messageIds: providerMessageIds, prisma: tx });
         await materializeHostedSignupWelcomeHomeRouteTx({
           directRecipientPhoneNumber,
           fromPhoneNumber,

--- a/apps/web/changelog/entries/2026-09-08/more-reliable-imessage-recovery.json
+++ b/apps/web/changelog/entries/2026-09-08/more-reliable-imessage-recovery.json
@@ -9,6 +9,6 @@
     "summary": "Murph handles overlapping delivery updates more reliably when an iMessage needs a retry.",
     "details": "A failure arriving while a send is being recorded can now trigger the existing one-time retry. Older updates also preserve the status of the replacement message. Recovery keeps the same conversation, content and messaging restrictions.",
     "relevanceTags": ["imessage", "reliability"],
-    "sourcePullRequests": []
+    "sourcePullRequests": [3044]
   }
 }

--- a/apps/web/changelog/entries/2026-09-08/more-reliable-imessage-recovery.json
+++ b/apps/web/changelog/entries/2026-09-08/more-reliable-imessage-recovery.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-08",
+  "order": 100,
+  "item": {
+    "id": "more-reliable-imessage-recovery",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "More reliable iMessage recovery",
+    "summary": "Murph handles overlapping delivery updates more reliably when an iMessage needs a retry.",
+    "details": "A failure arriving while a send is being recorded can now trigger the existing one-time retry. Older updates also preserve the status of the replacement message. Recovery keeps the same conversation, content and messaging restrictions.",
+    "relevanceTags": ["imessage", "reliability"],
+    "sourcePullRequests": []
+  }
+}

--- a/apps/web/src/lib/hosted-onboarding/linq-delivery-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-delivery-store.ts
@@ -5,6 +5,7 @@ import {
 } from "../hosted-routing/linq-chat-ownership-lock";
 import { LINQ_API_DEFAULT_TIMEOUT_MS } from "../linq/api";
 import { generateHostedRandomPrefixedId, sha256Hex } from "../primitives";
+import { lockHostedLinqMessageReceiptsTx } from "./linq-message-receipt-lock";
 import {
   createHostedLinqChatLookupKey,
   createHostedLinqChatLookupKeyReadCandidates,
@@ -1538,6 +1539,7 @@ export async function recordHostedLinqRuntimeDeliveryOutcomeTx(input: {
   };
 
   return await runHostedLinqDeliveryStoreTransaction(input.prisma, async (prisma) => {
+    await lockHostedLinqMessageReceiptsTx({ messageIds: providerMessageIds, prisma });
     let acceptedAdvanced = false;
     let failedAdvanced = false;
     const existing = await prisma.hostedLinqDelivery.findUnique({
@@ -2187,9 +2189,20 @@ export async function applyHostedLinqDeliveryReceiptTx(input: {
     await lockHostedMemberRow(input.prisma, deliveryOnboardingLink.memberId);
   }
 
+  // A terminal retry can promote a legacy parent-only delivery to a message
+  // owner after our first lookup. Recheck under the same lock as promotion.
+  await lockHostedLinqDeliveryRow(input.prisma, delivery.id);
+  const promotedMessageReceipt = await applyHostedLinqDeliveryMessageReceiptTx(input);
+  if (promotedMessageReceipt) return promotedMessageReceipt;
+
   const updated = await input.prisma.hostedLinqDelivery.updateMany({
     where: {
       id: delivery.id,
+      messageLookupKey: {
+        in: input.event.messageLookupKeyReadCandidates.length > 0
+          ? input.event.messageLookupKeyReadCandidates
+          : [input.event.messageLookupKey],
+      },
       OR: buildReceiptOrderingWhere(input.event),
     },
     data: buildReceiptUpdate(input.event),
@@ -2638,6 +2651,7 @@ export async function recordHostedLinqTerminalRetryAcceptedTx(input: {
   phoneNumberLookupKey: string;
   prisma: Prisma.TransactionClient;
 }): Promise<void> {
+  await lockHostedLinqMessageReceiptsTx({ messageIds: [input.messageId], prisma: input.prisma });
   await lockHostedLinqDeliveryRow(input.prisma, input.deliveryId);
   const messageLookupKey = requireHostedLinqMessageLookupKey(input.messageId);
   const messageLookupKeyCandidates =

--- a/apps/web/src/lib/hosted-onboarding/linq-message-receipt-lock.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-message-receipt-lock.ts
@@ -1,0 +1,31 @@
+import { Prisma } from "@prisma/client";
+import { sha256Hex } from "../primitives";
+import type { ParsedHostedLinqProviderEvent } from "./linq-provider-events";
+
+export async function lockHostedLinqProviderReceiptTx(input: {
+  event: ParsedHostedLinqProviderEvent;
+  prisma: Pick<Prisma.TransactionClient, "$queryRaw">;
+}): Promise<void> {
+  if (!input.event.deliveryStatus || !input.event.linqMessageId) return;
+  await lockHostedLinqMessageReceiptsTx({
+    messageIds: [input.event.linqMessageId], prisma: input.prisma,
+  });
+}
+
+/**
+ * Receipts and acceptance must see each other's committed state. Take these
+ * locks before member, line or delivery writes, inside the owning transaction.
+ * Hash raw provider identity independently of rotating contact-privacy keys.
+ */
+export async function lockHostedLinqMessageReceiptsTx(input: {
+  messageIds: readonly string[];
+  prisma: Pick<Prisma.TransactionClient, "$queryRaw">;
+}): Promise<void> {
+  if (input.messageIds.length > 10) throw new Error("Linq message receipt lock limit exceeded.");
+  const keys = [...new Set(input.messageIds.map((id) => id.trim()).filter(Boolean))]
+    .map((id) => BigInt.asIntN(64, BigInt(`0x${sha256Hex(`linq-message-receipt:${id}`).slice(0, 16)}`)).toString())
+    .sort();
+  for (const key of keys) {
+    await input.prisma.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(${key}::bigint)::text`);
+  }
+}

--- a/apps/web/src/lib/hosted-onboarding/linq-provider-event-store.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-provider-event-store.ts
@@ -23,6 +23,7 @@ import {
 import type { ParsedHostedLinqProviderEvent } from "./linq-provider-events";
 import { toHostedOnboardingLogIdSuffix } from "./logging";
 import { sha256Hex } from "../primitives";
+import { lockHostedLinqProviderReceiptTx } from "./linq-message-receipt-lock";
 
 type HostedLinqProviderEventClient = PrismaClient | Prisma.TransactionClient;
 
@@ -39,6 +40,7 @@ export async function ingestHostedLinqProviderEventTx(input: {
   >;
 }> {
   const receivedAt = input.receivedAt ?? new Date();
+  await lockHostedLinqProviderReceiptTx(input);
   const health = input.event.providerHealth ?? {
     chat: null,
     line: null,

--- a/apps/web/src/lib/hosted-onboarding/linq-terminal-retry.ts
+++ b/apps/web/src/lib/hosted-onboarding/linq-terminal-retry.ts
@@ -18,6 +18,9 @@ import {
   readHostedThreadRouteByThreadIdentity,
 } from "../hosted-routing/thread-route-store";
 import { sha256Hex } from "../primitives";
+import { isHostedOnboardingError } from "./errors";
+import { LinqApiTimeoutError } from "../linq/api";
+import { logHostedOnboardingDiagnostic, logHostedOnboardingWarning, toHostedOnboardingLogIdSuffix } from "./logging";
 import type { ParsedHostedLinqProviderEvent } from "./linq-provider-events";
 
 // Recovery cannot extend the provider's optional 24-hour content lifetime.
@@ -36,11 +39,23 @@ export async function retryHostedLinqTerminalSendForEvent(input: {
   event: ParsedHostedLinqProviderEvent;
   prisma: PrismaClient;
 }): Promise<void> {
-  if (input.event.eventType !== "message.failed" || !isHostedLinqTerminalSendFailure(input.event)) return;
+  if (input.event.eventType !== "message.failed") return;
+  if (!isHostedLinqTerminalSendFailure(input.event)) {
+    try {
+      logHostedOnboardingDiagnostic("hosted-onboarding.linq.terminal-retry", {
+        trigger: "failure_webhook", stage: "candidate", outcome: "skipped",
+        reason: "failure_not_retryable", attemptClaimed: false,
+        eventIdSuffix: toHostedOnboardingLogIdSuffix(input.event.eventId),
+      });
+    } catch { /* Diagnostics do not grant or block a retry. */ }
+    return;
+  }
   await retryHostedLinqTerminalSend({
     chatId: input.event.linqChatId,
     messageId: input.event.linqMessageId,
     prisma: input.prisma,
+    trigger: "failure_webhook",
+    eventId: input.event.eventId,
   });
 }
 
@@ -90,17 +105,18 @@ async function readRetryCandidate(input: {
 }) {
   const delivery = await input.prisma.hostedLinqDelivery.findFirst({
     where: {
-      source: "hosted_runtime_linq_delivery",
-      status: "failed",
       linqChatLookupKey: { in: input.chatKeys },
-      acceptedAt: { gte: new Date(input.now.getTime() - RETRY_MAX_AGE_MS) },
       OR: [
         { messageLookupKey: { in: input.messageKeys } },
-        { messages: { some: { messageLookupKey: { in: input.messageKeys } } } },
+        { messages: { some: { OR: [
+          { messageLookupKey: { in: input.messageKeys } },
+          { terminalRetryOriginalMessageLookupKey: { in: input.messageKeys } },
+        ] } } },
       ],
     },
     select: {
       id: true,
+      source: true,
       acceptedAt: true,
       messageLookupKey: true,
       messageIdSuffix: true,
@@ -120,37 +136,46 @@ async function readRetryCandidate(input: {
           status: true,
           failureCode: true,
           failureReason: true,
+          terminalRetryOriginalMessageLookupKey: true,
           terminalRetryAttemptedAt: true,
         },
         take: 11,
       },
     },
   });
-  if (
-    !delivery?.phoneNumberLookupKey
-    || !delivery.acceptedAt
-    || delivery.threadIsDirect === null
-    || delivery.messages.length > 10
-  ) return null;
-  const message = delivery.messages.find((item) =>
-    input.messageKeys.includes(item.messageLookupKey));
-  if (delivery.messages.length && !message) return null;
+  if (!delivery) return { candidate: null, reason: "delivery_missing" } as const;
+  if (delivery.source !== "hosted_runtime_linq_delivery") {
+    return { candidate: null, reason: "delivery_not_runtime_owned" } as const;
+  }
+  if (delivery.messages.some((item) =>
+    item.terminalRetryOriginalMessageLookupKey
+    && input.messageKeys.includes(item.terminalRetryOriginalMessageLookupKey)
+  )) return { candidate: null, reason: "original_already_replaced" } as const;
+  if (delivery.status !== "failed") return { candidate: null, reason: "delivery_not_failed" } as const;
+  if (!delivery.phoneNumberLookupKey || !delivery.acceptedAt || delivery.threadIsDirect === null) {
+    return { candidate: null, reason: "delivery_authority_incomplete" } as const;
+  }
+  if (delivery.acceptedAt.getTime() < input.now.getTime() - RETRY_MAX_AGE_MS) {
+    return { candidate: null, reason: "delivery_expired" } as const;
+  }
+  if (delivery.messages.length > 10) return { candidate: null, reason: "delivery_message_limit" } as const;
+  const message = delivery.messages.find((item) => input.messageKeys.includes(item.messageLookupKey));
+  if (delivery.messages.length && !message) return { candidate: null, reason: "message_not_owned" } as const;
   const failed = message ?? delivery;
-  if (
-    failed.status !== "failed"
-    || !isHostedLinqTerminalSendFailure(failed)
-    || message?.terminalRetryAttemptedAt
-  ) return null;
-  return { delivery, message };
+  if (message?.terminalRetryAttemptedAt) return { candidate: null, reason: "attempt_already_consumed" } as const;
+  if (failed.status !== "failed" || !isHostedLinqTerminalSendFailure(failed)) {
+    return { candidate: null, reason: "failure_not_retryable" } as const;
+  }
+  return { candidate: { delivery, message }, reason: null } as const;
 }
 
-async function assertRetryRouteAndPolicy(input: {
+async function readRetryPolicyBlock(input: {
   chatId: string;
   chatKeys: string[];
   lineKey: string;
   threadIsDirect: boolean;
   prisma: RetryClient;
-}): Promise<boolean> {
+}): Promise<string | null> {
   const group = await readHostedThreadRouteByThreadIdentity({
     channel: "linq", threadId: input.chatId, prisma: input.prisma,
   });
@@ -161,12 +186,12 @@ async function assertRetryRouteAndPolicy(input: {
   const memberId = group?.containerMemberId ?? direct?.memberId;
   const lineKey = group?.accountLookupKey ?? direct?.linqRecipientPhoneLookupKey;
   if (!memberId || lineKey !== input.lineKey || Boolean(direct) !== input.threadIsDirect) {
-    return false;
+    return "route_mismatch";
   }
   const access = await readHostedRuntimeAiAccessDecision({
     memberId, prisma: input.prisma,
   });
-  if (!access.allowed) return false;
+  if (!access.allowed) return access.reason;
   const line = await input.prisma.hostedLinqLine.findUnique({
     where: { phoneNumberLookupKey: input.lineKey },
     select: {
@@ -174,34 +199,35 @@ async function assertRetryRouteAndPolicy(input: {
       providerReputationStatus: true, providerServiceStatus: true,
     },
   });
-  if (!line?.configuredAt) return false;
+  if (!line?.configuredAt) return "line_not_configured";
   const chat = await input.prisma.hostedLinqChatHealth.findFirst({
     where: { linqChatLookupKey: { in: input.chatKeys } },
     select: { providerStatus: true, phoneNumberLookupKey: true },
   });
-  if (chat?.phoneNumberLookupKey && chat.phoneNumberLookupKey !== input.lineKey) return false;
-  return evaluateHostedLinqEgressPolicy({
+  if (chat?.phoneNumberLookupKey && chat.phoneNumberLookupKey !== input.lineKey) return "chat_line_mismatch";
+  const policy = evaluateHostedLinqEgressPolicy({
     chatHealthStatus: chat?.providerStatus,
     lineDeliveryHealthStatus: line.healthStatus,
     lineEgressPolicy: line.egressPolicy,
     lineReputationStatus: line.providerReputationStatus,
     lineServiceStatus: line.providerServiceStatus,
     newConversation: false,
-  }).kind === "allow";
+  });
+  return policy.kind === "allow" ? null : policy.code;
 }
 
-function isMatchingFailedOutbound(
+function readFailedOutboundMismatch(
   original: Message,
   input: { messageId: string; chatId: string; lineKey: string },
-): boolean {
-  return original.id === input.messageId
-    && original.chat_id === input.chatId
-    && original.is_from_me === true
-    && original.delivery_status === "failed"
-    && original.service === "iMessage"
-    && createHostedPhoneLookupKeyReadCandidates(
-      original.from_handle?.handle ?? original.from,
-    ).includes(input.lineKey);
+): string | null {
+  if (original.id !== input.messageId) return "provider_message_mismatch";
+  if (original.chat_id !== input.chatId) return "provider_chat_mismatch";
+  if (original.is_from_me !== true) return "provider_direction_mismatch";
+  if (original.delivery_status !== "failed") return "provider_status_not_failed";
+  if (original.service !== "iMessage") return "provider_service_not_imessage";
+  return createHostedPhoneLookupKeyReadCandidates(
+    original.from_handle?.handle ?? original.from,
+  ).includes(input.lineKey) ? null : "provider_sender_mismatch";
 }
 
 /**
@@ -209,11 +235,69 @@ function isMatchingFailedOutbound(
  * arrival order can strand a known terminal failure. The existing message row
  * owns the one-attempt fence, including duplicate/concurrent webhook delivery.
  */
+type RetryStage = "candidate" | "policy" | "retrieve" | "content" | "claim" | "send" | "record";
+type RetryDiagnostic = {
+  stage: RetryStage;
+  outcome: "skipped" | "accepted" | "error";
+  reason: string;
+  attemptClaimed: boolean;
+  trigger: "failure_webhook" | "acceptance_callback";
+  messageRef: string | null;
+  eventIdSuffix: string | null;
+  providerStatus?: number;
+  errorKind?: "timeout" | "provider_http" | "database" | "unexpected";
+};
+
 export async function retryHostedLinqTerminalSend(input: {
   chatId: string | null;
   messageId: string | null;
   prisma: PrismaClient;
+  trigger?: RetryDiagnostic["trigger"];
+  eventId?: string;
 }): Promise<void> {
+  const startedAt = Date.now();
+  const diagnostic: RetryDiagnostic = {
+    stage: "candidate", outcome: "skipped", reason: "missing_provider_identity",
+    attemptClaimed: false, trigger: input.trigger ?? "acceptance_callback",
+    eventIdSuffix: toHostedOnboardingLogIdSuffix(input.eventId),
+    messageRef: input.messageId ? sha256Hex(input.messageId).slice(0, 16) : null,
+  };
+  try {
+    await runTerminalRetry(input, diagnostic);
+  } catch (error) {
+    diagnostic.outcome = "error";
+    if (diagnostic.reason !== "replacement_identity_invalid") {
+      diagnostic.reason = diagnostic.stage === "send" ? "send_outcome_unknown" : "operation_failed";
+    }
+    diagnostic.errorKind = error instanceof Prisma.PrismaClientKnownRequestError ? "database" : "unexpected";
+    if (isHostedOnboardingError(error)) {
+      if (error.cause instanceof LinqApiTimeoutError) diagnostic.errorKind = "timeout";
+      const status = error.details?.status;
+      if (typeof status === "number" && Number.isInteger(status) && status >= 100 && status <= 599) {
+        diagnostic.providerStatus = status;
+        diagnostic.errorKind = "provider_http";
+      }
+    }
+    throw error;
+  } finally {
+    // Successful acceptance checks are ordinary, high-volume bookkeeping.
+    // A failed-event trigger always leaves an explanation, even without a row.
+    if (!(diagnostic.trigger === "acceptance_callback"
+      && ["delivery_missing", "delivery_not_failed"].includes(diagnostic.reason))) {
+      try {
+        const log = diagnostic.outcome === "accepted"
+          ? logHostedOnboardingDiagnostic : logHostedOnboardingWarning;
+        log("hosted-onboarding.linq.terminal-retry", { ...diagnostic, elapsedMs: Math.max(0, Date.now() - startedAt) });
+      } catch { /* Optional diagnostics must never change delivery ownership. */ }
+    }
+  }
+}
+
+async function runTerminalRetry(input: {
+  chatId: string | null;
+  messageId: string | null;
+  prisma: PrismaClient;
+}, diagnostic: RetryDiagnostic): Promise<void> {
   if (!input.chatId || !input.messageId) return;
   const { chatId, messageId, prisma } = input;
   const keys = {
@@ -221,31 +305,44 @@ export async function retryHostedLinqTerminalSend(input: {
     messageKeys: createHostedLinqMessageLookupKeyReadCandidates(messageId),
     now: new Date(),
   };
-  const candidate = await readRetryCandidate({ ...keys, prisma });
-  if (!candidate) return;
-  const { delivery } = candidate;
-  const lineKey = delivery.phoneNumberLookupKey;
-  const threadIsDirect = delivery.threadIsDirect;
-  if (!lineKey || threadIsDirect === null) return;
+  const result = await readRetryCandidate({ ...keys, prisma });
+  if (!result.candidate) { diagnostic.reason = result.reason; return; }
+  const { delivery } = result.candidate;
+  const lineKey = delivery.phoneNumberLookupKey!;
+  const threadIsDirect = delivery.threadIsDirect!;
   const policyInput = { chatId, chatKeys: keys.chatKeys, lineKey, threadIsDirect };
-  if (!await assertRetryRouteAndPolicy({ ...policyInput, prisma })) return;
+  diagnostic.stage = "policy";
+  const policyReason = await readRetryPolicyBlock({ ...policyInput, prisma });
+  if (policyReason) { diagnostic.reason = policyReason; return; }
 
+  diagnostic.stage = "retrieve";
   const original = await readHostedLinqFailedMessage(messageId);
-  if (!isMatchingFailedOutbound(original, { messageId, chatId, lineKey })) return;
-  const messageRowId = candidate.message?.id
+  const mismatch = readFailedOutboundMismatch(original, { messageId, chatId, lineKey });
+  if (mismatch) { diagnostic.reason = mismatch; return; }
+  const messageRowId = result.candidate.message?.id
     ?? `hlm_terminal_${sha256Hex(delivery.id)}`;
-  const body = buildHostedLinqTerminalRetryMessage(
-    original, `terminal-retry:${messageRowId}`,
-  );
-  if (!body) return;
+  diagnostic.stage = "content";
+  const body = buildHostedLinqTerminalRetryMessage(original, `terminal-retry:${messageRowId}`);
+  if (!body) {
+    diagnostic.reason = !original.parts?.length ? "content_missing"
+      : original.parts.length > 100 ? "content_part_limit"
+      : original.parts.some((part) => part.type === "imessage_app") ? "app_card_not_reconstructible"
+      : original.parts.some((part) => part.type === "media" && part.mime_type?.startsWith("audio/")) ? "audio_not_reconstructible"
+      : "content_not_reconstructible";
+    return;
+  }
 
+  diagnostic.stage = "claim";
   const claimed = await prisma.$transaction(async (tx) => {
     await tx.$queryRaw(Prisma.sql`
       SELECT id FROM hosted_linq_delivery WHERE id = ${delivery.id} FOR UPDATE
     `);
-    const current = await readRetryCandidate({ ...keys, now: new Date(), prisma: tx });
-    if (!current || current.delivery.id !== delivery.id) return false;
-    if (!await assertRetryRouteAndPolicy({ ...policyInput, prisma: tx })) return false;
+    const currentResult = await readRetryCandidate({ ...keys, now: new Date(), prisma: tx });
+    const current = currentResult.candidate;
+    if (!current) { diagnostic.reason = currentResult.reason; return false; }
+    if (current.delivery.id !== delivery.id) { diagnostic.reason = "delivery_changed"; return false; }
+    const reason = await readRetryPolicyBlock({ ...policyInput, prisma: tx });
+    if (reason) { diagnostic.reason = reason; return false; }
     if (!current.message) {
       await tx.hostedLinqDeliveryMessage.create({
         data: {
@@ -267,22 +364,25 @@ export async function retryHostedLinqTerminalSend(input: {
       where: { id: messageRowId, terminalRetryAttemptedAt: null },
       data: { terminalRetryAttemptedAt: new Date() },
     });
+    if (claim.count !== 1) diagnostic.reason = "claim_lost";
     return claim.count === 1;
   }, HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
   if (!claimed) return;
+  diagnostic.attemptClaimed = true;
 
-  // A transport-ambiguous response consumes this attempt too. Never open a
-  // second retry or release the fence after dispatch may have reached Linq.
+  // Ambiguous dispatch consumes the attempt; never release this fence.
+  diagnostic.stage = "send";
   const accepted = await resendHostedLinqMessage({ chatId, message: body });
   if (accepted.chatId !== chatId || !accepted.messageId || accepted.messageId === messageId) {
+    diagnostic.stage = "record";
+    diagnostic.reason = "replacement_identity_invalid";
     throw new Error("Linq terminal retry response omitted the expected identity.");
   }
+  diagnostic.stage = "record";
   await prisma.$transaction((tx) => recordHostedLinqTerminalRetryAcceptedTx({
-    acceptedAt: new Date(),
-    deliveryId: delivery.id,
-    messageRowId,
-    messageId: accepted.messageId!,
-    phoneNumberLookupKey: lineKey,
-    prisma: tx,
+    acceptedAt: new Date(), deliveryId: delivery.id, messageRowId,
+    messageId: accepted.messageId!, phoneNumberLookupKey: lineKey, prisma: tx,
   }), HOSTED_ONBOARDING_TRANSACTION_OPTIONS);
+  diagnostic.outcome = "accepted";
+  diagnostic.reason = "replacement_accepted_delivery_unconfirmed";
 }

--- a/apps/web/test/hosted-onboarding-linq-terminal-retry-postgres.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-terminal-retry-postgres.test.ts
@@ -1,4 +1,6 @@
 import { randomInt, randomUUID } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
+import { Prisma } from "@prisma/client";
 import type { Message } from "@linqapp/sdk/resources/messages";
 import { describe, expect, it, vi } from "vitest";
 
@@ -9,6 +11,7 @@ import {
   createHostedPhoneLookupKey,
 } from "@/src/lib/hosted-onboarding/contact-privacy";
 import {
+  applyHostedLinqDeliveryReceiptTx,
   recordHostedLinqRuntimeDeliveryOutcomeTx,
 } from "@/src/lib/hosted-onboarding/linq-delivery-store";
 import { ingestHostedLinqProviderEventTx } from "@/src/lib/hosted-onboarding/linq-provider-event-store";
@@ -25,6 +28,7 @@ import {
 import { createPrismaClient } from "@/src/lib/prisma";
 
 const provider = vi.hoisted(() => ({
+  log: vi.fn(),
   read: vi.fn<() => Promise<Message>>(),
   send: vi.fn<() => Promise<{ chatId: string; messageId: string }>>(),
 }));
@@ -32,6 +36,12 @@ vi.mock("@/src/lib/hosted-onboarding/linq-client", async (importOriginal) => ({
   ...await importOriginal<typeof import("@/src/lib/hosted-onboarding/linq-client")>(),
   readHostedLinqFailedMessage: provider.read,
   resendHostedLinqMessage: provider.send,
+}));
+
+vi.mock("@/src/lib/hosted-onboarding/logging", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/src/lib/hosted-onboarding/logging")>(),
+  logHostedOnboardingDiagnostic: provider.log,
+  logHostedOnboardingWarning: provider.log,
 }));
 
 const enabled = process.env.MURPH_TEST_POSTGRES_CONCURRENCY === "1";
@@ -61,6 +71,7 @@ async function withFixture(run: (fixture: Awaited<ReturnType<typeof seed>>) => P
 }
 
 async function seed() {
+  provider.log.mockReset();
   provider.read.mockReset();
   provider.send.mockReset();
   const prisma = createPrismaClient({ databaseUrl, poolMax: 4 });
@@ -144,7 +155,194 @@ async function seed() {
   };
 }
 
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+async function pauseLegacyReceipt(
+  f: Awaited<ReturnType<typeof seed>>,
+  event: NonNullable<ReturnType<typeof parseHostedLinqProviderEvent>>,
+  ingest = true,
+) {
+  const lookedUp = deferred();
+  const resume = deferred();
+  let paused = false;
+  const pending = f.prisma.$transaction(async (tx) => {
+    const delivery = new Proxy(tx.hostedLinqDelivery, {
+      get(target, key) {
+        if (key !== "findFirst") return Reflect.get(target, key);
+        return async (...args: Parameters<typeof target.findFirst>) => {
+          const value = await target.findFirst(...args);
+          if (!paused) {
+            paused = true;
+            lookedUp.resolve();
+            await resume.promise;
+          }
+          return value;
+        };
+      },
+    });
+    const prisma = new Proxy(tx, {
+      get(target, key) { return key === "hostedLinqDelivery" ? delivery : Reflect.get(target, key); },
+    });
+    return ingest ? ingestHostedLinqProviderEventTx({ event, prisma })
+      : applyHostedLinqDeliveryReceiptTx({ event, prisma });
+  }, { timeout: 10_000 });
+  await lookedUp.promise;
+  return { pending, resume };
+}
+
+async function settleOrBlock(prisma: Awaited<ReturnType<typeof seed>>["prisma"], work: Promise<unknown>) {
+  let settled = false;
+  void work.then(() => { settled = true; }, () => { settled = true; });
+  for (let i = 0; i < 200 && !settled; i++) {
+    const [row] = await prisma.$queryRaw<Array<{ blocked: boolean }>>(Prisma.sql`
+      SELECT EXISTS(SELECT 1 FROM pg_locks WHERE locktype = 'advisory'
+        AND NOT granted AND database = (SELECT oid FROM pg_database WHERE datname = current_database())) AS blocked
+    `);
+    if (row?.blocked) return;
+    await delay(5);
+  }
+  if (!settled) throw new Error("Synthetic acceptance neither settled nor waited for its receipt lock.");
+}
+
 describe.skipIf(!enabled)("terminal Linq retry with PostgreSQL and provider boundary", () => {
+  it("keeps successful acceptance quiet and explains failed-event skips and accepted retries", async () => {
+    await withFixture(async (f) => {
+      await f.retry();
+      expect(provider.log).not.toHaveBeenCalled();
+      const event = await f.receipt();
+      provider.read.mockResolvedValue({ ...f.original, delivery_status: "pending" });
+      await retryHostedLinqTerminalSendForEvent({ event, prisma: f.prisma });
+      expect(provider.log).toHaveBeenLastCalledWith("hosted-onboarding.linq.terminal-retry", expect.objectContaining({
+        trigger: "failure_webhook", stage: "retrieve", outcome: "skipped",
+        reason: "provider_status_not_failed", attemptClaimed: false,
+      }));
+      provider.read.mockResolvedValue(f.original);
+      await f.retry();
+      expect(provider.log).toHaveBeenLastCalledWith("hosted-onboarding.linq.terminal-retry", expect.objectContaining({
+        stage: "record", outcome: "accepted", reason: "replacement_accepted_delivery_unconfirmed", attemptClaimed: true,
+      }));
+      await f.retry();
+      expect(provider.log).toHaveBeenLastCalledWith("hosted-onboarding.linq.terminal-retry", expect.objectContaining({
+        reason: "original_already_replaced", attemptClaimed: false,
+      }));
+      const logged = JSON.stringify(provider.log.mock.calls);
+      for (const privateValue of [f.chatId, f.messageId, f.retryId, f.original.from!, "Here is the requested document."]) {
+        expect(logged).not.toContain(privateValue);
+      }
+    });
+  });
+
+  it("diagnoses retrieval and ambiguous-send errors without exposing provider prose", async () => {
+    await withFixture(async (f) => {
+      await f.receipt();
+      const error = new Error("synthetic private provider body and credential");
+      provider.read.mockRejectedValue(error);
+      await expect(f.retry()).rejects.toBe(error);
+      expect(provider.log).toHaveBeenLastCalledWith("hosted-onboarding.linq.terminal-retry", expect.objectContaining({
+        stage: "retrieve", outcome: "error", reason: "operation_failed", attemptClaimed: false,
+      }));
+      provider.read.mockResolvedValue(f.original);
+      provider.send.mockRejectedValue(error);
+      await expect(f.retry()).rejects.toBe(error);
+      expect(provider.log).toHaveBeenLastCalledWith("hosted-onboarding.linq.terminal-retry", expect.objectContaining({
+        stage: "send", outcome: "error", reason: "send_outcome_unknown", attemptClaimed: true,
+      }));
+      expect(JSON.stringify(provider.log.mock.calls)).not.toContain(error.message);
+      await f.retry();
+      expect(provider.log).toHaveBeenLastCalledWith("hosted-onboarding.linq.terminal-retry", expect.objectContaining({ reason: "attempt_already_consumed" }));
+      expect(provider.send).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it.each(["empty", "app", "audio", "sender", "expired", "missing"])("explains %s recovery exclusions", async (kind) => {
+    await withFixture(async (f) => {
+      const event = await f.receipt();
+      if (kind === "missing") await f.prisma.hostedLinqDelivery.delete({ where: { id: f.deliveryId } });
+      if (kind === "expired") await f.prisma.hostedLinqDelivery.update({
+        where: { id: f.deliveryId }, data: { acceptedAt: new Date(Date.now() - 25 * 3_600_000) },
+      });
+      if (kind === "empty") provider.read.mockResolvedValue({ ...f.original, parts: [] });
+      if (kind === "sender") provider.read.mockResolvedValue({ ...f.original, from: "+15559999999" });
+      if (kind === "app") provider.read.mockResolvedValue({ ...f.original, parts: [{
+        type: "imessage_app", reactions: null, url: "https://example.test/private-card",
+        app: { bundle_id: "test.app", team_id: "TEST", name: "Example" }, layout: { caption: "Private caption" },
+      }] });
+      if (kind === "audio") provider.read.mockResolvedValue({ ...f.original, parts: [{
+        type: "media", id: "synthetic-audio", filename: "audio.m4a", mime_type: "audio/mp4",
+        size_bytes: 100, reactions: null, url: "https://example.test/private-audio",
+      }] });
+      await retryHostedLinqTerminalSendForEvent({ event, prisma: f.prisma });
+      expect(provider.log).toHaveBeenLastCalledWith("hosted-onboarding.linq.terminal-retry", expect.objectContaining({
+        outcome: "skipped", attemptClaimed: false,
+        reason: { empty: "content_missing", app: "app_card_not_reconstructible", audio: "audio_not_reconstructible",
+          sender: "provider_sender_mismatch", expired: "delivery_expired", missing: "delivery_missing" }[kind],
+      }));
+      expect(provider.send).not.toHaveBeenCalled();
+      expect(JSON.stringify(provider.log.mock.calls)).not.toContain("example.test");
+      expect(JSON.stringify(provider.log.mock.calls)).not.toContain("Private caption");
+    });
+  });
+
+  it("does not let diagnostic failures prevent or duplicate recovery", async () => {
+    await withFixture(async (f) => {
+      await f.receipt();
+      provider.log.mockImplementation(() => { throw new Error("logger unavailable"); });
+      await f.retry();
+      await f.retry();
+      expect(provider.send).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it.each(["original", "replacement"])("serializes a concurrent receipt before %s acceptance", async (kind) => {
+    await withFixture(async (f) => {
+      if (kind === "original") await f.prisma.hostedLinqDelivery.delete({ where: { id: f.deliveryId } });
+      else await f.receipt();
+      const event = parseHostedLinqProviderEvent({
+        event: {
+          api_version: "v3", webhook_version: "2026-02-03", event_id: `receipt-${randomUUID()}`,
+          event_type: kind === "original" ? "message.failed" : "message.delivered",
+          created_at: new Date().toISOString(),
+          data: { chat_id: f.chatId, message_id: kind === "original" ? f.messageId : f.retryId,
+            service: "iMessage", ...(kind === "original" ? { code: 4001, reason: "Message send failed" } : {}) },
+        } as HostedLinqWebhookEvent,
+      });
+      if (!event) throw new Error("Synthetic receipt must parse.");
+      const paused = await pauseLegacyReceipt(f, event);
+      const acceptance = kind === "original" ? f.accepted() : f.retry();
+      try { await settleOrBlock(f.prisma, acceptance); }
+      finally { paused.resume.resolve(); }
+      await Promise.all([paused.pending, acceptance]);
+      expect(await f.prisma.hostedLinqDelivery.findUnique({
+        where: { id: f.deliveryId }, select: { status: true },
+      })).toEqual({ status: kind === "original" ? "failed" : "delivered" });
+      if (kind === "original") {
+        await retryHostedLinqTerminalSendForEvent({ event, prisma: f.prisma });
+        expect(provider.send).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+
+  it("does not let a legacy receipt that already read the parent overwrite a replacement", async () => {
+    await withFixture(async (f) => {
+      const event = await f.receipt();
+      const paused = await pauseLegacyReceipt(f, event, false);
+      try { await f.retry(); }
+      finally { paused.resume.resolve(); }
+      expect(await paused.pending).toMatchObject({ advanced: false });
+      expect(await f.prisma.hostedLinqDelivery.findUnique({
+        where: { id: f.deliveryId }, select: { status: true },
+      })).toEqual({ status: "accepted" });
+      await f.receipt(f.retryId, "delivered");
+      expect(await f.prisma.hostedLinqDelivery.findUnique({
+        where: { id: f.deliveryId }, select: { status: true },
+      })).toEqual({ status: "delivered" });
+    });
+  });
+
   it.each(["granted", "missing-legacy"])("recovers with %s consent", async (consent) => {
     await withFixture(async (f) => {
       if (consent === "granted") await f.grantConsent();
@@ -321,6 +519,12 @@ describe.skipIf(!enabled)("terminal Linq retry with PostgreSQL and provider boun
         await f.retry();
         expect(provider.send).not.toHaveBeenCalled();
         expect(provider.read).not.toHaveBeenCalled();
+        expect(provider.log).toHaveBeenLastCalledWith("hosted-onboarding.linq.terminal-retry", expect.objectContaining({
+          stage: "policy", outcome: "skipped", attemptClaimed: false,
+          reason: { disabled: "operator_disabled", FLAGGED: "line_flagged", CRITICAL: "line_critical",
+            unhealthy: "delivery_unhealthy", OPTED_OUT: "chat_opted_out", suspended: "hosted_access_inactive",
+            "route-changed": "route_mismatch" }[restriction],
+        }));
       });
     },
   );

--- a/apps/web/test/hosted-onboarding-linq-terminal-retry.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-terminal-retry.test.ts
@@ -1,5 +1,6 @@
 import type { Message } from "@linqapp/sdk/resources/messages";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { lockHostedLinqMessageReceiptsTx } from "@/src/lib/hosted-onboarding/linq-message-receipt-lock";
 
 import {
   buildHostedLinqTerminalRetryMessage,
@@ -15,6 +16,21 @@ const original: Message = {
 };
 
 describe("one terminal Linq retry request", () => {
+  it("bounds receipt serialization and gives reversed message batches the same lock order", async () => {
+    const prisma = { $queryRaw: vi.fn().mockResolvedValue([]) };
+    const messageIds = Array.from({ length: 10 }, (_, index) => `synthetic-message-${index}`);
+    await lockHostedLinqMessageReceiptsTx({ messageIds, prisma });
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(10);
+    const first = prisma.$queryRaw.mock.calls.map(([query]) => query);
+    prisma.$queryRaw.mockClear();
+    await lockHostedLinqMessageReceiptsTx({ messageIds: [...messageIds].reverse(), prisma });
+    expect(prisma.$queryRaw.mock.calls.map(([query]) => query)).toEqual(first);
+    expect(JSON.stringify(first)).not.toContain("synthetic-message");
+    prisma.$queryRaw.mockClear();
+    await expect(lockHostedLinqMessageReceiptsTx({ messageIds: [...messageIds, "overflow"], prisma })).rejects.toThrow("limit exceeded");
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["4001", "Message send failed", true],
     ["4001", "Message delivery failed", false],

--- a/apps/web/test/hosted-runtime-linq-delivery-route.test.ts
+++ b/apps/web/test/hosted-runtime-linq-delivery-route.test.ts
@@ -53,6 +53,7 @@ type RouteModule = typeof import(
 
 let route: RouteModule;
 let prisma: {
+  $queryRaw: ReturnType<typeof vi.fn>;
   $transaction: ReturnType<typeof vi.fn>;
   hostedMemberRouting: {
     findUnique: ReturnType<typeof vi.fn>;
@@ -69,6 +70,7 @@ describe("hosted runtime Linq delivery route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     prisma = {
+      $queryRaw: vi.fn().mockResolvedValue([]),
       $transaction: vi.fn(async (operation) => operation(prisma)),
       hostedMemberRouting: {
         findUnique: vi.fn().mockResolvedValue(null),
@@ -106,6 +108,10 @@ describe("hosted runtime Linq delivery route", () => {
 
     expect(response.status).toBe(200);
     expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(prisma.$queryRaw.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.materializeHostedSignupWelcomeHomeRouteTx.mock.invocationCallOrder[0]!,
+    );
     expect(mocks.materializeHostedSignupWelcomeHomeRouteTx).toHaveBeenCalledWith({
       directRecipientPhoneNumber: "+15550100001",
       fromPhoneNumber: "+15550100099",


### PR DESCRIPTION
## Why and outcome

A terminal Linq receipt and the runtime acceptance callback could each miss the other's uncommitted state, leaving an eligible failed message unretried or a replacement's delivered status unapplied. A legacy receipt could also overwrite the parent after a retry replaced its active identity.

Serialize receipt ingestion and runtime/replacement acceptance by provider-message identity, and recheck legacy ownership under the parent lock. Structured diagnostics now explain every failed-event retry decision and exceptional acceptance reconciliation without retaining message content. Replacement acceptance remains distinct from confirmed delivery.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Eligible direct and group iMessages keep the existing one-time recovery in the same conversation with the same supported content. Consent, access, route and line restrictions still block sends. App cards, audio, expired or unavailable content remain excluded; ambiguous retry dispatch permanently consumes the attempt.

## Evidence

- Direct: Three deterministic real-PostgreSQL overlap scenarios failed against the original source and pass with this patch: original failure versus acceptance, replacement delivery versus acceptance, and stale legacy receipt versus replacement promotion. Synthetic provider-boundary tests follow the replacement through its delivered receipt and prove only one resend.
- Coverage: 314 tests passed across terminal-retry PostgreSQL/unit, Linq HTTP, observability-store, runtime-delivery-route and webhook-idempotency suites. Followup unit/changelog proof passed 20 tests. Web typecheck, changed-file ESLint and diff whitespace checks passed. The database proof uses only an isolated loopback database with `MURPH_TEST_POSTGRES_CONCURRENCY=1`; no production resend or deployment was performed. Final ReviewGPT passed on `deb1f3c3396cfe206ab9ae83468f095ff306101e`; the exact response digest and GPT-6 Pro capture metadata were validated. All required CI, four Web test shards, Web build and release typecheck passed on that reviewed candidate. The final commit changes only explanatory docs and closes the execution plan; all required CI checks passed on final head `8440fea4406ebbc4c5fb7c2b963f62e73f1860d9`. Broader CI also passed, including all Web test shards, builds, package coverage, viewport checks and Temporal compatibility.
- Commands: `pnpm --dir apps/web test:prepared test/hosted-onboarding-linq-terminal-retry-postgres.test.ts test/hosted-onboarding-linq-terminal-retry.test.ts test/hosted-onboarding-linq-http.test.ts test/hosted-onboarding-linq-observability-store.test.ts test/hosted-runtime-linq-delivery-route.test.ts test/hosted-onboarding-webhook-idempotency.test.ts`; `pnpm --dir apps/web typecheck:prepared`; `pnpm --dir apps/web test:prepared test/changelog-page.test.tsx`.

## Non-obvious affected surfaces

Signup-welcome acceptance materializes its route inside an outer transaction. It now takes message locks before route/member locks; the callback test asserts this ordering. Webhook ingestion shares the same message lock before line writes; existing webhook/health projection tests pass. Normal accepted sends still perform no provider lookup and produce no retry warning.

## Architecture and reuse

- Existing systems reused: Existing Web receipt ingestion, delivery/message rows, parent row lock, permanent retry claim, policy readers and structured logging seam.
- New logic: Serialize concurrent receipt/acceptance transactions; fence stale parent-only receipt writes; describe each retry guard and failure stage using safe codes.
- New abstractions: One bounded transaction-lock helper, keyed by a stable digest independent of contact-key rotation; no new persistent owner.
- Complexity intentionally avoided: No migration, dependency, queue, scheduler, durable message body or retry mechanism beyond the existing one-attempt path.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base f291b4287104235921e16e8a3c40f0848c346250`; no additional complexity debt.
- Hotspots: Existing delivery-store transaction callbacks (26, 48), recomputeHostedLinqDeliveryFromMessagesTx (36), claimExistingHostedLinqDeliveryProviderDispatchTx (63), delivery route (31), and ingestHostedLinqProviderEventTx (45) remain at their baseline scores. Inspected ordering and owners at each changed seam. Retry functions remain below 20; the new lock helper is 3.
- Agent judgment: Further extraction would spread the ordering contract across more owners; the focused lock/recheck and existing guards are the smallest maintainable correction.

## Hot reply path impact

- Path status: Touched at durable runtime handoff after provider acceptance; model execution and initial provider send are unchanged.
- Database calls: Runtime acceptance adds one advisory-lock query per distinct provider ID, serial and sorted, maximum ten. Signup-welcome takes the same locks before route materialization and reacquires them in its shared inner store path: maximum twenty queries in the same transaction. Receipt ingestion adds one message lock. Legacy receipt fallback adds a parent lock and child-owner recheck; a promoted child uses the existing child receipt path. Replacement acceptance adds one message lock before its existing parent lock. No parallel fanout or additional pooled transaction is introduced; existing database transaction timeouts apply, and lock failure aborts the transaction without dispatching under a lock.
- Network/provider calls: None added; existing failed-message retrieval and single resend remain outside database transactions.
- Other awaited latency: None. Contention can wait for the matching message transaction; uncontended cost is one database round trip per lock, without a measured production latency claim.
- Before/after proof: Ten-ID/reversed-order bound test, outer signup ordering assertion and three real-PostgreSQL blocking interleavings. Existing direct/group, multipart, policy, duplicate and ambiguous-send cases remain green. Candidate lookup stays bounded to eleven child rows and at most ten sequential callback evaluations.

## Murph initial provider input impact

Not applicable for individual and group runtimes: this patch changes deterministic Web receipt/retry transport, with no assistant prompt, model request, tool schema or provider-input assembly changes. Real-Codex journey and token measurements are not applicable to this boundary.

## Design proof

- Design page: [Existing changelog archive presentation](https://www.withmurph.ai/screenshots/ops#changelog-archive)
- Evidence: Content-only JSON under the changelog README exception; reviewed copy and passing changelog archive rendering tests. No renderer or style changes.
- Coverage: The existing archive component renders all authored fragments; an additional screenshot or branch preview adds no proof for this text-only entry.

## Risks

The permanent retry fence intentionally leaves an ambiguous resend or post-dispatch recording failure unresolved rather than sending again. New diagnostics report this limitation. This change establishes reproduced ordering bugs; it does not assert the cause of any historical event whose silent early return was not retained.

<!-- ReviewGPT context sensitivity: sensitive -->
<!-- Classification reason: Receipt ordering, retry concurrency and external messaging effects. -->

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing Web and runtime callback payloads and database shapes are unchanged. Old and new Web functions can coexist, but an old function does not participate in the new advisory-lock protocol.
- Safe order: Deploy the Web patch through the normal reviewed release path; no runtime/Worker or database migration order is required. Full race protection starts once old Web executions drain.
- Rollback floor: Existing schema and runtime remain compatible; rollback removes these ordering protections and diagnostics.
- Expected exposure: Overlapping affected receipt/acceptance transactions can still race during mixed Web execution; no new persisted shape or duplicate-send permission is introduced.
- Reversibility: Code-only change, no data rewrite. Any deployment or rollback is a separate authorized operation.
- Convergence proof: Unchanged callback contract tests and legacy parent/child tests pass; deterministic current/current PostgreSQL tests prove serialization. Mixed old/new code remains contract-compatible but cannot guarantee the new lock protection.
- Post-deploy checks: Confirm the new Web version, inspect bounded terminal-retry stage/reason outcomes, and match accepted replacements with canonical delivered/read receipts. A replacement-accepted log alone is not delivery proof.

## Change-shape breakdown

Classification rule: authored TypeScript outside tests is Source; test files are Tests / fixtures; owner docs, execution plan and public changelog copy are Docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 211 | 62 |
| Tests / fixtures | 227 | 1 |
| Docs | 118 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **556** | **64** |

## Changelog

- Changelog: updated
- Items: 2026-09-08 · more-reliable-imessage-recovery

ReviewGPT first-reviewed head: deb1f3c3396cfe206ab9ae83468f095ff306101e
