### PR TITLE
Preserve container namespace declarations in Worker-only releases

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-08-runner-container-enablement.md
+++ b/agent-docs/exec-plans/active/2026-09-08-runner-container-enablement.md
@@ -1,0 +1,51 @@
+# Preserve runner namespace container declarations
+
+Status: active
+Created: 2026-09-08
+
+## Outcome and invariant
+
+Restore native candidate creation after a Worker-only release. Keep native
+admission before Worker upload, preserve serving capacity and release identity,
+and do not introduce namespace migrations or new production credentials.
+
+## Proven cause and scope
+
+The protected native POST rejected with `DURABLE_OBJECT_NOT_CONTAINER_ENABLED`.
+Worker-only staging omits absent applications from its container array. Pinned
+Wrangler derives Worker container-enabled class metadata from that same array,
+so receipt filtering also drops namespace capability declarations. Two focused
+regressions fail before source edits: the absent class is missing and the CLI
+uploads the receipt config instead of the complete class declaration config.
+
+Keep the existing native receipt config. For Worker-only uploads with omitted
+applications, derive a complete container declaration config from the same
+rendered entries, require existing namespace bindings, and preserve every live
+application setting and release variable. Only version upload uses that config.
+The regular full-release admission sequence stays unchanged.
+
+## Work and verification
+
+- Reproduced both failures with synthetic staging and CLI scenarios.
+- Implement the declaration-preserving upload and verify both bank directions,
+  absent namespace rejection, native receipt scope, and admission ordering.
+- Run focused tests, Cloudflare typecheck, complexity and parent review, then
+  required exact-head CI and ReviewGPT on a scoped PR.
+- After merge, a protected Worker-only release must restore declarations. A
+  subsequent protected full release must prove actual native admission, signed
+  smoke, and release convergence before claiming the runner fix is live.
+
+Cloudflare recovery for an already provisioned namespace remains unverified
+until the protected follow-up. Do not infer success from local mocks or delete
+and recreate existing namespaces. No matching open repair PR was found.
+
+## Candidate evidence
+
+All 69 focused provider, image, staging and deployment CLI tests pass. Both
+member bank directions retain complete Worker metadata while native receipts
+exclude absent applications; missing namespaces fail before upload. Cloudflare
+typecheck and complexity guard pass, with no function above the threshold.
+Pinned Wrangler passes `config.containers` to version upload metadata and does
+not deploy native applications in that command. Parent review found no serving
+image, capacity, release pointer, native mutation or admission-order change.
+The change is internal deployment repair; no separate member changelog item.

--- a/agent-docs/exec-plans/completed/2026-09-08-runner-container-enablement.md
+++ b/agent-docs/exec-plans/completed/2026-09-08-runner-container-enablement.md
@@ -1,6 +1,6 @@
 # Preserve runner namespace container declarations
 
-Status: active
+Status: completed
 Created: 2026-09-08
 
 ## Outcome and invariant
@@ -49,3 +49,14 @@ Pinned Wrangler passes `config.containers` to version upload metadata and does
 not deploy native applications in that command. Parent review found no serving
 image, capacity, release pointer, native mutation or admission-order change.
 The change is internal deployment repair; no separate member changelog item.
+
+## Final implementation review
+
+Required ReviewGPT passed on `73005470c0209e5eb0c3b197018e33ca1d1287f6`,
+with the captured response hash and actual `gpt-6-pro` model verified. Its
+independent staging checks reproduced the omission in both bank directions and
+found no blocking defect. Parent final review confirms that the reviewed source
+remains unchanged. Exact-head CI and protected deployment remain release gates;
+this archived implementation record is not a production recovery receipt.
+Updated: 2026-09-08
+Completed: 2026-09-08

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -44,7 +44,15 @@ checks before a second Worker-only activation selects the candidate. Worker
 version commands preserve existing secrets and non-versioned settings; namespace
 bootstrap/migrations and changes to triggers or non-versioned settings remain
 separate infrastructure operations. The helper requires the candidate and smoke
-namespaces to exist before native preparation. Never substitute full
+namespaces to exist before native preparation. Worker-only releases also retain
+container declarations for existing namespaces whose native applications have
+not been admitted. Version upload uses that complete declaration config; native
+receipts and live-state verification continue to describe only admitted
+applications. This does not create missing namespaces or activate a candidate.
+If native creation reports `DURABLE_OBJECT_NOT_CONTAINER_ENABLED`, first restore
+the declaration through the protected Worker-only path and verify the following
+full release. Do not treat namespace existence or a local mock as recovery proof.
+Never substitute full
 `wrangler deploy` in this sequence: even `rollout_kind: none` can create a
 missing application after activating Worker code.
 

--- a/apps/cloudflare/scripts/deploy-worker-version.cli.ts
+++ b/apps/cloudflare/scripts/deploy-worker-version.cli.ts
@@ -125,7 +125,7 @@ export async function runDeployWorkerVersionCli(
           await assertLiveVersion(input.workerName, input.configPath, versionId);
           return versionId;
         };
-        const stageVersionId = await uploadAndActivate(staged.configPath, currentVersionId);
+        const stageVersionId = await uploadAndActivate(staged.uploadConfigPath ?? staged.configPath, currentVersionId);
         await runSmokeHostedDeploy({
           source: {
             ...env,

--- a/apps/cloudflare/scripts/stage-runner-release.ts
+++ b/apps/cloudflare/scripts/stage-runner-release.ts
@@ -18,6 +18,7 @@ export interface StagedRunnerRelease {
   activeApplicationName: string;
   applications: RunnerApplicationPreparation[];
   configPath: string;
+  uploadConfigPath?: string;
   deployment: HostedRunnerDeployment;
   promotionConfigPath: string;
   workerOnly: boolean;
@@ -124,12 +125,25 @@ export async function stageHostedRunnerRelease(input: {
   const attempt = randomUUID();
   const configPath = path.join(path.dirname(input.configPath), `wrangler.stage-${attempt}.jsonc`);
   const promotionConfigPath = path.join(path.dirname(input.configPath), `wrangler.promote-${attempt}.jsonc`);
-  const render = (release: HostedRunnerDeployment) => `${JSON.stringify({
-    ...config, containers: effectiveContainers, vars: { ...vars, HOSTED_EXECUTION_RUNNER_DEPLOYMENT: JSON.stringify(release) },
+  const render = (release: HostedRunnerDeployment, containers = effectiveContainers) => `${JSON.stringify({
+    ...config, containers, vars: { ...vars, HOSTED_EXECUTION_RUNNER_DEPLOYMENT: JSON.stringify(release) },
   }, null, 2)}\n`;
   await writeFile(configPath, render(deployment), { encoding: "utf8", flag: "wx" });
   await writeFile(promotionConfigPath, render(promoted), { encoding: "utf8", flag: "wx" });
-  return { activeApplicationName: serving.name, applications, configPath, deployment, promotionConfigPath, workerOnly };
+  let uploadConfigPath: string | undefined;
+  if (effectiveContainers.length !== entries.length) {
+    // Native receipts describe admitted applications. Worker metadata must still
+    // declare container capability for existing namespaces without an application.
+    const uploadContainers = entries.map((entry) => {
+      const effective = effectiveContainers.find((container) => container.class_name === entry.className);
+      if (effective) return effective;
+      readNamespaceId(input.currentVersion, entry.className);
+      return entry.rendered;
+    });
+    uploadConfigPath = path.join(path.dirname(input.configPath), `wrangler.upload-${attempt}.jsonc`);
+    await writeFile(uploadConfigPath, render(deployment, uploadContainers), { encoding: "utf8", flag: "wx" });
+  }
+  return { activeApplicationName: serving.name, applications, configPath, uploadConfigPath, deployment, promotionConfigPath, workerOnly };
 }
 
 function assertBoundedSmoke(live: unknown, specification: RunnerApplicationSpecification): void {

--- a/apps/cloudflare/test/deploy-worker-version-cli.test.ts
+++ b/apps/cloudflare/test/deploy-worker-version-cli.test.ts
@@ -207,7 +207,7 @@ describe("runDeployWorkerVersionCli", () => {
   it("forwards explicit retention and records only the effective application set", async () => {
     releaseMocks.stageHostedRunnerRelease.mockImplementation(async ({ configPath, retainServingRunner }) => {
       expect(retainServingRunner).toBe(true);
-      return { configPath: `${configPath}.retained`, promotionConfigPath: `${configPath}.retained`,
+      return { configPath: `${configPath}.retained`, promotionConfigPath: `${configPath}.retained`, uploadConfigPath: `${configPath}.upload`,
         activeApplicationName: "serving", workerOnly: true, applications: [] };
     });
     await runDeployWorkerVersionCli([], {
@@ -222,6 +222,9 @@ describe("runDeployWorkerVersionCli", () => {
     });
     expect(imageMocks.prepareHostedContainerDeployImage.mock.calls[0]![0]).not.toHaveProperty("release");
     expect(receiptMocks.readRenderedContainerIdentities).toHaveBeenCalledWith("/tmp/generated.jsonc.retained");
+    expect(wranglerMocks.runWranglerLoggedCaptured).toHaveBeenCalledWith(expect.arrayContaining([
+      "versions", "upload", "--config", "/tmp/generated.jsonc.upload",
+    ]));
     expect(releaseMocks.runSmokeHostedDeploy).toHaveBeenCalledOnce();
     expect(wranglerMocks.runWranglerLoggedCaptured).toHaveBeenCalledOnce();
     expect(fileMocks.writeFile).toHaveBeenCalledWith("/tmp/generated.jsonc", "{}", "utf8");

--- a/apps/cloudflare/test/stage-runner-release.test.ts
+++ b/apps/cloudflare/test/stage-runner-release.test.ts
@@ -122,21 +122,44 @@ describe("runner deployment staging", () => {
       .every((entry: { max_instances: number; image: string }) => entry.max_instances === 10 && entry.image !== image)).toBe(true);
   });
 
-  it.each([false, true])("retains only existing pending candidate authority (exists=%s)", async (exists) => {
+  it.each([[false, false], [false, true], [true, false], [true, true]])("retains only existing pending candidate authority (exists=%s, reversed=%s)", async (exists, reversed) => {
+    const active = reversed ? next : primary;
+    const candidate = reversed ? primary : next;
+    const candidateClass = reversed ? "RunnerContainer" : "NextRunnerContainer";
     await writeFile(path.join(directory, "source.json"), JSON.stringify({ ...config,
       containers: config.containers.map((entry) => ({ ...entry, max_instances: entry.class_name === "DeploySmokeRunnerContainer" ? 1 : 12 })),
     }));
     const staged = await stageHostedRunnerRelease({
       releaseSha: "2".repeat(40), retainServingRunner: true,
       configPath: path.join(directory, "source.json"), currentVersionId: "worker-live",
-      currentVersion: version({ active: primary, candidate: next, previous: null }),
-      listApplications: async (name) => !exists && name.endsWith("-nextrunnercontainer") ? []
+      currentVersion: version({ active, candidate, previous: null }),
+      listApplications: async (name) => !exists && name.endsWith(`-${candidateClass.toLowerCase()}`) ? []
         : (await listApplications(name)).map((entry) => ({ ...entry, max_instances: name.endsWith("-deploysmokerunnercontainer") ? 1 : 10 })),
     });
-    expect(staged.deployment).toEqual({ active: primary, candidate: null, previous: exists ? next : null });
+    expect(staged.deployment).toEqual({ active, candidate: null, previous: exists ? candidate : null });
     const effective = JSON.parse(await readFile(staged.configPath, "utf8"));
-    expect(effective.containers.some((entry: { class_name: string }) => entry.class_name === "NextRunnerContainer")).toBe(exists);
+    expect(effective.containers.some((entry: { class_name: string }) => entry.class_name === candidateClass)).toBe(exists);
     expect(staged.applications.map((entry) => entry.className)).toEqual(["DeploySmokeRunnerContainer"]);
+    const upload = JSON.parse(await readFile(staged.uploadConfigPath ?? staged.configPath, "utf8"));
+    // Worker upload metadata must retain the namespace's container capability even
+    // when the native application has not been admitted yet.
+    expect(upload.containers.map((entry: { class_name: string }) => entry.class_name)).toEqual(classes);
+    expect(upload.vars).toEqual(effective.vars);
+    expect(upload.containers.filter((entry: { class_name: string }) => entry.class_name !== candidateClass))
+      .toEqual(effective.containers.filter((entry: { class_name: string }) => entry.class_name !== candidateClass));
+  });
+
+  it("does not enable a missing namespace as an incidental Worker-only migration", async () => {
+    await writeFile(path.join(directory, "source.json"), JSON.stringify({ ...config,
+      containers: config.containers.map((entry) => ({ ...entry, max_instances: entry.class_name === "DeploySmokeRunnerContainer" ? 1 : 12 })),
+    }));
+    const currentVersion = version();
+    currentVersion.resources.bindings = currentVersion.resources.bindings.filter((binding) => !("class_name" in binding && binding.class_name === "NextRunnerContainer"));
+    await expect(stageHostedRunnerRelease({ releaseSha: "2".repeat(40), retainServingRunner: true,
+      configPath: path.join(directory, "source.json"), currentVersionId: "worker-live", currentVersion,
+      listApplications: async (name) => name.endsWith("-nextrunnercontainer") ? []
+        : (await listApplications(name)).map((entry) => ({ ...entry, max_instances: name.endsWith("-deploysmokerunnercontainer") ? 1 : 10 })),
+    })).rejects.toThrow("authoritative live configuration");
   });
 
   it("refuses a Worker-only release that would expand the smoke application", async () => {


### PR DESCRIPTION
Superseded by PR #3062, which fixes the same provider failure by moving the existing inactive metadata upload before native admission. That approach preserves activation gating and avoids a separate Worker-only recovery deployment. This independent candidate is closed to avoid overlapping deployment fixes. Its reviewed patch is retained for reference; it was not deployed.

## Why and outcome

Worker-only releases remove absent native applications from their receipt config. Reusing that config for Worker upload also removes those classes from Cloudflare's container capability metadata. A following native create can then fail with `DURABLE_OBJECT_NOT_CONTAINER_ENABLED` despite an existing Durable Object binding.

Preserve complete container declarations in a derived upload config, while retaining the existing native application receipt config. Require existing namespace bindings and preserve serving settings and release pointers.

## Product UX

- Effort: Not applicable — internal deployment repair.
- Result: Not applicable.
- Walkthrough: No member-facing flow or runtime protocol changes.

## Evidence

- Direct: Two regressions failed before source changes: absent candidate declaration and incorrect CLI upload config. Both pass after the correction.
- Coverage: 69 focused provider, image, staging and CLI tests pass. Both bank directions, absent namespace rejection, unchanged serving settings, bounded smoke, receipt scope, and native admission before upload are covered. Cloudflare typecheck passes.
- Review: Required ReviewGPT PASS on `73005470c0209e5eb0c3b197018e33ca1d1287f6`; actual model and response hash verified. Final commit only archives the implementation evidence; reviewed source and tests are unchanged.
- Production: The provider rejected creation with `DURABLE_OBJECT_NOT_CONTAINER_ENABLED`. Repairing an already provisioned namespace remains unverified until protected Worker-only and full deployment follow-up.

## Non-obvious affected surfaces

Native receipts still exclude absent applications; Worker metadata keeps those classes. Pinned Wrangler projects container declarations into version upload metadata without creating native applications.

## Architecture and reuse

- Existing systems reused: Staged runner release renderer, live namespace bindings, version upload and native receipt owners.
- New logic: Derive an upload config only when receipt filtering omitted declarations; validate each omitted namespace exists.
- New abstractions: None; one optional upload path on the existing staged result.
- Complexity intentionally avoided: No new API, migrations, quota changes, retries, state owner or native mutation path.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: None above 20; staging maximum stays 19, CLI maximum becomes 9.
- Agent judgment: Deriving declarations from existing entries keeps the change bounded; native receipt semantics remain intact.

## Hot reply path impact

Not applicable — only deployment tooling changes. No member-path database, provider, or awaited operations change.

## Murph initial provider input impact

Not applicable for individual and group Murph: no prompts, tool definitions, instructions or provider-visible runtime input changes.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing Worker and runner runtime protocols are unchanged; retained images remain supported.
- Safe order: Merge; run protected Worker-only deployment to restore declarations; run full deployment to prove native admission and signed candidate smoke.
- Rollback floor: Unchanged. No new persisted runtime state or migration.
- Expected exposure: Existing namespace container capability metadata during version publication. Serving image, capacity and release identity remain retained.
- Reversibility: Forward deployment repair; no deletion or namespace recreation. Rollback remains a separately authorized operation.
- Convergence proof: Full protected deployment must admit the native candidate and pass signed smoke and live release verification. Pending.
- Post-deploy checks: Confirm absence of the native enablement error, exact runner release convergence and device-sync queue progress.

## Change-shape breakdown

Classification rule: Script TypeScript is source, test files are tests, deployment guidance and execution plan are docs. No binaries or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 18 | 4 |
| Tests / fixtures | 32 | 6 |
| Docs | 71 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **121** | **11** |

## Changelog

- Changelog: not applicable
- Reason: Internal deployment metadata repair; no independent member-facing feature or behavior change.

ReviewGPT context sensitivity: sensitive
Classification reason: Cloudflare deployment and provider boundary.
ReviewGPT first-reviewed head: 73005470c0209e5eb0c3b197018e33ca1d1287f6
