### PR TITLE
fix: converge concurrent device webhook payload writes

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1703,15 +1703,40 @@ Last verified: 2026-09-04
   member/connection/source authority check, then prepares through the same
   request-local, non-serializable dirty-store capability outside every database
   lock. The final transaction reacquires the canonical member/connection locks,
-  re-reads consent and exact connection/source authority, and requires both the
-  exact dirty-marker snapshot and, when payloads exist, device-domain root
-  before inserting them.
+  re-reads consent and exact connection/source authority, and revalidates the
+  dirty-marker snapshot and, when payloads exist, device-domain root before
+  inserting them. For prepared payloads only, monotonic sibling ingress may
+  advance the marker while acknowledgement stays unchanged and the marker
+  remains pending. Under the existing dirty-row lock, the store then locally
+  opens and reseals the already-compressed envelope against the new commit
+  revision, retaining its opaque payload id and classification. Each admitted
+  webhook has at most two resources and companion admission has one; rebinding
+  is serial, adds one local authenticated open/seal per payload and no datastore,
+  KMS, provider, compression, or classification calls. A previously missing
+  marker may converge only onto an owned pending row with processed revision
+  zero. Owner, acknowledgement, deletion, clean-state, and root drift still
+  require the full replan. The stored ciphertext format and read-time AAD stay
+  unchanged, so existing readers and rollback writers remain compatible.
   A clean-to-dirty wake similarly uses an ingress-root capability prepared
   outside the locks. Drift permits one full replan with a fresh root cache;
   repeated drift fails retryably. Withdrawal may commit while ephemeral
   preparation is in flight, but the final consent re-read then rejects without
   durable dirty, receipt, signal, trace-completion, or mailbox state. The
   steady-state connection-replacement path reads no payload and uses set-based writes only.
+  Web ingress logs `device_webhook.transport_selected` once after preflight,
+  with `transport`, the finite decision reason (`provider_not_enabled`,
+  `body_too_large`, or `queue_enabled`), and raw body byte count only.
+  `device_sync.prepared_write_drift` records operation, attempt budget,
+  exhaustion, and a bounded cause (domain root, dirty marker/owner/acknowledgement,
+  contention, or admission/wake preparation); a successful replan records
+  `device_sync.prepared_write_recovered`. The store's
+  `device_sync.prepared_payload_rebound` describes an attempted rebind, not
+  transaction success. Correlate these records within the Vercel invocation
+  and its HTTP result; no event/account/member identity, headers, raw exception
+  details, or health payload enters these diagnostics. A future retryable 503
+  can therefore be attributed without reopening private payloads. After deploy,
+  inspect bounded 5xx counts and drift exhaustion alongside transport reasons;
+  rebinding followed by a successful response is expected burst convergence.
   Nullable rows from mixed-version writers are the bounded transitional
   exception: replacement classifies at most 800 rows after taking the existing
   member lock, re-reading health-data consent, and locking the dirty marker.

--- a/agent-docs/exec-plans/completed/junction-webhook-contention.md
+++ b/agent-docs/exec-plans/completed/junction-webhook-contention.md
@@ -1,0 +1,95 @@
+# Junction webhook contention and diagnostics
+
+## Outcome and protected invariants
+
+Reproduce concurrent payload-bearing webhook preparation against local PostgreSQL,
+preserve every accepted payload and its authenticated revision, and report enough
+content-free diagnostics to distinguish transport selection and stale state.
+Consent, connection/source epochs, root authority, trace completion, and the
+clean-to-dirty mailbox handoff remain atomic at their existing owners.
+
+## Owner and hypothesis
+
+Web webhook ingress owns transport selection. The dirty store seals payloads before
+the final admission lock and requires an exact dirty-marker snapshot. Concurrent
+valid ingress can advance that snapshot before either bounded preparation attempt
+commits. Prove this using synthetic events before changing the owner.
+
+## Smallest correction to investigate
+
+Retain existing encryption and compression outside locks. For only monotonic
+ingress revision advancement with unchanged acknowledgement and authority, locally
+rebind the already-compressed, authenticated envelope to the current revision under
+the existing dirty-row lock. Preserve payload identity, schema, root checks, and
+full replan on acknowledgement or authority drift. Add no state, queue, dependency,
+schema migration, or retry owner. Compare this with existing rejection behavior.
+
+## Proof and completion
+
+- [x] Deterministic local reproduction, including two stale preparation attempts.
+- [x] Focused correction with decrypt/readback, wake, acknowledgement, root, and
+  consent regression proof; verify no KMS or compression enters locked work.
+- [x] Bounded diagnostics for transport decisions, replan causes, and recovery;
+  prove private payloads, identifiers, and arbitrary error details stay absent.
+- [x] Focused tests, relevant typecheck, complexity check, and parent diff review.
+- [x] Update the durable owner; close and commit through the final task wrapper.
+
+## Boundaries
+
+Local implementation and tests only. No production mutation or deployment.
+The separately observed overdue dirty frontier is not assumed to share this cause.
+The existing ciphertext schema and readers remain compatible across deployment.
+
+## Evidence
+
+- Before the change, a synthetic sibling transaction after each actual webhook
+  preparation reproduced `HOSTED_DEVICE_SYNC_PREPARATION_STALE` through the
+  production two-attempt retry owner against local PostgreSQL.
+- After the change, that scenario commits on the first preparation. Twelve
+  simultaneous prepared payloads all commit at distinct authenticated revisions.
+  Initially missing and clean markers converge without duplicate mailbox wakes.
+- Readback decrypts every payload at its persisted revision and rejects a wrong
+  revision. Separate real secure-box encryption proof rejects changed connection
+  AAD, forged capabilities, and reverse revision movement without additional KMS
+  calls. Compression instrumentation proves rebind performs neither compression
+  nor decompression.
+- Dirty acknowledgement, owner, missing-marker, and metadata drift remain
+  retryable. Existing PostgreSQL consent-withdrawal and deletion ordering proof
+  passes. Root drift retains its exact diagnostic category and bounded retry.
+- Route and retry tests prove finite transport/drift reason logging and exclusion
+  of synthetic private body, header, exception, and unknown reason content.
+- Web typecheck passes. Complexity guard passes: dirty-store maximum 34 to 29;
+  other modified source owners do not add complexity debt. No broader refactor
+  is justified by the changed path.
+- Consolidated focused proof: 373 tests passed in 12 files, including opt-in real
+  PostgreSQL cases and changelog rendering. Documentation drift/gardening and
+  whitespace checks pass. All fixtures are synthetic; the local database was
+  initialized from the current Prisma schema using its ordinary CLI.
+- Final review removed a redundant companion dirty-row lock after an initially
+  missing marker converges. The affected 34 store tests, typecheck, and complexity
+  guard pass after that adjustment.
+- No new dependencies, schema, persistent state, environment variables, or
+  provider calls. Rebind adds one local authenticated open/seal per payload,
+  serially (at most two webhook resources or one companion resource). No extra
+  datastore calls on an existing-marker rebind; convergence from missing to
+  existing adds the same single dirty-row lock and reread as ordinary preparation.
+
+## Product and deployment disposition
+
+Patch-sized reliability improvement. Journeys: pending webhook burst, first-dirty
+race, clean-to-dirty race, root rotation, acknowledged/replaced state, revoked
+consent, and deletion. Local admission outcome is Ready; actual provider redelivery
+and production deployment are not claimed. No assistant prompt/tool/reply changes.
+The changelog entry describes only fewer delivery retries; no new notification.
+
+Ciphertext schema, payload ids, AAD fields, public responses, and retry budget stay
+compatible. Existing readers can read rebound ciphertext using its stored revision.
+No coordinated Web/Worker deployment order or migration is required. After release,
+inspect bounded 5xx and exhausted-drift counts with the transport decision and
+same-invocation rebind/recovery logs. An attempted rebind is not itself commit proof.
+
+Scope ends at a tested local commit. No PR, remote review, CI, merge, or deployment
+was requested or performed; release review and CI remain future release gates.
+Status: completed
+Updated: 2026-09-08
+Completed: 2026-09-08

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -4,6 +4,10 @@ Last verified: 2026-09-05
 
 ## Purpose
 
+Prepared device-webhook revision rebinding and content-free transport/replan
+diagnostics are owned by `agent-docs/RELIABILITY.md`; local PostgreSQL burst and
+cryptographic-binding proof is indexed in `agent-docs/references/testing-ci-map.md`.
+
 Personal Patterns expiry and checkpoint wake diagnostics are specified in
 `agent-docs/RELIABILITY.md` and the hosted runtime protocol reference.
 

--- a/agent-docs/references/testing-ci-map.md
+++ b/agent-docs/references/testing-ci-map.md
@@ -10,6 +10,18 @@ Code-mode fixtures omit deferred response, exercise-routine, and Telegram rich
 content cards from resident descriptions while requiring discovery. Both plain
 and namespaced code-mode wrappers retain an exact resident-tool inventory check.
 
+Payload webhook preparation contention is covered by
+`device-sync-webhook-preparation-contention-postgres.test.ts` with an isolated
+loopback `murph_test*` database and `MURPH_TEST_POSTGRES_CONCURRENCY=1` through
+`pnpm --dir apps/web test:prepared -- test/<file>`. It exercises the actual
+webhook retry owner, a deterministic sibling write during every preparation,
+and twelve simultaneously prepared payloads with decrypt/readback. Prepared
+root authentication and no extra KMS calls are covered in
+`hosted-crypto-domain-root-store.test.ts`; `device-sync-dirty-payload-rebinding.test.ts`
+proves rebinding does not recompress or decompress. Dirty-store, hosted-wake,
+agent-route, and webhook-batch tests cover acknowledgement/authority rejection,
+bounded diagnostic reasons, recovery, and private-data exclusion.
+
 Linq email identity remediation is covered by the focused
 `hosted-onboarding-linq-email-authority.test.ts` and
 `hosted-onboarding-linq-email-crypto.test.ts` suites, plus linked-account,

--- a/apps/web/app/api/device-sync/webhooks/[provider]/route.ts
+++ b/apps/web/app/api/device-sync/webhooks/[provider]/route.ts
@@ -42,6 +42,15 @@ export const POST = withJsonError(async (
     provider,
     rawBody,
   });
+  // Vercel groups this content-free decision with the same invocation's
+  // completion/error and prepared-write diagnostics. Never log the raw provider
+  // path, request headers, provider/account/trace identity, or body contents.
+  console.info("Hosted device webhook transport selected.", {
+    eventCode: "device_webhook.transport_selected",
+    transport: queueTransport.enabled ? "queue" : "synchronous",
+    reason: queueTransport.reason,
+    rawBodyBytes: rawBody.byteLength,
+  });
   if (queueTransport.enabled) {
     const preparedWebhook = await publicIngress.prepareWebhookForDurableEnqueue(
       provider,

--- a/apps/web/changelog/entries/2026-09-08/connected-device-burst-sync.json
+++ b/apps/web/changelog/entries/2026-09-08/connected-device-burst-sync.json
@@ -9,6 +9,6 @@
     "summary": "Connected-device updates that arrive together are less likely to need another delivery attempt.",
     "details": "Updates remain protected by the same connection and health-data permission checks.",
     "relevanceTags": ["wearables", "reliability"],
-    "sourcePullRequests": []
+    "sourcePullRequests": [3057]
   }
 }

--- a/apps/web/changelog/entries/2026-09-08/connected-device-burst-sync.json
+++ b/apps/web/changelog/entries/2026-09-08/connected-device-burst-sync.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-08",
+  "order": 100,
+  "item": {
+    "id": "connected-device-burst-sync",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "More reliable device updates during busy syncs",
+    "summary": "Connected-device updates that arrive together are less likely to need another delivery attempt.",
+    "details": "Updates remain protected by the same connection and health-data permission checks.",
+    "relevanceTags": ["wearables", "reliability"],
+    "sourcePullRequests": []
+  }
+}

--- a/apps/web/src/lib/device-sync/prisma-store/dirty-connections.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/dirty-connections.ts
@@ -26,12 +26,12 @@ import {
   sha256Hex,
   toIsoTimestamp,
 } from "../shared";
-import { HostedDomainRootPreparationMismatchError } from "../../hosted-crypto/domain-root-store";
 import { runWithHostedDomainRootUnwrapCache } from "../../hosted-crypto/domain-root-unwrap-cache";
 import { toNullablePrismaJsonValue } from "./prisma-json";
 import {
   openHostedDeviceSyncDirtyPayloadJson,
   prepareHostedDeviceSyncDirtyPayloadCrypto,
+  rebindHostedDeviceSyncDirtyPayloadRevision,
   revalidatePreparedHostedDeviceSyncDirtyPayloadCryptoTx,
   sealHostedDeviceSyncDirtyPayloadJson,
   sealHostedDeviceSyncDirtyPayloadJsonFromPreparedCrypto,
@@ -125,7 +125,11 @@ export function hasHostedDeviceSyncDirtyResourcePayload(
 export class HostedDeviceSyncDirtyPreparationMismatchError extends Error {
   readonly code = "HOSTED_DEVICE_SYNC_DIRTY_PREPARATION_MISMATCH";
 
-  constructor() {
+  constructor(readonly reason:
+    | "dirty_marker_missing"
+    | "dirty_marker_changed"
+    | "dirty_acknowledgement_changed"
+    | "dirty_owner_changed" = "dirty_marker_changed") {
     super("Hosted device-sync dirty preparation is stale.");
     this.name = "HostedDeviceSyncDirtyPreparationMismatchError";
   }
@@ -582,25 +586,18 @@ export class PrismaHostedDirtyConnectionStore {
       },
     });
     if (input.preparedPayloadCrypto) {
-      try {
-        await revalidatePreparedHostedDeviceSyncDirtyPayloadCryptoTx({
-          prepared: input.preparedPayloadCrypto,
-          tx: prisma,
-        });
-      } catch (error) {
-        if (error instanceof HostedDomainRootPreparationMismatchError) {
-          throw new HostedDeviceSyncDirtyPreparationMismatchError();
-        }
-        throw error;
-      }
+      await revalidatePreparedHostedDeviceSyncDirtyPayloadCryptoTx({
+        prepared: input.preparedPayloadCrypto,
+        tx: prisma,
+      });
     }
-    if (input.expectedPreparationSnapshot?.exists === true) {
+    if (input.expectedPreparationSnapshot && existing) {
       const locked = await lockDirtyConnectionForCompanionReceipt({
         connectionId: input.connectionId,
         tx: prisma,
       });
       if (!locked) {
-        throw new HostedDeviceSyncDirtyPreparationMismatchError();
+        throw new HostedDeviceSyncDirtyPreparationMismatchError("dirty_marker_missing");
       }
       existing = await prisma.deviceSyncDirtyConnection.findUnique({
         where: {
@@ -608,19 +605,10 @@ export class PrismaHostedDirtyConnectionStore {
         },
       });
     }
-    if (
-      input.expectedPreparationSnapshot
-      && !dirtyConnectionMatchesPreparationSnapshot(
-        existing,
-        input.expectedPreparationSnapshot,
-      )
-    ) {
-      throw new HostedDeviceSyncDirtyPreparationMismatchError();
-    }
+    let preparedDirtyPayloadRows = await resolvePreparedDirtyPayloadRowsForSnapshot(existing, input);
     const hasCompanionNightResource = input.resourceBatch.payloadResources.some(
       (resource) => readCompanionHrvDirtyResourceNightDate(resource) !== null,
     );
-    let preparedDirtyPayloadRows = input.precomputedPayloadRows;
     if (
       input.resourceBatch.payloadResources.length > 0
       && !preparedDirtyPayloadRows
@@ -638,7 +626,7 @@ export class PrismaHostedDirtyConnectionStore {
     if (
       hasCompanionNightResource
       && existing
-      && input.expectedPreparationSnapshot?.exists !== true
+      && !input.expectedPreparationSnapshot
     ) {
       // Companion replay receipts reference the parent connection. Lock the
       // dirty marker first so account deletion and ingress retain one lock
@@ -1448,6 +1436,91 @@ function dirtyConnectionMatchesPreparationSnapshot(
     && existing.provider === snapshot.provider
     && existing.updatedAt.toISOString() === snapshot.updatedAt
     && existing.userId === snapshot.userId;
+}
+
+function canRebasePreparedDirtyIngress(
+  existing: DeviceSyncDirtyConnectionPrismaRecord | null,
+  snapshot: DirtyConnectionPreparationSnapshot,
+  input: {
+    provider: string;
+    userId: string;
+  },
+): boolean {
+  // Only sibling ingress may move the snapshot. An acknowledgement, deletion,
+  // owner change, or clean marker still needs the ordinary full replan so its
+  // mailbox and connection admission are prepared against current authority.
+  return existing !== null
+    && existing.userId === input.userId
+    && existing.provider === input.provider
+    && existing.dirtyRevision > existing.processedRevision
+    && (snapshot.exists
+      ? existing.userId === snapshot.userId
+        && existing.provider === snapshot.provider
+        && existing.processedRevision === snapshot.processedRevision
+        && existing.dirtyRevision > snapshot.dirtyRevision
+      : existing.processedRevision === 0n);
+}
+
+async function rebindPreparedDirtyPayloadRows(input: {
+  crypto: PreparedHostedDeviceSyncDirtyPayloadCrypto;
+  nextDirtyRevision: bigint;
+  prepared: PreparedDirtyPayloadRows;
+}): Promise<PreparedDirtyPayloadRows> {
+  const rows: PreparedDirtyPayloadRow[] = [];
+  // Payload ids identify these exact prepared resources, independently of the
+  // marker's eventual commit revision. Preserve them inside the compressed
+  // envelope and bind both the stored row and its AAD to the new revision.
+  for (const row of input.prepared.rows) {
+    rows.push({
+      ...row,
+      dirtyRevision: input.nextDirtyRevision,
+      resourceEncrypted: await rebindHostedDeviceSyncDirtyPayloadRevision({
+        ...row,
+        nextDirtyRevision: input.nextDirtyRevision,
+        payloadId: row.id,
+        prepared: input.crypto,
+        value: row.resourceEncrypted,
+      }),
+    });
+  }
+  return { ...input.prepared, dirtyRevision: input.nextDirtyRevision, rows };
+}
+
+async function resolvePreparedDirtyPayloadRowsForSnapshot(
+  existing: DeviceSyncDirtyConnectionPrismaRecord | null,
+  input: {
+    expectedPreparationSnapshot?: DirtyConnectionPreparationSnapshot;
+    preparedPayloadCrypto?: PreparedHostedDeviceSyncDirtyPayloadCrypto;
+    precomputedPayloadRows?: PreparedDirtyPayloadRows;
+    provider: string;
+    userId: string;
+  },
+): Promise<PreparedDirtyPayloadRows | undefined> {
+  const snapshot = input.expectedPreparationSnapshot;
+  if (!snapshot || dirtyConnectionMatchesPreparationSnapshot(existing, snapshot)) {
+    return input.precomputedPayloadRows;
+  }
+  if (!input.precomputedPayloadRows || !input.preparedPayloadCrypto
+    || !canRebasePreparedDirtyIngress(existing, snapshot, input)) {
+    throw new HostedDeviceSyncDirtyPreparationMismatchError(
+      !existing ? "dirty_marker_missing"
+        : existing.userId !== input.userId || existing.provider !== input.provider
+          ? "dirty_owner_changed"
+          : snapshot.exists && existing.processedRevision !== snapshot.processedRevision
+            ? "dirty_acknowledgement_changed"
+            : "dirty_marker_changed",
+    );
+  }
+  const rebound = await rebindPreparedDirtyPayloadRows({
+    nextDirtyRevision: resolveDirtyPayloadRevision(existing),
+    prepared: input.precomputedPayloadRows,
+    crypto: input.preparedPayloadCrypto,
+  });
+  console.info("Hosted device-sync prepared payload revision rebound.", {
+    eventCode: "device_sync.prepared_payload_rebound",
+    payloadCount: rebound.rows.length,
+  });
+  return rebound;
 }
 
 function requirePreparedDirtyConnectionUpsert(

--- a/apps/web/src/lib/device-sync/prisma-store/dirty-payloads.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/dirty-payloads.ts
@@ -16,6 +16,7 @@ import {
 import {
   isHostedSecureBoxStringTestCodecConfiguredForTests,
   openHostedUserSecureBoxString,
+  openHostedUserSecureBoxStringFromPreparedRoot,
   sealHostedUserSecureBoxString,
   sealHostedUserSecureBoxStringFromPreparedRoot,
   type HostedSecureBoxPrismaClient,
@@ -144,7 +145,7 @@ export async function sealHostedDeviceSyncDirtyPayloadJsonFromPreparedCrypto(inp
   userId: string;
   value: unknown;
 }): Promise<string> {
-  const details = requirePreparedHostedDeviceSyncDirtyPayloadCrypto(input.prepared);
+  requirePreparedHostedDeviceSyncDirtyPayloadCrypto(input.prepared);
   if (
     input.prepared.domain !== HOSTED_DEVICE_SYNC_DIRTY_PAYLOAD_DOMAIN
     || input.prepared.userId !== input.userId
@@ -163,12 +164,60 @@ export async function sealHostedDeviceSyncDirtyPayloadJsonFromPreparedCrypto(inp
     encoding: "base64url",
     schema: HOSTED_DEVICE_SYNC_DIRTY_PAYLOAD_SCHEMA,
   };
+  return sealPreparedDirtyPayloadEnvelope({ ...input, value: JSON.stringify(envelope) });
+}
+
+// The dirty store owns both the ciphertext and its exact request-local root.
+// Revision drift needs only local authenticated open/seal of the compressed
+// envelope: never another compression, classifier, database read, or KMS call.
+export async function rebindHostedDeviceSyncDirtyPayloadRevision(input: {
+  connectionId: string;
+  dirtyRevision: bigint;
+  nextDirtyRevision: bigint;
+  payloadId: string;
+  prepared: PreparedHostedDeviceSyncDirtyPayloadCrypto;
+  provider: string;
+  userId: string;
+  value: string;
+}): Promise<string> {
+  requirePreparedHostedDeviceSyncDirtyPayloadCrypto(input.prepared);
+  if (input.prepared.userId !== input.userId || input.nextDirtyRevision <= input.dirtyRevision) {
+    throw new TypeError("Dirty payload revision rebinding requires the same owner and a newer revision.");
+  }
+  const envelope = await openHostedUserSecureBoxStringFromPreparedRoot({
+    aad: buildHostedDeviceSyncDirtyPayloadAad(input),
+    lane: "device-sync-payload",
+    preparedRootKeyId: input.prepared.rootKeyId,
+    scope: buildHostedDeviceSyncDirtyPayloadScope(input.payloadId),
+    userId: input.userId,
+    value: input.value,
+  });
+  if (!envelope) {
+    throw new TypeError("Dirty payload revision rebinding returned an empty envelope.");
+  }
+  return sealPreparedDirtyPayloadEnvelope({
+    ...input,
+    dirtyRevision: input.nextDirtyRevision,
+    value: envelope,
+  });
+}
+
+async function sealPreparedDirtyPayloadEnvelope(input: {
+  connectionId: string;
+  dirtyRevision: bigint;
+  payloadId: string;
+  prepared: PreparedHostedDeviceSyncDirtyPayloadCrypto;
+  provider: string;
+  userId: string;
+  value: string;
+}): Promise<string> {
+  const details = requirePreparedHostedDeviceSyncDirtyPayloadCrypto(input.prepared);
   const sealInput = {
     aad: buildHostedDeviceSyncDirtyPayloadAad(input),
     lane: "device-sync-payload" as const,
     scope: buildHostedDeviceSyncDirtyPayloadScope(input.payloadId),
     userId: input.userId,
-    value: JSON.stringify(envelope),
+    value: input.value,
   };
   const encrypted = details.mode === "test-codec"
     ? await sealHostedUserSecureBoxString(sealInput)

--- a/apps/web/src/lib/device-sync/wake-service.ts
+++ b/apps/web/src/lib/device-sync/wake-service.ts
@@ -2273,7 +2273,7 @@ async function persistHostedDeviceSyncCompanionResource(input: {
       ? JUNCTION_COMPANION_HRV_SOURCE_PROVIDER
       : input.resource.sourceProviderSlug,
   );
-  const result = await runWithHostedDeviceSyncPreparedWriteReplan(async () => {
+  const result = await runWithHostedDeviceSyncPreparedWriteReplan("companion", async () => {
     const authority = await input.store.withHealthDataAdmissionLock(
       input.userId,
       input.connectionId,
@@ -2355,7 +2355,7 @@ async function persistHostedDeviceSyncCompanionResource(input: {
             return { wakeMailboxItemId: null };
           }
           if (!preparedMailbox) {
-            throw createHostedDeviceSyncDirtyPreparationMismatchError();
+            throw createHostedDeviceSyncDirtyPreparationMismatchError("wake_preparation_missing");
           }
 
           const mailboxAppend = await appendHostedMailboxEnvelopeWithPreparedCryptoTx({
@@ -2819,7 +2819,7 @@ async function persistHostedDeviceSyncWebhookAccepted(
       || input.eventType === "provider.connection.updated"
     );
   try {
-    result = await runWithHostedDeviceSyncPreparedWriteReplan(async (attempt) => {
+    result = await runWithHostedDeviceSyncPreparedWriteReplan("webhook", async (attempt) => {
       const hasPayloadResources = input.dirtyResources.some(
         hasHostedDeviceSyncDirtyResourcePayload,
       );
@@ -2983,7 +2983,7 @@ async function persistHostedDeviceSyncWebhookAccepted(
                   !== initialAdmission.status.hasNonTerminalLegacyFitbitSource
               )
             ) {
-              throw createHostedDeviceSyncDirtyPreparationMismatchError();
+              throw createHostedDeviceSyncDirtyPreparationMismatchError("admission_classification_changed");
             }
 
             const wakeMailboxItemIds: string[] = [];
@@ -2996,7 +2996,7 @@ async function persistHostedDeviceSyncWebhookAccepted(
                 || !finalAdmission.currentConnectionRecord
                 || !finalAdmission.currentSource
               ) {
-                throw createHostedDeviceSyncDirtyPreparationMismatchError();
+                throw createHostedDeviceSyncDirtyPreparationMismatchError("source_preparation_missing");
               }
               const sourceMailboxAppend = await commitHostedDeviceSyncConnectionEstablishedTx({
                 account: sourceConnectionAccount,
@@ -3118,7 +3118,7 @@ async function persistHostedDeviceSyncWebhookAccepted(
               && !sourceEstablishmentOwnsWebhookHandoff
             ) {
               if (!preparedMailbox) {
-                throw createHostedDeviceSyncDirtyPreparationMismatchError();
+                throw createHostedDeviceSyncDirtyPreparationMismatchError("wake_preparation_missing");
               }
               const wake = buildHostedDeviceSyncWake({
                 connectionId: input.connectionId,
@@ -3739,12 +3739,16 @@ const HOSTED_DEVICE_SYNC_DIRTY_PREPARATION_MISMATCH_CODE =
 const HOSTED_DEVICE_SYNC_PREPARATION_STALE_CODE =
   "HOSTED_DEVICE_SYNC_PREPARATION_STALE";
 
-function createHostedDeviceSyncDirtyPreparationMismatchError(): Error & {
+function createHostedDeviceSyncDirtyPreparationMismatchError(
+  reason: "admission_authority_changed" | "admission_classification_changed"
+    | "source_preparation_missing" | "wake_preparation_missing" = "admission_authority_changed",
+): Error & {
   code: typeof HOSTED_DEVICE_SYNC_DIRTY_PREPARATION_MISMATCH_CODE;
+  reason: string;
 } {
   return Object.assign(
     new Error("Hosted device-sync dirty preparation is stale."),
-    { code: HOSTED_DEVICE_SYNC_DIRTY_PREPARATION_MISMATCH_CODE } as const,
+    { code: HOSTED_DEVICE_SYNC_DIRTY_PREPARATION_MISMATCH_CODE, reason } as const,
   );
 }
 
@@ -3759,6 +3763,7 @@ function isHostedWebhookAdmissionAuthorityDriftError(error: unknown): boolean {
 }
 
 async function runWithHostedDeviceSyncPreparedWriteReplan<T>(
+  operationKind: "webhook" | "companion",
   operation: (attempt: number) => Promise<T>,
 ): Promise<T> {
   for (
@@ -3768,13 +3773,29 @@ async function runWithHostedDeviceSyncPreparedWriteReplan<T>(
   ) {
     try {
       const attemptOperation = () => operation(attempt);
-      return await (attempt === 0
+      const result = await (attempt === 0
         ? runWithHostedDomainRootUnwrapCache(attemptOperation)
         : runWithFreshHostedDomainRootUnwrapCache(attemptOperation));
+      if (attempt > 0) {
+        console.info("Hosted device-sync prepared write recovered.", {
+          eventCode: "device_sync.prepared_write_recovered",
+          operation: operationKind,
+          attempts: attempt + 1,
+        });
+      }
+      return result;
     } catch (error) {
       if (!isHostedDeviceSyncPreparedWriteReplanError(error)) {
         throw error;
       }
+      console.warn("Hosted device-sync prepared write changed before commit.", {
+        eventCode: "device_sync.prepared_write_drift",
+        operation: operationKind,
+        attempt: attempt + 1,
+        maxAttempts: HOSTED_DEVICE_SYNC_PREPARED_WRITE_ATTEMPTS,
+        exhausted: attempt === HOSTED_DEVICE_SYNC_PREPARED_WRITE_ATTEMPTS - 1,
+        reason: readHostedDeviceSyncPreparedWriteDriftReason(error),
+      });
       if (attempt === HOSTED_DEVICE_SYNC_PREPARED_WRITE_ATTEMPTS - 1) {
         if (isDeviceSyncError(error)) {
           throw error;
@@ -3790,6 +3811,24 @@ async function runWithHostedDeviceSyncPreparedWriteReplan<T>(
   }
 
   throw new Error("Hosted device-sync prepared-write replan loop exhausted unexpectedly.");
+}
+
+function readHostedDeviceSyncPreparedWriteDriftReason(error: unknown): string {
+  if (error instanceof HostedDomainRootPreparationMismatchError) {
+    return "domain_root_changed";
+  }
+  if (error && typeof error === "object") {
+    if ("code" in error && error.code === HOSTED_DEVICE_SYNC_DIRTY_STATE_CONTENTION_CODE) {
+      return "dirty_state_contention";
+    }
+    if ("reason" in error && typeof error.reason === "string"
+      && ["dirty_marker_missing", "dirty_marker_changed", "dirty_acknowledgement_changed",
+        "dirty_owner_changed", "admission_authority_changed", "admission_classification_changed",
+        "source_preparation_missing", "wake_preparation_missing"].includes(error.reason)) {
+      return error.reason;
+    }
+  }
+  return "admission_or_wake_changed";
 }
 
 function isHostedDeviceSyncPreparedWriteReplanError(error: unknown): boolean {

--- a/apps/web/src/lib/device-sync/webhook-queue.ts
+++ b/apps/web/src/lib/device-sync/webhook-queue.ts
@@ -34,20 +34,19 @@ export function prepareHostedDeviceWebhookQueueTransport(input: {
   provider: string;
   rawBody: Uint8Array;
   source?: Readonly<Record<string, string | undefined>>;
-}): { enabled: boolean } {
+}): { enabled: boolean; reason: "provider_not_enabled" | "body_too_large" | "queue_enabled" } {
   const providerEnabled = readHostedDeviceWebhookQueueProviders(input.source).has(
     input.provider.toLowerCase(),
   );
   if (!providerEnabled) {
-    return { enabled: false };
+    return { enabled: false, reason: "provider_not_enabled" };
   }
   // Decide synchronous oversize fallback before provider verification. Once a
   // verified event is prepared for Queue, an enqueue failure never falls
   // through to synchronous admission; the signature/parser never runs twice.
-  return {
-    enabled:
-      input.rawBody.byteLength <= HOSTED_DEVICE_WEBHOOK_QUEUE_MAX_RAW_BODY_BYTES,
-  };
+  return input.rawBody.byteLength <= HOSTED_DEVICE_WEBHOOK_QUEUE_MAX_RAW_BODY_BYTES
+    ? { enabled: true, reason: "queue_enabled" }
+    : { enabled: false, reason: "body_too_large" };
 }
 
 export async function enqueueHostedDeviceWebhook(input: {

--- a/apps/web/test/agent-route.test.ts
+++ b/apps/web/test/agent-route.test.ts
@@ -123,6 +123,7 @@ describe("hosted device-sync agent and webhook routes", () => {
     mocks.resolveWebhookPreflight.mockResolvedValue(null);
     mocks.prepareHostedDeviceWebhookQueueTransport.mockReturnValue({
       enabled: false,
+      reason: "provider_not_enabled",
     });
     mocks.pairAgent.mockResolvedValue({
       agent: {
@@ -432,6 +433,41 @@ describe("hosted device-sync agent and webhook routes", () => {
     expect(response.status).toBe(503);
     expect(mocks.handleWebhook).not.toHaveBeenCalled();
   });
+
+  it.each(["body_too_large", "provider_not_enabled", "queue_enabled"])(
+    "records a content-free %s transport decision alongside retryable failures",
+    async (reason) => {
+      const info = vi.spyOn(console, "info").mockImplementation(() => {});
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const privateBody = Buffer.from("synthetic-private-payload-and-account");
+      mocks.readWebhookRawBody.mockResolvedValueOnce(privateBody);
+      mocks.prepareHostedDeviceWebhookQueueTransport.mockReturnValueOnce({
+        enabled: reason === "queue_enabled", reason,
+      });
+      const error = deviceSyncError({ code: "HOSTED_DEVICE_SYNC_PREPARATION_STALE",
+        httpStatus: 503, retryable: true, message: "Retry the request.",
+        details: { payload: privateBody.toString() } });
+      if (reason === "queue_enabled") {
+        mocks.prepareWebhookForDurableEnqueue.mockRejectedValueOnce(error);
+      } else {
+        mocks.handleWebhook.mockRejectedValueOnce(error);
+      }
+      const response = await webhookRoute.POST(new Request("https://example.test/api/device-sync/webhooks/junction", {
+        method: "POST", headers: { authorization: "synthetic-private-header" },
+      }), createRouteContext({ provider: "junction" }));
+      expect(response.status).toBe(503);
+      expect(info).toHaveBeenCalledWith("Hosted device webhook transport selected.", {
+        eventCode: "device_webhook.transport_selected", reason,
+        transport: reason === "queue_enabled" ? "queue" : "synchronous",
+        rawBodyBytes: privateBody.byteLength,
+      });
+      const emitted = JSON.stringify([info.mock.calls, warn.mock.calls]);
+      expect(emitted).not.toContain(privateBody.toString());
+      expect(emitted).not.toContain("synthetic-private-header");
+      info.mockRestore();
+      warn.mockRestore();
+    },
+  );
 
   it("returns 202 for hosted Junction orphan webhook deliveries instead of 503", async () => {
     mocks.handleWebhook.mockResolvedValue({

--- a/apps/web/test/device-sync-dirty-payload-rebinding.test.ts
+++ b/apps/web/test/device-sync-dirty-payload-rebinding.test.ts
@@ -1,0 +1,48 @@
+import { zstdCompress, zstdDecompress } from "node:zlib";
+
+import { expect, it, vi } from "vitest";
+
+vi.mock("node:zlib", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:zlib")>();
+  return {
+    ...actual,
+    zstdCompress: vi.fn(actual.zstdCompress),
+    zstdDecompress: vi.fn(actual.zstdDecompress),
+  };
+});
+
+import {
+  openHostedDeviceSyncDirtyPayloadJson,
+  prepareHostedDeviceSyncDirtyPayloadCrypto,
+  rebindHostedDeviceSyncDirtyPayloadRevision,
+  sealHostedDeviceSyncDirtyPayloadJsonFromPreparedCrypto,
+} from "@/src/lib/device-sync/prisma-store/dirty-payloads";
+
+it("rebinds only the encrypted compressed envelope without recompressing the payload", async () => {
+  const identity = {
+    connectionId: "synthetic-connection",
+    dirtyRevision: 3n,
+    payloadId: "synthetic-payload",
+    provider: "junction",
+    userId: "synthetic-member",
+  };
+  // The normal test codec bypasses external root provisioning. The separate
+  // real-crypto proof authenticates revision, connection, and prepared root.
+  const prepared = await prepareHostedDeviceSyncDirtyPayloadCrypto({
+    prisma: {} as never,
+    userId: identity.userId,
+  });
+  const resource = { payload: { webhookDataJson: JSON.stringify({ value: 321 }) } };
+  const value = await sealHostedDeviceSyncDirtyPayloadJsonFromPreparedCrypto({
+    ...identity, prepared, value: resource,
+  });
+  expect(zstdCompress).toHaveBeenCalledTimes(1);
+  const rebound = await rebindHostedDeviceSyncDirtyPayloadRevision({
+    ...identity, prepared, value, nextDirtyRevision: 8n,
+  });
+  expect(zstdCompress).toHaveBeenCalledTimes(1);
+  expect(zstdDecompress).not.toHaveBeenCalled();
+  expect(await openHostedDeviceSyncDirtyPayloadJson({
+    ...identity, dirtyRevision: 8n, value: rebound,
+  })).toEqual(resource);
+});

--- a/apps/web/test/device-sync-hosted-wake.test.ts
+++ b/apps/web/test/device-sync-hosted-wake.test.ts
@@ -8184,6 +8184,8 @@ describe("hosted device-sync wakes", () => {
   });
 
   it("performs one full fresh-cache replan after the real mailbox root preparation drifts", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
     const preparationCaches: unknown[] = [];
     mocks.prepareDirtyConnectionUpsert.mockImplementation(async (input) => {
       preparationCaches.push(getHostedDomainRootUnwrapCache());
@@ -8217,9 +8219,17 @@ describe("hosted device-sync wakes", () => {
     expect(preparationCaches[1]).not.toBe(preparationCaches[0]);
     expect(mocks.completeWebhookTrace).toHaveBeenCalledTimes(2);
     expect(mocks.appendHostedMailboxEnvelope).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith("Hosted device-sync prepared write changed before commit.", {
+      eventCode: "device_sync.prepared_write_drift", operation: "webhook",
+      attempt: 1, maxAttempts: 2, exhausted: false, reason: "domain_root_changed",
+    });
+    expect(info).toHaveBeenCalledWith("Hosted device-sync prepared write recovered.", {
+      eventCode: "device_sync.prepared_write_recovered", operation: "webhook", attempts: 2,
+    });
   });
 
   it("returns a retryable error when the real mailbox root preparation drifts twice", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     mocks.appendHostedMailboxEnvelopeTx
       .mockRejectedValueOnce(new HostedDomainRootPreparationMismatchError())
       .mockRejectedValueOnce(new HostedDomainRootPreparationMismatchError());
@@ -8243,6 +8253,39 @@ describe("hosted device-sync wakes", () => {
     expect(mocks.completeWebhookTrace).toHaveBeenCalledTimes(2);
     expect(mocks.createSignal).not.toHaveBeenCalled();
     expect(mocks.appendHostedMailboxEnvelope).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith("Hosted device-sync prepared write changed before commit.", {
+      eventCode: "device_sync.prepared_write_drift", operation: "webhook",
+      attempt: 2, maxAttempts: 2, exhausted: true, reason: "domain_root_changed",
+    });
+  });
+
+  it.each([
+    ["dirty_marker_missing", "dirty_marker_missing"],
+    ["dirty_marker_changed", "dirty_marker_changed"],
+    ["dirty_acknowledgement_changed", "dirty_acknowledgement_changed"],
+    ["dirty_owner_changed", "dirty_owner_changed"],
+    ["synthetic-private-reason", "admission_or_wake_changed"],
+  ])("logs bounded preparation reason %s without private exception details", async (reason, expectedReason) => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const failure = Object.assign(new Error("synthetic-private-exception"), {
+      code: "HOSTED_DEVICE_SYNC_DIRTY_PREPARATION_MISMATCH", reason,
+    });
+    mocks.upsertDirtyConnectionWithPreparedPlanTx
+      .mockRejectedValueOnce(failure).mockRejectedValueOnce(failure);
+    const controlPlane = createHostedDeviceSyncPublicIngressService(new Request(
+      "https://control.example.test/api/device-sync/webhooks/oura", {
+        body: JSON.stringify({ event: "sleep.updated" }),
+        headers: { "content-type": "application/json" }, method: "POST",
+      },
+    ));
+    await expect(controlPlane.handleWebhook("oura")).rejects.toMatchObject({
+      code: "HOSTED_DEVICE_SYNC_PREPARATION_STALE", httpStatus: 503,
+    });
+    expect(warn).toHaveBeenCalledWith("Hosted device-sync prepared write changed before commit.", {
+      eventCode: "device_sync.prepared_write_drift", operation: "webhook",
+      attempt: 2, maxAttempts: 2, exhausted: true, reason: expectedReason,
+    });
+    expect(JSON.stringify(warn.mock.calls)).not.toContain("synthetic-private");
   });
 
   it("keeps webhook acceptance retryable when dirty wake mailbox dedupe conflicts", async () => {

--- a/apps/web/test/device-sync-webhook-batch.test.ts
+++ b/apps/web/test/device-sync-webhook-batch.test.ts
@@ -29,12 +29,15 @@ describe("hosted device webhook batch admission", () => {
       provider: "oura",
       rawBody: new Uint8Array(32 * 1024),
       source: { HOSTED_DEVICE_WEBHOOK_QUEUE_PROVIDERS: "oura" },
-    })).toEqual({ enabled: true });
+    })).toEqual({ enabled: true, reason: "queue_enabled" });
     expect(prepareHostedDeviceWebhookQueueTransport({
       provider: "oura",
       rawBody: new Uint8Array(32 * 1024 + 1),
       source: { HOSTED_DEVICE_WEBHOOK_QUEUE_PROVIDERS: "oura" },
-    })).toEqual({ enabled: false });
+    })).toEqual({ enabled: false, reason: "body_too_large" });
+    expect(prepareHostedDeviceWebhookQueueTransport({
+      provider: "junction", rawBody: new Uint8Array(12), source: {},
+    })).toEqual({ enabled: false, reason: "provider_not_enabled" });
   });
 
   it("admits 100 same-account deliveries in order with one active event lease", async () => {

--- a/apps/web/test/device-sync-webhook-preparation-contention-postgres.test.ts
+++ b/apps/web/test/device-sync-webhook-preparation-contention-postgres.test.ts
@@ -1,0 +1,158 @@
+import { randomUUID } from "node:crypto";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaDeviceSyncControlPlaneStore } from "@/src/lib/device-sync/prisma-store";
+import { openHostedDeviceSyncDirtyPayloadJson } from "@/src/lib/device-sync/prisma-store/dirty-payloads";
+import { handleHostedDeviceSyncWebhookAccepted } from "@/src/lib/device-sync/wake-service";
+import { setHostedSecureBoxStringTestCodecForTests } from "@/src/lib/hosted-crypto/secure-box";
+import { createPrismaClient } from "@/src/lib/prisma";
+
+const mailboxPreparation = vi.hoisted(() => vi.fn(async () => Object.freeze({
+  testOnlyUnusedMailboxPreparation: true,
+})));
+vi.mock("@/src/lib/hosted-mailbox/store", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/src/lib/hosted-mailbox/store")>(),
+  // These cases lose the first-dirty race to a sibling before final admission,
+  // so the optimistic mailbox capability must never be consumed. Only the
+  // external root preparation is substituted; actual append stays production.
+  prepareHostedMailboxItemAppendCrypto: mailboxPreparation,
+}));
+
+const enabled = process.env.MURPH_TEST_POSTGRES_CONCURRENCY === "1";
+const databaseUrl = process.env.DATABASE_URL ?? "";
+if (enabled) {
+  const url = new URL(databaseUrl);
+  if (!["localhost", "127.0.0.1", "[::1]"].includes(url.hostname)
+    || !url.pathname.startsWith("/murph_test")) {
+    throw new Error("Webhook contention proof requires local murph_test PostgreSQL.");
+  }
+}
+
+describe.skipIf(!enabled)("payload webhook preparation contention (PostgreSQL)", () => {
+  it.each(["interleaved", "burst", "first_dirty", "clean_to_dirty"] as const)("accepts payloads through %s preparation contention", async (mode) => {
+    const prisma = createPrismaClient({ databaseUrl, poolMax: 2 });
+    mailboxPreparation.mockClear();
+    const store = new PrismaDeviceSyncControlPlaneStore({ prisma });
+    const suffix = randomUUID();
+    const userId = `member_webhook_contention_${suffix}`;
+    const connectionId = `dsc_webhook_contention_${suffix}`;
+    const traceId = `trace_webhook_contention_${suffix}`;
+    const count = mode === "burst" ? 12 : 1;
+    const traceIds = Array.from({ length: count }, (_, index) => `${traceId}_${index}`);
+    const connectedAt = new Date("2026-08-01T00:00:00.000Z");
+    const now = "2026-08-02T00:00:00.000Z";
+    // Authenticate all binding fields, including the revision, in this local
+    // codec. Provider/KMS transport is outside the concurrency proof.
+    const binding = (input: { aad: unknown; lane: string; scope: string; userId: string }) =>
+      JSON.stringify([input.aad, input.lane, input.scope, input.userId],
+        (_key, value: unknown) => typeof value === "bigint" ? value.toString() : value);
+    setHostedSecureBoxStringTestCodecForTests({
+      encrypt: (input) => JSON.stringify({ binding: binding(input), value: input.value }),
+      decrypt: (input) => {
+        const envelope = JSON.parse(input.value) as { binding: string; value: string };
+        if (envelope.binding !== binding(input)) throw new Error("Payload binding mismatch.");
+        return envelope.value;
+      },
+    });
+    try {
+      await prisma.hostedMember.create({ data: { id: userId } });
+      await prisma.deviceConnection.create({ data: {
+        id: connectionId, userId, provider: "junction", status: "active",
+        setupPhase: "source_confirmed", credentialKind: "none", connectedAt,
+        providerAccountBlindIndex: `blind_${suffix}`, scopesJson: [], metadataJson: {},
+      } });
+      await prisma.deviceConnectionSource.create({ data: {
+        id: `source_${suffix}`, connectionId, firstSeenAt: connectedAt,
+        lastSeenAt: connectedAt, sourceProviderSlug: "garmin", status: "connected",
+        sourceInstanceKey: `source_instance_${suffix}`, resourceAvailabilitySummaryJson: {},
+      } });
+      if (mode !== "first_dirty") {
+        await store.upsertDirtyConnection({
+          connectionId, userId, provider: "junction", dirtyAt: now, resources: [],
+        });
+        if (mode === "clean_to_dirty") {
+          await prisma.deviceSyncDirtyConnection.update({
+            where: { connectionId }, data: { processedRevision: 1n },
+          });
+        }
+      }
+      await prisma.deviceWebhookTrace.createMany({ data: traceIds.map((id) => ({
+        provider: "junction", traceId: id, claimToken: "synthetic-claim",
+        eventType: "daily.data.steps.created", providerAccountBlindIndex: `blind_${suffix}`,
+        receivedAt: new Date(now), status: "processing",
+        processingExpiresAt: new Date("2026-08-02T01:00:00.000Z"),
+      })) });
+
+      const originalPrepare = store.prepareDirtyConnectionUpsert.bind(store);
+      let preparedCount = 0;
+      let releaseBurst!: () => void;
+      const burstPrepared = new Promise<void>((resolve) => { releaseBurst = resolve; });
+      const prepare = vi.spyOn(store, "prepareDirtyConnectionUpsert")
+        .mockImplementation(async (input) => {
+          const prepared = await originalPrepare(input);
+          if (mode === "burst") {
+            preparedCount += 1;
+            if (preparedCount === count) releaseBurst();
+            await burstPrepared;
+            return prepared;
+          }
+          // A completed independent transaction deterministically lands in the
+          // vulnerable prepare/commit window, including the real owner's retry.
+          await store.upsertDirtyConnection({
+            connectionId, userId, provider: "junction", dirtyAt: now,
+            resources: [{ count: 1, jobKind: "reconcile", resource: "activity",
+              resourceCategory: "activity", sourceProviderSlug: "garmin",
+              windowStart: null, windowEnd: null }],
+          });
+          return prepared;
+        });
+      const payload = { resource: "steps", webhookDataJson: JSON.stringify({ value: 321 }) };
+      const results = await Promise.allSettled(traceIds.map((id) => handleHostedDeviceSyncWebhookAccepted({
+        account: { connectedAt: connectedAt.toISOString(), id: connectionId, provider: "junction" },
+        claimToken: "synthetic-claim", now, ownerId: userId, processingAttemptedAt: now,
+        store, traceId: id,
+        webhook: {
+          acceptanceMode: "level_dirty_hint", dataSourceProviderSlug: "garmin",
+          eventType: "daily.data.steps.created", occurredAt: now,
+          resourceCategory: "timeseries", sourceProviderSlug: "garmin",
+          jobs: [{ kind: "resource", payload }],
+        },
+      })));
+      for (const result of results) {
+        if (result.status === "rejected") throw result.reason;
+      }
+      expect(prepare).toHaveBeenCalledTimes(count);
+      const dirty = await prisma.deviceSyncDirtyConnection.findUniqueOrThrow({ where: { connectionId } });
+      expect(dirty.dirtyRevision).toBe(mode === "burst" ? 13n : mode === "first_dirty" ? 2n : 3n);
+      expect(dirty.processedRevision).toBe(mode === "clean_to_dirty" ? 1n : 0n);
+      const rows = await prisma.deviceSyncDirtyPayload.findMany({ where: { connectionId } });
+      expect(rows).toHaveLength(count);
+      expect(new Set(rows.map((row) => row.dirtyRevision)).size).toBe(count);
+      for (const row of rows) {
+      const openInput = { connectionId, dirtyRevision: row.dirtyRevision,
+        payloadId: row.id, prisma, provider: "junction", userId, value: row.resourceEncrypted };
+      expect(await openHostedDeviceSyncDirtyPayloadJson(openInput)).toMatchObject({ payload });
+      await expect(openHostedDeviceSyncDirtyPayloadJson({ ...openInput, dirtyRevision: row.dirtyRevision + 1n }))
+        .rejects.toThrow("Payload binding mismatch");
+      }
+      expect(await prisma.deviceWebhookTrace.count({
+        where: { provider: "junction", traceId: { in: traceIds }, status: "processed" },
+      })).toBe(count);
+      expect(await prisma.hostedMailboxItem.count({ where: { userId } })).toBe(0);
+      expect(mailboxPreparation).toHaveBeenCalledTimes(
+        mode === "first_dirty" || mode === "clean_to_dirty" ? 1 : 0,
+      );
+    } finally {
+      vi.restoreAllMocks();
+      setHostedSecureBoxStringTestCodecForTests(null);
+      await prisma.deviceWebhookTrace.deleteMany({ where: { provider: "junction", traceId: { in: traceIds } } });
+      await prisma.deviceSyncDirtyPayload.deleteMany({ where: { connectionId } });
+      await prisma.deviceSyncDirtyConnection.deleteMany({ where: { connectionId } });
+      await prisma.deviceConnectionSource.deleteMany({ where: { connectionId } });
+      await prisma.deviceConnection.deleteMany({ where: { id: connectionId } });
+      await prisma.hostedMember.deleteMany({ where: { id: userId } });
+      await prisma.$disconnect();
+    }
+  });
+});

--- a/apps/web/test/hosted-crypto-domain-root-store.test.ts
+++ b/apps/web/test/hosted-crypto-domain-root-store.test.ts
@@ -2574,6 +2574,55 @@ test("the prepared Web root token commits and reuses only its exact scoped root"
   assert.equal(tx.persistedEnvelopes.length, 1);
 });
 
+test("dirty payload revision rebinding preserves real ciphertext AAD without another KMS call", async () => {
+  const { tx, decryptMetrics, encryptCalls, signCalls } = await createHostedWebCryptoTransactionFixture();
+  const { provisionActiveHostedDomainRootEnvelopeForUserOnly } = await import("../src/lib/hosted-crypto/domain-root-store");
+  const { runWithHostedDomainRootUnwrapCache, runWithHostedDomainRootProviderCallsDisabled } = await import(
+    "../src/lib/hosted-crypto/domain-root-unwrap-cache"
+  );
+  const {
+    openHostedDeviceSyncDirtyPayloadJson,
+    prepareHostedDeviceSyncDirtyPayloadCrypto,
+    rebindHostedDeviceSyncDirtyPayloadRevision,
+    revalidatePreparedHostedDeviceSyncDirtyPayloadCryptoTx,
+    sealHostedDeviceSyncDirtyPayloadJsonFromPreparedCrypto,
+  } = await import("../src/lib/device-sync/prisma-store/dirty-payloads");
+  const userId = "member-test-payload-rebinding";
+  await provisionActiveHostedDomainRootEnvelopeForUserOnly({
+    domain: "device", prisma: tx.prisma, reason: "test.payload-rebinding", userId,
+  });
+  await runWithHostedDomainRootUnwrapCache(async () => {
+    const prepared = await prepareHostedDeviceSyncDirtyPayloadCrypto({ prisma: tx.prisma, userId });
+    const identity = { connectionId: "connection-rebinding", dirtyRevision: 2n,
+      payloadId: "payload-rebinding", provider: "junction", userId };
+    const resource = { payload: { webhookDataJson: JSON.stringify({ value: 321 }) } };
+    const value = await sealHostedDeviceSyncDirtyPayloadJsonFromPreparedCrypto({
+      ...identity, prepared, value: resource,
+    });
+    const callsBefore = [decryptMetrics.calls.length, encryptCalls.length, signCalls.length];
+    await runWithHostedDomainRootProviderCallsDisabled(async () => {
+      await revalidatePreparedHostedDeviceSyncDirtyPayloadCryptoTx({
+        prepared, tx: tx.prisma as Prisma.TransactionClient,
+      });
+      const rebound = await rebindHostedDeviceSyncDirtyPayloadRevision({
+        ...identity, prepared, value, nextDirtyRevision: 7n,
+      });
+      expect(rebound).not.toBe(value);
+      const openInput = { ...identity, dirtyRevision: 7n, prisma: tx.prisma, value: rebound };
+      expect(await openHostedDeviceSyncDirtyPayloadJson(openInput)).toEqual(resource);
+      await expect(openHostedDeviceSyncDirtyPayloadJson({ ...openInput, dirtyRevision: 2n })).rejects.toThrow();
+      await expect(openHostedDeviceSyncDirtyPayloadJson({ ...openInput, connectionId: "another-connection" })).rejects.toThrow();
+      await expect(rebindHostedDeviceSyncDirtyPayloadRevision({
+        ...identity, prepared: { ...prepared }, value, nextDirtyRevision: 7n,
+      })).rejects.toThrow("not the exact request-local capability");
+      await expect(rebindHostedDeviceSyncDirtyPayloadRevision({
+        ...identity, prepared, value, nextDirtyRevision: 1n,
+      })).rejects.toThrow("same owner and a newer revision");
+      expect([decryptMetrics.calls.length, encryptCalls.length, signCalls.length]).toEqual(callsBefore);
+    });
+  });
+});
+
 test("the prepared Web root token rejects an exact winner drift", async () => {
   const { tx } = await createHostedWebCryptoTransactionFixture();
   const {

--- a/apps/web/test/prisma-store-dirty-connections.test.ts
+++ b/apps/web/test/prisma-store-dirty-connections.test.ts
@@ -1154,7 +1154,8 @@ describe("PrismaHostedDirtyConnectionStore dirty pending state", () => {
     }
   });
 
-  it("rejects forged or stale prepared dirty-write capabilities before mutation", async () => {
+  it.each(["acknowledgement", "owner", "missing", "metadata"] as const)("rejects forged capabilities and %s drift before mutation", async (drift) => {
+    installHostedSecureBoxStringTestCodec();
     const dirtyAt = new Date("2026-05-26T12:00:00.000Z");
     const existing = {
       connectionId: "dsc_prepared_stale_1",
@@ -1190,7 +1191,8 @@ describe("PrismaHostedDirtyConnectionStore dirty pending state", () => {
       resourceCategory: "sleep",
       resources: [{
         count: 1,
-        jobKind: "reconcile",
+        jobKind: "delete",
+        payload: { objectId: "synthetic-sleep-record" },
         resource: "sleep",
         resourceCategory: "sleep",
         sourceProviderSlug: "oura",
@@ -1201,9 +1203,11 @@ describe("PrismaHostedDirtyConnectionStore dirty pending state", () => {
       userId: existing.userId,
     });
     const updateManyAndReturn = vi.fn();
-    const changed = {
+    const changed = drift === "missing" ? null : {
       ...existing,
-      dirtyRevision: 3n,
+      dirtyRevision: drift === "metadata" ? 2n : 3n,
+      processedRevision: drift === "acknowledgement" ? 3n : 2n,
+      userId: drift === "owner" ? "another-synthetic-member" : existing.userId,
       updatedAt: new Date("2026-05-26T12:00:01.000Z"),
     };
     const tx = {
@@ -1219,6 +1223,9 @@ describe("PrismaHostedDirtyConnectionStore dirty pending state", () => {
       tx: tx as never,
     })).rejects.toMatchObject({
       code: "HOSTED_DEVICE_SYNC_DIRTY_PREPARATION_MISMATCH",
+      reason: drift === "acknowledgement" ? "dirty_acknowledgement_changed"
+        : drift === "owner" ? "dirty_owner_changed"
+          : drift === "missing" ? "dirty_marker_missing" : "dirty_marker_changed",
     });
     expect(updateManyAndReturn).not.toHaveBeenCalled();
 


### PR DESCRIPTION
## Why and outcome

Concurrent device webhooks can advance the dirty revision between payload preparation and commit, exhausting both stale-preparation retries with a 503. The local PostgreSQL reproduction fails before this fix and succeeds after it.

Converge only sibling-ingress revision drift under the existing lock by rebinding the prepared encrypted payload to its actual committed revision. Preserve full replanning for authority, acknowledgement, deletion, and root drift. Add bounded, privacy-safe transport, drift, recovery, and rebinding diagnostics.

## Product UX

- Effort: Patch.
- Result: Ready — focused local recovery and safety journeys pass; production verification remains post-deploy.
- Walkthrough: Connected-device members receive overlapping updates with fewer delivery retries. Existing consent, connection ownership, acknowledgement, and deletion protections remain enforced. No connection UI or assistant-response change; no deviation from the scoped plan.

## Evidence

- Direct: Real PostgreSQL webhook-admission reproduction injects a committed sibling dirty write after each actual preparation: previously exhausted two retries with stale-preparation 503; now succeeds on its first attempt.
- Coverage: Twelve concurrent payload preparations commit distinct revisions with decryptable ciphertext. Initially absent and clean markers converge. Acknowledgement, owner, deletion, metadata-only, and domain-root drift retain rejection/replan behavior.
- Focused tests: 12 files / 373 tests passed, including the PostgreSQL contention, consent-withdrawal and account-deletion lanes, dirty-store/preseal, real secure-box, compression, route, wake, queue and changelog tests. After the final redundant-lock removal, the affected 34 store/preseal tests passed again.
- Commands: `MURPH_TEST_POSTGRES_CONCURRENCY=1 pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage <focused files>` against an isolated loopback test database; `pnpm --dir apps/web typecheck:prepared`; `pnpm complexity:diff`; `pnpm docs:drift`; `pnpm docs:gardening`; `git diff --check` — passed.
- External proof: All four required checks passed on `76455b54ff03b9cff0779acb782ec3b75c8addb0`: Linux/macOS CLI host matrices, release checks, and hosted Stripe billing boundary. All release test/coverage/build shards passed. [CI run](https://github.com/cobuildwithus/murph/actions/runs/34254593504).
- Final review: ReviewGPT round 1 PASS with no findings on the exact head; model and committed-turn capture verified. [Review evidence](https://github.com/cobuildwithus/murph/pull/3057#issuecomment-5588951668). Parent final review found no unresolved issue; current-base merge-tree is clean against `f5ce8c310d6cf51a6401cb8d1363e5907845f741`. No production mutation, merge, or deploy performed.

## Non-obvious affected surfaces

Companion HRV payload admission shares the dirty store; existing companion/preseal tests cover its locking and receipt invariants. Domain-root mismatches now retain their distinct retry diagnostic. Real AES secure-box tests prove revised AAD succeeds, old/wrong AAD and forged capabilities fail, with no extra KMS calls. Compression tests prove rebind adds no compression or decompression.

## Architecture and reuse

- Existing systems reused: Dirty-marker owner and row lock, prepared-root secure-box crypto, two-attempt preparation retry owner, route queue preflight.
- New logic: Allow only same-owner/provider pending monotonic ingress drift with unchanged processed revision; reseal prepared compressed envelopes against the current revision. Emit finite diagnostic categories.
- New abstractions: Two local dirty-store helpers for eligibility/resolution and a narrow dirty-payload rebind operation using the existing authenticated open/seal primitive; no new state owner.
- Complexity intentionally avoided: No new queue, lock table, migration, retry budget, reconciliation loop, compatibility protocol, dependency, or payload logging.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: Dirty upsert decreased from 34 to 29; hydration remains 21. Existing admission inspection 57, nested admission callbacks 41/40/37/31, and source commit 24 remain unchanged; inspected for preserved authority and retry ordering.
- Agent judgment: No further behavior-preserving simplification justified in this fix. Rebinding stays at the existing locked dirty-store boundary; a redundant companion lock was removed.

## Hot reply path impact

- Path status: Not applicable — background device ingress, not conversation acceptance through provider start/reply handoff.
- Database calls: None added to the foreground path.
- Network/provider calls: None added.
- Other awaited latency: None added to the foreground path.
- Before/after proof: Changed call paths are device webhook/companion admission only; focused tests exercise those owners.

## Murph initial provider input impact

Not applicable for both individual and group Murph: no prompts, tools, schemas, provider-input builders, or generated guidance changed.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Risks

The bounded rebind adds one serial local authenticated open/seal per prepared payload while holding the existing transaction lock (at most two webhook resources or one companion resource). It adds no remote crypto/provider calls, classification, compression, or per-payload database reads. Existing-row ingress uses the existing lock/re-read; an initially missing snapshot that now exists also takes that lock/re-read. Concurrency remains one admission transaction per request, bounded by the existing two-attempt retry owner; the 12-way test covers contention without enlarging collection fanout.

Rebind logging describes an attempted operation inside a transaction, not proof of commit: correlate with the same invocation's final HTTP result. Logs contain bounded categories/counts only, not payloads, credentials, raw provider parameters, or member/account identifiers.

ReviewGPT context sensitivity: sensitive
ReviewGPT first-reviewed head: 76455b54ff03b9cff0779acb782ec3b75c8addb0
Classification reason: Concurrent health-data persistence, authenticated ciphertext, retry behavior, and external webhook handling.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old/new Web and worker readers use the same persisted ciphertext schema and AAD layout. The payload row and ciphertext both carry the actual committed revision; no reader capability change.
- Safe order: Ordinary Web deployment; no migration or worker/container rollout order required.
- Rollback floor: The existing reader remains compatible; previous Web code can read new writes.
- Expected exposure: Overlapping device-update bursts benefit after Web rollout; requests on the previous deployment retain existing bounded retries and can still return stale-preparation 503.
- Reversibility: Web rollback restores previous admission behavior without data conversion. No rollback or deployment is included in this PR task.
- Convergence proof: Real secure-box and PostgreSQL readback tests use the existing reader against rebound writes, reject old revision AAD, and verify all concurrent rows remain decryptable.
- Post-deploy checks: Inspect bounded webhook 5xx aggregates and same-invocation transport/drift/recovery logs. Confirm successful final HTTP outcomes for rebound attempts and no growth in stale-preparation exhaustion.

## Change-shape breakdown

Classification rule: Runtime TypeScript is Source; test files are Tests / fixtures; agent docs and completed plan are Docs; the isolated authored changelog JSON is Generated / other (authored content, not generated). No binaries or generated output.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 212 | 43 |
| Tests / fixtures | 350 | 6 |
| Docs | 139 | 3 |
| Config / tooling | 0 | 0 |
| Generated / other | 14 | 0 |
| **Total** | **715** | **52** |

## Changelog

- Changelog: updated
- Items: 2026-09-08 · connected-device-burst-sync
