### PR TITLE
Show saved comparison dates in pattern details

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -823,6 +823,13 @@ descriptions to one short sentence.
 
 Keep the copy observational and conversational. Prefer `You slept less after cycling` over a statistical sentence. Never use `caused` or `proved`. Show the activity result and other comparable days as two labeled bars in the cell detail. Keep matched-day counts out of the main result grid; expose them in supporting detail. On narrow screens, use one card per factor with its illustration, compact evidence-coverage bars, and available comparisons in a two-column grid. Use serif values for changed results. Show changed results without a neutral-results footer. Neutral-only cards use a compact factor header with a plain `No clear changes` status beneath the name and no expandable list. Omit measures without enough comparable data from mobile cards. Open mobile result details in a bottom drawer with comparison bars, evidence dates, a close control, and safe-area spacing. Keep mobile result headlines free of redundant metric eyebrows. Show the number of days beside each comparison label in mobile detail drawers. Coverage bars open their own mobile drawer leading with the recorded-day count and the factor name underneath. Reuse the detail content in desktop hover popovers. Desktop keeps the sortable comparison matrix.
 
+Comparison details keep their average bars and expose saved dates in one
+`Days compared` disclosure. Use a week-column calendar with filled factor marks,
+bordered sand confirmed-absence marks, and hollow unrecorded marks. Dates reveal
+their group on selection or keyboard focus. Keep the unrecorded-basis warning,
+label partial arrays, and omit the calendar when no valid saved dates exist.
+Do not repeat statistics, evidence grades, or idle tap instructions below it.
+
 ## 6. Do's and Don'ts
 
 ### Do:

--- a/agent-docs/exec-plans/completed/2026-09-08-patterns-evidence-calendar.md
+++ b/agent-docs/exec-plans/completed/2026-09-08-patterns-evidence-calendar.md
@@ -1,0 +1,27 @@
+# Comparison dates in Personal Patterns details
+
+## Outcome and invariant
+Members can inspect the saved dates behind a comparison from its existing drawer or popover. The query remains the sole owner of results; presentation does not invent dates, daily outcomes, or confirmed absence.
+
+## Ownership and design
+Extend the existing Personal Patterns details with one Days compared disclosure below the average bars. Derive a bounded Gregorian UTC week grid from report dates and the saved cell arrays. Use filled factor marks, bordered filled confirmed-absence marks, and hollow unrecorded marks. Selecting a date reveals its group. Retain the short unrecorded warning without idle instructions or repeated statistics.
+
+## Product UX
+- Entry: open a metric on phone or desktop, then Days compared.
+- Reaches: single and grouped sleep outcomes, confirmed and unrecorded comparisons, partial or absent dates, keyboard and touch users.
+- Proof: focused date-boundary tests, existing synthetic production-component browser journey, phone and desktop screenshots, Web typecheck and targeted lint.
+- Done when: saved dates are inspectable, missing dates are honest, drawer dismissal/focus restoration and desktop behavior remain usable.
+
+## Work
+- [x] Implement the presentation and update the existing design study.
+- [x] Verify dates, interaction, rendering, and types; inspect privacy and final diff.
+- [x] Add changelog and prepare the reviewed candidate for PR publication.
+
+## Verification outcome
+Ready: the two date-boundary unit tests passed. The existing browser journey passed at 320, 390, 640, and 1440 pixels, covering touch selection, keyboard week navigation, unrecorded and confirmed comparisons, grouped sleep results, drawer dismissal and focus restoration. Web typecheck and targeted ESLint passed. Complexity passed with no changed functions above 20. Synthetic phone and desktop screenshots were inspected; authenticated member data was not used. Hosted CI and publication follow on the exact candidate.
+
+## Deployment
+Presentation-only consumption of existing optional fields, no backend or data migration dependency. Legacy cells without dates omit the disclosure.
+Status: completed
+Updated: 2026-09-08
+Completed: 2026-09-08

--- a/apps/web/app/design/personal-patterns-study.tsx
+++ b/apps/web/app/design/personal-patterns-study.tsx
@@ -5,6 +5,7 @@ import type {
   PersonalPatternReport,
 } from "@murphai/query/browser-overview";
 
+import { PatternEvidenceCalendar } from "@/src/components/overview/pattern-evidence-calendar";
 import { PersonalPatternsSection } from "@/src/components/overview/personal-patterns-section";
 
 const POPULATED_REPORT: PersonalPatternReport = {
@@ -430,7 +431,12 @@ export function PersonalPatternsStudy() {
 }
 
 export function PersonalPatternsComponentStudy() {
-  return <PersonalPatternsSection report={POPULATED_REPORT} />;
+  return <>
+    <PersonalPatternsSection report={POPULATED_REPORT} />
+    <div id="pattern-comparison-calendar" className="mt-8 max-w-sm" inert>
+      <PatternEvidenceCalendar defaultOpen report={POPULATED_REPORT} cell={POPULATED_REPORT.cells[0]} factorLabel="Running" />
+    </div>
+  </>;
 }
 
 function cell(
@@ -458,15 +464,15 @@ function cell(
       : { classification: null, grade: null };
   return {
     ...evidence,
-    comparisonBasis: "unobserved_baseline" as const,
-    comparisonDates: ["2026-04-05", "2026-05-03"],
+    comparisonBasis: factorId === "sauna" ? "confirmed_absence" as const : "unobserved_baseline" as const,
+    comparisonDates: factorId === "custom-tag" ? undefined : ["2026-04-09", "2026-05-03", "2026-06-07", "2026-06-28", "2026-07-12", "2026-07-26"],
     comparisonDays: exposedDays,
     comparisonMean,
     delta: exposedMean - comparisonMean,
     deltaPercent,
     direction,
     exposedDays,
-    exposedDates: ["2026-04-12", "2026-08-02"],
+    exposedDates: factorId === "custom-tag" ? undefined : ["2026-04-12", "2026-05-10", "2026-05-24", "2026-06-14", "2026-07-05", "2026-07-19", "2026-08-02"],
     exposedMean,
     factorId,
     firstExposedDate: "2026-04-12",

--- a/apps/web/changelog/entries/2026-09-08/pattern-comparison-dates.json
+++ b/apps/web/changelog/entries/2026-09-08/pattern-comparison-dates.json
@@ -7,7 +7,12 @@
     "priority": 3,
     "title": "See the days behind a pattern",
     "summary": "Pattern details now show the saved comparison dates in a compact calendar. Select a day to see which group it belongs to.",
-    "relevanceTags": ["patterns", "usability"],
-    "sourcePullRequests": []
+    "relevanceTags": [
+      "patterns",
+      "usability"
+    ],
+    "sourcePullRequests": [
+      3069
+    ]
   }
 }

--- a/apps/web/changelog/entries/2026-09-08/pattern-comparison-dates.json
+++ b/apps/web/changelog/entries/2026-09-08/pattern-comparison-dates.json
@@ -1,0 +1,13 @@
+{
+  "publishedOn": "2026-09-08",
+  "order": 100,
+  "item": {
+    "id": "pattern-comparison-dates",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "See the days behind a pattern",
+    "summary": "Pattern details now show the saved comparison dates in a compact calendar. Select a day to see which group it belongs to.",
+    "relevanceTags": ["patterns", "usability"],
+    "sourcePullRequests": []
+  }
+}

--- a/apps/web/e2e/patterns-mobile.spec.ts
+++ b/apps/web/e2e/patterns-mobile.spec.ts
@@ -68,6 +68,16 @@ test("pattern cards show available comparisons on phones and retain result detai
   await expect(drawer).toContainText("42.7 ms");
   await expect(drawer.locator("dt")).toHaveText(["After running · 9 days", "Other · 9 days"]);
   await expect(drawer).toContainText("Data from");
+  await drawer.locator("summary").filter({ hasText: "Days compared" }).tap();
+  const dates = drawer.getByRole("group", { name: "Comparison dates" });
+  await expect(dates).toBeVisible();
+  await expect(dates.getByRole("button")).toHaveCount(120);
+  await expect(drawer).toContainText("Some dates unavailable");
+  await expect(drawer).toContainText("No running record doesn't mean no running.");
+  await dates.getByRole("button", { name: "May 10, 2026 · Running", exact: true }).tap();
+  await expect(drawer.getByRole("status")).toHaveText("May 10, 2026 · Running");
+  await expect(drawer).not.toContainText("Tap a day");
+
   await expect.poll(async () => {
     const bounds = await drawer.boundingBox();
     return bounds ? Math.abs(bounds.y + bounds.height - 844) : 844;
@@ -83,6 +93,10 @@ test("pattern cards show available comparisons on phones and retain result detai
   await sleepQuality.tap();
   await expect(drawer.getByRole("region", { name: "Sleep score", exact: true })).toBeVisible();
   await expect(drawer.getByRole("region", { name: "Sleep efficiency", exact: true })).toBeVisible();
+  const score = drawer.getByRole("region", { name: "Sleep score", exact: true });
+  await score.locator("summary").click();
+  await expect(score.getByRole("group", { name: "Comparison dates" })).toBeVisible();
+
   await expect(drawer.getByRole("region", { name: "Sleep score", exact: true }).locator("dt")).toHaveText(["After running · 8 days", "Other · 8 days"]);
   await expect(drawer.getByRole("region", { name: "Sleep efficiency", exact: true }).locator("dt")).toHaveText(["After running · 7 days", "Other · 7 days"]);
   await expect.poll(async () => {
@@ -94,6 +108,16 @@ test("pattern cards show available comparisons on phones and retain result detai
   }
   await page.keyboard.press("Escape");
   await expect(page.getByRole("dialog")).toHaveCount(0);
+
+  const sauna = mobile.locator('[data-pattern-factor-row="sauna"]');
+  await sauna.getByRole("button", { name: /^Your HRV was higher/ }).tap();
+  await drawer.locator("summary").click();
+  await expect(drawer).toContainText("Without sauna");
+  await expect(drawer).not.toContainText("doesn't mean");
+  if (process.env.DESIGN_PROOF_OUTPUT_DIR) {
+    await page.screenshot({ path: path.join(process.env.DESIGN_PROOF_OUTPUT_DIR, "patterns-confirmed-drawer.png"), animations: "disabled", style: "nextjs-portal, main > .sticky { visibility: hidden !important; }" });
+  }
+  await page.keyboard.press("Escape");
   await expect(running.locator("details")).toHaveCount(0);
   await expect(running.getByText("No clear change", { exact: true })).toHaveCount(0);
   await expect(mobile.locator('[data-pattern-state="no-clear-pattern"]')).toHaveCount(0);
@@ -147,6 +171,8 @@ test("pattern cards show available comparisons on phones and retain result detai
         const bounds = await drawer.boundingBox();
         return bounds ? Math.abs(bounds.y + bounds.height - 900) : 900;
       }).toBeLessThanOrEqual(1);
+      await drawer.locator("summary").click();
+      await expect(drawer.getByRole("group", { name: "Comparison dates" })).toBeVisible();
       expect(await drawer.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
       await drawer.getByRole("button", { name: "Close pattern details" }).tap();
       await expect(drawer).toHaveCount(0);
@@ -158,6 +184,18 @@ test("pattern cards show available comparisons on phones and retain result detai
       const popover = page.locator('[data-slot="popover-content"]');
       await expect(popover).toBeVisible();
       await expect(popover).toContainText("48 ms");
+      await popover.locator("summary").click();
+      const calendar = popover.getByRole("group", { name: "Comparison dates" });
+      await expect(calendar).toBeVisible();
+      const date = calendar.getByRole("button", { name: "May 10, 2026 · Running", exact: true });
+      await date.focus();
+      await page.keyboard.press("ArrowRight");
+      await expect(calendar.getByRole("button", { name: "May 17, 2026 · No comparison date shown", exact: true })).toBeFocused();
+      await expect(popover.getByRole("status")).toHaveText("May 17, 2026 · No comparison date shown");
+      if (process.env.DESIGN_PROOF_OUTPUT_DIR && width === 1440) {
+        await popover.screenshot({ path: path.join(process.env.DESIGN_PROOF_OUTPUT_DIR, "patterns-evidence-desktop.png"), animations: "disabled" });
+      }
+
       await expect(drawer).toHaveCount(0);
       await page.keyboard.press("Escape");
     }

--- a/apps/web/src/components/overview/pattern-evidence-calendar.tsx
+++ b/apps/web/src/components/overview/pattern-evidence-calendar.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+import type { PersonalPatternCell } from "@murphai/query/browser-overview";
+import { cn } from "@/src/lib/utils";
+import { patternEvidenceDays, type PatternEvidenceWindow } from "./pattern-evidence-days";
+
+export function PatternEvidenceCalendar({ report, cell, factorLabel, defaultOpen = false }: {
+  defaultOpen?: boolean;
+  report: PatternEvidenceWindow;
+  cell: PersonalPatternCell;
+  factorLabel: string;
+}) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const evidence = patternEvidenceDays(report, cell);
+  const factor = factorLabel.toLocaleLowerCase();
+  const confirmed = cell.comparisonBasis === "confirmed_absence";
+  const comparisonLabel = confirmed ? `Without ${factor}` : "Not recorded";
+  const warning = !confirmed ? <p className="text-xs leading-5 text-muted-foreground">No {factor} record doesn&apos;t mean no {factor}.</p> : null;
+  if (!evidence) return warning;
+  const description = (day: (typeof evidence.days)[number]) => {
+    const label = day.exposed && day.comparison ? "Both groups" : day.exposed ? factorLabel : day.comparison ? comparisonLabel : "No comparison date shown";
+    return `${new Date(day.date + "T00:00:00Z").toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" })} · ${label}`;
+  };
+  const selectedDay = evidence.days.find((day) => day.date === selected);
+  const focusDate = selectedDay?.date ?? evidence.days.find((day) => day.exposed || day.comparison)?.date;
+  const mark = (exposed: boolean, comparison: boolean) => cn(
+    "block size-3 rounded-[3px]",
+    exposed ? "bg-primary" : comparison && confirmed ? "bg-[#d4c4a8]" : "bg-transparent",
+    comparison && "border-[1.5px] border-muted-foreground",
+    !exposed && !comparison && "size-[3px] rounded-full bg-border",
+  );
+  return (
+    <details open={defaultOpen || undefined} className="group/evidence min-w-0">
+      <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 rounded-sm text-sm font-medium focus-visible:outline-2 focus-visible:outline-ring [&::-webkit-details-marker]:hidden">
+        Days compared
+        <ChevronDown aria-hidden="true" className="size-4 transition-transform group-open/evidence:rotate-180 motion-reduce:transition-none" />
+      </summary>
+      <div className="space-y-4 pt-3">
+        <div className="flex min-w-0 gap-2">
+          <div aria-hidden="true" className="grid shrink-0 grid-rows-[repeat(8,24px)] items-center text-[10px] text-muted-foreground">
+            {["", "M", "", "W", "", "F", "", ""].map((label, index) => <span key={index}>{label}</span>)}
+          </div>
+          <div className="min-w-0 overflow-x-auto pb-1" role="group" aria-label="Comparison dates" data-vaul-no-drag>
+            <div className="grid w-max grid-flow-col grid-rows-[repeat(7,24px)] pt-6 relative">
+              {evidence.days.map((day, index) => {
+                const month = day.date.slice(0, 7);
+                const startsMonth = index % 7 === 0 && (index === 0 || evidence.days[index - 7].date.slice(0, 7) !== month);
+                const label = new Date(day.date + "T00:00:00Z").toLocaleDateString("en-US", { month: "short", timeZone: "UTC" });
+                return (
+                  <div key={day.date} className="relative size-6">
+                    {startsMonth ? <span aria-hidden="true" className="absolute -top-6 left-0 text-[10px] leading-6 text-muted-foreground">{label}</span> : null}
+                    {day.inWindow ? <button type="button" aria-label={description(day)} aria-pressed={selected === day.date} tabIndex={day.date === focusDate ? 0 : -1} onFocus={() => setSelected(day.date)} onKeyDown={(event) => {
+                      const offset = { ArrowUp: -1, ArrowDown: 1, ArrowLeft: -7, ArrowRight: 7 }[event.key];
+                      if (offset === undefined) return;
+                      event.preventDefault();
+                      const next = evidence.days[index + offset];
+                      if (next?.inWindow) event.currentTarget.closest('[role="group"]')?.querySelector<HTMLButtonElement>(`button[data-date="${next.date}"]`)?.focus();
+                    }} data-date={day.date} onClick={() => setSelected(day.date)} className="flex size-6 items-center justify-center rounded-sm hover:bg-muted focus-visible:outline-2 focus-visible:outline-ring aria-pressed:bg-muted">
+                      <span aria-hidden="true" className={mark(day.exposed, day.comparison)} />
+                    </button> : null}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-2"><span aria-hidden="true" className={mark(true, false)} />{factorLabel}</span>
+          <span className="inline-flex items-center gap-2"><span aria-hidden="true" className={mark(false, true)} />{comparisonLabel}</span>
+        </div>
+        <div role="status" className="text-xs text-foreground">{selectedDay ? description(selectedDay) : null}</div>
+        {evidence.hasMissingDates ? <p className="text-xs text-muted-foreground">Some dates unavailable</p> : null}
+        {warning}
+      </div>
+    </details>
+  );
+}

--- a/apps/web/src/components/overview/pattern-evidence-days.ts
+++ b/apps/web/src/components/overview/pattern-evidence-days.ts
@@ -1,0 +1,31 @@
+import type { PersonalPatternCell, PersonalPatternReport } from "@murphai/query/browser-overview";
+
+const DAY_MS = 86_400_000;
+export type PatternEvidenceWindow = Pick<PersonalPatternReport, "asOfDate" | "windowDays">;
+
+function parseDate(value: string): number | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const date = Date.parse(value + "T00:00:00Z");
+  return Number.isFinite(date) && new Date(date).toISOString().slice(0, 10) === value ? date : null;
+}
+
+export function patternEvidenceDays(report: PatternEvidenceWindow, cell: PersonalPatternCell) {
+  const end = parseDate(report.asOfDate);
+  if (end === null || !Number.isInteger(report.windowDays) || report.windowDays < 1 || report.windowDays > 366) return null;
+  const start = end - (report.windowDays - 1) * DAY_MS;
+  const validDates = (dates: string[] | undefined) => new Set((dates ?? []).filter((value) => {
+    const date = parseDate(value);
+    return date !== null && date >= start && date <= end;
+  }));
+  const exposed = validDates(cell.exposedDates);
+  const comparison = validDates(cell.comparisonDates);
+  if (!exposed.size && !comparison.size) return null;
+  const gridStart = start - ((new Date(start).getUTCDay() + 6) % 7) * DAY_MS;
+  const length = Math.ceil(((end - gridStart) / DAY_MS + 1) / 7) * 7;
+  const days = Array.from({ length }, (_, index) => {
+    const time = gridStart + index * DAY_MS;
+    const date = new Date(time).toISOString().slice(0, 10);
+    return { date, inWindow: time >= start && time <= end, exposed: exposed.has(date), comparison: comparison.has(date) };
+  });
+  return { days, hasMissingDates: exposed.size < cell.exposedDays || comparison.size < cell.comparisonDays };
+}

--- a/apps/web/src/components/overview/personal-patterns-section.tsx
+++ b/apps/web/src/components/overview/personal-patterns-section.tsx
@@ -60,6 +60,8 @@ import {
 } from "@/src/components/ui/tooltip";
 import { usePointerPopoverAnchor } from "@/src/components/ui/use-pointer-popover-anchor";
 import { cn } from "@/src/lib/utils";
+import { PatternEvidenceCalendar } from "./pattern-evidence-calendar";
+import type { PatternEvidenceWindow } from "./pattern-evidence-days";
 import { resolvePatternFactorIcon } from "./pattern-factor-icon";
 
 const INITIAL_VISIBLE_FACTOR_COUNT = 15;
@@ -714,6 +716,7 @@ function PatternOutcomeColumnCell({
 
     return (
       <PatternBubble
+        report={report}
         cell={checked?.cell}
         card={card}
         factorLabel={factorLabel}
@@ -730,6 +733,7 @@ function PatternOutcomeColumnCell({
     const [{ cell, outcome }] = effects;
     return (
       <PatternBubble
+        report={report}
         cell={cell}
         card={card}
         factorLabel={factorLabel}
@@ -744,6 +748,7 @@ function PatternOutcomeColumnCell({
 
   return (
     <PatternCompositeBubble
+      report={report}
       card={card}
       entries={effects}
       factorLabel={factorLabel}
@@ -764,10 +769,12 @@ function isPatternEffectEntry(entry: {
 }
 
 function PatternCompositeBubble({
+  report,
   card = false,
   entries,
   factorLabel,
 }: {
+  report: PatternEvidenceWindow;
   card?: boolean;
   entries: PatternEffectEntry[];
   factorLabel: string;
@@ -845,7 +852,7 @@ function PatternCompositeBubble({
             </p>
             {cell.exposedMean !== null && cell.comparisonMean !== null ? (
               <PatternComparisonBars
-                comparisonLabel={card ? "Other" : "Other days"}
+                comparisonLabel={cell.comparisonBasis === "confirmed_absence" ? `Without ${factor}` : card ? "Other" : "Other days"}
                 comparisonMean={cell.comparisonMean}
                 comparisonDays={card ? cell.comparisonDays : undefined}
                 exposedLabel={`After ${factor}`}
@@ -855,6 +862,7 @@ function PatternCompositeBubble({
                 unit={outcome.unit}
               />
             ) : null}
+            <PatternEvidenceCalendar report={report} cell={cell} factorLabel={factorLabel} />
           </section>
         ))}
       </div>
@@ -867,6 +875,7 @@ function PatternCompositeBubble({
 }
 
 function PatternBubble({
+  report,
   cell,
   card = false,
   factorLabel,
@@ -876,6 +885,7 @@ function PatternBubble({
   outcomeLabel,
   outcomeUnit,
 }: {
+  report: PatternEvidenceWindow;
   cell?: PersonalPatternCell;
   card?: boolean;
   factorLabel: string;
@@ -936,6 +946,7 @@ function PatternBubble({
 
   return (
     <PatternDetails
+      report={report}
       card={card}
       cell={cell}
       factorLabel={factorLabel}
@@ -1124,6 +1135,7 @@ function PatternResultDetails({
 }
 
 function PatternDetails({
+  report,
   card,
   trigger,
   cell,
@@ -1134,6 +1146,7 @@ function PatternDetails({
   outcomeLabel,
   outcomeUnit,
 }: {
+  report: PatternEvidenceWindow;
   card: boolean;
   trigger: ReactElement;
   cell: PersonalPatternCell;
@@ -1184,7 +1197,7 @@ function PatternDetails({
         </>
       ) : null}
 
-      <Separator />
+      <PatternEvidenceCalendar report={report} cell={cell} factorLabel={factorLabel} />
       <p className="text-xs leading-5 text-muted-foreground">
         Data from {formatEvidencePeriod(cell)}.
       </p>

--- a/apps/web/test/pattern-evidence-days.test.ts
+++ b/apps/web/test/pattern-evidence-days.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "vitest";
+import type { PersonalPatternCell } from "@murphai/query/browser-overview";
+import { patternEvidenceDays } from "@/src/components/overview/pattern-evidence-days";
+
+const cell: PersonalPatternCell = {
+  factorId: "running", outcomeId: "hrv", stage: "seen_again", direction: "higher",
+  exposedMean: 48, comparisonMean: 44, delta: 4, deltaPercent: 9,
+  exposedDays: 2, comparisonDays: 1, repeatedDirection: true,
+  firstExposedDate: "2024-02-29", lastExposedDate: "2024-03-01",
+  exposedDates: ["2024-02-29", "2024-03-01"], comparisonDates: ["2024-02-28"],
+};
+
+test("preserves saved group membership across leap day and Monday week boundaries", () => {
+  const evidence = patternEvidenceDays({ asOfDate: "2024-03-02", windowDays: 4 }, cell);
+  expect(evidence?.days.map(day => day.date)).toEqual([
+    "2024-02-26", "2024-02-27", "2024-02-28", "2024-02-29", "2024-03-01", "2024-03-02", "2024-03-03",
+  ]);
+  expect(evidence?.days.filter(day => day.exposed).map(day => day.date)).toEqual(cell.exposedDates);
+  expect(evidence?.days.filter(day => day.comparison).map(day => day.date)).toEqual(cell.comparisonDates);
+  expect(evidence?.days.filter(day => day.inWindow)).toHaveLength(4);
+  expect(evidence?.hasMissingDates).toBe(false);
+});
+
+test("does not invent missing dates or normalize invalid dates into valid observations", () => {
+  const report = { asOfDate: "2024-03-02", windowDays: 4 };
+  const incomplete = { ...cell, exposedDates: ["2024-02-29", "2024-02-29", "2024-02-30", "2024-03-03", "2024-02-01"], comparisonDates: [] };
+  const evidence = patternEvidenceDays(report, incomplete);
+  expect(evidence?.days.filter(day => day.exposed).map(day => day.date)).toEqual(["2024-02-29"]);
+  expect(evidence?.hasMissingDates).toBe(true);
+  expect(patternEvidenceDays(report, { ...cell, exposedDates: undefined, comparisonDates: undefined })).toBeNull();
+  expect(patternEvidenceDays({ ...report, asOfDate: "2024-02-30" }, cell)).toBeNull();
+  for (const windowDays of [0, 367, 1.5, Infinity, NaN]) expect(patternEvidenceDays({ ...report, windowDays }, cell)).toBeNull();
+  expect(patternEvidenceDays({ ...report, windowDays: 366 }, cell)?.days.length).toBeLessThanOrEqual(378);
+});


### PR DESCRIPTION
## Why and outcome

Pattern details now show the saved comparison dates beneath their average bars. Days compared opens a compact calendar; selecting a day reveals its group. The same presentation works in phone drawers and desktop popovers, including separate sleep score and efficiency comparisons.

## Product UX

- Effort: Product change
- Result: Ready
- Walkthrough: Phone touch and desktop keyboard selection, grouped sleep outcomes, confirmed absence, unrecorded baselines, and partial dates. Missing date arrays omit the calendar. Existing dismissal, focus restoration, and neutral-card behavior remain usable.

## Evidence

- Direct: Two date-boundary tests and the production-component Playwright journey passed. Browser proof covers 320, 390, 640, and 1440 pixels, selected dates, arrow-key navigation, group distinctions, drawer dismissal, and focus restoration. Web typecheck and targeted ESLint passed.
- Coverage: Strict UTC dates, leap-day/week alignment, duplicates, invalid/out-of-window dates, missing arrays, and the 366-day bound. Synthetic props exercise the real components; authenticated member data was not used.

## Non-obvious affected surfaces

Desktop popovers and grouped sleep quality use the same component; both passed the browser journey. The visible design study includes an expanded calendar with inert controls.

## Architecture and reuse

- Existing systems reused: Saved Personal Patterns report, existing comparison details, native HTML disclosure, and existing drawer/popover owners.
- New logic: Bounded date-only presentation and transient date selection.
- New abstractions: One date projection helper and one shared calendar for single and grouped comparisons.
- Complexity intentionally avoided: No scoring, daily-value inference, persistence, API changes, or new dependency.

## Complexity impact

- Guard: Pass, `pnpm complexity:diff`.
- Hotspots: None above 20 in changed functions.
- Agent judgment: The helper keeps validation testable while the shared calendar prevents repeated presentation logic.

## Hot reply path impact

Not applicable: client presentation only, with no database, provider, or awaited reply-path work.

## Murph initial provider input impact

Not applicable to individual or group turns: no prompt, tool, or provider-input changes. No token measurement claimed.

## Design proof

- Design page: [Expanded comparison calendar](https://murph-2vq51pox1-cobuildwithus.vercel.app/design?tab=components#pattern-comparison-calendar). Preview deployment is Ready; the design page returns HTTP 200 and contains the expanded production calendar. Local rendered proof passed.
- Evidence: Synthetic browser captures attached below.
- Coverage: Phone confirmed/unrecorded comparisons, selected date, grouped sleep, and desktop keyboard selection. Marks indicate saved group membership, not outcome values or confidence.

## Deployment concerns

- Deployment: not applicable
- Reason: Presentation of existing optional saved fields; no independently deployed protocol, migration, or backend dependency.

## Changelog

- Changelog: updated
- Items: 2026-09-08 · pattern-comparison-dates

Final ReviewGPT: not required under the frontend-only presentation/interaction exemption. Parent diff review, focused checks, rendered proof, and all exact-head hosted checks passed.

## Change-shape breakdown

Classification: application and changelog files are source, design and test files are fixtures, Markdown is documentation.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 143 | 2 |
| Tests / fixtures | 82 | 4 |
| Docs | 34 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |

Evidence head: `d78a0f1053f9a3619f6c57eb4dbdc43415e8df4f`. Screenshots contain synthetic study data only.

<img width="360" alt="patterns result drawer" src="https://github.com/user-attachments/assets/32ccb78d-e6b2-4e10-96b5-153c6e92bb74" />

<img width="360" alt="patterns confirmed drawer" src="https://github.com/user-attachments/assets/dcb1bf83-fca2-4ae9-8361-9f84e6d7013a" />

<img width="360" alt="patterns evidence desktop" src="https://github.com/user-attachments/assets/373b958b-33ab-49ee-9082-bf7df9a52189" />


Production verification: the Ready deployment `murph-gxqvekjup-cobuildwithus.vercel.app` serves `www.withmurph.ai` from main commit `1e9e2e8905cbc11cb8b68a5fc458a9d6f978ab60`, which contains this merge. The public design page returns HTTP 200 and contains the updated calendar anchor, disclosure, and date controls.
