### PR TITLE
fix: retire idle previous-release runners after completion

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-08-previous-runner-idle-handoff.md
+++ b/agent-docs/exec-plans/active/2026-09-08-previous-runner-idle-handoff.md
@@ -1,0 +1,34 @@
+# Retire completed idle previous-release runners
+
+Status: active
+Created: 2026-09-08
+Updated: 2026-09-08
+
+## Outcome and protected invariants
+
+Outcome: completed background work on a previous release can retire and recover on the active image instead of repeatedly retaining an obsolete shell for an overdue wake.
+Reaches: post-completion container lifecycle only; active foreground work, recent conversation warmth, exact slot ownership, and canonical completion recording remain protected.
+Proof: synthetic previous/active release cases with overdue and immediate wakes, completion acknowledgement, active children, conversation warmth, and unavailable health; focused lifecycle tests and typecheck, final ReviewGPT, exact-head CI, then protected Worker deployment and runtime observation.
+
+## Owner and evidence
+
+RunnerContainer owns completion cleanup and serializes it with native lifecycle changes. Its pending-wake optimization returns before the ordinary idle checks for every release. A completed previous-release invocation with an overdue wake therefore renews warmth repeatedly and cannot pick up the active image. The regression must exercise invoke plus the matching completion-recorded callback, not a copied helper.
+
+## Smallest correction
+
+Derive previous-release status from existing deployment metadata and scoped release identity. Apply pending-wake warmth retention only when the container is not the previous release. Reuse the existing completion barrier, interaction-generation checks, active-operation/child checks, conversation lease, and native cleanup owner. Add no state, endpoint, process supervisor, admission authority, or quota-transfer machinery.
+
+## Failure, compatibility, and scope
+
+Unknown health or racing work continues to retain the shell. Active/candidate and legacy metadata behavior remains unchanged. Previous warm foreground sessions remain valid until their existing completion and idle checks permit retirement. The Worker consumes the already-deployed runner health shape; an old child without warmth evidence stays protected. A Worker-only deployment preserves runner images and release pointers, with existing smoke and convergence gates. No manual process stop or Temporal mutation is part of this correction.
+
+## Tasks
+
+1. Prove the overdue-wake retention defect through the real completion path.
+2. Derive the release-specific retention choice and cover protected journeys.
+3. Update the lifecycle owner documentation and complete focused verification.
+4. Complete final review and exact-head CI, deploy through the protected owner, and check recovery.
+
+## Verification
+
+Pending focused reproduction, lifecycle tests, typecheck, complexity guard, final ReviewGPT, and exact-head CI. Production recovery remains separate from local proof.

--- a/agent-docs/exec-plans/completed/2026-09-08-previous-runner-idle-handoff.md
+++ b/agent-docs/exec-plans/completed/2026-09-08-previous-runner-idle-handoff.md
@@ -1,6 +1,6 @@
 # Retire completed idle previous-release runners
 
-Status: active
+Status: completed
 Created: 2026-09-08
 Updated: 2026-09-08
 
@@ -31,4 +31,13 @@ Unknown health or racing work continues to retain the shell. Active/candidate an
 
 ## Verification
 
-Pending focused reproduction, lifecycle tests, typecheck, complexity guard, final ReviewGPT, and exact-head CI. Production recovery remains separate from local proof.
+The initial two real-completion-path regression cases failed before the change and passed afterward. Final focused proof covers both bank directions, overdue/immediate wakes, matching completion acknowledgement, active/candidate/legacy release preservation, active children, recent conversation warmth, missing metadata, and unavailable health.
+
+- Container, runtime-callback, and release suites: 260 tests pass.
+- Cloudflare and Web typechecks: pass.
+- Changelog archive component: 10 tests pass.
+- Complexity diff: pass, unchanged debt 75 and maximum 74; existing unrelated hotspots retained.
+- Parent review: four source lines derive release role; no state, protocol, endpoint, or provider-input changes. Product UX patch evidence is Ready for review.
+
+This implementation plan records local proof only. PR 3079 still requires final ReviewGPT and green exact-head CI before merge; the protected Worker-only release must then prove signed smoke, convergence, and actual runtime recovery. No production handoff success is claimed here.
+Completed: 2026-09-08

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -88,7 +88,11 @@ This mode does not change account quota or the overlap requirement of full image
 releases. Land the public selector before enabling its private workflow input.
 
 A bound, still-warm previous session retains its exact namespace, member, claim,
-and write fence through promotion. Fresh member allocation selects only the
+and write fence through promotion. After its matching runtime completion is
+recorded, a previous release no longer retains warmth solely for an overdue or
+immediate wake. The ordinary lifecycle checks still require no active operation
+or child, no recent conversation warmth, available health, and no interaction
+race before retiring the shell. Fresh member allocation selects only the
 active release. Previous inventory cannot prepare, bind new members, or restart
 cold processes. Before reusing its namespace, CI requires native drain evidence
 from every page of the Containers dashboard instance endpoint used by Wrangler. Only an empty

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -1999,6 +1999,10 @@ export class RunnerContainer extends Container {
 
     if (
       input.trigger === "invoke-completed"
+      // A completed previous release must reach the normal idle checks so
+      // an overdue wake cannot indefinitely retain an obsolete runner image.
+      && readHostedRunnerDeployment(this.environment)?.previous?.id
+        !== resolveHostedRunnerReleaseId(this.environment)
       && this.retainCompletedInvocationForPendingWake(
         input.result,
         lifecycleObservedAtMs,

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -9861,6 +9861,80 @@ describe("RunnerContainer", () => {
     }
   });
 
+  it.each([
+    ["primary", "overdue"], ["primary", "immediate"],
+    ["next", "overdue"], ["next", "immediate"],
+  ] as const)(
+    "retires completed idle previous bank %s despite an %s wake",
+    async (bank, wake) => {
+      const previous = { bank, id: `${bank}-old`, bundleFingerprint: "a".repeat(64), sourceFingerprint: "b".repeat(64) };
+      const active = { bank: bank === "primary" ? "next" : "primary", id: bank === "primary" ? "next-current" : "primary-current", bundleFingerprint: "c".repeat(64), sourceFingerprint: "d".repeat(64) };
+      const result = {
+        ...createRunnerResult(),
+        ...(wake === "immediate"
+          ? { immediateRecheckRequested: true }
+          : { nextWakeAt: "2026-01-01T00:00:00.000Z" }),
+      };
+      const { container, destroy, startAndWaitForPorts } = createContainerDouble({
+        containerClass: bank === "primary" ? RunnerContainer : NextRunnerContainer,
+        initialStatus: "running",
+        env: { HOSTED_EXECUTION_RUNNER_DEPLOYMENT: JSON.stringify({ active, candidate: null, previous }) },
+        containerFetch: vi.fn(async (url: string) => new Response(JSON.stringify(
+          url.endsWith("/health")
+            ? { ...createRunnerHealthResult(), runnerBundle: { bundleFingerprint: previous.bundleFingerprint, sourceFingerprint: previous.sourceFingerprint } }
+            : result,
+        ), { headers: { "content-type": "application/json" } })),
+      });
+      const request = createRunnerRequest("evt_previous_release_completion");
+      await container.invoke({ job: { kind: "workspace-invocation", request }, timeoutMs: 30_000, userId: request.userId });
+      expect(destroy).not.toHaveBeenCalled();
+      await container.onRuntimeCompletionRecorded({ attemptId: "attempt_unrelated", leaseGeneration: request.leaseGeneration, userId: request.userId });
+      expect(destroy).not.toHaveBeenCalled();
+      await container.onRuntimeCompletionRecorded({ attemptId: request.attemptId, leaseGeneration: request.leaseGeneration, userId: request.userId });
+      expect(destroy).toHaveBeenCalledOnce();
+      expect(startAndWaitForPorts).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    "active-release", "candidate-release", "legacy-release", "active-child",
+    "conversation-warm", "missing-warmth", "unknown-health",
+  ] as const)("preserves %s after previous-release completion checks", async (protection) => {
+    const previous = { bank: "primary", id: "primary-old", bundleFingerprint: "a".repeat(64), sourceFingerprint: "b".repeat(64) };
+    const active = { bank: "next", id: "next-current", bundleFingerprint: "c".repeat(64), sourceFingerprint: "d".repeat(64) };
+    const currentBank = protection === "active-release" || protection === "candidate-release";
+    const release = currentBank ? active : previous;
+    const deployment = protection === "candidate-release"
+      ? { active: previous, candidate: active, previous: null }
+      : { active, candidate: null, previous };
+    let completionRecorded = false;
+    const { container, destroy, startAndWaitForPorts } = createContainerDouble({
+      containerClass: currentBank ? NextRunnerContainer : RunnerContainer,
+      initialStatus: "running",
+      env: protection === "legacy-release" ? {} : { HOSTED_EXECUTION_RUNNER_DEPLOYMENT: JSON.stringify(deployment) },
+      containerFetch: vi.fn(async (url: string) => {
+        if (!url.endsWith("/health")) {
+          return Response.json({ ...createRunnerResult(), nextWakeAt: "2026-01-01T00:00:00.000Z" });
+        }
+        if (completionRecorded && protection === "unknown-health") return new Response(null, { status: 503 });
+        const health: Record<string, unknown> = {
+          ...createRunnerHealthResult(),
+          runnerBundle: { bundleFingerprint: release.bundleFingerprint, sourceFingerprint: release.sourceFingerprint },
+        };
+        if (completionRecorded && protection === "active-child") health.activeJobCount = 1;
+        if (completionRecorded && protection === "conversation-warm") health.conversationWarmActivityCompletedAtEpochMs = Date.now();
+        if (completionRecorded && protection === "missing-warmth") delete health.conversationWarmActivityCompletedAtEpochMs;
+        return Response.json(health);
+      }),
+    });
+    const request = createRunnerRequest("evt_protected_completion");
+    await container.invoke({ job: { kind: "workspace-invocation", request }, timeoutMs: 30_000, userId: request.userId });
+    completionRecorded = true;
+    await container.onRuntimeCompletionRecorded({ attemptId: request.attemptId, leaseGeneration: request.leaseGeneration, userId: request.userId });
+    expect(destroy).not.toHaveBeenCalled();
+    expect(startAndWaitForPorts).not.toHaveBeenCalled();
+  });
+
   it("rejects runner lifecycle env values with trailing junk", async () => {
     expect(() =>
       createContainerDouble({

--- a/apps/web/changelog/entries/2026-09-08/background-recovery-after-updates.json
+++ b/apps/web/changelog/entries/2026-09-08/background-recovery-after-updates.json
@@ -11,6 +11,8 @@
     "relevanceTags": [
       "reliability"
     ],
-    "sourcePullRequests": []
+    "sourcePullRequests": [
+      3079
+    ]
   }
 }

--- a/apps/web/changelog/entries/2026-09-08/background-recovery-after-updates.json
+++ b/apps/web/changelog/entries/2026-09-08/background-recovery-after-updates.json
@@ -1,0 +1,16 @@
+{
+  "publishedOn": "2026-09-08",
+  "order": 100,
+  "item": {
+    "id": "background-recovery-after-updates",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Background recovery after updates",
+    "summary": "Idle background sessions can pick up fixes after an update instead of remaining stuck on an older version.",
+    "details": "The handoff waits for work to finish and completion to be recorded, while preserving active work and recent conversation activity.",
+    "relevanceTags": [
+      "reliability"
+    ],
+    "sourcePullRequests": []
+  }
+}


### PR DESCRIPTION
## Why and outcome

A completed previous-release invocation with an overdue or immediate wake renews the old shell before reaching ordinary idle retirement. Repeated background work can therefore keep using an obsolete image after a healthy release. Derive the release role from existing deployment metadata and bypass that warmth optimization only for the previous release.

Completion must still be recorded for the exact attempt and lease. Existing active-operation, native-health, active-child, conversation-warmth, and interaction-race checks decide whether retirement is safe. Active, candidate, and legacy deployment behavior stays unchanged.

## Product UX

- Effort: Patch.
- Result: Ready; merged and deployed through the protected Worker-only path, with production handoff verified.
- Walkthrough: Idle completed background work can move to the active image. Active work and recent conversations retain their existing owner. Unknown health stays protected. No member action or new control is introduced.

## Evidence

- Direct: Two focused tests failed before the source change because a recorded completion never retired the previous shell. They pass after it; the final cases cover both bank directions and both wake forms.
- Coverage: 260 container, runtime-callback, and release tests pass. The new cases prove no stop before a matching completion acknowledgement, no previous cold restart, and preservation of active/candidate/legacy releases, active children, recent conversation warmth, missing warmth metadata, and failed health reads.
- `pnpm --dir apps/cloudflare typecheck` and `pnpm --dir apps/web typecheck` pass.
- `pnpm --dir apps/web test -- changelog-page.test.tsx`: 10 tests pass.
- Final ReviewGPT passed at 2c78170ce4da2a95df28482f2b1c72340773c94a with verified gpt-6-pro: https://chatgpt.com/c/6aa0a7ce-2c70-83ea-8cf5-cdd55faa701f. All required exact-head CI checks pass. A repository-tool test initially received HTTP 403 from GitHub Markdown rendering; the completed workflow retry passed without a code change. The protected Worker-only deployment passed its predeploy gates, production smoke, and exact live-state verification. Separate read-only production observations confirmed transition to the current runtime and renewed checkpoint progress; private row details are omitted.

## Non-obvious affected surfaces

The existing `RuntimeInvocationController` records completion before its best-effort container notification. This change consumes that existing acknowledgement; it adds no callback, new wire shape, or checkpoint writer. The deployment guide and one public changelog item describe the narrower previous-release warmth rule.

## Architecture and reuse

- Existing systems reused: Deployment metadata, scoped release identity, completion cleanup, lifecycle lock, native health, conversation lease, and native retirement owner.
- New logic: Previous-release completion reaches the existing idle checks despite a pending wake.
- New abstractions: None; authoritative release role is derived where the optimization is selected.
- Complexity intentionally avoided: No restart endpoint, persisted flag, scheduler, process supervisor, new lock, capacity transfer, or provider credential path.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`; debt 75 → 75 and maximum 74 → 74.
- Hotspots: Existing `wakeRuntime` 74, `ensureContainerReady` 30, `destroyIfRunning` 26, `classifyHostedRunnerContainerErrorResponse` 24, and `invokeHostedExecution` 21 are unchanged. Their ownership and failure behavior remain outside this condition change.
- Agent judgment: One derived condition is sufficient; splitting or refactoring the surrounding lifecycle would add unrelated risk.

## Hot reply path impact

- Path status: No new work before provider start or durable reply handoff; the changed path follows recorded completion and runs through the existing best-effort cleanup notification.
- Database calls: None added.
- Network/provider calls: No model/provider call added. Previous-release cleanup can now reach the existing native status, bounded health, and stop checks after completion.
- Other awaited latency: Existing lifecycle cleanup only. Active operation, conversation warmth, and racing work preserve the shell.
- Before/after proof: Tests call the real invocation and matching completion-notification boundary and assert native stop/start effects.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no prompt assembly, tools, schemas, guidance, model options, or provider-visible input changes. No token measurement was run.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: Content-only changelog path; all 10 archive component tests pass. No rendering or interaction changes.
- Coverage: New fragment copy and unchanged production archive presentation; no new visual is needed for background recovery.

## Deployment concerns

- Deployment: applicable
- Supported skew: New Worker with existing warm runner images and their existing health metadata. Missing warmth evidence and active children retain the shell. Old Workers retain their previous behavior until propagation completes.
- Safe order: Deploy the runtime fix that should receive fresh work, then deploy this Worker coordination change. Use the protected Worker-only path to preserve existing images and release pointers, with its required predeploy, signed smoke, and convergence gates.
- Rollback floor: No new persisted schema or authority. Existing runtime/write-fence and deployment floors remain; an older Worker restores retention behavior and can recur the problem. Any rollback requires separate explicit authorization.
- Expected exposure: Completed idle previous-release work only; active foreground work and recent conversation warmth remain protected.
- Reversibility: A forward Worker correction can restore retention; this change does not replace images or rewrite bindings.
- Convergence proof: Both bank directions, actual completion acknowledgement, and old/current health shapes are covered locally. Production verification must separately establish the Worker version and a subsequent fresh runtime/checkpoint.
- Post-deploy checks: Signed smoke, exact live deployment state, and bounded runtime/checkpoint observations. No forced process stop or Temporal mutation is part of this PR.

## Change-shape breakdown

Classification rule: runtime TS is source; Vitest cases are tests; the lifecycle guide and execution plan are docs; the authored changelog fragment is other content. No binaries or generated output.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 0 |
| Tests / fixtures | 74 | 0 |
| Docs | 48 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 18 | 0 |
| **Total** | **144** | **1** |

## Changelog

- Changelog: updated
- Items: 2026-09-08 · background-recovery-after-updates

ReviewGPT context sensitivity: sensitive — hosted runtime lifecycle, completion ordering, and Worker/warm-image compatibility.

ReviewGPT first-reviewed head: 2c78170ce4da2a95df28482f2b1c72340773c94a
