### PR TITLE
Fix Journal capture verification and missed-save recovery

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-08-journal-capture-recovery.md
+++ b/agent-docs/exec-plans/completed/2026-09-08-journal-capture-recovery.md
@@ -1,0 +1,63 @@
+# Restore private Journal capture and truthful recovery
+
+Status: completed
+Created: 2026-09-08
+Updated: 2026-09-08
+
+## Goal
+
+- Restore automatic private Journal capture of clearly reported facts and truthful save/display explanations using existing canonical records.
+
+## Success criteria
+
+- A focused synthetic live Codex journey on gpt-5.6-terra proves capture without a logging command, exclusion of guessed causes, respect for no-retention requests, verified save answers, and truthful recovery.
+- Deterministic tests cover composed instructions and any reproduced working-directory or projection defects; relevant typecheck passes.
+
+## Scope
+
+- In scope: private capture policy, canonical CLI targeting, save/readback and display explanations, and locally proven Journal display defects.
+- Out of scope: production mutations, member messaging, model preference changes, speculative UI fixes, and copied private evidence.
+
+## Constraints
+
+- Technical constraints: retain event ownership in core and the query-owned Journal projection; add no store, capture service, dependency, or blanket retry loop.
+- Product/process constraints: synthetic scenarios only; do not infer causes or require explicit logging for ordinary clear facts. Preserve group boundaries and explicit no-retention intent.
+
+## Risks and mitigations
+
+1. Risk: stochastic proof passes without reproducing a reported failure.
+   Mitigation: distinguish baseline observations from proved regressions; use exact production builders and real canonical readback.
+2. Risk: conflating canonical persistence with Browser Vault visibility.
+   Mitigation: trace both owners and require evidence before claiming a refresh or a display cause.
+
+## Tasks
+
+1. Inspect capture, CLI working-directory, and Journal projection boundaries.
+2. Add deterministic contracts and run a synthetic live Terra baseline before production edits.
+3. Correct proved gaps at their smallest existing owners and rerun focused live scenarios.
+4. Run focused tests/typecheck, inspect the complete diff, add a public-safe changelog, and commit.
+
+## Decisions
+
+- Product UX effort: Patch.
+- Outcome: clear private facts survive the conversation; save and display claims match evidence.
+- Reaches: private conversations with facts, uncertain causes, explicit no-save intent, missed saves, canonical saves absent from the current display, and corrections.
+- Proof: production prompt composition, real CLI writes and query readback, synthetic live Terra replies, and focused recovery regressions.
+
+## Verification
+
+- Product UX: Ready. Reviewed synthetic replies and canonical state for automatic capture, missing-entry repair, existing-entry verification, launch failure, no-retention, and date/detail correction.
+- Current main already includes automatic capture, English note quality, date/timing corrections, and Journal refresh-on-open from #2970. This patch addresses remaining recovery guidance; it does not replace those owners.
+- Before edits, the current prompt captured the synthetic observation but suggested an unsupported all-day-note filter when asked about an empty page.
+- A replay using the production prompt preceding #2970 and current CLI/runtime saved the observation plus a speculative explanation, then invented legacy Journal-day linking as a visibility repair. The new regression failed because two facts existed instead of one. That run did not reproduce the original omitted-save behavior; this is historical-prompt evidence, not a replay of a complete historical deployment.
+- After edits, five focused real Codex journeys passed on `gpt-5.6-terra` through subscription auth: automatic observation-only capture plus bounded readback; repair of a missed eligible save; recovery after a real pre-launch `ENOENT`; explicit no-retention with zero writes; and the existing English note/date/time correction journey. The latter preserved the original event ID and corrected its duration and timestamp.
+- The launch-failure fixture proves the canonical command did not start and left zero events, then presents that failure context to a live turn. It does not emulate a lost response after an ambiguous committed write.
+- Live command: `pnpm test:assistant:live -- --test <one exact journey name> --model gpt-5.6-terra`. Initial subscription profiles failed before any provider action; one available alternate profile succeeded and was retained for every final journey. No credentials were read or copied.
+- Focused assistant contracts: 98 tests passed across Journal recovery, CLI access, model behavior, and health-record ingestion. Route composition and turn planning: 106 tests passed; reviewed the expected direct/group/scheduled-email snapshot changes.
+- Existing Browser Vault context tests: 71 passed. Dashboard page tests: 39 passed after the declared `pnpm health-commons:generate` prerequisite. Changelog page tests: 9 passed.
+- `pnpm --dir packages/assistant-engine typecheck`, `pnpm --dir apps/web typecheck`, and `pnpm --filter @murphai/murph... build` passed. The CLI build prepared the existing live note-quality journey.
+- `pnpm complexity:diff` passed with no added branch debt. The two existing prompt hotspots are unchanged; new behavior is guidance at existing owners. Authored stable-route text grew by 1,456 characters; this is not a complete provider-input token measurement.
+- Parent review checked the complete diff, bounded canonical readback, duplicate prevention, private/group scope, explicit no-retention, current-directory launch recovery, truthful visibility claims, and synthetic-only artifacts. No new state store, API, dependency, runtime retry loop, or Web control was added.
+- Public changelog: `journal-save-verification`. No new repository friction required a workaround or entry. Final external review is not routed for this prompt-primary local patch; no PR or production deployment is part of this task.
+- Limits: local synthetic proof does not establish the historical member page's display failure cause or validate a deployed fix. Existing refresh-on-open behavior is covered by its focused tests; no speculative UI change was made.
+Completed: 2026-09-08

--- a/agent-docs/product-specs/journal.md
+++ b/agent-docs/product-specs/journal.md
@@ -1,6 +1,6 @@
 # Journal
 
-Last verified: 2026-09-06
+Last verified: 2026-09-08
 
 ## Product boundary
 
@@ -22,6 +22,17 @@ bounded comparisons.
 Clear facts remain eligible when the member asks for advice. Missing time or
 intensity does not block a save. Hypothetical questions are not events. An
 explicit no-retention request prevents capture.
+
+A member's speculative explanation is not a separate Journal fact. Save the
+reported observation without that speculation. When asked whether a fact was
+saved, Murph checks the relevant canonical records. It acknowledges and repairs
+a missed eligible capture without inventing an explicit-logging requirement.
+
+Canonical persistence and current page visibility are separate facts. Murph
+does not diagnose a filter, stale page, or sync failure without evidence, invent
+filter controls, or claim an unverified refresh. It can explain that opening
+Journal requests updated data and that the member can select the relevant date.
+It never creates legacy Journal days or day links to make an event appear.
 
 Journal titles and notes use English. Chat replies use the member's language.
 Titles name the event without relative-day words or dates. Notes add detail

--- a/apps/web/changelog/entries/2026-09-08/journal-save-verification.json
+++ b/apps/web/changelog/entries/2026-09-08/journal-save-verification.json
@@ -1,0 +1,18 @@
+{
+  "publishedOn": "2026-09-08",
+  "order": 100,
+  "item": {
+    "id": "journal-save-verification",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Clearer answers about saved Journal entries",
+    "summary": "When you ask whether something was saved, Murph checks your records and corrects missed eligible entries.",
+    "details": "Murph keeps speculative explanations out of Journal facts and distinguishes a saved record from what the page currently shows. Clear private health facts do not require a separate logging request; requests not to save are respected.",
+    "relevanceTags": ["journal"],
+    "sourcePullRequests": [],
+    "tryIt": {
+      "label": "Check a saved entry",
+      "prompt": "Did you save the health context I shared earlier?"
+    }
+  }
+}

--- a/packages/assistant-engine/src/assistant-cli-access.ts
+++ b/packages/assistant-engine/src/assistant-cli-access.ts
@@ -87,6 +87,7 @@ export function buildAssistantCliGuidanceText(
   return [
     `\`${access.rawCommand}\` is the canonical Murph CLI. \`${access.setupCommand}\` is the setup entrypoint and also exposes the same top-level \`chat\` and \`run\` aliases after setup.`,
     'Use the matching local CLI command directly, prefer `--format json` for machine-readable output, and do not run recursive assistant or delivery commands such as `assistant chat`, `assistant ask`, `assistant run`, `assistant deliver`, `chat`, or `run` from inside an assistant turn.',
+    'Use the current turn working directory for CLI commands; do not invent a workspace path or reuse one from an older transcript. If a working-directory error proves the process failed before the command started, use `pwd` in the default current directory, then run the corrected command there once. Do not create a replacement workspace. If execution may have started, verify canonical state before another write.',
     '`stage` names the failure. For a read-only command, `retryable: true` permits at most one unchanged retry in the turn; never retry an unchanged write. Fixing a `fieldErrors` field, a `hint` prerequisite, or a precise bounded `message` is a new attempt. Otherwise stop; never guess or echo omitted details.',
   ].join('\n\n')
 }

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -1560,7 +1560,7 @@ function buildAssistantJournalCaptureGuidanceText(
   if (conversationScope !== "direct") return null;
   return `Private Journal capture:
 - In private conversation, save clear lived health facts during the turn, including reported symptoms, completed actions, and relevant context, even when the member is asking for advice. An extra request to save is not required. Keep routine saves quiet. Respect an explicit no-retention request; hypothetical questions are not events. Give urgent help first when needed.
-- Save facts, not inferred causes or diagnoses. Missing time or intensity must not prevent saving a clear fact. Ask one focused question for a material ambiguity, then update the same record from the answer.
+- Save facts, not inferred causes or diagnoses. A suggested explanation is not a separate Journal fact, even when the member proposes it; omit the speculation and save the reported observation. Missing time or intensity must not prevent saving a clear fact. Ask one focused question for a material ambiguity, then update the same record from the answer.
 - Use \`vault-cli event note add\` per independent fact. A symptom and a completed action need separate entries, even when reported together; do not bury one in the other's description. Before finishing, check that each clear fact has its own saved entry. Use the event's local date, never the note-writing date for a past fact. Save a sustained multi-day report on each explicitly reported day. Use \`--related-id\` only when the note describes that same existing event.
 - Before saving, make \`--title\` a short English event name, with no relative-day words or date. Write \`--note\` in English and include only additional detail, such as amount, duration, location on the body, or response. Do not repeat or paraphrase the event name in the note; a duration alone is sufficient. If there is no extra detail, use the title as the note; the view hides this duplicate. Do not pad descriptions with generic confirmation language. Keep chat replies in the member's language.
 - Read \`vault-cli event note add --help\` for the available \`--icon\` and \`--timing\` values when they are not already known. Choose an existing icon that matches; use \`note\` when none fits. Never invent an icon id or asset.
@@ -1574,7 +1574,8 @@ function buildAssistantJournalCaptureGuidanceText(
 - Mute \`personal-pattern-notifications\`; stop proactive questions when asked.
 - For connected calendar or email Journal capture and opt-outs, read \`journal-connected-context\`.
 - Group consent: call \`set_journal_capture\` before saves.
-- Explain capture, fixes, and refresh.
+- When asked whether a fact was saved or why it is missing from Journal, read the relevant canonical records with a bounded query. If an eligible fact was missed, acknowledge the missed capture and save it once under the same capture policy; never explain it as requiring an explicit logging request. Verify existing records before creating anything, and respect no-retention instructions.
+- Journal derives from canonical events; never use legacy \`vault-cli journal\` day commands or add day links to make an entry visible. A canonical save does not prove that the web page has refreshed. Do not diagnose a stale page, filter, or sync failure without evidence, invent filter controls, or claim a refresh you did not verify. If the record exists, confirm that fact and explain that opening Journal requests an update; the member can select the relevant date. State when the page's current visibility or failure cause cannot be verified.
 - Never expose it in groups.`
 }
 

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -13472,6 +13472,136 @@ describeRealCodex('real Codex Journal and Patterns help e2e', () => {
   }, 720_000)
 })
 
+describeRealCodex('real Codex private Journal capture recovery e2e', () => {
+  it('saves a reported symptom without its guessed cause and verifies an empty-page complaint without duplicating it', async () => {
+    const config = await resolveRealCodexE2eConfig()
+    const workingDirectory = await mkdtemp(path.join(tmpdir(), 'murph-journal-recovery-e2e-'))
+    try {
+      await initializeVault({ vaultRoot: workingDirectory, timezone: 'America/New_York' })
+      const binDirectory = path.join(workingDirectory, 'bin')
+      const commandLogPath = path.join(workingDirectory, 'commands.log')
+      await materializeRealWorkoutVaultCli({ binDirectory, commandLogPath, vaultRoot: workingDirectory })
+      const input: Omit<CodexAppServerTurnInput, 'prompt'> = {
+        approvalPolicy: 'never', baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+        codexCommand: normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND) ?? undefined,
+        codexHome: config.codexHome,
+        developerInstructions: buildAssistantSystemPrompt({
+          assistantCliContract: null, assistantKnowledgeToolsAvailable: false,
+          channel: 'telegram', conversationScope: 'direct', hostedRuntime: true,
+          cliAccess: { rawCommand: 'vault-cli', setupCommand: 'murph' },
+          currentInstant: '2026-05-18T16:00:00Z', currentLocalDate: '2026-05-18',
+          currentTimeZone: 'America/New_York', modelBehaviorProfile: 'gpt5-agentic',
+          onboardingGuidance: false,
+        }),
+        dynamicTools: [],
+        env: { ...config.env, PATH: `${binDirectory}:${config.env.PATH ?? ''}`,
+          [MURPH_ASSISTANT_SKILLS_ROOT_ENV]: resolveAssistantSkillsRoot() },
+        excludeResumeTurns: true, groupConversation: false,
+        model: config.model, modelProvider: config.modelProvider,
+        reasoningEffort: 'low', sandbox: 'workspace-write', workingDirectory,
+      }
+      const first = await executeRealCodexAppServerTurn({
+        ...input,
+        prompt: 'My left wrist has felt stiff since I woke up this morning. Maybe it is the weather, but that is only a guess. Keep this in mind when we talk about my routines; I do not need advice right now.',
+      })
+      const initial = await readVaultRawTolerant(workingDirectory)
+      const initialFacts = initial.events.filter((event) => event.kind === 'note' || event.kind === 'symptom')
+      process.stdout.write(`[journal-capture-recovery] ${JSON.stringify({ phase: 'capture', reply: first.finalMessage, facts: initialFacts.length })}\n`)
+      const beforeReadback = await readFile(commandLogPath, 'utf8').catch(() => '')
+      const second = await executeRealCodexAppServerTurn({
+        ...input, resumeSessionId: first.sessionId,
+        prompt: 'Did you actually save that? I cannot see it on my Journal page. Is that because of a filter or a sync bug?',
+      })
+      const after = await readVaultRawTolerant(workingDirectory)
+      const facts = after.events.filter((event) => event.kind === 'note' || event.kind === 'symptom')
+      const readbackCommands = (await readFile(commandLogPath, 'utf8').catch(() => '')).slice(beforeReadback.length)
+      process.stdout.write(`[journal-capture-recovery] ${JSON.stringify({ phase: 'verify', reply: second.finalMessage, facts: facts.length })}\n`)
+      expect(initialFacts).toHaveLength(1)
+      expect(facts).toHaveLength(1)
+      expect(facts[0]?.entityId).toBe(initialFacts[0]?.entityId)
+      expect(JSON.stringify(initialFacts[0])).toMatch(/wrist|stiff/iu)
+      expect(JSON.stringify(initialFacts[0])).not.toMatch(/weather/iu)
+      const view = buildJournalView(after, [], { asOf: '2026-05-18' })
+      expect(view.days.find((day) => day.date === '2026-05-18')?.events
+        .flatMap((event) => event.records).some((record) => record.id === facts[0]?.entityId)).toBe(true)
+      expect(readbackCommands).toMatch(/(?:event (?:list|show)|(?:^|\n)(?:list|show|timeline|search)\b|batch)/u)
+      expect(second.finalMessage).toMatch(/saved|recorded|entry|note/iu)
+      expect(second.finalMessage).toMatch(/cannot|can.t|unable|don.t know|haven.t|could|may|might|not sure/iu)
+      expect(second.finalMessage).not.toMatch(/(?:only|always).{0,45}(?:explicit|ask.{0,15}(?:log|save))|(?:refreshed|fixed).{0,25}(?:page|sync|filter)/iu)
+      expect(readbackCommands).not.toMatch(/(?:^|\n)journal\b/u)
+      expect(after.entities.filter((entity) => entity.kind === 'journal_day')).toHaveLength(0)
+      expect(second.finalMessage).not.toMatch(/(?:check|change|clear|reset|turn on|enable|select).{0,35}filters?|includes? all.day Journal notes|(?:linked|linking).{0,25}Journal day/iu)
+      expect(second.finalMessage.length).toBeLessThan(1000)
+    } finally {
+      await removeRealCodexTemporaryPaths([workingDirectory, ...config.temporaryPaths])
+    }
+  }, 360_000)
+})
+
+describeRealCodex('real Codex private Journal capture recovery boundaries e2e', () => {
+  it.each(['missed', 'launch-failure', 'opt-out'] as const)('handles %s without inventing policy or duplicating facts', async (scenario) => {
+    const config = await resolveRealCodexE2eConfig()
+    const workingDirectory = await mkdtemp(path.join(tmpdir(), 'murph-journal-boundary-e2e-'))
+    try {
+      await initializeVault({ vaultRoot: workingDirectory, timezone: 'America/New_York' })
+      const before = await readVaultRawTolerant(workingDirectory)
+      const binDirectory = path.join(workingDirectory, 'bin')
+      const commandLogPath = path.join(workingDirectory, 'commands.log')
+      await materializeRealWorkoutVaultCli({ binDirectory, commandLogPath, vaultRoot: workingDirectory })
+      if (scenario === 'launch-failure') {
+        await expect(execFileAsync(path.join(binDirectory, 'vault-cli'), [
+          'event', 'note', 'add', '--title', 'Ankle stiffness', '--note', 'Right ankle; since waking.',
+          '--note-type', 'journal-outcome', '--occurred-at', '2026-05-18', '--timing', 'all_day',
+        ], { cwd: path.join(workingDirectory, 'retired-workspace') })).rejects.toMatchObject({ code: 'ENOENT' })
+        expect((await readVaultRawTolerant(workingDirectory)).events).toHaveLength(0)
+      }
+      const prompts = {
+        missed: 'Earlier today I told you my right ankle felt stiff on waking. You said ordinary conversation never gets saved unless I ask to log it. Is that actually your policy? Please check whether you saved it.',
+        'launch-failure': 'Please save that my right ankle has been stiff since waking today. The previous save attempt failed before the command started because its working directory did not exist. Nothing was saved. Finish the save here and check it.',
+        'opt-out': 'Do not save or remember anything from this message: my right ankle has felt stiff since waking today. This is just a private passing conversation, not something I want retained. Please acknowledge without giving advice.',
+      }
+      const result = await executeRealCodexAppServerTurn({
+        approvalPolicy: 'never', baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+        codexCommand: normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND) ?? undefined,
+        codexHome: config.codexHome,
+        developerInstructions: buildAssistantSystemPrompt({
+          assistantCliContract: null, assistantKnowledgeToolsAvailable: false,
+          channel: 'telegram', conversationScope: 'direct', hostedRuntime: true,
+          cliAccess: { rawCommand: 'vault-cli', setupCommand: 'murph' },
+          currentInstant: '2026-05-18T16:00:00Z', currentLocalDate: '2026-05-18',
+          currentTimeZone: 'America/New_York', modelBehaviorProfile: 'gpt5-agentic', onboardingGuidance: false,
+        }),
+        dynamicTools: [],
+        env: { ...config.env, PATH: `${binDirectory}:${config.env.PATH ?? ''}`,
+          [MURPH_ASSISTANT_SKILLS_ROOT_ENV]: resolveAssistantSkillsRoot() },
+        excludeResumeTurns: true, model: config.model, modelProvider: config.modelProvider,
+        prompt: prompts[scenario], reasoningEffort: 'low', sandbox: 'workspace-write', workingDirectory,
+      })
+      const after = await readVaultRawTolerant(workingDirectory)
+      const facts = after.events.filter((event) => event.kind === 'note' || event.kind === 'symptom')
+      const commands = (await readFile(commandLogPath, 'utf8').catch(() => '')).split('\n').filter(Boolean)
+      const writes = commands.filter((command) => /^event (?:note|symptom) add\b/u.test(command)
+        && !/--help|--schema/u.test(command))
+      process.stdout.write(`[journal-capture-boundary] ${JSON.stringify({ scenario, reply: result.finalMessage, facts: facts.length, writes: writes.length })}\n`)
+      if (scenario === 'opt-out') {
+        expect(after.entities).toEqual(before.entities)
+        expect(writes).toHaveLength(0)
+        expect(result.finalMessage).toMatch(/won.t|will not|not (?:save|retain|record)|without (?:saving|recording)/iu)
+      } else {
+        expect(facts).toHaveLength(1)
+        expect(writes).toHaveLength(1)
+        expect(JSON.stringify(facts[0])).toMatch(/ankle/iu)
+        expect(result.finalMessage).toMatch(/saved|recorded|logged|added/iu)
+        expect(result.finalMessage).not.toMatch(/(?:would you like|want me|shall I|should I).{0,30}(?:save|log|record)/iu)
+        expect(after.journalEntries).toHaveLength(0)
+      }
+      expect(result.finalMessage.length).toBeLessThan(1000)
+    } finally {
+      await removeRealCodexTemporaryPaths([workingDirectory, ...config.temporaryPaths])
+    }
+  }, 240_000)
+})
+
 describeRealCodex('real Codex private Journal note quality e2e', () => {
   it('automatically saves English facts with honest timing and corrects the same canonical note', async () => {
     const config = await resolveRealCodexE2eConfig()

--- a/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
@@ -369,11 +369,11 @@ describe('assistant Codex turn planning', () => {
       Object.entries(plans).map(([name, plan]) => [name, digestPlan(plan)]),
     )).toMatchInlineSnapshot(`
       {
-        "direct": "beedb5985aa161710fbfe74c9503ef1093fc664046dfc03c2977cb9695b24969",
-        "group": "ead4ee04f2ca83fc9dd1db3a581b0ab3afa60b612d7c9372a26833b8bb98a904",
+        "direct": "a0b89b6349944ff568a9677289421453d075210a3c2f7b7e138c2c54c744b882",
+        "group": "a34e5931c8eb92d827be99b2be5e1e8f1f0f948721b04ce0217742e1d55634a7",
         "maintenance": "4c439dbf05ccb6d2cd7540b1ef7f94c99e898afd9b9658abefa860a8b421ca55",
         "outputOnly": "a83a04afea06e5290de36b14a0fee5d18970077a8294dde129b2e2dfa99116b4",
-        "scheduledEmail": "d0ead287d6398f30c94d6bc9ff8cc997a0c7a309fb8f7a9c3b20d70f82c261c3",
+        "scheduledEmail": "dea0bd0d22a9a00ae3f7340687e61ad67003d6990ab34ef790d843fd83f14807",
       }
     `)
   })

--- a/packages/assistant-engine/test/model-behavior.test.ts
+++ b/packages/assistant-engine/test/model-behavior.test.ts
@@ -664,7 +664,7 @@ describe('assistant execution prompt contract', () => {
     )
     expect(directPrompt).toContain('exactly once')
     expect(directPrompt).toContain('stop proactive questions when asked')
-    expect(directPrompt).toContain('Explain capture, fixes, and refresh')
+    expect(directPrompt).toContain('read the relevant canonical records with a bounded query')
     expect(directPrompt).toContain(
       'tell users to ask Murph; never claim web controls',
     )
@@ -2216,7 +2216,9 @@ describe('assistant system prompt cache stability', () => {
     // event names in descriptions. Keep the explicit rules within this cap.
     // Automation control-copy authoring adds 227 characters; reviewed Terra and
     // Luna journeys cover clean saved instructions and retained user controls.
-    expect(layers.stableRouteCapabilityPrompt.length).toBeLessThanOrEqual(70_738)
+    // Journal recovery adds 1,456 characters for verified saves, honest page
+    // visibility, and workspace-safe launch recovery; focused Terra proof owns it.
+    expect(layers.stableRouteCapabilityPrompt.length).toBeLessThanOrEqual(72_194)
   })
 
   it('passes the injected CLI contract through byte-for-byte at the stable-route tail', () => {

--- a/packages/assistant-engine/test/system-prompt.journal-recovery.test.ts
+++ b/packages/assistant-engine/test/system-prompt.journal-recovery.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { buildAssistantSystemPromptLayers } from '../src/assistant/system-prompt.js'
+import { buildAssistantCliGuidanceText } from '../src/assistant-cli-access.js'
+
+function privateLayers() {
+  return buildAssistantSystemPromptLayers({
+    assistantCliContract: null, assistantKnowledgeToolsAvailable: false,
+    channel: 'telegram', conversationScope: 'direct', hostedRuntime: true,
+    cliAccess: { rawCommand: 'vault-cli', setupCommand: 'murph' },
+    currentLocalDate: '2026-05-18', currentTimeZone: 'UTC',
+    modelBehaviorProfile: 'gpt5-agentic', onboardingGuidance: false,
+  })
+}
+
+describe('private Journal capture and recovery instructions', () => {
+  it('retains automatic fact capture and its no-retention and causality boundaries', () => {
+    const policy = privateLayers().stableRouteCapabilityPrompt
+    expect(policy).toContain('An extra request to save is not required')
+    expect(policy).toContain('Respect an explicit no-retention request')
+    expect(policy).toContain('hypothetical questions are not events')
+    expect(policy).toContain('Save facts, not inferred causes or diagnoses')
+    expect(policy).toContain('A suggested explanation is not a separate Journal fact')
+    expect(policy).toContain('same existing event')
+  })
+
+  it('requires record verification and an honest distinction between saves and web visibility', () => {
+    const policy = privateLayers().stableRouteCapabilityPrompt
+    expect(policy).toContain('When asked whether a fact was saved or why it is missing from Journal, read the relevant canonical records')
+    expect(policy).toContain('acknowledge the missed capture')
+    expect(policy).toContain('never explain it as requiring an explicit logging request')
+    expect(policy).toContain('A canonical save does not prove that the web page has refreshed')
+    expect(policy).toContain('Do not diagnose a stale page, filter, or sync failure without evidence')
+    expect(policy).toContain('never use legacy `vault-cli journal` day commands or add day links')
+    expect(policy).toContain('invent filter controls')
+  })
+
+  it('grounds shell execution in the current workspace and distinguishes launch failures from ambiguous writes', () => {
+    const guidance = buildAssistantCliGuidanceText({ rawCommand: 'vault-cli', setupCommand: 'murph' })
+    expect(privateLayers().prompt).toContain(guidance)
+    expect(guidance).toContain('Use the current turn working directory')
+    expect(guidance).toContain('do not invent a workspace path or reuse one from an older transcript')
+    expect(guidance).toContain('before the command started')
+    expect(guidance).toContain('If execution may have started, verify canonical state before another write')
+    expect(guidance).toContain('never retry an unchanged write')
+  })
+})


### PR DESCRIPTION
## Why and outcome

Murph could save a speculative explanation as a separate Journal fact and invent a page-filter or legacy day-link repair when asked about a missing entry. This change requires canonical verification, repairs missed eligible captures without demanding another logging instruction, and keeps save claims separate from unverified page visibility.

It also grounds CLI execution in the current workspace and distinguishes a proven pre-launch directory failure from an ambiguous write. Existing automatic capture, note quality, timing correction, and refresh-on-open behavior from #2970 remain the implementation owners.

## Product UX

- Effort: Patch.
- Result: Ready.
- Walkthrough: Private observation-only capture, missed-save repair, existing-record verification, pre-launch directory recovery, explicit no-retention, and date/detail corrections all passed live synthetic Terra journeys. Group capture scope is unchanged. Historical page-display causality remains unproven; no speculative UI change is included.

## Evidence

- Direct: Five real Codex journeys on `gpt-5.6-terra` passed with production prompt builders, real CLI writes, and canonical/query readback. Run each with `pnpm test:assistant:live -- --test <exact journey name> --model gpt-5.6-terra`.
- Coverage: Exactly one observation without its guessed cause; readback without duplication or invented filters/day links; one repaired missing save; one write after a real pre-launch ENOENT; zero writes under no-retention; and preserved event ID with corrected duration/time.
- Historical-prompt replay reproduced speculative capture and invented day-link repair. It did not reproduce the original omission in that sample, and used current CLI/runtime rather than a complete historical deployment.
- Focused deterministic proof: 98 assistant contract tests, 106 route/turn-planning tests, 71 Browser Vault context tests, 39 dashboard page tests, and 9 changelog tests passed (323 total).
- `pnpm --dir packages/assistant-engine typecheck`, `pnpm --dir apps/web typecheck`, and `pnpm --filter @murphai/murph... build` passed.
- Exact-head CI: 32 checks passed, with 2 intentionally skipped, on `fb2aac74aac08a7bd620bc4311f513f21c039afd`. [Release verification](https://github.com/cobuildwithus/murph/actions/runs/34251482069), [repo hygiene](https://github.com/cobuildwithus/murph/actions/runs/34251481925), and [Temporal compatibility](https://github.com/cobuildwithus/murph/actions/runs/34251857470) passed. The fixture artifact upload recovered on one CI retry. Current-base merge-tree proof is clean.
- Parent candidate review complete. Final ReviewGPT is exempt for this prompt-primary patch: no runtime implementation, schema, auth boundary, or persistence protocol changes.

## Non-obvious affected surfaces

Shared CLI guidance also appears in group and scheduled-email routes. Reviewed their expected snapshot changes; maintenance/output-only routes remain unchanged. Browser Vault refresh and date-selection owners were traced and their focused tests passed.

## Architecture and reuse

- Existing systems reused: Production prompt assembly, canonical event CLI, query-owned Journal projection, and existing real Codex harness.
- New logic: More precise assistant guidance for capture and evidence-based recovery.
- New abstractions: None; existing prompt and canonical owners suffice.
- Complexity intentionally avoided: No new store, day-link mechanism, service, dependency, or runtime retry loop.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: Unchanged `buildStableRouteCapabilityPrompt` (28) and `buildAssistantHostedGroupGuidanceText` (25); branch debt unchanged.
- Agent judgment: Added guidance at existing owners is the smallest maintainable correction. No extra abstraction is justified.

## Hot reply path impact

- Path status: Prompt text touched; executable orchestration is unchanged.
- Database calls: None added or moved by runtime code.
- Network/provider calls: No mandatory provider call added. Status questions now explicitly require a bounded canonical read before a possible save.
- Other awaited latency: Existing CLI tool execution remains model-selected. One corrected attempt is permitted after a proven pre-launch directory error; ambiguous writes require state verification first. No timeout or retry-loop changes.
- Before/after proof: Live readback preserved one event; missed-save and pre-launch recovery produced one canonical write each; opt-out produced zero writes. No latency benchmark claim.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | 27,322 | 27,596 | +274 | +1.003% | 127,034 | 128,493 | +1,459 |
| Group Murph | 22,784 | 22,862 | +78 | +0.342% | 106,386 | 106,801 | +415 |

- Assembled instructions: Individual 78,661 → 80,117 characters (+1,456); group 58,474 → 58,887 (+413). Changes are in the private Journal block and shared CLI guidance.
- Tool/schema/generated guidance: Same production catalogue capabilities at base/head: 6 direct and 12 group tools. Native generated tool guidance is included in the captured input; no tool/schema definition changed.
- Other provider-visible input: Same synthetic question, date, timezone, base instructions, and native settings. Other selected provider fields are unchanged.
- Measurement method: Real pinned Codex 0.153.4 App Server targeting `gpt-5.6-terra`, low reasoning, loopback-only Responses capture with no upstream request or credentials. Compared `4b9aefa7a1e9` with `fb2aac74aac0`; reconstructed the base assembled prompt by reversing the exact two source guidance changes before native request assembly. Serialized all present content-bearing fields: `include`, `input`, `parallel_tool_calls`, `text`, and `tool_choice`. Native tool guidance is inside `input`; there are no separate `instructions` or `tools` fields. Normalized generated UUIDs and fixture/repository paths identically.
- Tokenizer: Installed `gpt-tokenizer 3.4.0`, `o200k_base`; diagnostic proxy counts, not a verified Terra billing counter. Byte counts are exact for the normalized serialized input. Excludes transport/account/cache metadata, generation settings, private member history/overlays, and unseen provider-side additions.

## Deployment concerns

- Deployment: applicable
- Supported skew: Prompt-only guidance uses existing canonical read/write commands and current Journal projection; event shapes and APIs are unchanged.
- Safe order: Normal assistant rollout; no coordinated migration or consumer-first dependency.
- Rollback floor: Existing canonical records remain compatible with the previous prompt.
- Expected exposure: Assistant turns begin using the new guidance as updated runtimes are adopted.
- Reversibility: Prompt revision can be reverted without data migration.
- Convergence proof: Existing CLI build, real canonical writes/readback, and unchanged route ownership; no protocol transition introduced.
- Post-deploy checks: Synthetic observation-only save and save-status verification; confirm no duplicate or legacy Journal-day record. No deployment performed here.

## Change-shape breakdown

Classification rule: Production TypeScript is source; test files are tests; Markdown is docs; the isolated changelog JSON is authored content under other. No binary or generated artifacts.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 2 |
| Tests / fixtures | 183 | 5 |
| Docs | 75 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 18 | 0 |
| **Total** | **280** | **8** |

## Changelog

- Changelog: updated
- Items: 2026-09-08 · journal-save-verification
- Content-only entry; existing changelog rendering is unchanged and its 9 tests pass.

