### PR TITLE
fix: make Junction ops recovery actionable and truthful

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-08-junction-recovery.md
+++ b/agent-docs/exec-plans/active/2026-09-08-junction-recovery.md
@@ -1,0 +1,76 @@
+# Make Junction operator recovery truthful and usable
+
+Status: active
+Created: 2026-09-08
+Updated: 2026-09-08
+
+## Outcome and ownership
+
+Operators can distinguish a shared Junction account from its selected source,
+request one refresh, and see the provider outcome and a fresh source status.
+Device-syncd owns provider requests and safe response interpretation. Existing
+Web ops routes own authorization and target resolution. Source persistence and
+the hourly reconciliation owner remain authoritative; diagnostics do not write
+connection state or infer freshness from a successful read.
+
+## Evidence and approach
+
+Synthetic delayed responses reproduce a client deadline shorter than the
+requested upstream refresh wait. The diagnostic accepts contradictory success
+envelopes and the current UI exposes no recovery action or selected-source
+error. Extend these existing owners; add no dependencies, queue, persistence,
+automatic provider retries, or member messages.
+
+## Product UX
+
+- Entry: Ops runtime maintenance, existing Junction diagnostic form.
+- Outcome: source status/error, one manual refresh of the shared account, and
+  automatic status read after the attempt; an explicit read-only status check
+  supports delayed recovery without repeating the mutation.
+- Journeys: source error under an active parent; rejected/no-op refresh;
+  partial/in-progress refresh; timeout with unknown outcome; connected source;
+  status read failure; changed form target; denied operator access; mobile.
+- Proof: provider fixtures, composed route tests, client interaction tests,
+  and an inert design study of the production recovery panel.
+
+## Tasks
+
+1. Correct refresh deadline and timeout diagnostics without automatic POST replay.
+2. Interpret provider-declared errors and empty results truthfully; expose the
+   selected source status using bounded provider-list reads.
+3. Reuse ops endpoints for refresh and status checks; omit irrelevant backfill
+   reads during recovery and pin actions to the inspected public connection ID.
+4. Compose a small recovery panel beside existing diagnostics and add focused proof.
+5. Review privacy, authority, complexity and rendered states; run tests/typechecks,
+   update the owner documentation, and commit the scoped change.
+
+## Verification and delivery
+
+Focused device-syncd client/diagnostic tests; Web ops-route and UI tests; affected
+typechecks; complexity diff; browser rendering with synthetic fixtures. Exercise
+provider failure and parent cancellation separately. Preserve disconnect fences
+and existing diagnostic authorization. Additive response fields tolerate older
+callers. Internal ops changes do not require a member changelog. Final external
+review follows the completion workflow for the cross-package provider boundary.
+
+## Progress
+
+- Implementation complete. Existing diagnostic owners now classify refresh
+  outcomes, preserve timeout identity, and expose an independent source status.
+- Focused proof: 39 client tests and 46 provider diagnostic tests passed;
+  22 Web route/client tests passed. Both affected typechecks passed.
+- Product UX: Ready. Verified rejected refresh, partial/in-progress response,
+  unknown timeout outcome, status-read failure, disconnected source denial,
+  inspected-target pinning, changed-target clearing, and operator access guards.
+- Rendered the real panel through the synthetic ops design study at 390 and
+  1280 pixels. Inspected error and pending states, UTC receipt time, disabled
+  controls, and no horizontal overflow. Removed the temporary capture spec.
+- Complexity guard passed: no added debt; diagnostic runner and request failure
+  handling are simpler. Existing unrelated dispatch and matrix hotspots remain
+  outside this bounded change.
+- Parent candidate review completed: no secrets, production rows, persistence,
+  new scheduling, dependencies, or member messaging added. Existing account and
+  source selection retain one authority. Shared request timeout classification
+  preserves parent cancellation and never retries mutations.
+- Delivery pending: candidate commit, isolated preview, required CI and final
+  ReviewGPT for the provider/Web boundary.

--- a/agent-docs/exec-plans/completed/2026-09-08-junction-recovery.md
+++ b/agent-docs/exec-plans/completed/2026-09-08-junction-recovery.md
@@ -1,6 +1,6 @@
 # Make Junction operator recovery truthful and usable
 
-Status: active
+Status: completed
 Created: 2026-09-08
 Updated: 2026-09-08
 
@@ -72,5 +72,19 @@ review follows the completion workflow for the cross-package provider boundary.
   new scheduling, dependencies, or member messaging added. Existing account and
   source selection retain one authority. Shared request timeout classification
   preserves parent cancellation and never retries mutations.
-- Delivery pending: candidate commit, isolated preview, required CI and final
-  ReviewGPT for the provider/Web boundary.
+- Final ReviewGPT: PASS on the full production candidate at
+  70a8a56495495448230a3f8ad8bbcd5e45be886c. Mountain lane, GPT-6 Pro platform
+  metadata and response digest verified; observed run approximately 391 seconds
+  including staging. The review traced the Ops/provider boundary, disconnect
+  admission, and cancellation/retry behavior; no qualifying findings.
+- The isolated Vercel preview built successfully. Verified that its deployed
+  ops study serves the recovery anchor and controls. Captures are synthetic.
+- Broad CI identified one stale timeout-code assertion in the existing backfill
+  test. Updated it to the implemented timeout identity and GET retryability;
+  the one-attempt and zero-summary-call assertions remain intact. All 36
+  backfill tests and the affected typecheck passed. Total focused proof:
+  143 tests. This test-only correction does not alter the reviewed implementation.
+- Parent final review complete. PR #3049 retains the reviewed production code;
+  the final commit adds only this task record and the corrected regression
+  assertion. Required CI gates the final PR head. Production is not deployed.
+Completed: 2026-09-08

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1514,7 +1514,16 @@ alias proofs, elapsed drain, and post-drain verification as rollout evidence.
   trusted auth edge that signs browser assertions for lower-level device-sync
   bridge routes.
 - Set `DEVICE_SYNC_BACKFILL_DIAGNOSTIC_ENABLED=true` when admin
-  device-sync diagnostics should be available outside localhost.
+  device-sync diagnostics should be available outside localhost. Ops runtime
+  maintenance separates the shared Junction account from the selected source's
+  live status and Murph's latest data receipt. An operator can request one
+  account-wide refresh and inspect the status read performed afterward, or use
+  Check status for a provider-list read without a refresh. These narrow probes
+  skip historical-data scans. Provider-declared errors and empty refresh results
+  do not prove recovery, even inside a successful HTTP envelope. The client
+  deadline outlives Junction's requested refresh wait; timeouts report an unknown
+  outcome and never automatically replay the POST. Diagnostics do not rewrite
+  source state or data freshness; normal reconciliation and ingestion own them.
 
 ## Browser auth contract
 

--- a/apps/web/app/(dashboard)/ops/runtime-maintenance/junction-recovery-panel.tsx
+++ b/apps/web/app/(dashboard)/ops/runtime-maintenance/junction-recovery-panel.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { RefreshCwIcon, SearchIcon } from "lucide-react";
+
+import { Alert, AlertDescription } from "@/src/components/ui/alert";
+import { Badge } from "@/src/components/ui/badge";
+import { Button } from "@/src/components/ui/button";
+import type { HostedOpsJunctionSourceStatus } from "@/src/lib/hosted-ops/device-sync-diagnostic-types";
+
+interface JunctionRecoveryPanelProps {
+  memberId: string;
+  sourceProvider: string;
+  selectedSource: HostedOpsJunctionSourceStatus | null;
+  response: Record<string, unknown> | null;
+  error: string | null;
+  pending: "refresh" | "status" | null;
+  disabled: boolean;
+  onRefresh: () => void;
+  onCheckStatus: () => void;
+}
+
+export function JunctionRecoveryPanel(props: JunctionRecoveryPanelProps) {
+  const status = props.selectedSource?.status ?? "unknown";
+  return (
+    <section aria-label="Junction recovery" aria-busy={props.pending !== null} className="mt-5 flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <h3 className="font-serif text-lg font-semibold">Selected source: {props.sourceProvider}</h3>
+        <Badge variant={status === "error" ? "destructive" : "outline"}>{status}</Badge>
+        {props.selectedSource?.errorCode ? (
+          <span className="break-all font-mono text-xs text-muted-foreground">{props.selectedSource.errorCode}</span>
+        ) : null}
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Last data received: {props.selectedSource?.lastDataAt
+          ? new Date(props.selectedSource.lastDataAt).toLocaleString("en-US", { timeZone: "UTC", timeZoneName: "short" })
+          : "No receipt recorded"}
+      </p>
+      <p className="text-sm text-muted-foreground">
+        Retry asks Junction to refresh all connected sources for this account.
+        Source status is checked afterward; a connected status alone does not confirm fresh data.
+      </p>
+      <div className="flex flex-wrap gap-2">
+        <Button disabled={props.disabled || status === "disconnected"} onClick={props.onRefresh} type="button" size="lg" variant="outline">
+          <RefreshCwIcon data-icon="inline-start" />
+          {props.pending === "refresh" ? "Retrying…" : "Retry Junction sync"}
+        </Button>
+        <Button disabled={props.disabled} onClick={props.onCheckStatus} type="button" size="lg" variant="outline">
+          <SearchIcon data-icon="inline-start" />
+          {props.pending === "status" ? "Checking…" : "Check status"}
+        </Button>
+      </div>
+      <div aria-live="polite" className="text-sm">
+        {props.pending ? <p>{props.pending === "refresh" ? "Requesting refresh and checking source status…" : "Checking source status without requesting another refresh…"}</p> : null}
+        {props.response ? (
+          <Alert variant={props.response.ok === false ? "destructive" : "default"}>
+            <AlertDescription>{describeRefreshResponse(props.response)}</AlertDescription>
+          </Alert>
+        ) : null}
+        {props.error ? <Alert variant="destructive"><AlertDescription>{props.error}</AlertDescription></Alert> : null}
+      </div>
+      <p className="break-all font-mono text-xs text-muted-foreground">Member: {props.memberId}</p>
+    </section>
+  );
+}
+
+function describeRefreshResponse(response: Record<string, unknown>): string {
+  switch (response.errorCode) {
+    case "JUNCTION_REFRESH_NO_CONNECTED_SOURCES":
+      return "Junction reported no connected sources. No sources were refreshed. Ask Junction to restore the connection or have the member reconnect.";
+    case "JUNCTION_REFRESH_NO_SOURCES":
+      return "Junction did not report any sources refreshed or in progress. Recovery is not confirmed.";
+    case "JUNCTION_API_REQUEST_TIMEOUT":
+      return "The refresh request timed out. Its outcome is unknown. Check status before requesting another refresh.";
+  }
+  if (response.ok !== true) {
+    return `Junction refresh failed (${typeof response.errorCode === "string" ? response.errorCode : "unknown error"}). Check source status before trying again.`;
+  }
+  const count = (value: unknown) => typeof value === "number" ? value : 0;
+  return `Junction reports ${count(response.refreshedSourceCount)} resources refreshed, ${count(response.inProgressSourceCount)} in progress, and ${count(response.failedSourceCount)} failed across this account. Check the selected source status above.`;
+}

--- a/apps/web/app/(dashboard)/ops/runtime-maintenance/runtime-maintenance-client.tsx
+++ b/apps/web/app/(dashboard)/ops/runtime-maintenance/runtime-maintenance-client.tsx
@@ -30,7 +30,9 @@ import type {
   HostedRuntimeRecheckResult,
   HostedRuntimeStalledRecheckOverview,
 } from "@/src/lib/hosted-ops/runtime-maintenance";
-import type { HostedOpsJunctionDiagnosticResult } from "@/src/lib/hosted-ops/device-sync-diagnostic-types";
+import type { HostedOpsJunctionDiagnosticResult, HostedOpsJunctionRecoveryResult } from "@/src/lib/hosted-ops/device-sync-diagnostic-types";
+
+import { JunctionRecoveryPanel } from "./junction-recovery-panel";
 
 import {
   hasUnresolvedRuntimeRecheckWitness,
@@ -47,6 +49,8 @@ interface RuntimeMaintenanceClientProps {
 
 type PendingAction =
   | { kind: "junction-diagnostic" }
+  | { kind: "junction-refresh" }
+  | { kind: "junction-status" }
   | { kind: "refresh" }
   | { kind: "refresh-stalled-discovery" }
   | { kind: "recheck-runtime-batch" }
@@ -75,6 +79,8 @@ export function RuntimeMaintenanceClient({
     useState<string | null>(null);
   const [junctionDiagnosticResult, setJunctionDiagnosticResult] =
     useState<HostedOpsJunctionDiagnosticResult | null>(null);
+  const [junctionRecoveryResult, setJunctionRecoveryResult] = useState<HostedOpsJunctionRecoveryResult | null>(null);
+  const [junctionRecoveryError, setJunctionRecoveryError] = useState<string | null>(null);
   const [pending, setPending] = useState<PendingAction | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [junctionDiagnosticError, setJunctionDiagnosticError] = useState<string | null>(null);
@@ -82,6 +88,7 @@ export function RuntimeMaintenanceClient({
     () => formatDateTime(overview.generatedAt),
     [overview.generatedAt],
   );
+  const pendingKind = pending?.kind;
   const pendingLabel = describeMaintenancePendingAction(pending);
   const hasUnresolvedRuntimeRecheckBatch = hasUnresolvedRuntimeRecheckWitness(
     runtimeRecheckResult,
@@ -263,6 +270,8 @@ export function RuntimeMaintenanceClient({
     setPending({ kind: "junction-diagnostic" });
     setJunctionDiagnosticError(null);
     setJunctionDiagnosticResult(null);
+    setJunctionRecoveryResult(null);
+    setJunctionRecoveryError(null);
     try {
       const result = await requestJson<HostedOpsJunctionDiagnosticResult>(
         "/api/ops/device-sync/junction-diagnostics",
@@ -285,6 +294,44 @@ export function RuntimeMaintenanceClient({
       setJunctionDiagnosticResult(result);
     } catch (diagnosticError) {
       setJunctionDiagnosticError(describeClientError(diagnosticError));
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function runJunctionRecovery(refresh: boolean): Promise<void> {
+    if (!junctionDiagnosticResult || pending) return;
+    const target = {
+      memberId: junctionDiagnosticResult.memberId,
+      connectionId: junctionDiagnosticResult.selectedConnection.id,
+      sourceProvider: junctionDiagnosticResult.sourceProvider,
+    };
+    setPending({ kind: refresh ? "junction-refresh" : "junction-status" });
+    setJunctionRecoveryError(null);
+    if (refresh) setJunctionRecoveryResult(null);
+    try {
+      if (refresh) {
+        const result = await requestJson<HostedOpsJunctionRecoveryResult>("/api/ops/device-sync/junction-recovery", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...target, action: "refresh" }),
+        });
+        setJunctionRecoveryResult(result);
+        setJunctionDiagnosticResult(previous => previous ? { ...previous, selectedSource: result.selectedSource } : null);
+      } else {
+        const result = await requestJson<HostedOpsJunctionDiagnosticResult>("/api/ops/device-sync/junction-diagnostics", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ...target, statusOnly: true }),
+        });
+        setJunctionDiagnosticResult(previous => previous ? {
+          ...previous,
+          selectedSource: result.selectedSource,
+          selectedConnection: result.selectedConnection,
+        } : null);
+      }
+    } catch (error) {
+      setJunctionRecoveryError(`${describeClientError(error)} ${refresh ? "Refresh outcome unknown. Check status before retrying." : "The latest source status could not be checked."}`);
     } finally {
       setPending(null);
     }
@@ -314,7 +361,7 @@ export function RuntimeMaintenanceClient({
       </header>
 
       <section
-        aria-busy={pending?.kind === "junction-diagnostic"}
+        aria-busy={pendingKind?.startsWith("junction-")}
         aria-labelledby="runtime-junction-diagnostic-title"
         className="rounded-xl border border-border/70 bg-card/90 p-5"
       >
@@ -343,6 +390,11 @@ export function RuntimeMaintenanceClient({
 
         <form
           className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] xl:grid-cols-4"
+          onInput={() => {
+            setJunctionDiagnosticResult(null);
+            setJunctionRecoveryResult(null);
+            setJunctionRecoveryError(null);
+          }}
           onSubmit={(event) => {
             event.preventDefault();
             void runJunctionDiagnostic(new FormData(event.currentTarget));
@@ -350,6 +402,7 @@ export function RuntimeMaintenanceClient({
         >
           <Field label="Member id" htmlFor="junction-diagnostic-member-id">
             <Input
+              disabled={pending !== null}
               autoComplete="off"
               id="junction-diagnostic-member-id"
               name="memberId"
@@ -360,6 +413,7 @@ export function RuntimeMaintenanceClient({
           </Field>
           <Field label="Source provider" htmlFor="junction-diagnostic-source-provider">
             <Input
+              disabled={pending !== null}
               autoComplete="off"
               id="junction-diagnostic-source-provider"
               name="sourceProvider"
@@ -370,6 +424,7 @@ export function RuntimeMaintenanceClient({
           </Field>
           <Field label="Connection id" htmlFor="junction-diagnostic-connection-id" optional>
             <Input
+              disabled={pending !== null}
               autoComplete="off"
               id="junction-diagnostic-connection-id"
               name="connectionId"
@@ -379,6 +434,7 @@ export function RuntimeMaintenanceClient({
           </Field>
           <Field label="Lookback days" htmlFor="junction-diagnostic-lookback-days">
             <Input
+              disabled={pending !== null}
               autoComplete="off"
               id="junction-diagnostic-lookback-days"
               inputMode="numeric"
@@ -392,6 +448,7 @@ export function RuntimeMaintenanceClient({
           </Field>
           <Field label="Timeseries probe days" htmlFor="junction-diagnostic-timeseries-days">
             <Input
+              disabled={pending !== null}
               autoComplete="off"
               id="junction-diagnostic-timeseries-days"
               inputMode="numeric"
@@ -405,6 +462,7 @@ export function RuntimeMaintenanceClient({
           </Field>
           <Field label="Window start" htmlFor="junction-diagnostic-window-start" optional>
             <Input
+              disabled={pending !== null}
               autoComplete="off"
               id="junction-diagnostic-window-start"
               name="windowStart"
@@ -414,6 +472,7 @@ export function RuntimeMaintenanceClient({
           </Field>
           <Field label="Window end" htmlFor="junction-diagnostic-window-end" optional>
             <Input
+              disabled={pending !== null}
               autoComplete="off"
               id="junction-diagnostic-window-end"
               name="windowEnd"
@@ -423,14 +482,14 @@ export function RuntimeMaintenanceClient({
           </Field>
           <div className="flex flex-col gap-3 lg:col-span-2 xl:col-span-4 sm:flex-row sm:items-center sm:justify-between">
             <div aria-live="polite" className="min-h-5 text-sm text-muted-foreground">
-              {pending?.kind === "junction-diagnostic" ? "Running Junction diagnostic." : ""}
+              {pendingKind === "junction-diagnostic" ? "Running Junction diagnostic." : ""}
             </div>
             <Button
               disabled={pending !== null}
               type="submit"
             >
               <ActivityIcon data-icon="inline-start" />
-              {pending?.kind === "junction-diagnostic" ? "Running..." : "Run diagnostic"}
+              {pendingKind === "junction-diagnostic" ? "Running..." : "Run diagnostic"}
             </Button>
           </div>
         </form>
@@ -443,7 +502,20 @@ export function RuntimeMaintenanceClient({
         ) : null}
 
         {junctionDiagnosticResult ? (
-          <JunctionDiagnosticResultPanel result={junctionDiagnosticResult} />
+          <>
+            <JunctionRecoveryPanel
+              disabled={pending !== null}
+              error={junctionRecoveryError}
+              memberId={junctionDiagnosticResult.memberId}
+              onCheckStatus={() => void runJunctionRecovery(false)}
+              onRefresh={() => void runJunctionRecovery(true)}
+              pending={pendingKind === "junction-refresh" ? "refresh" : pendingKind === "junction-status" ? "status" : null}
+              response={junctionRecoveryResult?.response ?? null}
+              selectedSource={junctionDiagnosticResult.selectedSource}
+              sourceProvider={junctionDiagnosticResult.sourceProvider}
+            />
+            <JunctionDiagnosticResultPanel result={junctionDiagnosticResult} />
+          </>
         ) : null}
       </section>
 
@@ -499,7 +571,7 @@ export function RuntimeMaintenanceClient({
               variant="outline"
             >
               <RefreshCwIcon data-icon="inline-start" />
-              {pending?.kind === "refresh" ? "Refreshing..." : "Refresh"}
+              {pendingKind === "refresh" ? "Refreshing..." : "Refresh"}
             </Button>
             <Button
               disabled={pending !== null}
@@ -648,7 +720,7 @@ function JunctionDiagnosticResultPanel({
   return (
     <div className="mt-5 flex flex-col gap-4 rounded-lg border border-border/70 bg-muted/20 p-4">
       <div className="grid gap-3 md:grid-cols-4">
-        <MetricTile label="Connection" value={result.selectedConnection.status} />
+        <MetricTile label="Junction account" value={result.selectedConnection.status} />
         <MetricTile
           label="Sources"
           value={formatInteger(result.webSourceProjection.sourceCount)}
@@ -1007,6 +1079,8 @@ function describeMaintenancePendingAction(pending: PendingAction | null): string
   if (pending.kind === "wake-batch") {
     return `Waking ${formatInteger(pending.limit)} workspace${pending.limit === 1 ? "" : "s"}.`;
   }
+  if (pending.kind === "junction-refresh") return "Requesting Junction refresh.";
+  if (pending.kind === "junction-status") return "Checking Junction source status.";
   if (pending.kind === "junction-diagnostic") {
     return "";
   }

--- a/apps/web/app/api/ops/device-sync/junction-diagnostics/route.ts
+++ b/apps/web/app/api/ops/device-sync/junction-diagnostics/route.ts
@@ -23,6 +23,7 @@ export const POST = withJsonError(async (request: Request) => {
   });
 
   return jsonOk(await runHostedOpsJunctionDiagnostic({
+    statusOnly: body.statusOnly === true,
     connectionId: readOptionalStringField(body, "connectionId"),
     lookbackDays: readOptionalNumberOrStringField(body, "lookbackDays"),
     memberId: readOptionalStringField(body, "memberId"),

--- a/apps/web/app/design/runtime-maintenance-study.tsx
+++ b/apps/web/app/design/runtime-maintenance-study.tsx
@@ -2,6 +2,8 @@
 
 import type { ComponentProps } from "react";
 
+import { JunctionRecoveryPanel } from "../(dashboard)/ops/runtime-maintenance/junction-recovery-panel";
+
 import { RuntimeRecheckPanel } from "../(dashboard)/ops/runtime-maintenance/runtime-recheck-panel";
 
 type RuntimeRecheckPanelProps = ComponentProps<
@@ -88,6 +90,36 @@ export function RuntimeMaintenanceStudy() {
         userIdsText={"hbm_demo_bravo\nhbm_demo_charlie\nhbm_demo_manual"}
         verificationError={null}
         verificationResult={DESIGN_STALLED_RECHECK_VERIFICATION}
+      />
+    </div>
+  );
+}
+
+
+export function JunctionRecoveryStudy() {
+  return (
+    <div className="flex flex-col gap-8" data-design-section="junction-recovery" inert>
+      <JunctionRecoveryPanel
+        disabled={false}
+        error={null}
+        memberId="member_demo"
+        onCheckStatus={() => undefined}
+        onRefresh={() => undefined}
+        pending={null}
+        response={{ ok: false, errorCode: "JUNCTION_REFRESH_NO_CONNECTED_SOURCES" }}
+        selectedSource={{ status: "error", errorCode: "token_refresh_failed", lastDataAt: "2026-01-01T12:00:00Z" }}
+        sourceProvider="oura"
+      />
+      <JunctionRecoveryPanel
+        disabled={true}
+        error={null}
+        memberId="member_demo"
+        onCheckStatus={() => undefined}
+        onRefresh={() => undefined}
+        pending="refresh"
+        response={null}
+        selectedSource={{ status: "unknown", errorCode: null, lastDataAt: null }}
+        sourceProvider="oura"
       />
     </div>
   );

--- a/apps/web/app/design/sections-content.tsx
+++ b/apps/web/app/design/sections-content.tsx
@@ -64,7 +64,7 @@ import { HomepageAuthWarmRuntimeStudy } from "./homepage-auth-warm-runtime-study
 import { JoinFamilyBillingRecoveryStudy } from "./join-family-billing-recovery-study";
 import { OpsUsageStudy } from "./ops-usage-study";
 import { OpsOperatorTaskStudy } from "./ops-operator-task-study";
-import { RuntimeMaintenanceStudy } from "./runtime-maintenance-study";
+import { JunctionRecoveryStudy, RuntimeMaintenanceStudy } from "./runtime-maintenance-study";
 import {
   PersonaOnboardingStudy,
   PersonaSettingsStudy,
@@ -809,6 +809,10 @@ export function SectionsContent({
       {category === "ops" ? (
         <>
           <Separator />
+
+          <StudySection id="junction-recovery" title="Junction source recovery">
+            <JunctionRecoveryStudy />
+          </StudySection>
 
           <StudySection
             id="stalled-runtime-rechecks"

--- a/apps/web/src/lib/device-sync/backfill-diagnostic.ts
+++ b/apps/web/src/lib/device-sync/backfill-diagnostic.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { deviceSyncError } from "@murphai/device-syncd/errors";
+import { isDeviceSyncSourceDisconnectFenced } from "@murphai/device-syncd/public-account";
 import type {
   DeviceSyncAccount,
   DeviceSyncProvider,
@@ -14,6 +15,7 @@ import {
 } from "./control-plane";
 import {
   toHostedBrowserDeviceSyncConnectionSource,
+  type HostedBrowserDeviceSyncConnectionSource,
 } from "./browser-connection-source";
 import {
   toHostedBrowserDeviceSyncConnection,
@@ -41,6 +43,7 @@ export interface HostedDeviceSyncBackfillDiagnosticInput {
 }
 
 export interface HostedDeviceSyncBackfillDiagnosticResponse {
+  selectedSourceLastDataAt: string | null;
   diagnostic: Record<string, unknown>;
   generatedAt: string;
   ok: true;
@@ -60,6 +63,7 @@ export interface HostedDeviceSyncBackfillDiagnosticResponse {
     result: Record<string, unknown>;
   };
   selectedConnection: {
+    id: string;
     connectionMatchCount: number;
     externalAccountIdHash: string;
     lastErrorCode: string | null;
@@ -103,38 +107,7 @@ export async function runHostedDeviceSyncBackfillDiagnostic(
     entry.browserConnection.provider === providerName
     && (!connectionId || entry.browserConnection.id === connectionId)
   );
-  const activeCandidates = candidates.filter((entry) =>
-    entry.browserConnection.status === "active"
-  );
-
-  if (candidates.length === 0) {
-    throw deviceSyncError({
-      code: "DEVICE_SYNC_DIAGNOSTIC_CONNECTION_NOT_FOUND",
-      message: "No matching device-sync connection was found for the requested member.",
-      httpStatus: 404,
-      retryable: false,
-    });
-  }
-
-  if (activeCandidates.length === 0) {
-    throw deviceSyncError({
-      code: "DEVICE_SYNC_DIAGNOSTIC_CONNECTION_NOT_ACTIVE",
-      message: "Backfill diagnostics require an active device-sync connection.",
-      httpStatus: 409,
-      retryable: false,
-    });
-  }
-
-  if (!connectionId && activeCandidates.length > 1) {
-    throw deviceSyncError({
-      code: "DEVICE_SYNC_DIAGNOSTIC_CONNECTION_AMBIGUOUS",
-      message: "Backfill diagnostics require a connection id when multiple active connections match.",
-      httpStatus: 409,
-      retryable: false,
-    });
-  }
-
-  const selectedEntry = activeCandidates[0];
+  const selectedEntry = selectActiveDiagnosticConnection(candidates, connectionId);
   const connection = selectedEntry.browserConnection;
   const selectedSources = await input.controlPlane.store.listConnectionSources(
     selectedEntry.durableConnection.id,
@@ -143,17 +116,11 @@ export async function runHostedDeviceSyncBackfillDiagnostic(
     toHostedBrowserDeviceSyncConnectionSource(source, connection.id)
   );
   const restProbeSourceProviderSlug = normalizeQueryString(input.restProbe?.sourceProviderSlug ?? null);
-  if (
-    restProbeSourceProviderSlug
-    && !connectionSources.some((source) => source.sourceProviderSlug === restProbeSourceProviderSlug)
-  ) {
-    throw deviceSyncError({
-      code: "DEVICE_SYNC_DIAGNOSTIC_SOURCE_PROVIDER_NOT_FOUND",
-      message: "The selected device-sync connection does not expose the requested source provider for diagnostics.",
-      httpStatus: 409,
-      retryable: false,
-    });
-  }
+  const selectedSource = selectDiagnosticSource(
+    connectionSources,
+    restProbeSourceProviderSlug,
+    input.restProbe?.endpoint,
+  );
 
   const provider = createHostedDeviceSyncRegistry(process.env).get(connection.provider);
   if (!provider) {
@@ -210,13 +177,17 @@ export async function runHostedDeviceSyncBackfillDiagnostic(
   }
 
   const now = new Date().toISOString();
-  const diagnostic = await diagnoseBackfill({
-    account: diagnosticAccount,
-    now,
-    timeseriesProbeDays: input.timeseriesProbeDays,
-    windowStart: input.windowStart,
-    windowEnd: input.windowEnd,
-  });
+  const probeOnly = input.restProbe
+    && ["refresh", "providers", "trigger_historical_pull"].includes(input.restProbe.endpoint);
+  const diagnostic = probeOnly
+    ? { generatedAt: now, provider: providerName, result: {} }
+    : await diagnoseBackfill({
+        account: diagnosticAccount,
+        now,
+        timeseriesProbeDays: input.timeseriesProbeDays,
+        windowStart: input.windowStart,
+        windowEnd: input.windowEnd,
+      });
   const restDiagnostic = input.restProbe && probeRest
     ? await probeRest({
         account: diagnosticAccount,
@@ -231,11 +202,13 @@ export async function runHostedDeviceSyncBackfillDiagnostic(
     : null;
 
   return {
+    selectedSourceLastDataAt: selectedSource?.lastDataAt ?? null,
     generatedAt: diagnostic.generatedAt,
     ok: true,
     provider: diagnostic.provider,
     publicIngress: describeDiagnosticPublicIngress(input.controlPlane, provider),
     selectedConnection: {
+      id: connection.id,
       connectionMatchCount: candidates.length,
       externalAccountIdHash: sha256Hex(diagnosticAccount.externalAccountId),
       lastErrorCode: connection.lastErrorCode ?? null,
@@ -341,6 +314,77 @@ export function readRestProbe(searchParams: URLSearchParams): HostedDeviceSyncBa
   };
 }
 
+interface DiagnosticConnectionEntry {
+  browserConnection: HostedBrowserDeviceSyncConnection;
+  durableConnection: PublicDeviceSyncAccount;
+}
+
+function selectActiveDiagnosticConnection(
+  candidates: DiagnosticConnectionEntry[],
+  connectionId: string | null,
+): DiagnosticConnectionEntry {
+  const activeCandidates = candidates.filter((entry) =>
+    entry.browserConnection.status === "active"
+  );
+
+  if (candidates.length === 0) {
+    throw deviceSyncError({
+      code: "DEVICE_SYNC_DIAGNOSTIC_CONNECTION_NOT_FOUND",
+      message: "No matching device-sync connection was found for the requested member.",
+      httpStatus: 404,
+      retryable: false,
+    });
+  }
+
+  if (activeCandidates.length === 0) {
+    throw deviceSyncError({
+      code: "DEVICE_SYNC_DIAGNOSTIC_CONNECTION_NOT_ACTIVE",
+      message: "Backfill diagnostics require an active device-sync connection.",
+      httpStatus: 409,
+      retryable: false,
+    });
+  }
+
+  if (!connectionId && activeCandidates.length > 1) {
+    throw deviceSyncError({
+      code: "DEVICE_SYNC_DIAGNOSTIC_CONNECTION_AMBIGUOUS",
+      message: "Backfill diagnostics require a connection id when multiple active connections match.",
+      httpStatus: 409,
+      retryable: false,
+    });
+  }
+
+  return activeCandidates[0];
+}
+
+function selectDiagnosticSource(
+  sources: HostedBrowserDeviceSyncConnectionSource[],
+  sourceProviderSlug: string | null,
+  endpoint: DeviceSyncRestDiagnosticEndpoint | undefined,
+): HostedBrowserDeviceSyncConnectionSource | undefined {
+  const matchingSources = sources.filter((candidate) => candidate.sourceProviderSlug === sourceProviderSlug);
+  const source = matchingSources[0];
+  if (sourceProviderSlug && !source) {
+    throw deviceSyncError({
+      code: "DEVICE_SYNC_DIAGNOSTIC_SOURCE_PROVIDER_NOT_FOUND",
+      message: "The selected device-sync connection does not expose the requested source provider for diagnostics.",
+      httpStatus: 409,
+      retryable: false,
+    });
+  }
+  if (endpoint === "refresh" && matchingSources.some((candidate) =>
+    candidate.status === "disconnected" || isDeviceSyncSourceDisconnectFenced(candidate)
+  )) {
+    throw deviceSyncError({
+      code: "DEVICE_SYNC_DIAGNOSTIC_SOURCE_DISCONNECTED",
+      message: "Reconnect the selected source before requesting a refresh.",
+      httpStatus: 409,
+      retryable: false,
+    });
+  }
+  return source;
+}
+
 function normalizeRestProbeEndpoint(value: string): DeviceSyncRestDiagnosticEndpoint {
   const normalized = value.trim().toLowerCase();
   if (normalized === "1" || normalized === "true" || normalized === "yes") {
@@ -440,10 +484,7 @@ function describeDiagnosticWebSourceProjection(
 async function listDiagnosticConnectionEntries(input: {
   controlPlane: HostedDeviceSyncControlPlane;
   memberId: string;
-}): Promise<Array<{
-  browserConnection: HostedBrowserDeviceSyncConnection;
-  durableConnection: PublicDeviceSyncAccount;
-}>> {
+}): Promise<DiagnosticConnectionEntry[]> {
   const durableConnections = await input.controlPlane.store.listConnectionsForUser(input.memberId);
 
   return durableConnections.map((durableConnection) => ({

--- a/apps/web/src/lib/hosted-ops/device-sync-diagnostic-types.ts
+++ b/apps/web/src/lib/hosted-ops/device-sync-diagnostic-types.ts
@@ -1,4 +1,5 @@
 export interface HostedOpsJunctionDiagnosticInput {
+  statusOnly?: boolean;
   connectionId?: string | null;
   lookbackDays?: number | string | null;
   memberId?: string | null;
@@ -32,11 +33,20 @@ export interface HostedOpsJunctionRecoveryResult {
   response: Record<string, unknown> | null;
   generatedAt: string;
   memberId: string;
-  ok: true;
+  ok: boolean;
+  selectedSource: HostedOpsJunctionSourceStatus | null;
   sourceProvider: string;
 }
 
+export interface HostedOpsJunctionSourceStatus {
+  status: string;
+  errorCode: string | null;
+  /** Latest data receipt in Murph, independent of provider connection status. */
+  lastDataAt: string | null;
+}
+
 export interface HostedOpsJunctionDiagnosticResult {
+  selectedSource: HostedOpsJunctionSourceStatus | null;
   backfill: {
     hasUsefulHistoricalRecords: boolean | null;
     scope: "all_sources";
@@ -59,6 +69,7 @@ export interface HostedOpsJunctionDiagnosticResult {
   memberId: string;
   ok: true;
   selectedConnection: {
+    id: string;
     connectionMatchCount: number;
     lastErrorCode: string | null;
     lastSyncCompletedAt: string | null;

--- a/apps/web/src/lib/hosted-ops/device-sync-diagnostics.ts
+++ b/apps/web/src/lib/hosted-ops/device-sync-diagnostics.ts
@@ -41,7 +41,7 @@ export async function runHostedOpsJunctionDiagnostic(
     memberId,
     providerName: "junction",
     restProbe: {
-      endpoint: "matrix",
+      endpoint: input.statusOnly ? "providers" : "matrix",
       resource: null,
       sourceProviderSlug: sourceProvider,
       timeoutSeconds: null,
@@ -93,12 +93,15 @@ export async function runHostedOpsJunctionRecovery(
     windowStart: null,
   });
 
+  const result = readRecord(diagnostic.restProbe?.result);
+  const response = readRecord(result?.response);
   return {
     action,
     generatedAt: diagnostic.generatedAt,
     memberId,
-    ok: true,
-    response: readRecord(readRecord(diagnostic.restProbe?.result)?.response) ?? null,
+    ok: response?.ok === true,
+    response,
+    selectedSource: readSelectedSource(result?.selectedSource, diagnostic.selectedSourceLastDataAt),
     sourceProvider,
   };
 }
@@ -135,6 +138,7 @@ function summarizeHostedOpsJunctionDiagnostic(input: {
   }));
 
   return {
+    selectedSource: readSelectedSource(input.fullDiagnostic.restProbe?.result.selectedSource, input.fullDiagnostic.selectedSourceLastDataAt),
     backfill: {
       hasUsefulHistoricalRecords: readBoolean(summary?.hasUsefulHistoricalRecords),
       scope: "all_sources",
@@ -149,6 +153,7 @@ function summarizeHostedOpsJunctionDiagnostic(input: {
     memberId: input.memberId,
     ok: true,
     selectedConnection: {
+      id: input.fullDiagnostic.selectedConnection.id,
       connectionMatchCount: input.fullDiagnostic.selectedConnection.connectionMatchCount,
       lastErrorCode: input.fullDiagnostic.selectedConnection.lastErrorCode,
       lastSyncCompletedAt: input.fullDiagnostic.selectedConnection.lastSyncCompletedAt,
@@ -168,6 +173,12 @@ function summarizeHostedOpsJunctionDiagnostic(input: {
     },
     window: input.window,
   };
+}
+
+function readSelectedSource(value: unknown, lastDataAt: string | null): HostedOpsJunctionDiagnosticResult["selectedSource"] {
+  const source = readRecord(value);
+  const status = readString(source?.status);
+  return status ? { status, errorCode: readString(source?.errorCode), lastDataAt } : null;
 }
 
 function summarizeMatrix(value: unknown): HostedOpsJunctionDiagnosticResult["matrix"] {

--- a/apps/web/test/hosted-ops-device-sync-diagnostics.test.ts
+++ b/apps/web/test/hosted-ops-device-sync-diagnostics.test.ts
@@ -1142,7 +1142,7 @@ describe("hosted ops Junction diagnostics", () => {
 
     expect(failed.status).toBe(200);
     await expect(failed.json()).resolves.toMatchObject({
-      ok: true,
+      ok: false,
       response: {
         errorCode: "JUNCTION_TRIGGER_HISTORICAL_PULL_FAILED",
         ok: false,
@@ -1150,4 +1150,62 @@ describe("hosted ops Junction diagnostics", () => {
       },
     });
   });
+
+  it("checks live selected-source status without backfill or refresh work", async () => {
+    mocks.probeRest.mockResolvedValue({
+      generatedAt: "2026-01-03T00:00:00Z", provider: "junction",
+      result: { selectedSource: { status: "error", errorCode: "token_refresh_failed" } },
+    });
+    const response = await hostedOpsJunctionDiagnosticsRoute.POST(createJsonPostRequest(
+      "https://join.example.test/api/ops/device-sync/junction-diagnostics",
+      { memberId: "member_target", sourceProvider: SELECTED_SOURCE_PROVIDER, statusOnly: true },
+      { headers: { origin: "https://join.example.test" } },
+    ));
+    expect(response.status).toBe(200);
+    expect(mocks.diagnoseBackfill).not.toHaveBeenCalled();
+    expect(mocks.probeRest).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ endpoint: "providers" }));
+    await expect(response.json()).resolves.toMatchObject({
+      selectedConnection: { id: JUNCTION_PUBLIC_CONNECTION_ID, status: "active" },
+      selectedSource: { status: "error", errorCode: "token_refresh_failed" },
+    });
+  });
+
+  it("preserves a failed refresh and the independent status check without historical reads", async () => {
+    mocks.probeRest.mockResolvedValue({
+      generatedAt: "2026-01-03T00:00:00Z", provider: "junction",
+      result: {
+        response: { ok: false, errorCode: "JUNCTION_REFRESH_NO_CONNECTED_SOURCES" },
+        selectedSource: { status: "error", errorCode: "token_refresh_failed" },
+      },
+    });
+    const response = await hostedOpsJunctionRecoveryRoute.POST(createJsonPostRequest(
+      "https://join.example.test/api/ops/device-sync/junction-recovery",
+      { action: "refresh", memberId: "member_target", sourceProvider: SELECTED_SOURCE_PROVIDER },
+      { headers: { origin: "https://join.example.test" } },
+    ));
+    expect(response.status).toBe(200);
+    expect(mocks.diagnoseBackfill).not.toHaveBeenCalled();
+    expect(mocks.probeRest).toHaveBeenCalledTimes(1);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      response: { ok: false, errorCode: "JUNCTION_REFRESH_NO_CONNECTED_SOURCES" },
+      selectedSource: { status: "error", errorCode: "token_refresh_failed" },
+    });
+  });
+
+  it.each([
+    { status: "disconnected", lastErrorCode: null },
+    { status: "connected", lastErrorCode: "SOURCE_DISCONNECT_IN_PROGRESS" },
+  ])("refuses refresh for a source fenced by disconnect: %j", async (source) => {
+    const current = await mocks.listConnectionSources();
+    mocks.listConnectionSources.mockResolvedValue(current.map((entry: Record<string, unknown>) => ({ ...entry, ...source })));
+    const response = await hostedOpsJunctionRecoveryRoute.POST(createJsonPostRequest(
+      "https://join.example.test/api/ops/device-sync/junction-recovery",
+      { action: "refresh", memberId: "member_target", sourceProvider: SELECTED_SOURCE_PROVIDER },
+      { headers: { origin: "https://join.example.test" } },
+    ));
+    expect(response.status).toBe(409);
+    expect(mocks.probeRest).not.toHaveBeenCalled();
+  });
+
 });

--- a/apps/web/test/runtime-maintenance-client.test.tsx
+++ b/apps/web/test/runtime-maintenance-client.test.tsx
@@ -280,3 +280,90 @@ function recoveryWitness(userId: string) {
     workspaceVersion: "24",
   };
 }
+
+test("Junction recovery pins the inspected target and checks status without replaying refresh", async () => {
+  const diagnostic = {
+    generatedAt: "2026-01-03T00:00:00Z", memberId: "member_test", sourceProvider: "oura", ok: true,
+    selectedSource: { status: "error", errorCode: "token_refresh_failed", lastDataAt: null },
+    selectedConnection: {
+      id: "dspc_test", status: "active", provider: "junction", connectionMatchCount: 1,
+      lastSyncStartedAt: null, lastSyncCompletedAt: null, nextReconcileAt: null,
+    },
+    matrix: null,
+    backfill: { hasUsefulHistoricalRecords: null },
+    webSourceProjection: { sourceCount: 1, totalResourceCount: 1 },
+    window: { windowStart: "2026-01-01T00:00:00Z", windowEnd: "2026-01-03T00:00:00Z" },
+  };
+  let releaseRefresh: (() => void) | undefined;
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const body = readRequestBody(init);
+    if (String(input).endsWith("junction-recovery")) {
+      await new Promise<void>((resolve) => { releaseRefresh = resolve; });
+      return jsonResponse({
+        action: "refresh", ok: false, memberId: "member_test", sourceProvider: "oura",
+        response: { ok: false, errorCode: "JUNCTION_REFRESH_NO_CONNECTED_SOURCES" },
+        selectedSource: diagnostic.selectedSource,
+      });
+    }
+    if (body.statusOnly) return jsonResponse({
+      ...diagnostic,
+      selectedSource: { status: "connected", errorCode: null, lastDataAt: "2026-01-03T01:00:00Z" },
+    });
+    return jsonResponse(diagnostic);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  vi.stubGlobal("FormData", class {
+    private values: Map<string, string>;
+    constructor(form: HTMLFormElement) {
+      this.values = new Map(Array.from(form.querySelectorAll<HTMLInputElement>("input"), (input) => [input.name, input.value]));
+    }
+    get(key: string) { return this.values.get(key) ?? null; }
+  });
+  const rendered = await renderClientComponent(createElement(RuntimeMaintenanceClient, {
+    initialOverview: { candidates: [], generatedAt: "2026-01-03T00:00:00Z", limit: 20, nextCursor: null, totalCandidateCount: 0 },
+    initialStalledRecheckOverview: { candidates: [], generatedAt: "2026-01-03T00:00:00Z", limit: 100, scanTruncated: false, totalCandidateCount: 0 },
+  }), { requireButton: false });
+  const button = (label: string) => {
+    const result = Array.from(rendered.container.querySelectorAll("button")).find(element => element.textContent?.includes(label));
+    assert.ok(result, `Missing button: ${label}`);
+    return result;
+  };
+  try {
+    const member = rendered.container.querySelector<HTMLInputElement>('[name="memberId"]')!;
+    const source = rendered.container.querySelector<HTMLInputElement>('[name="sourceProvider"]')!;
+    member.value = "member_test";
+    source.value = "oura";
+    await act(async () => {
+      rendered.container.querySelector("form")!.dispatchEvent(new rendered.window.Event("submit", { bubbles: true, cancelable: true }));
+      await settleAsyncWork();
+    });
+    expect(rendered.container.textContent).toContain("token_refresh_failed");
+    await act(async () => {
+      button("Retry Junction sync").click();
+      await settleAsyncWork();
+    });
+    expect(button("Retrying").disabled).toBe(true);
+    expect(button("Check status").disabled).toBe(true);
+    expect(member.disabled).toBe(true);
+    expect(readRequestBody(fetchMock.mock.calls[1]?.[1])).toEqual({
+      action: "refresh", memberId: "member_test", connectionId: "dspc_test", sourceProvider: "oura",
+    });
+    await act(async () => { releaseRefresh?.(); await settleAsyncWork(); });
+    expect(rendered.container.textContent).toContain("No sources were refreshed");
+    await act(async () => { button("Check status").click(); await settleAsyncWork(); });
+    expect(readRequestBody(fetchMock.mock.calls[2]?.[1])).toEqual({
+      statusOnly: true, memberId: "member_test", connectionId: "dspc_test", sourceProvider: "oura",
+    });
+    expect(rendered.container.textContent).not.toContain("token_refresh_failed");
+    expect(rendered.container.textContent).toContain("connected");
+    expect(fetchMock.mock.calls.filter(([input]) => String(input).endsWith("junction-recovery"))).toHaveLength(1);
+    await act(async () => {
+      member.value = "member_other";
+      member.dispatchEvent(new rendered.window.Event("input", { bubbles: true }));
+      await settleAsyncWork();
+    });
+    expect(rendered.container.querySelector('[aria-label="Junction recovery"]')).toBeNull();
+  } finally {
+    await rendered.cleanup();
+  }
+});

--- a/packages/device-syncd/src/providers/junction-client.ts
+++ b/packages/device-syncd/src/providers/junction-client.ts
@@ -750,6 +750,8 @@ export class JunctionClient {
         endpointKind: "junction_user_refresh",
         queryParameterNames: timeout === null ? [] : ["timeout"],
         signal: input.signal ?? null,
+        // The client must outlive Junction's server-side refresh wait.
+        timeoutMs: Math.max(this.requestTimeoutMs, ((timeout ?? 10) + 5) * 1_000),
       },
       (clientOptions, requestOptions) => {
         const request: RefreshUserRequest = { userId: input.userId };
@@ -1065,10 +1067,17 @@ export class JunctionClient {
           throw normalizeProviderAbortError(providerError, options.signal);
         }
         if (
-          requestAbort.signal.aborted
-          && isProviderTimeoutError(providerError, requestAbort.signal)
+          isJunctionSdkTimeoutError(error)
+          || isProviderTimeoutError(providerError, requestAbort.signal)
         ) {
-          break;
+          throw deviceSyncError({
+            code: "JUNCTION_API_REQUEST_TIMEOUT",
+            message: `Junction API request timed out for ${options.endpointKind}.`,
+            retryable: method === "GET",
+            httpStatus: 504,
+            details: requestDiagnostics,
+            cause: providerError,
+          });
         }
 
         if (observedOptionalNotFound) {
@@ -1136,11 +1145,7 @@ export class JunctionClient {
           if (!providerError.retryable || attempt >= attempts) {
             throw providerError;
           }
-        } else if (
-          attempt >= attempts
-          || isJunctionSdkTimeoutError(error)
-          || isProviderTimeoutError(providerError, requestAbort.signal)
-        ) {
+        } else if (attempt >= attempts) {
           break;
         }
 

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -2275,6 +2275,11 @@ export function createJunctionDeviceSyncProvider(
           userId: context.account.externalAccountId,
         })
       );
+      const providers = context.sourceProviderSlug
+        ? await runJunctionDiagnosticCall(() =>
+            client.listUserProviders(context.account.externalAccountId)
+          )
+        : null;
 
       return {
         generatedAt: context.now,
@@ -2288,6 +2293,7 @@ export function createJunctionDeviceSyncProvider(
             timeoutSeconds,
           },
           response: describeJunctionRefreshUserData(payloadResult),
+          selectedSource: describeJunctionSelectedSource(providers, context.sourceProviderSlug),
         },
       };
     }
@@ -2393,6 +2399,7 @@ export function createJunctionDeviceSyncProvider(
         generatedAt: context.now,
         provider: "junction",
         result: {
+          selectedSource: describeJunctionSelectedSource(providerSnapshot, context.sourceProviderSlug),
           request: {
             endpoint: "providers",
             endpointKind: "junction_user_providers",
@@ -7308,6 +7315,7 @@ async function runJunctionRestDiagnosticMatrix(input: {
           shape: describeJunctionDiagnosticShape(providers.records ?? []),
         },
       },
+      selectedSource: describeJunctionSelectedSource(providers, sourceProviderSlug),
       devices: {
         request: {
           endpoint: "devices",
@@ -7600,11 +7608,17 @@ function describeJunctionRefreshUserData(
   const success = typeof data.success === "boolean"
     ? data.success
     : typeof root.success === "boolean" ? root.success : null;
+  const errorCode = classifyJunctionRefreshError(
+    data.error ?? root.error,
+    success,
+    refreshedSources.length + inProgressSources.length + failedSources.length,
+  );
 
   return {
-    ok: true,
+    ok: errorCode === null,
+    errorCode,
     responseStatus: result.responseStatus ?? 200,
-    success,
+    success: errorCode ? false : success,
     refreshedSourceCount: refreshedSources.length,
     inProgressSourceCount: inProgressSources.length,
     failedSourceCount: failedSources.length,
@@ -7613,6 +7627,16 @@ function describeJunctionRefreshUserData(
     failedSources: redactJunctionRefreshSourceNames(failedSources, sourceKeyMap),
     shape: describeJunctionDiagnosticShape([data]),
   };
+}
+
+function classifyJunctionRefreshError(error: unknown, success: boolean | null, sourceCount: number): string | null {
+  if (normalizeString(error)?.toLowerCase().includes("no connected sources")) {
+    return "JUNCTION_REFRESH_NO_CONNECTED_SOURCES";
+  }
+  if ((error !== undefined && error !== null && error !== false && error !== "") || success === false) {
+    return "JUNCTION_REFRESH_FAILED";
+  }
+  return sourceCount === 0 ? "JUNCTION_REFRESH_NO_SOURCES" : null;
 }
 
 function describeJunctionDiagnosticPayloadFailure(
@@ -7822,6 +7846,25 @@ function isSafeJunctionDiagnosticShapeKey(key: string): boolean {
     && !normalized.includes("secret")
     && !normalized.includes("authorization")
     && !normalized.includes("raw");
+}
+
+function describeJunctionSelectedSource(
+  result: JunctionDiagnosticCallResult | null,
+  sourceProviderSlug: string | null | undefined,
+): Record<string, unknown> | null {
+  const slug = canonicalizeJunctionProviderSlug(sourceProviderSlug);
+  if (!slug || !result) {
+    return null;
+  }
+  const sources = (result.records ?? []).filter(isJunctionProviderConnectionRecord)
+    .filter((source) => canonicalizeJunctionProviderSlug(source.slug) === slug);
+  const source = sources.length === 1 ? sources[0] : null;
+  return {
+    status: source ? mapJunctionSourceStatus(source.status) : "unknown",
+    errorCode: result.ok
+      ? readJunctionDiagnosticToken(source?.errorDetails?.errorType)
+      : result.errorCode ?? "JUNCTION_PROVIDER_LIST_FAILED",
+  };
 }
 
 function describeJunctionDiagnosticSourceProviders(

--- a/packages/device-syncd/test/junction-provider-backfill.test.ts
+++ b/packages/device-syncd/test/junction-provider-backfill.test.ts
@@ -1509,7 +1509,7 @@ test("Junction yieldable reconcile times out provider inventory once before the 
     );
 
     await vi.advanceTimersByTimeAsync(8_000);
-    await assert.rejects(execution, { code: "JUNCTION_API_REQUEST_FAILED" });
+    await assert.rejects(execution, { code: "JUNCTION_API_REQUEST_TIMEOUT", retryable: true });
     assert.equal(inventoryAttempts, 1);
     assert.equal(summaryAttempts, 0);
   } finally {

--- a/packages/device-syncd/test/junction-provider-client.test.ts
+++ b/packages/device-syncd/test/junction-provider-client.test.ts
@@ -316,7 +316,7 @@ test("Junction client treats request timeouts as terminal aborts", async () => {
     () => client.listUserProviders("junction-user-1"),
     (error) => {
       assert.ok(error instanceof DeviceSyncError);
-      assert.equal(error.code, "JUNCTION_API_REQUEST_FAILED");
+      assert.equal(error.code, "JUNCTION_API_REQUEST_TIMEOUT");
       assert.equal(error.cause instanceof DOMException, true);
       assert.equal((error.cause as DOMException).name, "TimeoutError");
       return true;
@@ -350,7 +350,7 @@ test("Junction client wraps generic abort errors caused by request timeouts", as
     () => client.listUserProviders("junction-user-1"),
     (error) => {
       assert.ok(error instanceof DeviceSyncError);
-      assert.equal(error.code, "JUNCTION_API_REQUEST_FAILED");
+      assert.equal(error.code, "JUNCTION_API_REQUEST_TIMEOUT");
       assert.equal(error.cause instanceof DOMException, true);
       assert.equal((error.cause as DOMException).name, "AbortError");
       return true;
@@ -456,7 +456,7 @@ test("Junction client does not misclassify request timeouts as late caller abort
     }),
     (error) => {
       assert.ok(error instanceof DeviceSyncError);
-      assert.equal(error.code, "JUNCTION_API_REQUEST_FAILED");
+      assert.equal(error.code, "JUNCTION_API_REQUEST_TIMEOUT");
       assert.notEqual(error.cause, abortError);
       assert.equal(error.cause instanceof DOMException, true);
       assert.equal((error.cause as DOMException).name, "AbortError");
@@ -1522,4 +1522,54 @@ test("Junction createLinkToken honors configured allowed Link hosts", async () =
     () => createClient([]),
     /Junction allowedLinkHosts must include at least one host/u,
   );
+});
+
+
+test("Junction refresh outlives the server wait and reports timeout without replay", async () => {
+  vi.useFakeTimers();
+  let requests = 0;
+  let delayMs = 16_000;
+  const client = new JunctionClient({
+    apiKey: "sk_us_test_123",
+    environment: "sandbox",
+    region: "us",
+    fetchImpl: async (_input, init) => {
+      requests += 1;
+      const signal = init?.signal;
+      assert.ok(signal);
+      return new Promise<Response>((resolve, reject) => {
+        const timer = setTimeout(() => resolve(createJsonResponse({
+          success: true,
+          user_id: "synthetic-user",
+          refreshed_sources: ["oura/sleep"],
+          failed_sources: [],
+          in_progress_sources: [],
+        })), delayMs);
+        signal.addEventListener("abort", () => {
+          clearTimeout(timer);
+          reject(signal.reason);
+        }, { once: true });
+      });
+    },
+  });
+  try {
+    const success = client.refreshUserData({ userId: "synthetic-user", timeoutSeconds: 30 });
+    await vi.advanceTimersByTimeAsync(16_000);
+    await assert.doesNotReject(success);
+    delayMs = 40_000;
+    const failure = assert.rejects(
+      client.refreshUserData({ userId: "synthetic-user", timeoutSeconds: 30 }),
+      (error) => {
+        assert.ok(error instanceof DeviceSyncError);
+        assert.equal(error.code, "JUNCTION_API_REQUEST_TIMEOUT");
+        assert.equal(error.retryable, false);
+        return true;
+      },
+    );
+    await vi.advanceTimersByTimeAsync(35_000);
+    await failure;
+    assert.equal(requests, 2);
+  } finally {
+    vi.useRealTimers();
+  }
 });

--- a/packages/device-syncd/test/junction-provider-diagnostics.test.ts
+++ b/packages/device-syncd/test/junction-provider-diagnostics.test.ts
@@ -2878,3 +2878,80 @@ test("Junction unproven historical coverage saturates at a daily retry without a
     false,
   );
 });
+
+
+test("Junction refresh reports a provider no-op and reads selected source status afterward", async () => {
+  const methods: string[] = [];
+  const provider = createJunctionProvider(async (input, init) => {
+    methods.push(init?.method ?? "GET");
+    if (readUrl(input).includes("/user/refresh/")) {
+      return createJsonResponse({
+        success: true,
+        user_id: "synthetic-user",
+        error: "user has no connected sources",
+        refreshed_sources: [],
+        failed_sources: [],
+        in_progress_sources: [],
+      });
+    }
+    return createJsonResponse({ providers: [{
+      slug: "oura", name: "Oura", logo: "https://example.test/logo.svg",
+      status: "error", created_on: "2026-01-01T00:00:00Z",
+      resource_availability: {},
+      error_details: {
+        error_type: "token_refresh_failed",
+        error_message: "Private provider account detail",
+        errored_at: "2026-01-02T00:00:00Z",
+      },
+    }] });
+  });
+  const result = await provider.diagnostics!.probeRest!({
+    account: createAccount(), endpoint: "refresh", sourceProviderSlug: "oura",
+    now: "2026-01-03T00:00:00Z",
+  });
+  assert.deepEqual(methods, ["POST", "GET"]);
+  const response = result.result.response as Record<string, unknown>;
+  assert.equal(response.ok, false);
+  assert.equal(response.success, false);
+  assert.equal(response.errorCode, "JUNCTION_REFRESH_NO_CONNECTED_SOURCES");
+  assert.deepEqual(result.result.selectedSource, { status: "error", errorCode: "token_refresh_failed" });
+  assert.doesNotMatch(JSON.stringify(result), /Private provider|synthetic-user/);
+});
+
+for (const payload of [
+  { success: false, refreshed_sources: ["oura.sleep"] },
+  { success: true, error: { reason: "rejected" }, refreshed_sources: ["oura.sleep"] },
+  { success: true, refreshed_sources: [] },
+]) {
+  test(`Junction refresh does not claim recovery from an unsuccessful envelope ${JSON.stringify(payload)}`, async () => {
+    const provider = createJunctionProvider(async () => createJsonResponse({
+      user_id: "synthetic-user", failed_sources: [], in_progress_sources: [], ...payload,
+    }));
+    const result = await provider.diagnostics!.probeRest!({
+      account: createAccount(), endpoint: "refresh", now: "2026-01-03T00:00:00Z",
+    });
+    const response = result.result.response as Record<string, unknown>;
+    assert.equal(response.ok, false);
+    assert.equal(response.errorCode, payload.refreshed_sources.length === 0
+      ? "JUNCTION_REFRESH_NO_SOURCES" : "JUNCTION_REFRESH_FAILED");
+  });
+}
+
+
+test("Junction refresh preserves its outcome when the following source status read fails", async () => {
+  const methods: string[] = [];
+  const provider = createJunctionProvider(async (_input, init) => {
+    methods.push(init?.method ?? "GET");
+    return init?.method === "POST"
+      ? createJsonResponse({ user_id: "synthetic-user", success: true, refreshed_sources: ["oura.sleep"], failed_sources: [], in_progress_sources: [] })
+      : new Response("unavailable", { status: 400 });
+  });
+  const result = await provider.diagnostics!.probeRest!({
+    account: createAccount(), endpoint: "refresh", sourceProviderSlug: "oura",
+    now: "2026-01-03T00:00:00Z",
+  });
+  assert.deepEqual(methods, ["POST", "GET"]);
+  assert.equal((result.result.response as Record<string, unknown>).ok, true);
+  assert.equal((result.result.selectedSource as Record<string, unknown>).status, "unknown");
+  assert.equal(typeof (result.result.selectedSource as Record<string, unknown>).errorCode, "string");
+});


### PR DESCRIPTION
## Why and outcome

Junction refresh diagnostics could expire before the upstream wait completed, and an HTTP-success response could still mean no sources were refreshed. Ops displayed the shared account status without identifying the selected source's error.

Operators can now retry once from runtime maintenance, inspect the refresh outcome and selected source status, and use Check status without another mutation. Empty/error responses and timeouts never imply recovery. The UI shows Murph's existing receipt timestamp in UTC.

## Product UX

- Effort: Patch.
- Result: Ready.
- Walkthrough: Inspect a member/source, retry the inspected connection, then check status. Covered source error beneath an active account, no-op/error, partial/in-progress, unknown timeout, failed status read, changed target, and disconnected-source denial. Refresh is explicitly account-wide. Connected status alone does not prove fresh data.

## Evidence

- Direct: 39 Junction client tests, 46 provider diagnostic tests, 36 backfill tests, and 22 Web route/client tests passed (143 total). Both affected typechecks passed.
- Commands: `pnpm --dir packages/device-syncd test test/junction-provider-client.test.ts test/junction-provider-diagnostics.test.ts test/junction-provider-backfill.test.ts`; `pnpm exec vitest run --config apps/web/vitest.config.ts apps/web/test/hosted-ops-device-sync-diagnostics.test.ts apps/web/test/runtime-maintenance-client.test.tsx`; `pnpm --dir packages/device-syncd typecheck`; `pnpm --dir apps/web typecheck`.
- Coverage: Delayed provider reply, timeout identity and parent cancellation, no POST replay, contradictory response envelopes, post-refresh status failure, public connection pinning, pending controls, changed-target clearing, operator/origin checks, and disconnect fences. Recovery/status omit historical reads.
- Browser: Real production panel rendered in the synthetic ops study at 390 and 1280 pixels; error and pending states inspected, no horizontal overflow.
- Final ReviewGPT passed on 70a8a56495495448230a3f8ad8bbcd5e45be886c (verified GPT-6 Pro platform metadata; observed run approximately 391 seconds including staging). The only later changes close the task record and update an existing timeout regression assertion; production source is unchanged. Required CI and the full Host Support release gate passed on final head 27c4d64053f2229604a72e85d5e7245624c2b990. These proofs do not claim vendor-side token restoration.

## Non-obvious affected surfaces

Shared Junction SDK timeout errors retain timeout identity and GET retryability. Broad CI exposed one backfill assertion still expecting the former generic error; the corrected test verifies the timeout code, GET retryability, one inventory attempt, and zero summary calls. Parent cancellation and bounded GET behavior remain covered. Historical-pull recovery retains its endpoint and response contract but skips unrelated diagnostic scans.

## Architecture and reuse

- Existing systems reused: JunctionClient, provider diagnostics, Ops access/target resolution, source receipt state, and shared UI primitives.
- New logic: Truthful refresh classification, deadline beyond the upstream wait, one post-refresh provider-list read, and read-only source checks.
- New abstractions: One recovery presentation component and source-status result type; local helpers isolate existing target validation and response interpretation.
- Complexity intentionally avoided: No scheduler, queue, table, dependency, recovery state machine, automatic POST retry, source-state rewriting, or member messaging.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; no added complexity debt.
- Hotspots: Diagnostic runner 30 (reduced), endpoint normalization 31 (unchanged), matrix result panel 22 (unchanged), requestSdkResource 45 (reduced). Existing Junction resource dispatch, import, source projection, and webhook hotspots are unchanged.
- Agent judgment: Target selection and provider error interpretation have explicit local boundaries. Extracting unrelated dispatch code would expand scope without improving this recovery path.

## Hot reply path impact

- Path status: Not applicable — operator diagnostics do not run on conversational acceptance or delivery.
- Database calls: None added to the reply path.
- Network/provider calls: None added to the reply path.
- Other awaited latency: None.
- Before/after proof: Recovery uses the existing three sequential control-store reads. One refresh POST followed by one provider-list operation; status-only uses the list operation. Existing GET policy permits up to three HTTP attempts; mutation remains exactly one. No database transactions span provider calls.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no assistant instructions, tools, schemas, routing, or assembled provider input changed. No token measurement needed.

## Design proof

- Design page: [Junction recovery study](https://murph-id2x0wb1h-cobuildwithus.vercel.app/screenshots/ops#junction-recovery). Isolated preview build passed; verified the deployed anchor and recovery controls through authenticated Vercel access. Local desktop and phone rendering inspected.
- Evidence: Attached synthetic desktop and phone captures of the real recovery panel.
- Coverage: Error/no-op and pending/unknown states, UTC receipt time, wrapping, and disabled controls. Interaction proof is in the composed client test.

ReviewGPT first-reviewed head: 70a8a56495495448230a3f8ad8bbcd5e45be886c
ReviewGPT context sensitivity: sensitive
Classification reason: Changes cross the Web/provider boundary and interpret external mutation outcomes.

## Deployment concerns

- Deployment: applicable
- Supported skew: Older Ops clients ignore response additions; new clients tolerate missing source status as unknown. No persisted schema changes.
- Safe order: Deploy the normal Web bundle, including its device-syncd provider implementation. Worker deployment can follow independently.
- Rollback floor: Previous application version; no new stored format or scheduled work.
- Expected exposure: Operators using the gated diagnostic page during a rollout.
- Reversibility: Revert the application change; no data migration or cleanup required.
- Convergence proof: Additive contracts and focused route/provider tests preserve prior success and failure paths.
- Post-deploy checks: Inspect a test connection, verify source status and UTC receipt time, issue one approved refresh, and check status without another refresh.

## Change-shape breakdown

Classification rule: Production and design-study TS/TSX are source; test-directory changes are tests; Markdown is docs. No binaries, dependencies, generated files, or runtime config changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 378 | 76 |
| Tests / fixtures | 277 | 5 |
| Docs | 100 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **755** | **82** |

## Changelog

- Changelog: not applicable
- Reason: Internal operator recovery controls and diagnostics; no member-facing workflow or message changes.

![Phone recovery error and pending states](https://github.com/user-attachments/assets/2f0fe8eb-d928-45a3-a67c-d14de51fb46c)

![Desktop recovery error and pending states](https://github.com/user-attachments/assets/c37a3c73-401c-41b2-bf2c-dbf3654c5b57)