### PR TITLE
fix(runtime): drain covered schedule backlogs during idle checkpoints

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-09-runtime-mailbox-recovery-rollout.md
+++ b/agent-docs/exec-plans/active/2026-09-09-runtime-mailbox-recovery-rollout.md
@@ -43,3 +43,20 @@ with the fix, 353 passing runtime tests, runtime and Web typechecks, ten passing
 changelog tests, and a passing complexity guard with unchanged file debt.
 The new live readback still shows the original failure pattern. Exact-head CI,
 ReviewGPT, deployment, and production convergence remain pending.
+
+## Reviewed rollout and follow-up
+
+PR #3082 passed exact-head ReviewGPT and required CI, merged, and entered the
+protected production deployment. The compatible Web reader from PR #3084 was
+verified Ready on the canonical alias before runner activation. Live telemetry
+from PR #3080 confirmed a valid retained-job field was rejected by the old reader.
+The original cohort remains the recovery boundary; deployment alone is not closure.
+
+A composed cold-restore regression then proved a second gap: three strictly
+covered schedule hints retired only one hint and parked the others behind the
+future retained retry. The follow-up derives invocation eligibility from the full
+admitted mailbox, while selecting runnable work from the existing frontier. Idle
+compaction can therefore retire every eligible covered hint in one checkpoint.
+Route, wake-kind, and dedupe-prefix restrictions still apply, and the retained
+owner and its jobs remain unchanged. The regression failed before this change
+and passes after it, including a second restore without another checkpoint.

--- a/apps/web/changelog/entries/2026-09-08/background-refresh-during-device-retry.json
+++ b/apps/web/changelog/entries/2026-09-08/background-refresh-during-device-retry.json
@@ -7,13 +7,14 @@
     "priority": 2,
     "title": "Background refreshes keep moving during device retries",
     "summary": "Pending background refreshes can proceed while an independent device import waits to retry.",
-    "details": "Unfinished device imports keep their retry timing after a restart, and completed scheduled refreshes no longer wait for another device retry to clear.",
+    "details": "Unfinished device imports keep their retry timing after a restart, and backlogs of completed scheduled refreshes clear together without waiting for another device retry.",
     "relevanceTags": [
       "devices",
       "reliability"
     ],
     "sourcePullRequests": [
-      3082
+      3082,
+      3086
     ]
   }
 }

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox.ts
@@ -360,33 +360,36 @@ export async function prepareHostedSystemMailboxItemForCheckpoint(input: {
           : input.allowedRouteActions == null
             ? projectHostedSystemMailboxWakeOwnerFrontier(admissionState, continuationItemIds)
             : admissionState;
+      const eligibleItemIds = new Set(admissionState.pending.filter((item) =>
+        (
+          input.allowedRouteActions?.includes(item.routeAction)
+          ?? item.routeAction !== "run-assistant-ask"
+        )
+        && (
+          input.allowedMailboxDedupeKeyPrefixes == null
+          || input.allowedMailboxDedupeKeyPrefixes.some((prefix) =>
+            item.mailboxDedupeKey.startsWith(prefix)
+          )
+        )
+        && (
+          input.allowedWakeKinds == null
+          || input.allowedWakeKinds.includes(item.wake.kind)
+        )
+        && (
+          item.wake.kind !== "assistant.ask.completed"
+          || !hasAssistantAskCompletionCutoff
+          || (
+            assistantAskCompletionOccurredBefore !== null
+            && hostedSystemMailboxTimestampPrecedes(
+              item.occurredAt,
+              assistantAskCompletionOccurredBefore,
+            )
+          )
+        )
+      ).map((item) => item.itemId));
       const selectionState = {
         pending: modelFreeProjectedState.pending.filter((item) =>
-          (
-            input.allowedRouteActions != null
-            || item.routeAction !== "run-assistant-ask"
-          )
-          && (
-            input.allowedMailboxDedupeKeyPrefixes == null
-            || input.allowedMailboxDedupeKeyPrefixes.some((prefix) =>
-              item.mailboxDedupeKey.startsWith(prefix)
-            )
-          )
-          && (
-            input.allowedWakeKinds == null
-            || input.allowedWakeKinds.includes(item.wake.kind)
-          )
-          && (
-            item.wake.kind !== "assistant.ask.completed"
-            || !hasAssistantAskCompletionCutoff
-            || (
-              assistantAskCompletionOccurredBefore !== null
-              && hostedSystemMailboxTimestampPrecedes(
-                item.occurredAt,
-                assistantAskCompletionOccurredBefore,
-              )
-            )
-          )
+          eligibleItemIds.has(item.itemId)
         ),
       };
       const pending = findNextHostedSystemMailboxQueueItem({
@@ -397,7 +400,7 @@ export async function prepareHostedSystemMailboxItemForCheckpoint(input: {
       if (!pending) {
         const compacted = retireHostedCoveredDeviceScheduleHints({
           continuationItemIds,
-          eligibleItemIds: new Set(selectionState.pending.map((item) => item.itemId)),
+          eligibleItemIds,
           now: startedAt,
           state,
         });

--- a/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
@@ -4460,7 +4460,7 @@ describe("hosted system mailbox notification execution context", () => {
     }
   });
 
-  it.each(["all", "route", "wake", "prefix", "selected-prefixes"])(
+  it.each(["all", "route", "wake", "prefix", "selected-prefixes", "unimported"])(
     "retires covered schedules only within the idle invocation filters (%s)", async (filter) => {
       const workspace = await createHostedRuntimeWorkspace("murph-covered-schedule-filters-");
       const retryAt = "2026-04-28T00:00:00.000Z";
@@ -4490,6 +4490,11 @@ describe("hosted system mailbox notification execution context", () => {
             lastAttemptAt: FIXED_NOW, nextAttemptAt: retryAt,
           } : item),
         }));
+        await writeHostedMailboxImportState({
+          state: { ...createEmptyHostedMailboxImportState(),
+            watermarks: { conversation: "0", system: filter === "unimported" ? "0" : "4" } },
+          vaultRoot: workspace.vaultRoot,
+        });
         const before = await readHostedSystemMailboxState(workspace.vaultRoot);
         const result = await prepareHostedSystemMailboxItemForCheckpoint({
           ...(filter === "route" ? { allowedRouteActions: ["apply-runtime-control-request" as const] } : {}),

--- a/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
@@ -4460,6 +4460,59 @@ describe("hosted system mailbox notification execution context", () => {
     }
   });
 
+  it.each(["all", "route", "wake", "prefix", "selected-prefixes"])(
+    "retires covered schedules only within the idle invocation filters (%s)", async (filter) => {
+      const workspace = await createHostedRuntimeWorkspace("murph-covered-schedule-filters-");
+      const retryAt = "2026-04-28T00:00:00.000Z";
+      const owner = buildHostedExecutionDeviceSyncWake({
+        connectionId: "dsc_synthetic_filtered_schedules",
+        eventId: "device-sync.wake:owner", expectedConnectedAt: FIXED_NOW,
+        occurredAt: FIXED_NOW, provider: "junction", reason: "reconcile_due",
+        userId: "member_123", hint: { nextReconcileAt: retryAt, jobs: [{
+          availableAt: retryAt, dedupeKey: "synthetic-filtered-retry", kind: "resource",
+        }] },
+      });
+      try {
+        for (const index of [0, 1, 2, 3]) {
+          const wake = index === 0 ? owner : buildHostedExecutionDeviceSyncWake({
+            ...owner, eventId: `device-sync.wake:hint-${index}`,
+            hint: { nextReconcileAt: FIXED_NOW },
+          });
+          await enqueueHostedSystemMailboxItem({
+            item: createResolvedDeviceSyncItem({ dedupeKey: wake.eventId,
+              id: `synthetic_filtered_schedule_${index}`, laneSeq: String(index + 1) }),
+            vaultRoot: workspace.vaultRoot, wake,
+          });
+        }
+        await updateHostedSystemMailboxState(workspace.vaultRoot, (state) => ({
+          pending: state.pending.map((item, index) => index === 0 ? {
+            ...item, deviceSyncContinuationOwner: true, attemptCount: 1,
+            lastAttemptAt: FIXED_NOW, nextAttemptAt: retryAt,
+          } : item),
+        }));
+        const before = await readHostedSystemMailboxState(workspace.vaultRoot);
+        const result = await prepareHostedSystemMailboxItemForCheckpoint({
+          ...(filter === "route" ? { allowedRouteActions: ["apply-runtime-control-request" as const] } : {}),
+          ...(filter === "wake" ? { allowedWakeKinds: ["runtime.maintenance-requested" as const] } : {}),
+          ...(filter === "prefix" ? { allowedMailboxDedupeKeyPrefixes: ["unrelated:"] } : {}),
+          ...(filter === "selected-prefixes" ? { allowedMailboxDedupeKeyPrefixes: [
+            "device-sync.wake:owner", "device-sync.wake:hint-1", "device-sync.wake:hint-3",
+          ] } : {}),
+          now: () => FIXED_NOW, runtime: createRuntime({}), runtimeEnv: {},
+          retainProcessedItemUntilRecorded: true, vaultRoot: workspace.vaultRoot,
+        });
+        const expectedIndexes = filter === "all" ? [0]
+          : filter === "selected-prefixes" ? [0, 2] : [0, 1, 2, 3];
+        expect((await readHostedSystemMailboxState(workspace.vaultRoot)).pending)
+          .toEqual(expectedIndexes.map((index) => before.pending[index]));
+        expect(result?.status ?? null).toBe(expectedIndexes.length < 4 ? "processed" : null);
+        expect(mocks.executeHostedMailboxEvent).not.toHaveBeenCalled();
+      } finally {
+        await workspace.cleanup();
+      }
+    },
+  );
+
   it.each(["due", "epoch", "future", "manual", "unbound"])(
     "admits a queued schedule through the same future cadence owner (%s)", async (boundary) => {
       const workspace = await createHostedRuntimeWorkspace("murph-scheduled-admission-");

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-system-mailbox.test.ts
@@ -1301,9 +1301,10 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
     }
   });
 
-  test.each(["maintenance", "covered-schedule"])("checkpoints independent work behind a future transferred device retry (%s)", async (kind) => {
+  test.each(["maintenance", "covered-schedule", "covered-schedules"])("checkpoints independent work behind a future transferred device retry (%s)", async (kind) => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-independent-maintenance-"));
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const handledThrough = kind === "covered-schedules" ? "4" : "2";
     const events: string[] = [];
     const retryAt = new Date(Date.parse(TEST_NOW) + 86_400_000).toISOString();
     const deviceItem = createMailboxItem({
@@ -1342,8 +1343,34 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
             provider: "whoop", reason: "reconcile_due", userId: TEST_USER_ID,
             hint: { nextReconcileAt: TEST_NOW } },
       });
+      if (kind === "covered-schedules") {
+        for (const seq of ["3", "4"]) {
+          const hint = createMailboxItem({
+            dedupeKey: `device-sync.wake:covered-${seq}`,
+            id: `covered_schedule_${seq}`,
+            kind: "device-sync.wake",
+            lane: "system",
+            laneSeq: seq,
+          });
+          await enqueueHostedSystemMailboxItem({
+            item: createResolvedDeviceSyncSystemMailboxItem(hint),
+            vaultRoot,
+            wake: {
+              connectionId: "device_connection_independent",
+              eventId: hint.dedupeKey,
+              expectedConnectedAt: TEST_NOW,
+              kind: "device-sync.wake",
+              occurredAt: TEST_NOW,
+              provider: "whoop",
+              reason: "reconcile_due",
+              userId: TEST_USER_ID,
+              hint: { nextReconcileAt: TEST_NOW },
+            },
+          });
+        }
+      }
       const importState = createEmptyHostedMailboxImportState();
-      importState.watermarks.system = "2";
+      importState.watermarks.system = handledThrough;
       await writeMailboxImportStateFile(vaultRoot, importState);
       const restored = await createVaultSnapshotBundle({
         key: "users/bundles/member-synthetic/independent-maintenance.bundle.json", vaultRoot,
@@ -1379,13 +1406,13 @@ describe("hosted workspace runtime entrypoint", () => {test("reads workspace, im
       const result = await runPass();
       assert.equal(result.nextWakeAt, retryAt);
       assert.deepEqual((await readHostedSystemMailboxState(vaultRoot)).pending, [retainedBefore]);
-      assert.equal(checkpointRequests.at(-1)?.redactedStatus?.hostedMailboxSystemHandledThroughSeq, "2");
+      assert.equal(checkpointRequests.at(-1)?.redactedStatus?.hostedMailboxSystemHandledThroughSeq, handledThrough);
       assert.deepEqual(checkpointRequests.at(-1)?.redactedStatus?.hostedMailboxSystemDeviceSyncContinuationSeqs, ["1"]);
       const checkpointCount = checkpointRequests.length;
       const restoredResult = await runPass();
       assert.equal(restoredResult.nextWakeAt, retryAt);
       assert.deepEqual((await readHostedSystemMailboxState(vaultRoot)).pending, [retainedBefore]);
-      assert.equal(currentWorkspace.redactedStatus?.hostedMailboxSystemHandledThroughSeq, "2");
+      assert.equal(currentWorkspace.redactedStatus?.hostedMailboxSystemHandledThroughSeq, handledThrough);
       assert.equal(checkpointRequests.length, checkpointCount);
     } finally {
       vi.useRealTimers();


### PR DESCRIPTION
## Why and outcome

When several queued device schedule hints are already covered by a retained future retry, an idle checkpoint clears only the frontier hint and parks the remaining backlog behind that retry. Derive invocation eligibility from the full admitted mailbox so the existing compactor clears all eligible covered hints in one checkpoint.

Runnable selection still uses the existing frontier. Retained jobs, retry timing, connection barriers, and foreground priority remain intact.

## Product UX

- Effort: Patch.
- Result: Ready for review; production recovery remains pending.
- Walkthrough: A restored workspace with three covered schedule hints clears all three, preserves its retained device job and future wake, and restores again without another checkpoint. Restricted invocations leave excluded work untouched.

## Evidence

- Direct: The composed three-hint regression failed on the base with two hints left behind and passes with this patch.
- Coverage: 217 focused tests pass across mailbox notification execution, workspace checkpoint restore, state selection, and preemption. Includes route, wake-kind, prefix, partial-prefix, and invalid-import ownership boundaries.
- Runtime and Web typechecks, docs drift, and all ten changelog rendering tests pass. ReviewGPT and all required CI passed on the exact head.

## Non-obvious affected surfaces

Invocation filters now supply both runnable selection and idle compaction eligibility. Six focused cases verify their restrictions, including invalid durable import ownership.

## Architecture and reuse

- Existing systems reused: Admitted mailbox state, frontier projection, covered-hint compaction, and checkpoint publication.
- New logic: Compute eligible item IDs before narrowing execution to its frontier.
- New abstractions: None; one local derived set serves both existing paths.
- Complexity intentionally avoided: No additional queue, scheduler, persisted owner, provider work, or recovery endpoint.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff --base origin/main`; file debt remains 20 and maximum remains 30.
- Hotspots: Existing preparation and post-checkpoint recording functions remain at 30. The eligibility move preserves preparation complexity; recording is unchanged.
- Agent judgment: The small shared eligibility set removes the mismatch without another abstraction.

## Hot reply path impact

- Path status: Shared mailbox preparation touched; execution ordering remains unchanged.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved; eligibility scans the already loaded bounded mailbox.
- Before/after proof: Existing preemption tests pass; covered schedules retire without executing a provider event.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no prompts, tools, schemas, generated guidance, or provider-visible input changes.

ReviewGPT result: PASS on d54888cd63c45b48f9b3e5a3fcb2f1ffd0694177; captured model gpt-6-pro; response SHA-256 f1eeb806848bde83aa3afa29e41455fe9598129c504ef64243a418702239ea49. [Review thread](https://chatgpt.com/c/6aa0e826-6aa0-83e9-9540-930ea285ce4f).

ReviewGPT first-reviewed head: d54888cd63c45b48f9b3e5a3fcb2f1ffd0694177
ReviewGPT context sensitivity: sensitive
Classification reason: Hosted runtime mailbox ordering and durable checkpoint recovery.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing mailbox and checkpoint representations are unchanged.
- Safe order: Deploy the reviewed runner through the protected production workflow after required CI passes.
- Rollback floor: Preserve the compatible retained-job reader shipped by PR #3084; this patch adds no fields.
- Expected exposure: Idle passes with validated retained owners and strictly covered schedule hints.
- Reversibility: Reverting this patch restores slower hint draining; any production rollback requires separate exact authorization.
- Convergence proof: Verify deployed runner release and durable handling of each original recovery target.
- Post-deploy checks: Bounded checkpoint and continuation diagnostics; confirm retained jobs and future retry timing survive.

## Change-shape breakdown

Classification rule: Production TypeScript is source, test paths are tests, execution-plan Markdown is docs, and changelog JSON is authored product content. No binaries or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 28 | 25 |
| Tests / fixtures | 89 | 4 |
| Docs | 17 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 3 | 2 |
| **Total** | **137** | **31** |

## Changelog

- Changelog: updated
- Items: 2026-09-08 · background-refresh-during-device-retry
