### PR TITLE
Keep group report participants on separate lines

### DIFF
--- a/apps/web/changelog/entries/2026-09-08/readable-group-reports.json
+++ b/apps/web/changelog/entries/2026-09-08/readable-group-reports.json
@@ -12,6 +12,8 @@
       "groups",
       "automations"
     ],
-    "sourcePullRequests": []
+    "sourcePullRequests": [
+      3060
+    ]
   }
 }

--- a/apps/web/changelog/entries/2026-09-08/readable-group-reports.json
+++ b/apps/web/changelog/entries/2026-09-08/readable-group-reports.json
@@ -1,0 +1,17 @@
+{
+  "publishedOn": "2026-09-08",
+  "order": 100,
+  "item": {
+    "id": "readable-group-reports",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Group reports are easier to scan",
+    "summary": "Structured group text reports separate dates and metrics into labeled sections, with each participant on their own line.",
+    "details": "Reports stay together in one message, with spacing that makes individual results easier to find.",
+    "relevanceTags": [
+      "groups",
+      "automations"
+    ],
+    "sourcePullRequests": []
+  }
+}

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -1817,6 +1817,7 @@ When an available response card or media path improves the answer, use the curre
       ? conversationScope === "group"
         ? `Group texting rhythm:
 - Send an ordinary group reply as one text bubble. Keep any needed paragraphs or list items inside that one message.
+- For structured text reports covering multiple participants and dates or metrics, use a labeled section for each date/metric combination, with blank lines between sections and one participant per line. Never combine different participants on one line with centered dots or other separators. Keep the report in one message; concision means removing unnecessary wording, not participant line breaks.
 - Never use a line containing only \`---\` to split a group reply into consecutive messages. Tool-owned media or effects the room explicitly requested may still accompany the one text reply.`
         : `Texting rhythm:
 - Keep a short reply with one natural section in one bubble. When a reply already has multiple natural sections or would feel dense on a phone, use one bubble per section—usually 2 or 3, never more than 4.

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -64,6 +64,7 @@ import {
 } from '@murphai/operator-config/assistant-cli-contracts'
 import { normalizeAssistantProviderConfig } from '@murphai/operator-config/assistant/provider-config'
 import { renderAssistantResponseCardText } from '@murphai/operator-config/assistant-response-cards'
+import { renderMarkdownMessageText } from '@murphai/operator-config/message-formatting'
 import {
   listEntitySchema,
   showResultSchema,
@@ -8475,6 +8476,175 @@ describeRealCodex('real Codex group-chat behavior e2e', () => {
         expect(result.finalMessage).not.toMatch(
           /no (?:usable |visible |shared )?workouts?|not (?:available|shared|showing)|sync (?:failed|error)/iu,
         )
+      } finally {
+        await removeRealCodexTemporaryPaths([
+          workingDirectory,
+          ...config.temporaryPaths,
+        ])
+      }
+    },
+    360_000,
+  )
+
+  it(
+    'keeps four-person scheduled sleep and steps reports in separate participant rows',
+    async () => {
+      const config = await resolveRealCodexE2eConfig()
+      const workingDirectory = await mkdtemp(
+        path.join(tmpdir(), 'murph-group-report-rows-e2e-'),
+      )
+      const sharedRequests: unknown[] = []
+
+      try {
+        const skillsRoot = path.join(workingDirectory, 'skills')
+        await materializeAssistantSkill({
+          skillsRoot,
+          slug: 'group-chat',
+        })
+        const result = await executeRealCodexAppServerTurn({
+          approvalPolicy: 'never',
+          baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+          codexCommand:
+            normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND)
+            ?? undefined,
+          codexHome: config.codexHome,
+          developerInstructions:
+            buildScheduledAutomationDeveloperInstructions(
+              'group',
+              'shared_read',
+            ),
+          dynamicTools: [MURPH_GROUP_SHARED_READ_PERMISSION_OFFER_TOOL],
+          env: {
+            ...config.env,
+            [MURPH_ASSISTANT_SKILLS_ROOT_ENV]: skillsRoot,
+          },
+          excludeResumeTurns: true,
+          groupConversation: true,
+          hostedToolContext: {
+            computerToolsAvailable: false,
+            currentHostedDeliveryContext: () => null,
+            currentHostedMailboxItemIds: () => [],
+            groupSharedReader: {
+              request: async (request) => {
+                sharedRequests.push(request)
+                return {
+                  status: 'ok',
+                  requestedProjectionScopeKeys: ['sleep-duration-days.v0', 'steps-days.v0'],
+                  members: ['Avery', 'Jordan', 'Casey', 'Morgan'].map((displayName, index) => ({
+                    displayName,
+                    currentTurnHandles: [],
+                    memberId: `member_report_${index}`,
+                    participantId: `participant_report_${index}`,
+                    projections: [
+                      {
+                        dataStatus: 'available',
+                        grantStatus: 'granted',
+                        grantedAt: '2026-07-01T12:00:00.000Z',
+                        projectionScope: { projectionKind: 'sleep-duration-days.v0' },
+                        projectionScopeKey: 'sleep-duration-days.v0',
+                        records: ['2026-08-03', '2026-08-04'].map((date, day) => ({
+                          recordKey: date,
+                          occurredAt: `${date}T00:00:00.000Z`,
+                          data: {
+                            date,
+                            metricKey: 'total-sleep-minutes',
+                            unit: 'minutes',
+                            value: 395 + index * 17 + day * 30,
+                          },
+                        })),
+                      },
+                      {
+                        dataStatus: 'available',
+                        grantStatus: 'granted',
+                        grantedAt: '2026-07-01T12:00:00.000Z',
+                        projectionScope: { projectionKind: 'steps-days.v0' },
+                        projectionScopeKey: 'steps-days.v0',
+                        records: [{
+                          recordKey: '2026-08-04',
+                          occurredAt: '2026-08-04T00:00:00.000Z',
+                          data: { date: '2026-08-04', metricKey: 'steps', unit: 'count', value: 6100 + index * 1320 },
+                        }],
+                      },
+                    ],
+                  })),
+                } satisfies AssistantHostedGroupSharedReadResponse
+              },
+            },
+            sendVaultFile: async () => {
+              throw new Error('Vault file sends are unavailable in this test.')
+            },
+            vaultFileSendAvailable: false,
+          },
+          model: config.model,
+          modelProvider: config.modelProvider,
+          prompt: [
+            'Scheduled group automation recipe:',
+            'Prepare the daily group check-in using the shared data. Cover sleep on August 3 and August 4 separately, then steps on August 4. Include every member and their values. The agreed targets are at least 7 hours of sleep and at least 8,000 steps.',
+            'Room preference: keep the recap brief, label what each part covers, and use ✅ for meeting a target and ❌ for falling short.',
+          ].join('\n'),
+          reasoningEffort: 'low',
+          sandbox: 'workspace-write',
+          workingDirectory,
+        })
+        const sharedReads = readCapabilityRoutingActions(
+          result.jsonEvents,
+        ).filter((action) =>
+          action.kind === 'dynamic'
+          && action.tool === MURPH_GROUP_SHARED_READ_PERMISSION_OFFER_TOOL.name
+        )
+
+        expect(sharedReads).toHaveLength(1)
+        expect(sharedReads[0]).toMatchObject({
+          argumentsValue: {
+            action: 'read_shared',
+            projectionScopes: expect.arrayContaining([
+              { projectionKind: 'sleep-duration-days.v0' },
+              { projectionKind: 'steps-days.v0' },
+            ]),
+          },
+        })
+        expect(sharedRequests).toHaveLength(1)
+        expect(readCapabilityRoutingActions(result.jsonEvents).filter(
+          (action) => action.kind === 'dynamic',
+        )).toHaveLength(1)
+        const decision = parseAssistantNotificationDecision(result.finalMessage)
+        expect(decision.kind).toBe('send_message')
+        if (decision.kind !== 'send_message') throw new Error('Expected a group report.')
+        const reply = renderMarkdownMessageText(decision.text).text
+        expect(reply).not.toMatch(/·|\|[^\n]+\||^\s*---\s*$/mu)
+        const names = ['Avery', 'Jordan', 'Casey', 'Morgan']
+        const sections = reply.split(/\n\s*\n/u).filter(
+          (section) => names.some((name) => section.includes(name)),
+        )
+        expect(sections).toHaveLength(3)
+        for (const [sectionIndex, section] of sections.entries()) {
+          const lines = section.split('\n')
+          const heading = lines[0] ?? ''
+          expect(heading).toMatch(sectionIndex < 2 ? /sleep/iu : /steps/iu)
+          expect(heading).toMatch(sectionIndex === 0 ? /(?:Aug(?:ust)?\.?\s+0?3|0?8[/-]0?3)\b/iu : /(?:Aug(?:ust)?\.?\s+0?4|0?8[/-]0?4)\b/iu)
+          const rows = lines.filter((line) => names.some((name) => line.includes(name)))
+          expect(rows).toHaveLength(4)
+          for (const [index, name] of names.entries()) {
+            const matches = rows.filter((line) => line.includes(name))
+            expect(matches).toHaveLength(1)
+            const row = matches[0] ?? ''
+            expect(names.filter((candidate) => row.includes(candidate))).toEqual([name])
+            const value = sectionIndex < 2
+              ? 395 + index * 17 + sectionIndex * 30
+              : 6100 + index * 1320
+            if (sectionIndex < 2) {
+              const hours = Math.floor(value / 60)
+              const minutes = value % 60
+              expect(row).toMatch(new RegExp(`${hours}\\s*(?:h(?:ours?)?\\s*0?${minutes}\\s*m(?:in(?:utes?)?)?|:0?${minutes})`, 'iu'))
+            } else {
+              expect(row.replaceAll(',', '')).toContain(String(value))
+            }
+            expect(row).toContain(value >= (sectionIndex < 2 ? 420 : 8000) ? '✅' : '❌')
+          }
+        }
+        process.stdout.write(`[group-report-rows-e2e] ${JSON.stringify({
+          model: config.model, sharedReadCount: sharedReads.length, reply,
+        })}\n`)
       } finally {
         await removeRealCodexTemporaryPaths([
           workingDirectory,

--- a/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
@@ -370,7 +370,7 @@ describe('assistant Codex turn planning', () => {
     )).toMatchInlineSnapshot(`
       {
         "direct": "a0b89b6349944ff568a9677289421453d075210a3c2f7b7e138c2c54c744b882",
-        "group": "a34e5931c8eb92d827be99b2be5e1e8f1f0f948721b04ce0217742e1d55634a7",
+        "group": "486f1772f242a1d4479d835c651b5f11a8feab72787e7a890ffc50dc44b1913d",
         "maintenance": "4c439dbf05ccb6d2cd7540b1ef7f94c99e898afd9b9658abefa860a8b421ca55",
         "outputOnly": "a83a04afea06e5290de36b14a0fee5d18970077a8294dde129b2e2dfa99116b4",
         "scheduledEmail": "dea0bd0d22a9a00ae3f7340687e61ad67003d6990ab34ef790d843fd83f14807",

--- a/packages/assistant-engine/test/system-prompt.reply-bubbles.test.ts
+++ b/packages/assistant-engine/test/system-prompt.reply-bubbles.test.ts
@@ -12,6 +12,7 @@ const TEXTING_RHYTHM_PROMPT = `Texting rhythm:
 
 const GROUP_TEXTING_RHYTHM_PROMPT = `Group texting rhythm:
 - Send an ordinary group reply as one text bubble. Keep any needed paragraphs or list items inside that one message.
+- For structured text reports covering multiple participants and dates or metrics, use a labeled section for each date/metric combination, with blank lines between sections and one participant per line. Never combine different participants on one line with centered dots or other separators. Keep the report in one message; concision means removing unnecessary wording, not participant line breaks.
 - Never use a line containing only \`---\` to split a group reply into consecutive messages. Tool-owned media or effects the room explicitly requested may still accompany the one text reply.`
 
 describe('assistant reply bubble prompt guidance', () => {
@@ -107,6 +108,33 @@ describe('assistant reply bubble prompt guidance', () => {
         'Skip group progress for challenge setup, the next setup question, permission offers, routine standings reads, and short tool sequences.',
       )
       expect(layers.prompt).not.toContain('Do not leave the member silent')
+    },
+  )
+
+  it.each([
+    ['linq', 'message'],
+    ['linq', 'automation-cron'],
+    ['telegram', 'message'],
+    ['telegram', 'automation-cron'],
+  ] as const)(
+    'keeps participant rows in the composed %s group %s prompt',
+    (channel, trigger) => {
+      const layers = buildAssistantSystemPromptLayers(createPromptInput({
+        channel,
+        conversationScope: 'group',
+        ...(trigger === 'automation-cron' ? {
+          turnTrigger: trigger,
+          scheduledOccurrenceAt: '2026-07-07T13:00:00.000Z',
+        } : {}),
+      }))
+
+      expect(layers.prompt).toContain(GROUP_TEXTING_RHYTHM_PROMPT)
+      expect(layers.prompt).not.toContain(TEXTING_RHYTHM_PROMPT)
+      expect(layers.prompt).toContain(
+        'concision means removing unnecessary wording, not participant line breaks',
+      )
+      const direct = buildAssistantSystemPromptLayers(createPromptInput({ channel }))
+      expect(direct.prompt).not.toContain('one participant per line')
     },
   )
 


### PR DESCRIPTION
## Why and outcome

Structured group reports could put several participants on dense lines. Group text replies now default to a labeled section per date/metric combination and one participant per line, preserving a single group message.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: iMessage and Telegram group text, both attended and scheduled. Direct-message pacing and Telegram Rich Message availability are preserved. A four-person synthetic scheduled report produces three sections and twelve individually attributable rows. No difference from plan.

## Evidence

- Direct: `pnpm test:assistant:live -- --test "keeps four-person scheduled sleep and steps reports in separate participant rows"` passed with gpt-5.6-terra through local subscription auth. Exactly one shared read, one send-message decision, twelve correct participant rows, matching dates, values and agreed-target markers. Rendered prose reviewed: Ready. No real member delivery was performed.
- Coverage: `pnpm --dir packages/assistant-engine exec vitest run --no-coverage test/system-prompt.reply-bubbles.test.ts test/model-behavior.test.ts` passed 96 tests; `pnpm --dir packages/assistant-engine typecheck` passed; `pnpm --dir apps/web test -- changelog-page.test.tsx` passed 9 tests; `git diff --check` passed.
- Planner snapshot coverage: `pnpm --dir packages/assistant-engine exec vitest run --no-coverage test/assistant-codex-turn-planning.test.ts -u` passed 102 tests. Reviewed the sole snapshot change: the group plan hash reflects the added prompt instruction; other route hashes are unchanged. Typecheck passed again.
- Exact-head CI: all 33 checks passed on `18b647eeddc8f6914f7f9f494f6cde8e8ff24a54`, including all four required merge gates.
- Final ReviewGPT: not required under the prompt-primary exemption; no independent state, authority, or external-effect change.

## Non-obvious affected surfaces

Telegram ordinary group text receives the same layout guidance; composed-prompt tests preserve its Rich Message option and exclude direct-message bubble guidance from group prompts.

## Architecture and reuse

- Existing systems reused: shared group texting prompt, real Codex scheduled-turn harness, consented shared-read tool contract, production text renderer, changelog fragments.
- New logic: one group-report presentation instruction.
- New abstractions: None; existing owners cover composition, execution and delivery.
- Complexity intentionally avoided: no post-generation punctuation rewriting, renderer changes, scheduling changes, or persisted formatting state.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; complexity debt and maximum unchanged.
- Hotspots: existing `buildStableRouteCapabilityPrompt` (28) and `buildAssistantHostedGroupGuidanceText` (25) are unchanged. The edited text adds no branching.
- Agent judgment: further refactoring would broaden this presentation patch without improving its behavior.

## Hot reply path impact

- Path status: Touched only in assembled group instructions.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added; timeout, retry, and fallback behavior unchanged.
- Before/after proof: the synthetic reproduction and fixed live journey each use one shared-data read; the production diff adds only prompt text.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | 24752 | 24752 | 0 | 0.00% | 113160 | 113160 | 0 |
| Group Murph | 20960 | 21029 | +69 | +0.33% | 96594 | 96994 | +400 |

- Assembled instructions: one group texting instruction added in `buildAssistantEvidenceAndReplyStyleText`; individual prompt unchanged.
- Tool/schema/generated guidance: unchanged; captured native code-mode and tool guidance are included inside the provider input.
- Other provider-visible input: identical synthetic fixtures; no history or wrapper change.
- Measurement method: real pinned Codex App Server against the existing local scripted Responses stub, four fresh direct/group base/head turns. Base 583cfd8fbbb3; head e936a3724ffa. Head composition minus the sole added instruction reproduces base. Tokenized serialized provider-visible model/input/tool-choice/parallel-tool-calls/reasoning/text fields using tiktoken 0.14.0, `encoding_for_model("gpt-5.6-terra")` = o200k_base. Normalized volatile UUIDs identically; excluded transport/cache metadata, client metadata, storage/stream/include controls and HTTP/auth headers. Counts describe that complete serialized input, not billed server framing. Temporary capture retained only aggregate measurements.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: content-only changelog fragment; production archive rendering passed. No new visual or layout component.
- Coverage: fragment copy renders through the existing archive. Assistant presentation is covered by the production text renderer in the live journey.

## Deployment concerns

- Deployment: applicable
- Supported skew: existing Worker/Web contracts and persisted records are unchanged; old runners retain the previous formatting guidance.
- Safe order: normal hosted runner release after merge; no consumer-first migration required.
- Rollback floor: unchanged; no new data or protocol shape.
- Expected exposure: old formatting can persist on runners that have not adopted the new image.
- Reversibility: prompt-only code revert; no data repair required.
- Convergence proof: composed channel tests and one real-Codex rendered journey pass; production rollout convergence remains a hosted deployment check.
- Post-deploy checks: confirm the deployed public source contains this commit and the hosted deployment smoke passes.

## Change-shape breakdown

Classification rule: runtime instructions are Source, regression code is Tests, and the isolated JSON release note is Generated / other (authored content). No binaries or generated outputs.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1 | 0 |
| Tests / fixtures | 199 | 1 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 19 | 0 |
| **Total** | **219** | **1** |

## Changelog

- Changelog: updated
- Items: 2026-09-08 · readable-group-reports
