### PR TITLE
fix: inspect paginated native instances before runner reuse

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-08-runner-overlap-capacity.md
+++ b/agent-docs/exec-plans/completed/2026-09-08-runner-overlap-capacity.md
@@ -1,0 +1,31 @@
+# Runner reservation investigation and native drain inspection
+
+Status: completed
+
+## Outcome
+
+An account can reserve the serving bank, another full candidate bank, retained legacy inventory and smoke simultaneously. A full-size overlap does not fit the observed quota. A temporary smaller member ceiling was explicitly authorized while the full-capacity architecture is investigated. Experimental automatic budget-transfer code was removed; the existing public capacity semantics remain unchanged.
+
+Independent ReviewGPT architecture review recommends preserving exact release banks and separating execution identity from capacity only through a compatible future migration. Automatic transfer requires authoritative closure of previous-release starts; sampled counts alone do not prove that boundary. Drained legacy retirement can reclaim headroom but cannot provide simultaneous full-sized old and new banks under the current quota.
+
+## Protected operation
+
+The private protected maintenance operation changes only the explicitly approved serving ceiling. Its implementation and diagnostic follow-up passed focused/full verification, exact-head CI and final review. Inspection then proved that the application-deployments endpoint returns HTTP 404. No native ceiling change or full runner release is claimed here. A private follow-up switches occupancy to Wrangler's paginated dashboard instance endpoint; its review and production validation remain separate work.
+
+## Public correction
+
+The public inactive-bank drain reader used the same unsupported endpoint. It now follows every dashboard instance page, permits reuse only for empty or entirely stopped native inventory, ignores historical Durable Object records, and preserves waiting for running or unknown state. Failed or malformed pages, repeated tokens, and bounded page/row/deadline exhaustion never authorize reuse. Provider error diagnostics additionally redact the exact opaque cursor and application identity.
+
+The existing deployment provider, admission, namespace fencing, readiness, Worker promotion, receipts and serving capacity remain the owners. No member-process stop, automatic capacity transfer, quota purchase, or local secret access is added. The endpoint correction does not turn a sampled drain check into an atomic start fence.
+
+## Evidence
+
+The endpoint, response fields and continuation token match pinned Wrangler 4.90.0. Source inspection also confirmed versions upload publishes Worker metadata without native application creation or traffic activation in that command path.
+
+The native-provider suite passed 32 tests. The composed staging/deployment suites passed 53 tests. Cloudflare typecheck passed. The complexity guard passed with no hotspots above 20. Parent diff/privacy review passed. Required final ReviewGPT and exact-head CI remain PR gates; protected inspection, the authorized reduction, full release smoke/convergence and workspace-loop recovery still require direct operational proof.
+
+## Product and documentation
+
+Internal deployment tooling only: no assistant prompt, member action, UI, hot reply path or initial model input changed. No public changelog entry is needed. The durable deployment guide now describes complete native-instance pagination. Execution plans remain indexed by the existing active/completed directory entries.
+Updated: 2026-09-08
+Completed: 2026-09-08

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -90,8 +90,11 @@ releases. Land the public selector before enabling its private workflow input.
 A bound, still-warm previous session retains its exact namespace, member, claim,
 and write fence through promotion. Fresh member allocation selects only the
 active release. Previous inventory cannot prepare, bind new members, or restart
-cold processes. Before reusing its namespace, CI requires native drain evidence;
-unknown state leaves the active release serving. Native rollout admission uses
+cold processes. Before reusing its namespace, CI requires native drain evidence
+from every page of the Containers dashboard instance endpoint used by Wrangler. Only an empty
+or entirely stopped native instance list proves drain; historical Durable Object
+identities are not occupancy. Unknown state, failed pages, invalid continuation
+tokens, and bounded-inspection exhaustion leave the active release serving. Native rollout admission uses
 the configured capacity without automatically reducing a serving ceiling.
 Account quota and overlap capacity must be verified against the actual account.
 

--- a/apps/cloudflare/scripts/runner-release-provider.ts
+++ b/apps/cloudflare/scripts/runner-release-provider.ts
@@ -10,7 +10,7 @@ export function createRunnerReleaseProvider(input: {
   fetchImpl?: typeof fetch;
 }) {
   const fetchImpl = input.fetchImpl ?? fetch;
-  const request = async (operation: string, pathname: string, method = "GET", body?: unknown): Promise<Record<string, unknown>> => {
+  const request = async (operation: string, pathname: string, method = "GET", body?: unknown, privateRequestValues: readonly string[] = []): Promise<Record<string, unknown>> => {
     let response: Response;
     try {
       response = await fetchImpl(
@@ -30,11 +30,42 @@ export function createRunnerReleaseProvider(input: {
     if (!response.ok || !isObjectRecord(value) || value.success !== true) {
       const requestBody = isObjectRecord(body) ? body : {};
       const configuration = isObjectRecord(requestBody.configuration) ? requestBody.configuration : {};
-      const privateValues = [input.apiToken, input.accountId, requestBody.name, configuration.image]
+      const privateValues = [input.apiToken, input.accountId, requestBody.name, configuration.image, ...privateRequestValues]
         .filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
       throw unavailable(`${operation}: HTTP ${response.status}; errors=${providerErrorSummary(value, privateValues)}.`);
     }
     return value;
+  };
+  const readDrainedInstances = async (applicationId: string, deadline: number): Promise<boolean> => {
+    const tokens = new Set<string>();
+    let pageToken: string | undefined;
+    let rows = 0;
+    for (let page = 0; page < 100; page++) {
+      if (Date.now() >= deadline) throw unavailable("Inactive instance inspection exceeded its deadline.");
+      const query = new URLSearchParams({ per_page: "100" });
+      if (pageToken) query.set("page_token", pageToken);
+      const response = await request("Read inactive instances",
+        `/containers/dash/applications/${encodeURIComponent(applicationId)}/instances?${query}`,
+        "GET", undefined, [applicationId, pageToken ?? ""]);
+      const instances = isObjectRecord(response.result) ? response.result.instances : undefined;
+      if (!Array.isArray(instances) || (rows += instances.length) > 10_000) throw unavailable();
+      // Historical Durable Object identities are not running native instances.
+      const stopped = instances.every((instance: unknown) => {
+        if (!isObjectRecord(instance) || !isObjectRecord(instance.current_placement)
+          || !isObjectRecord(instance.current_placement.status)) return false;
+        const status = instance.current_placement.status;
+        return (status.container_status ?? status.health) === "stopped";
+      });
+      if (!stopped) return false;
+      const info = response.result_info;
+      if (info !== undefined && !isObjectRecord(info)) throw unavailable();
+      const next = isObjectRecord(info) ? info.next_page_token : undefined;
+      if (next === undefined || next === null || next === "") return true;
+      if (typeof next !== "string" || !next.trim() || next.length > 2048 || tokens.has(next)) throw unavailable();
+      tokens.add(next);
+      pageToken = next;
+    }
+    throw unavailable("Inactive instance inspection exceeded its page bound.");
   };
   return {
     async readAccountLimits(): Promise<{ vcpu: number; memoryMiB: number; diskMB: number }> {
@@ -102,20 +133,10 @@ export function createRunnerReleaseProvider(input: {
     async assertDrained(applicationId: string): Promise<void> {
       // This waits in CI, while the active target continues serving messages.
       // Never stop a running member invocation to make a deployment progress.
-      // The application deployment list contains native instances, not the
-      // paginated historical Durable Object identities shown by the dashboard.
+      // Use the paginated Containers instance endpoint used by Wrangler.
       const deadline = Date.now() + 20 * 60_000;
       do {
-        const response = await request("Read inactive deployments", `/containers/applications/${encodeURIComponent(applicationId)}/deployments`);
-        if (!Array.isArray(response.result)) throw unavailable();
-        const info = response.result_info;
-        if (isObjectRecord(info) && info.next_page_token) throw unavailable();
-        const drained = response.result.every((instance: unknown) => {
-          if (!isObjectRecord(instance) || !isObjectRecord(instance.current_placement)
-            || !isObjectRecord(instance.current_placement.status)) return false;
-          const status = instance.current_placement.status;
-          return (status.container_status ?? status.health) === "stopped";
-        });
+        const drained = await readDrainedInstances(applicationId, deadline);
         if (drained) return;
         if (Date.now() >= deadline) break;
         await delay(10_000);

--- a/apps/cloudflare/test/prepare-container-deploy-image.test.ts
+++ b/apps/cloudflare/test/prepare-container-deploy-image.test.ts
@@ -223,7 +223,7 @@ describe("container image publication before Worker activation", () => {
       }
       const id = pathname.split("/").at(-1)!;
       if (method === "PATCH") native.set(id, { ...native.get(id), ...body });
-      const result = pathname.endsWith("/deployments") ? [] : native.get(id) ?? { id: "synthetic-rollout" };
+      const result = pathname.endsWith("/instances") ? { instances: [] } : native.get(id) ?? { id: "synthetic-rollout" };
       return Response.json({ success: true, result });
     } });
     const prepare = async () => stageHostedRunnerRelease({
@@ -246,7 +246,7 @@ describe("container image publication before Worker activation", () => {
     await provider.admitApplication(retryApplication);
     await provider.assertApplicationReady({ ...retryApplication, listApplications });
     expect(calls.filter((entry) => entry === "POST applications")).toHaveLength(1);
-    expect(calls.slice(-4)).toEqual([`GET deployments`, `GET ${application.name}`, `PATCH ${application.name}`, "POST rollouts"]);
+    expect(calls.slice(-4)).toEqual([`GET instances`, `GET ${application.name}`, `PATCH ${application.name}`, "POST rollouts"]);
     expect(JSON.stringify(native.get(`${config.name}-runnercontainer`))).toBe(servingBefore);
     expect(currentVersion.resources.bindings[0]).toMatchObject({ text: JSON.stringify(legacy) });
   });

--- a/apps/cloudflare/test/runner-release-provider.test.ts
+++ b/apps/cloudflare/test/runner-release-provider.test.ts
@@ -32,7 +32,7 @@ describe("native account capacity evidence", () => {
 describe("inactive runner target drain admission", () => {
   const response = (state: string) => new Response(JSON.stringify({
     success: true,
-    result: [{ current_placement: { status: { container_status: state } } }],
+    result: { instances: [{ id: "native-fixture", current_placement: { status: { container_status: state } } }] },
   }));
 
   it("permits reuse only when the provider reports stopped instances", async () => {
@@ -49,6 +49,68 @@ describe("inactive runner target drain admission", () => {
     const work = createRunnerReleaseProvider({ accountId: "fixture", apiToken: "fixture", fetchImpl })
       .assertDrained("inactive-app");
     await work;
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("reads every dashboard page before permitting reuse and ignores inactive historical objects", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ success: true, result: { instances: [],
+        durable_objects: [{ id: "historical-object" }] }, result_info: { next_page_token: "second page" } }))
+      .mockResolvedValueOnce(response("stopped"));
+    await createRunnerReleaseProvider({ accountId: "fixture", apiToken: "fixture", fetchImpl }).assertDrained("inactive-app");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const urls = fetchImpl.mock.calls.map(([url]) => new URL(String(url)));
+    expect(urls[0]?.pathname).toBe("/client/v4/accounts/fixture/containers/dash/applications/inactive-app/instances");
+    expect(urls[0]?.searchParams.get("per_page")).toBe("100");
+    expect(urls[1]?.searchParams.get("page_token")).toBe("second page");
+    expect(fetchImpl.mock.calls.every(([, init]) => init?.method === "GET")).toBe(true);
+  });
+
+  it("restarts the complete drain observation when a later page is still running", async () => {
+    const firstPage = () => Response.json({ success: true, result: { instances: [] }, result_info: { next_page_token: "more" } });
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(firstPage()).mockResolvedValueOnce(response("running"))
+      .mockResolvedValueOnce(firstPage()).mockResolvedValueOnce(response("stopped"));
+    await createRunnerReleaseProvider({ accountId: "fixture", apiToken: "fixture", fetchImpl }).assertDrained("inactive-app");
+    expect(fetchImpl.mock.calls.map(([url]) => new URL(String(url)).searchParams.get("page_token"))).toEqual([null, "more", null, "more"]);
+  });
+
+  it("waits for unplaced instances instead of treating them as drained", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ success: true, result: { instances: [{ id: "unplaced" }] } }))
+      .mockResolvedValueOnce(response("stopped"));
+    await createRunnerReleaseProvider({ accountId: "fixture", apiToken: "fixture", fetchImpl }).assertDrained("inactive-app");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects repeated page tokens without inferring drain", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => Response.json({ success: true,
+      result: { instances: [] }, result_info: { next_page_token: "same" } }));
+    await expect(createRunnerReleaseProvider({ accountId: "fixture", apiToken: "fixture", fetchImpl })
+      .assertDrained("inactive-app")).rejects.toThrow("unavailable");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds distinct pages and native rows", async () => {
+    let page = 0;
+    const pages = vi.fn<typeof fetch>(async () => Response.json({ success: true,
+      result: { instances: [] }, result_info: { next_page_token: String(++page) } }));
+    await expect(createRunnerReleaseProvider({ accountId: "fixture", apiToken: "fixture", fetchImpl: pages })
+      .assertDrained("inactive-app")).rejects.toThrow("page bound");
+    expect(pages).toHaveBeenCalledTimes(100);
+    const rows = vi.fn<typeof fetch>(async () => Response.json({ success: true,
+      result: { instances: Array.from({ length: 10_001 }, () => ({})) } }));
+    await expect(createRunnerReleaseProvider({ accountId: "fixture", apiToken: "fixture", fetchImpl: rows })
+      .assertDrained("inactive-app")).rejects.toThrow("unavailable");
+    expect(rows).toHaveBeenCalledOnce();
+  });
+
+  it("keeps opaque page tokens and application identity out of provider failure diagnostics", async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ success: true, result: { instances: [] }, result_info: { next_page_token: "opaque-cursor" } }))
+      .mockResolvedValueOnce(Response.json({ success: false, errors: [{ code: 10001, message: "inactive-app rejected opaque-cursor" }] }, { status: 404 }));
+    await expect(createRunnerReleaseProvider({ accountId: "fixture", apiToken: "fixture", fetchImpl })
+      .assertDrained("inactive-app")).rejects.toThrow('Read inactive instances: HTTP 404; errors=[{"code":10001,"message":"<redacted> rejected <redacted>"}]');
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## Why and outcome

Inactive runner-bank reuse currently reads a native application-deployments route that returns HTTP 404 on the Containers API. Read the paginated dashboard instance endpoint used by pinned Wrangler 4.90.0 instead, and prove every page contains only stopped native instances before permitting reuse.

Running or unknown state continues to wait. Failed/malformed pages, repeated tokens and bounded inspection exhaustion cannot authorize reuse. Opaque cursor and application values are redacted from provider errors.

## Product UX

- Effort: Not applicable — protected deployment tooling only.
- Result: Ready for review; live provider validation remains pending.
- Walkthrough: Operators retain the existing deployment path. The active release keeps serving while inactive inventory drains. No member UI, prompt, action or capacity setting changes.

## Evidence

- Direct: Native-provider suite passed 32 tests; staging and Worker deployment suites passed 53 tests. Cloudflare typecheck passed. After CI exposed an old response fixture, the prepare-container-image recovery suite passed all 9 tests against the corrected fixture, and typecheck passed again.
- Coverage: Complete pagination, later-page live instances, unknown placement, historical Durable Object exclusion, malformed/repeated/bounded continuation, cursor redaction and existing admission/promotion behavior.
- Commands: `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runner-release-provider.test.ts`; the same command for `deploy-worker-version.test.ts`, `deploy-worker-version-cli.test.ts`, and `stage-runner-release.test.ts`; `pnpm --dir apps/cloudflare typecheck`.
- Parent diff/privacy review and `git diff --check` passed. Final ReviewGPT passed on fd51629b5261729894339d01471940cdd98e1842 with verified gpt-6-pro model evidence: https://chatgpt.com/c/6aa07a20-b5e4-83ea-97e3-7332a50c76b7. The later correction changes only two fixture/expectation lines in an isolated recovery test; reviewed production source, runtime config and implemented contract are unchanged. Under the review loop's isolated-proof exemption, no new substantive review is needed. All exact-head CI is green at d62528509786c23bf1e52b194e91f53e0b3358a7, including the rerun of Temporal compatibility after its protected private-main revision moved during the first run.
- Provider contract: inspected the installed Wrangler 4.90.0 Containers client, which uses `/dash/applications/{application_id}/instances`, `per_page`, `page_token`, and `result_info.next_page_token`. The official client contract is also at https://github.com/cloudflare/workers-sdk/blob/main/packages/containers-shared/src/client/services/ApplicationsService.ts. Protected read-only inspection now reaches the replacement endpoint. Complete live pagination remains unproven because the private inspector rejects a cursor; separate private diagnostics are narrowing that rejection. This PR preserves rejection rather than accepting incomplete drain evidence.

## Non-obvious affected surfaces

The endpoint returns native instances alongside optional historical Durable Object identities. Only native instances establish drain. The request helper accepts exact private request values so provider error messages cannot echo a pagination token. The separately owned private operator-capacity inspection needs its own equivalent endpoint correction; this public change does not apply a capacity reduction.

## Architecture and reuse

- Existing systems reused: Native release provider, its request/redaction boundary, twenty-minute drain loop, native admission and Worker promotion owners.
- New logic: Complete bounded native-instance pagination within each drain observation.
- New abstractions: One local reader inside the existing provider, keeping pagination separate from retry timing.
- Complexity intentionally avoided: No second scheduler, runtime state, container stop, automatic capacity transfer, new dependency or local production-secret access.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff` against origin/main.
- Hotspots: No changed-file function above 20; maximum increased from 11 to 19, with zero complexity debt.
- Agent judgment: The local reader keeps pagination and retry responsibilities explicit; further abstraction is not justified.

## Hot reply path impact

- Path status: Not applicable — deployment-only inspection.
- Database calls: None.
- Network/provider calls: None on the reply path. Deployment observations read at most 100 pages and 10,000 native rows, within the existing twenty-minute drain deadline; each request retains its thirty-second timeout.
- Other awaited latency: None on the reply path.
- Before/after proof: Existing deployment staging/promotion tests and direct provider tests; no member request owner changes.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changes for either runtime.

ReviewGPT context sensitivity: sensitive
ReviewGPT first-reviewed head: fd51629b5261729894339d01471940cdd98e1842
Classification reason: Provider evidence authorizes reuse at a production deployment boundary.

## Deployment concerns

- Deployment: applicable
- Supported skew: Tooling remains compatible with the existing Worker and runner images; no runtime protocol changes.
- Safe order: Land provider correction before a protected release needs to reuse an inactive namespace. The independently approved capacity reduction remains a private protected operation.
- Rollback floor: Unchanged; no stored state, image or runtime migration is introduced.
- Expected exposure: Subsequent full-release drain inspection; active serving behavior is unchanged.
- Reversibility: Forward code correction is available. No Cloudflare rollback is proposed or authorized here.
- Convergence proof: Existing signed smoke and native release receipts remain mandatory. Endpoint correction is not an atomic closure of old release starts.
- Post-deploy checks: Prove live instance inspection succeeds, then normal admission, signed smoke and convergence. Workspace-loop recovery remains a separate direct runtime check.

## Change-shape breakdown

Classification rule: Provider is source; Vitest file is tests; deployment guide and completed execution plan are docs. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 35 | 14 |
| Tests / fixtures | 65 | 3 |
| Docs | 36 | 2 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **136** | **19** |

## Changelog

- Changelog: not applicable
- Reason: Internal deployment inspection only; no member-visible behavior changes.
