### PR TITLE
Recover orphaned device sync and expose continuation progress

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-08-device-queue-progress.md
+++ b/agent-docs/exec-plans/active/2026-09-08-device-queue-progress.md
@@ -1,0 +1,66 @@
+# Recover stalled device-sync wake and payload progress
+
+Status: active
+Created: 2026-09-08
+Updated: 2026-09-08
+
+## Outcome and invariants
+
+Accepted wearable work must retain a runnable owner until checkpoint-safe
+acknowledgement, and repeated bounded passes must advance durable progress.
+Preserve foreground priority, exact payload acknowledgement, canonical health
+writes, connection authority, bounded database work, and private-data boundaries.
+
+Product UX effort: Patch. Replays cover silent background recovery, new ingress
+during completion, cold restore after yield, and foreground preemption.
+
+## Evidence and ownership
+
+Two observed patterns require independent proof: a consumed wake with hosted
+payloads pending, and recurring timed-out worker passes without payload drain.
+Web owns dirty revisions/payloads and mailbox admission; runtime owns job
+execution and checkpoint records. Inspect existing owners before adding state.
+No production identities, payloads, or copied rows belong in this plan or tests.
+
+## Work
+
+1. Trace both patterns using bounded production metadata and current source;
+   inspect overlapping PRs. Add synthetic failing composed reproductions.
+2. Correct only proven causes at existing wake/admission/checkpoint owners.
+   Add bounded counts/stages if existing logs cannot establish progress.
+3. Test recovery and protected success/failure paths; run relevant typechecks,
+   complexity/docs checks, parent review, changelog, and required PR review/CI.
+4. Keep deployment coordination separate from diagnosis. Confirm rollout before
+   claiming live recovery; do not mutate private vaults or queues directly.
+
+## Failure and evolution
+
+No new persisted owner or schema is planned. Failed checkpoint/acknowledgement
+must retain accepted work and future retry. If evidence requires a protocol
+change, document supported deployment skew before implementation.
+
+## Progress
+
+- Created isolated checkout on current main; no overlapping open sync fix.
+- Recent merged ingress contention and callback fixes do not address runtime
+  wake completion or repeated worker drain. Existing diagnostics PRs inspected.
+- Reproduced owner removal when a clean-looking pass receives a still-dirty
+  acknowledgement; both single and batch record forms failed before the fix.
+  A fresh-runtime replay now processes the new exact payload and releases ownership.
+- Reproduced the existing scheduled identity being reused after its owner was
+  consumed. A real local PostgreSQL proof now selects a fresh recovery identity
+  only with complete durable evidence that no owner remains.
+- Runtime and foreground interaction proof: 325 tests passed. Runtime and
+  hosted-execution typechecks passed; Web prepared typecheck passed. Complexity
+  guard passes without increasing debt in changed files.
+- Added private progress fingerprints and checkpoint decision counts. Repeated
+  provider passes are observed, but current production telemetry cannot prove
+  whether their cursors advance; live confirmation requires runner rollout.
+- Web proof: 34 tests passed, including actual PostgreSQL recovery append,
+  stable replay across unrelated checkpoints and dirty revisions, and exclusions
+  for retained/pending owners and incomplete legacy projections.
+- Parent candidate review: existing bounded selection and admission owners reused;
+  no migration, provider data logging, foreground network call, or new queue.
+- Remaining: exact-head PR review/CI, and post-deploy
+  queue recovery/progress verification. The recurring-pass diagnosis stays open;
+  logging is evidence collection, not a claimed fix for an unproven cause.

--- a/agent-docs/exec-plans/completed/2026-09-08-device-queue-progress.md
+++ b/agent-docs/exec-plans/completed/2026-09-08-device-queue-progress.md
@@ -1,6 +1,6 @@
 # Recover stalled device-sync wake and payload progress
 
-Status: active
+Status: completed
 Created: 2026-09-08
 Updated: 2026-09-08
 
@@ -61,6 +61,17 @@ change, document supported deployment skew before implementation.
   for retained/pending owners and incomplete legacy projections.
 - Parent candidate review: existing bounded selection and admission owners reused;
   no migration, provider data logging, foreground network call, or new queue.
-- Remaining: exact-head PR review/CI, and post-deploy
-  queue recovery/progress verification. The recurring-pass diagnosis stays open;
-  logging is evidence collection, not a claimed fix for an unproven cause.
+- ReviewGPT Round 1 passed on a354504221e8a08e011f55284d87f2858646a2d8
+  with verified model metadata and exact response identity. No findings met its
+  qualifying bar. Parent review accepted the result without source remediation.
+- Preserved the separately merged retained-history cadence fix from PR #3074.
+  The base merge resolved additive test imports only. Combined runtime proof:
+  431 tests passed; typecheck and complexity checks passed again.
+- Implementation and diagnostic instrumentation are complete in PR #3075.
+  Required final-head CI remains the merge gate. Production convergence is
+  unverified: the independent runner rollout is still blocked. Neither the
+  owner repair nor progress logging is proof that a live queue has drained.
+  The recurring-pass diagnosis remains an operational follow-up requiring the
+  deployed fingerprints and acknowledgement counts; no private queue state was
+  changed or copied into this plan.
+Completed: 2026-09-08

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -41,7 +41,7 @@ not a guarantee that every claim was checked in this cleanup.
 | `docs/architecture.md` | Concise architecture summary, repo-shape overview, package-boundary hygiene notes, and hosted ownership baseline. | Current architectural baseline | High | 2026-05-13 |
 | `docs/contracts/` | Frozen contract docs for vault layout, schemas, commands, and cross-cutting invariants. | Canonical vault interface decisions | High | 2026-07-20 |
 | `docs/contracts/06-hosted-workspace-file-count.md` | Hosted workspace checkpoint/restore contract. | Hosted workspace checkpoint/restore contract | High | 2026-08-04 |
-| `docs/device-sync-hosted-control-plane.md` | Current hosted control-plane direction for device sync. | Device-sync architecture direction | Medium | 2026-08-13 |
+| `docs/device-sync-hosted-control-plane.md` | Current hosted control-plane direction for device sync. | Device-sync architecture direction | Medium | 2026-09-08 |
 | `docs/device-provider-contribution-kit.md` | Maintainer guide for adding wearable providers. | Provider contribution workflow | Medium | 2026-05-13 |
 | `docs/device-provider-compatibility-matrix.md` | Canonical provider planning matrix and evidence expectations. | Device-provider normalization planning | Medium | 2026-07-14 |
 | `docs/hosted-contact-privacy-rotation.md` | Hosted blind-index keyring seam and future rotation constraints. | Hosted contact-privacy rotation seam | Medium | 2026-07-16 |

--- a/apps/web/changelog/entries/2026-09-08/device-sync-wake-recovery.json
+++ b/apps/web/changelog/entries/2026-09-08/device-sync-wake-recovery.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-08",
+  "order": 110,
+  "item": {
+    "id": "device-sync-wake-recovery",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "More reliable background device sync",
+    "summary": "Device sync can recover when pending updates lose their scheduled wake.",
+    "details": "Updates that arrive as a sync finishes keep a follow-up wake so they can be processed automatically.",
+    "relevanceTags": ["wearables", "reliability"],
+    "sourcePullRequests": []
+  }
+}

--- a/apps/web/changelog/entries/2026-09-08/device-sync-wake-recovery.json
+++ b/apps/web/changelog/entries/2026-09-08/device-sync-wake-recovery.json
@@ -8,7 +8,12 @@
     "title": "More reliable background device sync",
     "summary": "Device sync can recover when pending updates lose their scheduled wake.",
     "details": "Updates that arrive as a sync finishes keep a follow-up wake so they can be processed automatically.",
-    "relevanceTags": ["wearables", "reliability"],
-    "sourcePullRequests": []
+    "relevanceTags": [
+      "wearables",
+      "reliability"
+    ],
+    "sourcePullRequests": [
+      3075
+    ]
   }
 }

--- a/apps/web/src/lib/device-sync/due-reconcile-sweeper.ts
+++ b/apps/web/src/lib/device-sync/due-reconcile-sweeper.ts
@@ -59,6 +59,9 @@ export async function runHostedDeviceSyncDueReconcileSweeper(input: {
     wakeBucketStartedAt: wakeBucketStartedAtIso,
     wakeLimit,
     selectedDueConnections: selectedDueConnections.length,
+    orphanedDirtyRecoveryCount: selectedDueConnections.filter(
+      (connection) => connection.orphanedDirtyRecoveryKey !== undefined,
+    ).length,
   });
 
   let wakeAccepted = 0;
@@ -77,11 +80,19 @@ export async function runHostedDeviceSyncDueReconcileSweeper(input: {
         wake = await requestWake({
           connectionId: dueConnection.connectionId,
           createdAt: nowIso,
-          eventId: buildHostedDeviceSyncScheduledReconcileWakeEventId({
-            connectionId: dueConnection.connectionId,
-            expectedConnectedAt: dueConnection.connectedAt,
-            nextReconcileAt: dueConnection.nextReconcileAt,
-          }),
+          eventId: [
+            buildHostedDeviceSyncScheduledReconcileWakeEventId({
+              connectionId: dueConnection.connectionId,
+              expectedConnectedAt: dueConnection.connectedAt,
+              nextReconcileAt: dueConnection.nextReconcileAt,
+            }),
+            // Reuse the scheduled sweep only after the durable mailbox proves
+            // no work owner remains. Bind recovery to the consumed lane
+            // frontier so unrelated checkpoints cannot create extra wakes.
+            ...(dueConnection.orphanedDirtyRecoveryKey
+              ? ["dirty-recovery", dueConnection.orphanedDirtyRecoveryKey]
+              : []),
+          ].join(":"),
           expectedConnectedAt: dueConnection.connectedAt,
           nextReconcileAt: dueConnection.nextReconcileAt,
           provider: dueConnection.provider,

--- a/apps/web/src/lib/device-sync/prisma-store/connections.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/connections.ts
@@ -1381,18 +1381,21 @@ export class PrismaHostedConnectionStore {
   }): Promise<HostedDeviceSyncDueReconcileConnectionRecord[]> {
     const limit = Math.max(1, Math.min(input.limit, 251));
     const rows = await this.prisma.$queryRaw<Array<{
+      orphaned_dirty_recovery_key: string | null;
       connected_at: Date;
       id: string;
       next_reconcile_at: Date;
       provider: string;
       user_id: string;
     }>>(Prisma.sql`
+      with due_connections as (
       select
         "connection"."connected_at",
         "connection"."id",
         "connection"."next_reconcile_at",
         "connection"."provider",
-        "connection"."user_id"
+        "connection"."user_id",
+        "connection"."updated_at" as sweep_updated_at
       from "device_connection" as "connection"
       join "hosted_member" as "member"
         on "member"."id" = "connection"."user_id"
@@ -1439,9 +1442,36 @@ export class PrismaHostedConnectionStore {
         "connection"."updated_at" asc,
         "connection"."id" asc
       limit ${limit}
+      )
+      select due.*,
+        case when
+          counters.consumed_seq = counters.next_seq - 1
+          and dirty.connection_id is not null
+          and workspace.redacted_status_json->>'hostedMailboxSystemHandledThroughSeq' = counters.consumed_seq::text
+          and workspace.redacted_status_json->'hostedMailboxSystemDeviceSyncContinuationSeqs' = '[]'::jsonb
+          and workspace.redacted_status_json->'hostedMailboxSystemFirstPendingSeq' = 'null'::jsonb
+          and (
+            dirty.dirty_revision > dirty.processed_revision
+            or exists (
+              select 1 from device_sync_dirty_payload payload
+              where payload.connection_id = due.id and payload.user_id = due.user_id
+            )
+          )
+        then counters.consumed_seq::text
+        else null end as orphaned_dirty_recovery_key
+      from due_connections due
+      left join device_sync_dirty_connection dirty
+        on dirty.connection_id = due.id and dirty.user_id = due.user_id
+      left join hosted_workspace workspace on workspace.user_id = due.user_id
+      left join hosted_mailbox_lane_counter counters
+        on counters.user_id = due.user_id and counters.lane = 'system'
+      order by due.next_reconcile_at, due.sweep_updated_at, due.id
     `);
 
     return rows.map((row) => ({
+      ...(row.orphaned_dirty_recovery_key
+        ? { orphanedDirtyRecoveryKey: row.orphaned_dirty_recovery_key }
+        : {}),
       connectionId: row.id,
       connectedAt: toIsoTimestamp(row.connected_at),
       nextReconcileAt: toIsoTimestamp(row.next_reconcile_at),

--- a/apps/web/src/lib/device-sync/prisma-store/types.ts
+++ b/apps/web/src/lib/device-sync/prisma-store/types.ts
@@ -92,6 +92,7 @@ export interface HostedDeviceSyncDirtyConnectionAckRecord {
 }
 
 export interface HostedDeviceSyncDueReconcileConnectionRecord {
+  orphanedDirtyRecoveryKey?: string;
   connectionId: string;
   connectedAt: string;
   userId: string;

--- a/apps/web/test/device-sync-scheduled-wake-retention-postgres.test.ts
+++ b/apps/web/test/device-sync-scheduled-wake-retention-postgres.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import type { PrismaClient } from "@prisma/client";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
+import { PrismaDeviceSyncControlPlaneStore } from "@/src/lib/device-sync/prisma-store";
 import { buildHostedDeviceSyncWake } from "@/src/lib/device-sync/wake";
 import { runHostedDeviceSyncDueReconcileSweeper } from "@/src/lib/device-sync/due-reconcile-sweeper";
 import { runHostedDeviceSyncRecoverySweep } from "@/src/lib/device-sync/recovery-sweeper";
@@ -15,6 +16,7 @@ import {
   HOSTED_MAILBOX_ITEM_PAYLOAD_SCHEMA,
 } from "@/src/lib/hosted-mailbox/store";
 import { createPrismaClient } from "@/src/lib/prisma";
+import { setHostedSecureBoxStringTestCodecForTests } from "@/src/lib/hosted-crypto/secure-box";
 import { checkpointHostedWorkspace } from "@/src/lib/hosted-workspace/store";
 
 const databaseUrl = process.env.DATABASE_URL?.trim() ?? "";
@@ -42,11 +44,106 @@ describe.skipIf(!runPostgresProof)(
 
     afterAll(async () => {
       if (prisma && memberIds.length > 0) {
+        await prisma.deviceConnection.deleteMany({ where: { userId: { in: memberIds } } });
         await prisma.hostedMember.deleteMany({
           where: { id: { in: memberIds } },
         });
       }
       await prisma?.$disconnect();
+    });
+
+    it("recovers dirty work after its scheduled mailbox owner was fully consumed", async () => {
+      const client = requirePrisma(prisma);
+      const fixture = await seedRetiredScheduledWake({
+        client, consumedSeq: 1n, importedSeq: "1", firstPendingSeq: null,
+        deviceSyncContinuationSeqs: [], memberIds,
+      });
+      const connectionId = fixture.wake.connectionId!;
+      await client.deviceConnection.create({ data: {
+        id: connectionId, userId: fixture.memberId, provider: "oura", status: "active",
+        providerAccountBlindIndex: `synthetic-${connectionId}`,
+        connectedAt: new Date(fixture.wake.expectedConnectedAt!),
+        nextReconcileAt: new Date(fixture.wake.hint!.nextReconcileAt!),
+        dirtyState: { create: {
+          userId: fixture.memberId, provider: "oura", dirtyRevision: 5n, processedRevision: 2n,
+          firstDirtyAt: new Date("2026-09-01T00:00:00Z"), latestDirtyAt: new Date("2026-09-01T00:00:00Z"),
+        } },
+      } });
+      const store = new PrismaDeviceSyncControlPlaneStore({ prisma: client });
+      const requestWake = vi.fn(async (_input: { connectionId: string; eventId: string }) => ({ wakeAccepted: true, wakeAppended: true, wakeDuplicate: false, wakeInserted: true }));
+      const now = new Date("2026-09-04T12:00:00Z");
+      await runHostedDeviceSyncDueReconcileSweeper({ store, now, requestWake, logger: { info() {}, warn() {} } });
+      const recovered = requestWake.mock.calls[0]?.[0];
+      expect(recovered).toMatchObject({ connectionId });
+      expect(recovered?.eventId).not.toBe(fixture.wake.eventId);
+      await client.hostedWorkspace.update({
+        where: { userId: fixture.memberId }, data: { version: { increment: 1 } },
+      });
+      await client.deviceSyncDirtyConnection.update({
+        where: { connectionId }, data: { dirtyRevision: 6n },
+      });
+      await runHostedDeviceSyncDueReconcileSweeper({ store, now, requestWake, logger: { info() {}, warn() {} } });
+      expect(requestWake.mock.calls[1]?.[0]?.eventId).toBe(recovered?.eventId);
+      await client.hostedMailboxLaneCounter.update({
+        where: { userId_lane: { userId: fixture.memberId, lane: "system" } },
+        data: { nextSeq: 3n },
+      });
+      requestWake.mockClear();
+      await runHostedDeviceSyncDueReconcileSweeper({ store, now, requestWake, logger: { info() {}, warn() {} } });
+      expect(requestWake.mock.calls[0]?.[0]?.eventId).toBe(fixture.wake.eventId);
+      await client.hostedMailboxLaneCounter.update({
+        where: { userId_lane: { userId: fixture.memberId, lane: "system" } },
+        data: { nextSeq: 2n },
+      });
+      await client.deviceSyncDirtyConnection.update({ where: { connectionId }, data: { processedRevision: 6n } });
+      requestWake.mockClear();
+      await runHostedDeviceSyncDueReconcileSweeper({ store, now, requestWake, logger: { info() {}, warn() {} } });
+      expect(requestWake.mock.calls[0]?.[0]?.eventId).toBe(fixture.wake.eventId);
+      await client.deviceSyncDirtyPayload.create({ data: {
+        id: `synthetic-payload-${connectionId}`, connectionId, userId: fixture.memberId,
+        provider: "oura", dirtyRevision: 5n, resourceEncrypted: "encrypted-synthetic-fixture",
+      } });
+      requestWake.mockClear();
+      await runHostedDeviceSyncDueReconcileSweeper({ store, now, requestWake, logger: { info() {}, warn() {} } });
+      expect(requestWake.mock.calls[0]?.[0]?.eventId).not.toBe(fixture.wake.eventId);
+      // An actual retained owner, pending mailbox work, or absent legacy proof
+      // must keep the ordinary stable schedule identity instead of reopening it.
+      for (const status of [
+        { hostedMailboxSystemHandledThroughSeq: "1", hostedMailboxSystemDeviceSyncContinuationSeqs: ["1"], hostedMailboxSystemFirstPendingSeq: null },
+        { hostedMailboxSystemHandledThroughSeq: "1", hostedMailboxSystemDeviceSyncContinuationSeqs: [], hostedMailboxSystemFirstPendingSeq: "1" },
+        {},
+      ]) {
+        await client.hostedWorkspace.update({ where: { userId: fixture.memberId }, data: { redactedStatusJson: status } });
+        requestWake.mockClear();
+        await runHostedDeviceSyncDueReconcileSweeper({ store, now, requestWake, logger: { info() {}, warn() {} } });
+        expect(requestWake.mock.calls[0]?.[0]?.eventId).toBe(fixture.wake.eventId);
+      }
+      if (!recovered) throw new Error("Expected recovered wake");
+      // Exercise the actual append boundary, including stable replay, using
+      // synthetic local crypto. A fresh identity must allocate new lane work.
+      setHostedSecureBoxStringTestCodecForTests({
+        decrypt: ({ value }) => value.replace(/^enc:/u, ""),
+        encrypt: ({ value }) => `enc:${value}`,
+      });
+      try {
+        const envelope = { ...fixture.wake, eventId: recovered.eventId };
+        const appended = await client.$transaction((tx) =>
+          appendHostedScheduledDeviceSyncWakeEnvelopeTx({ envelope, tx })
+        );
+        expect(appended.inserted).toBe(true);
+        const repeated = await client.$transaction((tx) =>
+          appendHostedScheduledDeviceSyncWakeEnvelopeTx({ envelope, tx })
+        );
+        expect(repeated.inserted).toBe(false);
+        expect(repeated.dedupeConflict).toBe(false);
+        const counter = await client.hostedMailboxLaneCounter.findUniqueOrThrow({
+          where: { userId_lane: { userId: fixture.memberId, lane: "system" } },
+        });
+        expect(counter.nextSeq).toBe(3n);
+        expect(counter.consumedSeq).toBe(1n);
+      } finally {
+        setHostedSecureBoxStringTestCodecForTests(null);
+      }
     });
 
     it("accepts only the producer-specific duplicate after runtime import", async () => {

--- a/docs/device-sync-hosted-control-plane.md
+++ b/docs/device-sync-hosted-control-plane.md
@@ -515,6 +515,34 @@ The current hosted runtime strategy is:
 
 This keeps control-plane truth in web while still allowing hosted execution to consume the runtime state it needs during a job.
 
+When a checkpoint acknowledgement reports remaining dirty work after the
+observed batch drained, the connection-scoped mailbox item becomes a retained
+continuation. Its completed job hints are cleared; the next pass fetches current
+dirty work through the same authoritative connection. The continuation remains
+separate from foreground mailbox progress and is released after a clean ack.
+
+The existing bounded due-reconcile selection can also recover an orphaned dirty
+connection. It requires the system lane to be fully consumed, the workspace to
+confirm that exact handled frontier, and explicit empty continuation and pending
+projections. Only then does it append a recovery suffix derived from the consumed
+mailbox frontier to the ordinary scheduled wake identity. Repeated
+selection of that same state deduplicates; existing pending or retained owners
+keep the ordinary identity. Connection epoch, member access, consent, and signal
+admission still use their existing owners. This is not a new dirty-row scan.
+
+`device-sync.checkpoint_recorded` reports whether acknowledgements retained the
+mailbox owner and discovered new dirty work. Finished pass logs include incoming
+and outgoing retained-job counts, exact-payload acknowledgement counts, and
+member-scoped SHA-256 fingerprints of job identity and cursor metadata. Compare
+an outgoing fingerprint with the next incoming fingerprint to distinguish saved
+progress from replay; unchanged fingerprints alone do not prove a bug because
+future retries may legitimately retain the same cursor. Raw provider payloads,
+source identities, and cursor values are never emitted by these diagnostics.
+Deploy the Web log parser before the runtime that emits the new event. Both
+recovery changes otherwise use the existing wake and checkpoint contracts;
+older runtimes can process the recovery wake, but can still lose ownership in
+the acknowledgement race. No schema change or new rollback floor is introduced.
+
 The local device-sync SQLite schema is version 11. Its bounded
 `device_job.canonical_import_receipts_json` column is written atomically with
 job success from the exact normalized source/resource identities already

--- a/packages/assistant-runtime/src/hosted-runtime/device-sync-maintenance.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/device-sync-maintenance.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import {
   createConfiguredDeviceSyncProvidersFromConfigs,
 } from "@murphai/device-syncd/config";
@@ -1594,6 +1596,7 @@ function writeHostedDeviceSyncPassLifecycleLog(input: {
         processedJobs: input.processedJobs,
         ...(input.lifecycle === "finished"
           ? {
+              ...buildHostedDeviceSyncPassProgressDiagnostics(input.input.wake, input.result),
               pendingJobCountAfter: queueSnapshotAfter?.jobCount ?? null,
               pendingJobCountAfterTruncated:
                 queueSnapshotAfter?.jobCountTruncated ?? null,
@@ -1633,6 +1636,42 @@ function writeHostedDeviceSyncPassLifecycleLog(input: {
     },
     platform: input.input.runtimeLogPlatform,
   });
+}
+
+function buildHostedDeviceSyncPassProgressDiagnostics(
+  wake: HostedRuntimeEvent,
+  result: HostedMaintenanceMetrics | null,
+): Record<string, string | number | boolean | null> {
+  const record = result?.postCheckpointRecord;
+  const retainedWake = record?.kind === "device-sync.dirty-processed-batch"
+    ? record.retainedWake
+    : null;
+  const incoming = wake.kind === "device-sync.wake" ? wake.hint?.jobs ?? [] : [];
+  const outgoing = retainedWake?.hint?.jobs ?? [];
+  const fingerprint = (jobs: typeof incoming) => createHash("sha256")
+    .update(JSON.stringify(["device-sync-continuation-progress-v1", wake.userId]))
+    .update(JSON.stringify(jobs.map((job) => JSON.stringify([
+      job.kind,
+      job.dedupeKey ?? null,
+      job.payload?.windowStart ?? null,
+      job.payload?.windowEnd ?? null,
+      job.payload?.timeseriesCursor ?? null,
+      job.payload?.timeseriesResourceCursor ?? null,
+      job.payload?.workoutStreamCursor ?? null,
+      job.payload?.emptyBackfillAttempts ?? null,
+    ])).sort()))
+    .digest("hex");
+  return {
+    incomingRetainedJobCount: incoming.length,
+    outgoingRetainedJobCount: outgoing.length,
+    incomingRetainedProgressFingerprint: fingerprint(incoming),
+    outgoingRetainedProgressFingerprint: fingerprint(outgoing),
+    retainedMailboxOwnerPresent: record?.kind === "device-sync.dirty-processed-batch"
+      && record.retainMailboxItemUntil != null,
+    stagedDirtyPayloadAckCount: result?.stagedDirtyAcks?.reduce(
+      (count, ack) => count + (ack.processedDirtyPayloadIds?.length ?? 0), 0,
+    ) ?? 0,
+  };
 }
 
 function summarizeHostedDeviceSyncJobTimings(

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
@@ -1012,12 +1012,18 @@ export async function recordHostedSystemMailboxItemAfterCheckpoint(input: {
       signal: input.signal,
       stillDirty: recordResult.stillDirty,
     });
-    const retainUntil = completion.retainUntil;
+    const { dirtyRemainderDiscovered, retainUntil } = resolveHostedDeviceSyncDirtyRemainderRetention({
+      item: input.item,
+      nextDirtyWakeAt: recordResult.nextWakeAt,
+      retainUntil: completion.retainUntil,
+      stillDirty: recordResult.stillDirty,
+    });
     const immediateDirtyContinuationCanProgress = retainUntil !== null
       && recordResult.newerRevisionPending
       && hostedDeviceSyncRetainedWakeHasCapacity(input.item);
     if (retainUntil) {
       await retainHostedDeviceSyncSystemMailboxItem({
+        dirtyRemainderDiscovered,
         immediateDirtyContinuationCanProgress,
         item: input.item,
         dirtyWakeAt: recordResult.nextWakeAt,
@@ -1030,6 +1036,13 @@ export async function recordHostedSystemMailboxItemAfterCheckpoint(input: {
         vaultRoot: input.vaultRoot,
       });
     }
+    await writeHostedDeviceSyncCheckpointRecordedLog({
+      dirtyRemainderDiscovered,
+      item: input.item,
+      recordResult,
+      retainUntil,
+      runtime: input.runtime,
+    });
     const deviceSyncWake = selectHostedRuntimeWakeCandidate([
       createHostedRuntimeWakeCandidate(
         retainUntil,
@@ -1112,6 +1125,64 @@ export async function recordHostedSystemMailboxItemAfterCheckpoint(input: {
   }
 }
 
+function resolveHostedDeviceSyncDirtyRemainderRetention(input: {
+  item: HostedSystemMailboxPendingItem;
+  nextDirtyWakeAt: string | null;
+  retainUntil: string | null;
+  stillDirty: boolean;
+}): { dirtyRemainderDiscovered: boolean; retainUntil: string | null } {
+  // Ingress may advance after the pass drained its observed batch. Keep its
+  // connection-scoped owner so the next pass can fetch the newly dirty work.
+  const dirtyRemainderDiscovered = input.retainUntil === null
+    && input.item.routeAction === "run-device-sync-wake"
+    && input.item.wake.kind === "device-sync.wake"
+    && input.item.wake.connectionId != null
+    && input.stillDirty;
+  return {
+    dirtyRemainderDiscovered,
+    retainUntil: input.retainUntil ?? (dirtyRemainderDiscovered
+      ? input.nextDirtyWakeAt
+        ?? new Date(Date.now() + HOSTED_SYSTEM_MAILBOX_RETRY_DELAY_MS).toISOString()
+      : null),
+  };
+}
+
+async function writeHostedDeviceSyncCheckpointRecordedLog(input: {
+  dirtyRemainderDiscovered: boolean;
+  item: HostedSystemMailboxPendingItem;
+  recordResult: {
+    recorded: number;
+    stillDirty: boolean;
+    newerRevisionPending: boolean;
+    nextWakeAt: string | null;
+  };
+  retainUntil: string | null;
+  runtime: HostedSystemMailboxRuntime;
+}): Promise<void> {
+  if (input.item.routeAction === "run-device-sync-wake") {
+    await writeHostedRuntimeLogBestEffort({
+      platform: input.runtime.platform,
+      entry: {
+        component: "device-sync",
+        eventCode: "device-sync.checkpoint_recorded",
+        level: "info",
+        phase: "checkpoint",
+        mailboxLane: "system",
+        mailboxSeqStart: input.item.mailboxLaneSeq,
+        mailboxSeqEnd: input.item.mailboxLaneSeq,
+        redactedJson: {
+          dirtyAckRecordedCount: input.recordResult.recorded,
+          stillDirty: input.recordResult.stillDirty,
+          newerRevisionPending: input.recordResult.newerRevisionPending,
+          retainedMailboxOwnerPresent: input.retainUntil !== null,
+          dirtyRemainderDiscovered: input.dirtyRemainderDiscovered,
+          nextWakeAtPresent: input.recordResult.nextWakeAt !== null,
+        },
+      },
+    });
+  }
+}
+
 function presentHostedRuntimeWakeCandidate(
   candidate: HostedRuntimeWakeCandidate,
 ): HostedRuntimeWakeCandidate | undefined {
@@ -1191,6 +1262,7 @@ function hostedDeviceSyncRetainedWakeHasCapacity(
 }
 
 async function retainHostedDeviceSyncSystemMailboxItem(input: {
+  dirtyRemainderDiscovered: boolean;
   dirtyWakeAt: string | null;
   immediateDirtyContinuationCanProgress: boolean;
   item: HostedSystemMailboxPendingItem;
@@ -1223,7 +1295,12 @@ async function retainHostedDeviceSyncSystemMailboxItem(input: {
             nextAttemptAt,
             postCheckpointRecord: null,
             status: "pending" as const,
-            wake: input.item.postCheckpointRecord?.kind === "device-sync.dirty-processed-batch"
+            wake: input.dirtyRemainderDiscovered && input.item.wake.kind === "device-sync.wake"
+              ? {
+                  ...input.item.wake,
+                  hint: { ...input.item.wake.hint, jobs: [], reason: "retained_dirty_remainder" },
+                }
+              : input.item.postCheckpointRecord?.kind === "device-sync.dirty-processed-batch"
               ? input.item.postCheckpointRecord.retainedWake ?? input.item.wake
               : input.item.wake,
           };

--- a/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
+++ b/packages/assistant-runtime/test/hosted-device-sync-runtime.test.ts
@@ -11,7 +11,9 @@ import {
   VaultError,
   withHostedCanonicalWritePort,
 } from "@murphai/core";
-import { parseHostedExecutionWake } from "@murphai/hosted-execution/parsers";
+import { parseHostedExecutionWake, parseHostedRuntimeLogRequest } from "@murphai/hosted-execution/parsers";
+import type { HostedRuntimeLogRequest } from "@murphai/hosted-execution/runtime-control";
+import { drainHostedRuntimeLogWritesBestEffort } from "../src/hosted-runtime/runtime-logs.ts";
 import { listMetricPoints, rebuildQueryProjection } from "@murphai/query";
 import { openSqliteRuntimeDatabase } from "@murphai/runtime-state/node";
 
@@ -6374,6 +6376,100 @@ describe("hosted device-sync runtime", () => {
       await restoredWorkspace.cleanup();
     }
   });
+
+  test.each(["device-sync.dirty-processed", "device-sync.dirty-processed-batch"] as const)(
+    "retains a drained wake when ingress advances during checkpoint acknowledgement (%s)",
+    async (kind) => {
+      const workspace = await createHostedRuntimeWorkspace("hosted-device-sync-ingress-at-ack-");
+      const restoredWorkspace = await createHostedRuntimeWorkspace("hosted-device-sync-ingress-at-ack-restored-");
+      const executeJob = vi.fn(async () => ({}));
+      const service = createDeviceSyncServiceForVault(restoredWorkspace.vaultRoot, [
+        createFakeProvider({ jobExecutor: { executeJob } }),
+      ]);
+      const logRequests: HostedRuntimeLogRequest[] = [];
+      const occurredAt = "2026-04-04T10:00:00.000Z";
+      const retryAt = "2026-04-04T10:00:01.000Z";
+      const connectionId = "hosted_ingress_at_ack";
+      const wake = buildDirtyDeviceSyncWake(connectionId, occurredAt);
+      const ack = { connectionId, processedRevision: "1", processedDirtyPayloadIds: ["payload-completed"], nextWakeAt: null };
+      const port: HostedRuntimeDeviceSyncPort = {
+        ...createNoDirtyStateDeviceSyncPortMethods(),
+        async ackDirtyStateProcessed(request) {
+          // The observed batch completed, then ingress committed another payload.
+          const stillDirty = request.processedRevision === "1";
+          return { connectionId, dirtyRevision: "2", processedRevision: request.processedRevision,
+            recorded: true, stillDirty, nextWakeAt: stillDirty ? retryAt : null, userId: "member_123" };
+        },
+        async fetchDirtyStates() {
+          return { hasMore: false, nextWakeAt: null, userId: "member_123", items: [buildDirtyState({
+            connectionId, dirtyRevision: "2", processedRevision: "1", dirtyResources: [{
+              count: 1, dirtyPayloadId: "payload-new", jobKind: "resource", payload: { resource: "steps" },
+              resource: "steps", resourceCategory: "timeseries", sourceProviderSlug: "demo", windowStart: null, windowEnd: null,
+            }],
+          })] };
+        },
+        async applyUpdates() { throw new Error("No control-plane update expected"); },
+        async createConnectLink() { throw new Error("No connection request expected"); },
+        async fetchSnapshot() { return buildRuntimeSnapshot({ connectionId, externalAccountId: "ingress-at-ack" }); },
+      };
+      const item: HostedSystemMailboxPendingItem = {
+        attemptCount: 1, itemId: "ingress-at-ack-owner", lastAttemptAt: occurredAt,
+        lastErrorCode: null, lastErrorMessage: null, mailboxDedupeKey: wake.eventId,
+        mailboxLaneSeq: "1", nextAttemptAt: null, occurredAt,
+        postCheckpointRecord: kind === "device-sync.dirty-processed"
+          ? { kind, ...ack }
+          : { kind, records: [ack], nextWakeAt: null },
+        preferenceCausalSeq: null, requestId: null, routeAction: "run-device-sync-wake",
+        status: "recording", wake,
+      };
+      const runtime = createDeviceSyncPostCheckpointRuntime(port);
+      runtime.platform.logPort = { async write(request) {
+        const parsed = parseHostedRuntimeLogRequest(request);
+        logRequests.push(parsed); return { loggedCount: parsed.entries.length };
+      } };
+      try {
+        await updateHostedSystemMailboxState(workspace.vaultRoot, () => ({ pending: [item] }));
+        const result = await recordHostedSystemMailboxItemAfterCheckpoint({
+          item, runtime, vaultRoot: workspace.vaultRoot,
+          deviceSyncCompletionAcceptedInCurrentAdmission: true,
+        });
+        assert.equal(result.failed, 0);
+        const pending = (await readHostedSystemMailboxState(workspace.vaultRoot)).pending;
+        assert.equal(pending.length, 1, "new dirty work must keep a connection-scoped mailbox owner");
+        assert.equal(pending[0]?.status, "pending");
+        assert.equal(pending[0]?.deviceSyncContinuationOwner, true);
+        assert.equal(pending[0]?.postCheckpointRecord, null);
+        assert.equal(pending[0]?.nextAttemptAt, retryAt);
+        const retained = pending[0]!;
+        assert.equal(retained.wake.kind, "device-sync.wake");
+        if (retained.wake.kind !== "device-sync.wake") throw new Error("Expected device wake");
+        assert.deepEqual(retained.wake.hint?.jobs, []);
+        const state = await syncHostedDeviceSyncControlPlaneState({
+          deviceSyncPort: port, secret: DEVICE_SYNC_SECRET, service, wake: retained.wake,
+        });
+        const accountId = state.hostedToLocalAccountIds.get(connectionId);
+        assert.ok(accountId);
+        assert.equal(await service.drainWorker(1, accountId), 1);
+        promoteHostedCompletedDirtyPayloadAcks({ service, state });
+        assert.equal(executeJob.mock.calls.length, 1);
+        assert.deepEqual(state.pendingDirtyAcks[0]?.processedDirtyPayloadIds, ["payload-new"]);
+        const completedItem = { ...retained, status: "recording" as const,
+          postCheckpointRecord: { kind: "device-sync.dirty-processed-batch" as const, records: state.pendingDirtyAcks, nextWakeAt: null } };
+        await updateHostedSystemMailboxState(workspace.vaultRoot, () => ({ pending: [completedItem] }));
+        await recordHostedSystemMailboxItemAfterCheckpoint({ item: completedItem, runtime, vaultRoot: workspace.vaultRoot });
+        assert.equal((await readHostedSystemMailboxState(workspace.vaultRoot)).pending.length, 0);
+        await drainHostedRuntimeLogWritesBestEffort();
+        assert.deepEqual(logRequests.flatMap((request) => request.entries)
+          .filter((entry) => entry.eventCode === "device-sync.checkpoint_recorded")
+          .map((entry) => [entry.redactedJson?.stillDirty, entry.redactedJson?.retainedMailboxOwnerPresent]),
+          [[true, true], [false, false]]);
+      } finally {
+        closeHostedRuntimeDeviceSyncService(service);
+        await workspace.cleanup();
+        await restoredWorkspace.cleanup();
+      }
+    },
+  );
 
   test("a full retained queue defers its webhook edge until capacity can advance", async () => {
     const workspace = await createHostedRuntimeWorkspace(

--- a/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
@@ -6625,6 +6625,52 @@ describe("runHostedAssistantAutomationLane", () => {
     );
   });
 
+  it("logs bounded continuation progress without retained provider payloads", async () => {
+    const logRequests: HostedRuntimeLogRequest[] = [];
+    const at = "2026-04-08T00:00:00.000Z";
+    const nextAt = "2026-04-08T00:30:00.000Z";
+    const incomingJobs = [{ kind: "resource", dedupeKey: "synthetic-job", payload: {
+      resource: "steps", windowStart: "2026-04-01T00:00:00Z", windowEnd: at,
+      webhookDataJson: "PRIVATE_FIXTURE_MUST_NOT_BE_LOGGED",
+    } }];
+    const wake = { eventId: "evt_progress", kind: "device-sync.wake" as const,
+      occurredAt: at, reason: "webhook_hint" as const, userId: "member_123",
+      hint: { jobs: incomingJobs } };
+    const outgoingWake = { ...wake, hint: { jobs: [{ ...incomingJobs[0]!,
+      payload: { ...incomingJobs[0]!.payload, windowStart: "2026-04-03T00:00:00Z" },
+    }] } };
+    mocks.resolveHostedDeviceSyncWakeRecovery.mockReturnValue({ retryAt: nextAt, wake: outgoingWake });
+    mocks.createHostedRuntimeDeviceSyncService.mockReturnValue({
+      drainWorker: vi.fn(async () => 1), getNextJobWakeAt: () => nextAt,
+      getNextWakeAt: () => nextAt, listAccounts: () => [],
+      listJobFailureDiagnostics: () => [], listJobTimingDiagnostics: () => [],
+      runSchedulerOnce: async () => undefined,
+    });
+    const platform = { logPort: { async write(request: HostedRuntimeLogRequest) {
+      const parsed = parseHostedRuntimeLogRequest(request);
+      logRequests.push(parsed); return { loggedCount: parsed.entries.length };
+    } } };
+    await runHostedDeviceSyncWakeLane({ wake, deviceSyncPort: createMaintenanceDeviceSyncPortStub(),
+      resolvedConfig: { deviceSync: DEVICE_SYNC_CONFIG }, retainFollowUpWakeUntilCheckpoint: true,
+      runtimeLogPlatform: platform, timeoutMs: null, vaultRoot: "/tmp/vault-root" });
+    await drainHostedRuntimeLogWritesBestEffort();
+    const first = logRequests.flatMap((r) => r.entries).find((e) => e.eventCode === "device-sync.pass_finished")?.redactedJson;
+    expect(first).toMatchObject({ incomingRetainedJobCount: 1, outgoingRetainedJobCount: 1,
+      stagedDirtyPayloadAckCount: 0, retainedMailboxOwnerPresent: true });
+    expect(first?.incomingRetainedProgressFingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(first?.outgoingRetainedProgressFingerprint).not.toBe(first?.incomingRetainedProgressFingerprint);
+    logRequests.length = 0;
+    await runHostedDeviceSyncWakeLane({ wake: outgoingWake, deviceSyncPort: createMaintenanceDeviceSyncPortStub(),
+      resolvedConfig: { deviceSync: DEVICE_SYNC_CONFIG }, retainFollowUpWakeUntilCheckpoint: true,
+      runtimeLogPlatform: platform, timeoutMs: null, vaultRoot: "/tmp/vault-root" });
+    await drainHostedRuntimeLogWritesBestEffort();
+    const second = logRequests.flatMap((r) => r.entries).find((e) => e.eventCode === "device-sync.pass_finished")?.redactedJson;
+    expect(second?.incomingRetainedProgressFingerprint).toBe(first?.outgoingRetainedProgressFingerprint);
+    expect(JSON.stringify([first, second])).not.toContain("PRIVATE_FIXTURE");
+    expect(JSON.stringify([first, second])).not.toContain("synthetic-job");
+    expect(JSON.stringify([first, second])).not.toContain("2026-04-03");
+  });
+
   it("reports unready hosted assistant profiles with the active provider label", async () => {
     mocks.readHostedAssistantRuntimeState.mockResolvedValue({
       assistantActiveProfileId: "platform-default",

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -8254,9 +8254,15 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
         title: "Synthetic scheduled reminder",
         vaultRoot,
       });
-      await enqueueDeviceSyncSystemMailboxItemForTest({
-        item: deviceItem,
+      await enqueueHostedSystemMailboxItem({
+        item: createResolvedDeviceSyncSystemMailboxItem(deviceItem),
         vaultRoot,
+        wake: {
+          ...createDeviceSyncSystemWakeForMailboxItem(deviceItem),
+          kind: "device-sync.wake",
+          reason: "reconcile_due",
+          connectionId: "device_sync_connection_synthetic",
+        },
       });
       if (defaultOwnedSystemMailboxWakeAt !== null) {
         await enqueueHostedSystemMailboxItem({
@@ -8442,7 +8448,9 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       );
       assert.deepEqual(
         (await readHostedSystemMailboxState(vaultRoot)).pending.map((item) => item.itemId),
-        defaultOwnedSystemMailboxWakeAt === null ? [] : [defaultOwnedItem.id],
+        defaultOwnedSystemMailboxWakeAt === null
+          ? [deviceItem.id]
+          : [deviceItem.id, defaultOwnedItem.id],
       );
       const followUpCheckpointIndex = checkpointRequests.findIndex((request) =>
         request.nextWakeAt === followUpWakeAt
@@ -8473,6 +8481,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
         });
         const runFollowUpPass = async (input: {
           attemptId: string;
+          processingMode?: "system_mailbox";
           workspace: HostedWorkspaceState;
         }) => {
           const followUpCheckpointRequests: HostedWorkspaceCheckpointRequest[] = [];
@@ -8488,6 +8497,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
             createWorkspaceRuntimeJobInput({
               request: {
                 attemptId: input.attemptId,
+                processingMode: input.processingMode,
                 workspace,
                 workspaceVersion: workspace.version,
               },
@@ -8558,8 +8568,8 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
           1,
         );
         assert.deepEqual(
-          (await readHostedSystemMailboxState(vaultRoot)).pending,
-          [],
+          (await readHostedSystemMailboxState(vaultRoot)).pending.map((item) => item.itemId),
+          [deviceItem.id],
         );
         assert.equal(defaultPass.checkpoint.nextWakeAt, followUpWakeAt);
         assert.equal(
@@ -8577,6 +8587,7 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
         vi.setSystemTime(new Date(followUpWakeAt));
         await runFollowUpPass({
           attemptId: "attempt_synthetic_saved_device_deadline_follow_up",
+          processingMode: "system_mailbox",
           workspace: defaultPass.workspace,
         });
         assert.ok(

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -3702,6 +3702,7 @@ export const HOSTED_RUNTIME_LOG_EVENT_CODES = [
   "device-sync.dense_raw_retention",
   "device-sync.companion_diagnostic",
   "device-sync.dirty_ack_persistence_failed",
+  "device-sync.checkpoint_recorded",
   "device-sync.fitbit_migration_cutover_failed",
   "device-sync.import_completed",
   "device-sync.job_failed",


### PR DESCRIPTION
## Why and outcome

A device pass can finish its observed batch while new ingress makes the connection dirty again. The checkpoint acknowledgement reports that remaining work, but the runtime removed the connection-scoped mailbox owner, leaving a generic timer unable to fetch it. Keep the owner with cleared completed-job hints until the new work is processed.

Recover existing orphaned dirty work through the bounded due-reconcile sweep when both the consumed system lane and workspace projection prove no pending or retained owner. A recovery identity tied to the consumed lane frontier creates one fresh mailbox item. Add checkpoint decisions and private continuation-progress fingerprints to distinguish advancing history from replay across attempts. The recurring-pass production symptom remains under investigation; diagnostics alone are not a claimed fix for it.

## Product UX

- Effort: Patch.
- Result: Ready for the scoped recovery behavior; live queue drain remains unverified.
- Walkthrough: Silent device updates arriving during completion survive a fresh runtime and acknowledge their exact payload. Existing orphaned work receives new mailbox work. Retained owners, pending work, missing legacy proof, and clean connections keep existing behavior. Foreground messages and scheduled assistant work retain priority. No UI changes.

## Evidence

- Direct: Both single and batch acknowledgement reproductions failed before the fix (the owner disappeared), then passed with a fresh-runtime fetch, execution, exact-payload acknowledgement, and owner release. The PostgreSQL recovery reproduction selected the already-consumed identity before the fix; it now performs a real mailbox append and stable duplicate replay using synthetic local crypto.
- Coverage: 431 runtime tests passed after combining the current base, across hosted-device-sync-runtime, hosted-runtime-maintenance, workspace-entrypoint-system-mailbox, workspace-entrypoint-system-preemption, and system-mailbox-notification. 34 Web tests passed across scheduled-wake-retention-postgres, due-reconcile-sweeper, due-reconcile-connections, and recovery-sweeper. The PostgreSQL lane used an isolated loopback database and `MURPH_TEST_POSTGRES_CONCURRENCY=1`.
- Checks: assistant-runtime and hosted-execution package typechecks, Web `typecheck:prepared`, `pnpm complexity:diff`, `pnpm docs:drift`, changelog generation, and diff/privacy checks passed. A focused diagnostic replay verifies parser acceptance and omission of raw provider payloads and cursor values.
- Limits: No production queue mutation or private workspace inspection. New runtime telemetry and live convergence require the separately coordinated runner deployment.

- ReviewGPT Round 1: PASS on `a354504221e8a08e011f55284d87f2858646a2d8`, with verified `gpt-6-pro` response metadata and matching captured-response SHA256. No qualifying findings. The subsequent base merge preserves both sides and resolves only additive imports in the runtime test file; 431 combined runtime tests, runtime typecheck, and complexity checks pass. The base-update-only exception applies; no new authored production behavior was added after review. Final bookkeeping closes the plan with explicit rollout limits and links the changelog to this PR; changelog generation, all 10 changelog page tests, and docs checks pass. These explanatory/content changes do not require another substantive review.
- Overlap check: #3074 merged separately and fixes scheduled reconciliation admission through retained history. This PR preserves that change and fixes the distinct missing-owner case. Neither PR is evidence that production queues have drained.

## Non-obvious affected surfaces

System mailbox continuation projection and default-lane wake handoff are covered by the five foreground variants plus preemption tests. Web log parsing must recognize the new event before the runtime emits it. Scheduled recovery preserves existing connection epoch, billing, suspension, consent, and signal admission checks.

## Architecture and reuse

- Existing systems reused: Runtime mailbox retention, exact dirty acknowledgement, bounded due-connection SQL, scheduled wake append, lane counters, workspace projections, and buffered runtime logs.
- New logic: Retain newly discovered dirty remainder; recover only proven ownerless dirty connections; emit bounded progress diagnostics.
- New abstractions: Two local helpers isolate the retention decision and checkpoint diagnostic; no additional state owner or service.
- Complexity intentionally avoided: No migration, new queue, cron, dirty-row recovery scan, private payload logging, provider retry rewrite, or global backlog change.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; no increased complexity debt.
- Hotspots: Existing connection token persistence (32), connection mapping callback (27), device pass (88), lifecycle logging (46), failure logging (31), mailbox preparation/record dispatch (30 each), and runtime timing inspection (25) remain unchanged in complexity. The new helpers stay below the threshold.
- Agent judgment: Existing ownership is sufficient. Broader refactoring would obscure the narrow concurrency and recovery proof.

## Hot reply path impact

- Path status: No new provider or network wait on foreground messages. Device checkpoint handling can run before a foreground handoff.
- Database calls: None added to the foreground path. Background due selection enriches at most 251 existing candidates with indexed owner/dirty lookups.
- Network/provider calls: None added to the foreground path. One informational checkpoint event uses the existing buffered best-effort writer; flushing remains with its existing owner.
- Other awaited latency: Existing retention storage replaces removal for the race; the info logging helper returns after buffer admission. Progress hashes use existing retained-job metadata with constant-size output.
- Before/after proof: Five composed foreground variants and the system preemption suite pass; new ingress is processed in a subsequent connection-scoped pass.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no prompts, tool definitions, schemas, generated guidance, or provider-input assembly changed. No tokenizer measurement was run.

ReviewGPT context sensitivity: sensitive
Classification reason: Cross-package checkpoint ordering, retry ownership, database recovery selection, and diagnostic protocol change.
ReviewGPT first-reviewed head: a354504221e8a08e011f55284d87f2858646a2d8

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing wake and checkpoint payload contracts are preserved. Old runtimes accept the recovery wake but still contain the acknowledgement race. Old Web log parsers do not accept the new event.
- Safe order: Deploy Web with the event parser and recovery selection, then the updated runner. Coordinate with the separate runner deployment work.
- Rollback floor: Existing device-sync SQLite schema v11 floor is unchanged. Keep the new event parser while new runners emit it.
- Expected exposure: Existing orphaned active due connections can receive a fresh scheduled wake; normal retained queues keep their owner.
- Reversibility: Source changes are reversible subject to consumer-first diagnostic compatibility. Accepted mailbox work and payload acknowledgements retain their normal durability semantics.
- Convergence proof: Local PostgreSQL append/dedupe proof plus fresh-runtime exact-payload drain; production convergence remains a post-deploy check.
- Post-deploy checks: Confirm Web and runner source fingerprints, observe retained checkpoint decisions, compare consecutive progress fingerprints, and verify pending payload counts decline without foreground regressions.

## Change-shape breakdown

Classification rule: Runtime and Web TypeScript are source; test files are tests; Markdown is docs; the authored changelog fragment is other. No binary or generated output is committed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 167 | 8 |
| Tests / fixtures | 256 | 6 |
| Docs | 106 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 19 | 0 |
| **Total** | **548** | **15** |

## Changelog

- Changelog: updated
- Items: 2026-09-08 · device-sync-wake-recovery
