### PR TITLE
Remove unused wake lookup and isolate request latency

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-09-wake-delivery-latency.md
+++ b/agent-docs/exec-plans/active/2026-09-09-wake-delivery-latency.md
@@ -1,0 +1,62 @@
+# Reduce hosted wake reconciliation work
+
+## Outcome and invariants
+
+Reduce avoidable work before a hot conversation wake while preserving durable
+Temporal handoff, current access and consent, authoritative usage admission,
+custom-funded inference, denied-work notices, and workflow replay ordering.
+
+## Evidence and owner
+
+Bounded production history attributes variable wake delay to the Web facts
+activity, with negligible activity queue wait and no retry or timer delay.
+The Web facts service reads custom inference concurrently with every usage gate,
+but uses that result only for a denied allowance. This adds an unnecessary read
+and failure dependency to allowed work. Existing facts-stage callbacks classify
+failures but do not measure successful stage duration, leaving the measured
+activity delay unpartitioned. Exact private worker source and relevant public
+contracts were inspected; removing its facts prerequisite is not safe.
+
+Web remains the canonical facts and usage owner. Temporal remains a pointer-only
+scheduler. No new authoritative state, activity command ordering, provider authority,
+cache, retry, dependency, configuration, or new service is required.
+
+## Smallest change and proof
+
+- Defer the existing custom inference override read until an allowance denial
+  actually requires it. Preserve the mutating usage owner and consent handling.
+- Use the existing route stage callback for bounded numeric timing logs, with
+  unchanged facts response and error behavior. No private rows or identifiers.
+- Prove allowed reconciliation survives an irrelevant override lookup failure;
+  preserve denied custom override, denied lookup failure, and revoked consent.
+- Exercise timing accumulation, bounded output, and response/error preservation.
+- Preserve direct Worker authentication and command durations in the existing
+  Web timing callback using optional numeric response headers. Pair these fields
+  with that exact direct request instead of the coalesced runtime wake.
+- Prove old Workers without headers remain compatible and malformed diagnostic
+  values are ignored without changing accepted processing.
+- Run focused Web tests, Web typecheck, and authored-code complexity review.
+- Complete parent review, required PR review and CI under existing authorization.
+
+## Failure, compatibility, and measurement limits
+
+The denied path still requires the override query and fails closed on its error.
+It performs that query after usage admission rather than concurrently. There is
+no wire-contract or replay change, so independent Web/worker deployment remains
+compatible. Timing is diagnostic only and cannot replace operation results.
+Removing a parallel query proves reduced work, not a fixed latency reduction.
+Production comparison after a protected release is required for that claim.
+The direct Web request's internal delay remains a separate evidence gap; do not
+infer transport/authentication durations from merged competing wake traces.
+
+## Progress
+
+- Completed bounded Temporal history, Web request, warm-turn cohort and source audit.
+- Implemented denied-only query and both measurements; no added awaits or calls.
+- Regression proof failed on the original unused lookup; final focused owner
+  runs passed 264 cases. Web, Cloudflare, hosted-execution and control-client
+  typechecks passed. Parent source review and complexity guard passed; the
+  existing parser and reconciliation hotspots did not gain complexity.
+- Required exact-head PR review and CI are next. No production deployment yet.
+- Production latency improvement remains unmeasured; this patch closes the
+  request-attribution and facts-stage evidence gaps for the next observation.

--- a/agent-docs/exec-plans/completed/2026-09-09-wake-delivery-latency.md
+++ b/agent-docs/exec-plans/completed/2026-09-09-wake-delivery-latency.md
@@ -57,6 +57,18 @@ infer transport/authentication durations from merged competing wake traces.
   runs passed 264 cases. Web, Cloudflare, hosted-execution and control-client
   typechecks passed. Parent source review and complexity guard passed; the
   existing parser and reconciliation hotspots did not gain complexity.
-- Required exact-head PR review and CI are next. No production deployment yet.
+- PR #3087 round 1 passed with no qualifying findings on the pushed candidate.
+  The exact-turn capture and response hash match the independently captured
+  gpt-6-pro model metadata. The response text self-attested UNKNOWN; acceptance
+  uses that exact-response model evidence, confirmed attachment, substantive
+  full-snapshot review, and more than 301 seconds of attached response waiting.
+  An earlier browser attempt failed before staging and was recovered on another
+  existing lane without changing the candidate or completing a review round.
+- All candidate CI checks passed. This final plan closure changes documentation
+  only; final-head CI and merge remain operational gates. Production deployment
+  and observed latency improvement are not claimed by this completed code plan.
 - Production latency improvement remains unmeasured; this patch closes the
   request-attribution and facts-stage evidence gaps for the next observation.
+Status: completed
+Updated: 2026-09-09
+Completed: 2026-09-09

--- a/agent-docs/references/hosted-temporal-orchestration.md
+++ b/agent-docs/references/hosted-temporal-orchestration.md
@@ -574,6 +574,15 @@ Vercel OIDC for Web's existing direct ingress wake; both forms bind the target
 user before the same processing adapter runs.
 Do not introduce a static shared bearer token for this adapter.
 
+Successful OIDC direct responses also return optional numeric authentication and
+handler duration headers. The existing Web timing callback records them as
+`directEnsureAuthDurationMs` and `directEnsureHandlerDurationMs` for that exact
+HTTP response. Generic orchestration timestamps in a merged mailbox trace may
+come from a competing Temporal wake and must not be paired with the direct
+request to infer its transport or authentication duration. Old clients ignore
+the headers; new clients accept their absence and ignore malformed values. These
+diagnostics never authorize work or change the JSON response contract.
+
 Request summary:
 
 - `orchestrationAttemptId`: an opaque Temporal attempt id for observability and
@@ -608,6 +617,15 @@ gate so the runtime can reconcile an already-created outbox delivery; the
 runtime/provider layer still enforces spend before any actual model call. There
 is no Activity-local signed usage-decision endpoint in the Temporal execution
 path.
+
+The facts owner retains authoritative usage admission and queries a selected
+custom inference override only when a denied managed allowance needs that
+exemption. Allowed and consent-withdrawn decisions do not depend on unrelated
+custom inference configuration. The existing route stage callback records
+bounded, numeric durations for authentication and facts processing, including
+repeated stages. Timing records contain no member or request identifiers and
+cannot change the response or failure behavior. Temporal activity duration
+includes the Web request lifecycle; it is not a measurement of worker queueing.
 
 Response summary:
 

--- a/apps/cloudflare/src/worker/route-handlers/runtime-control.ts
+++ b/apps/cloudflare/src/worker/route-handlers/runtime-control.ts
@@ -13,7 +13,9 @@ import {
 import {
   assertHostedRuntimeProcessingTimeoutMs,
   HOSTED_RUNTIME_ENSURE_PROCESSING_ACTIVITY_STARTED_AT_MS_HEADER,
+  HOSTED_RUNTIME_ENSURE_PROCESSING_AUTH_DURATION_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_DIRECT_REQUEST_STARTED_AT_MS_HEADER,
+  HOSTED_RUNTIME_ENSURE_PROCESSING_HANDLER_DURATION_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_REQUEST_STARTED_AT_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_TIMEOUT_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_TOKEN_ACQUIRED_AT_MS_HEADER,
@@ -236,7 +238,23 @@ export async function handleRuntimeEnsureProcessingRoute(
           phase: "runtime.starting",
           userId,
         });
-        return json(result);
+        const response = json(result);
+        const authTiming = context.runtimeControlAuthTiming;
+        if (authTiming) {
+          response.headers.set(
+            HOSTED_RUNTIME_ENSURE_PROCESSING_AUTH_DURATION_MS_HEADER,
+            String(Math.max(
+              0,
+              authTiming.runtimeControlAuthFinishedAtEpochMs
+                - authTiming.runtimeControlAuthStartedAtEpochMs,
+            )),
+          );
+        }
+        response.headers.set(
+          HOSTED_RUNTIME_ENSURE_PROCESSING_HANDLER_DURATION_MS_HEADER,
+          String(Math.max(0, Date.now() - cloudflareRouteReceivedAtEpochMs)),
+        );
+        return response;
       } catch (error) {
         emitHostedExecutionStructuredLog({
           component: "worker",

--- a/apps/cloudflare/test/index.test.ts
+++ b/apps/cloudflare/test/index.test.ts
@@ -83,7 +83,9 @@ import {
   HOSTED_EXECUTION_SIGNATURE_HEADER,
   HOSTED_EXECUTION_USER_ID_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_ACTIVITY_STARTED_AT_MS_HEADER,
+  HOSTED_RUNTIME_ENSURE_PROCESSING_AUTH_DURATION_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_DIRECT_REQUEST_STARTED_AT_MS_HEADER,
+  HOSTED_RUNTIME_ENSURE_PROCESSING_HANDLER_DURATION_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_REQUEST_STARTED_AT_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_TIMEOUT_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_TOKEN_ACQUIRED_AT_MS_HEADER,
@@ -3328,6 +3330,8 @@ describe("cloudflare worker routes", () => {
       );
 
       expect(response.status).toBe(200);
+      expect(response.headers.has(HOSTED_RUNTIME_ENSURE_PROCESSING_AUTH_DURATION_MS_HEADER)).toBe(false);
+      expect(response.headers.has(HOSTED_RUNTIME_ENSURE_PROCESSING_HANDLER_DURATION_MS_HEADER)).toBe(false);
       await expect(response.json()).resolves.toEqual({
         action: "started",
         kind: "runtime_processing_accepted",
@@ -3450,6 +3454,8 @@ describe("cloudflare worker routes", () => {
     it("returns the real Durable Object outcome to web-plane OIDC callers", async () => {
       const infoLog = vi.spyOn(console, "info").mockImplementation(() => {});
       vi.stubEnv("MURPH_HOSTED_EXECUTION_STDIO_LOGS", "1");
+      let nowEpochMs = Date.now();
+      const now = vi.spyOn(Date, "now").mockImplementation(() => nowEpochMs++);
       let resolveEnsure!: (value: {
         action: "woken";
         kind: "runtime_processing_accepted";
@@ -3521,6 +3527,12 @@ describe("cloudflare worker routes", () => {
       expect(directInput?.commandStartedAtEpochMs).toBe(
         directInput?.orchestration?.runtimeControlAuthStartedAtEpochMs,
       );
+      const orchestration = directInput?.orchestration;
+      expect(orchestration).toBeDefined();
+      const authDurationMs = orchestration!.runtimeControlAuthFinishedAtEpochMs!
+        - orchestration!.runtimeControlAuthStartedAtEpochMs!;
+      expect(authDurationMs).toBeGreaterThan(0);
+      now.mockReturnValue(orchestration!.cloudflareRouteReceivedAtEpochMs! + 37);
       resolveEnsure({
         action: "woken",
         kind: "runtime_processing_accepted",
@@ -3529,6 +3541,10 @@ describe("cloudflare worker routes", () => {
       });
       const response = await responsePromise;
       expect(response.status).toBe(200);
+      expect(response.headers.get(HOSTED_RUNTIME_ENSURE_PROCESSING_AUTH_DURATION_MS_HEADER)).toBe(
+        String(authDurationMs),
+      );
+      expect(response.headers.get(HOSTED_RUNTIME_ENSURE_PROCESSING_HANDLER_DURATION_MS_HEADER)).toBe("37");
       await expect(response.json()).resolves.toEqual({
         action: "woken",
         kind: "runtime_processing_accepted",

--- a/apps/web/app/api/internal/hosted-orchestration/users/[userId]/reconciliation-facts/route.ts
+++ b/apps/web/app/api/internal/hosted-orchestration/users/[userId]/reconciliation-facts/route.ts
@@ -29,6 +29,14 @@ const HOSTED_RUNTIME_RECONCILIATION_FAILURE_LOG_MESSAGE =
   "Hosted runtime reconciliation facts failed.";
 const HOSTED_RUNTIME_RECONCILIATION_FAILURE_LOG_SCHEMA =
   "murph.hosted-runtime.reconciliation-facts.failure.v1";
+const HOSTED_RUNTIME_RECONCILIATION_TIMING_LOG_SCHEMA =
+  "murph.hosted-runtime.reconciliation-facts.timing.v1";
+
+type HostedRuntimeReconciliationTimingStage =
+  | HostedRuntimeReconciliationFactsProcessingStage
+  | "authentication"
+  | "request_validation"
+  | "response_projection";
 
 type HostedRuntimeReconciliationFailureErrorClass =
   | "hosted_onboarding"
@@ -40,40 +48,69 @@ export const GET = withJsonError(async (
   request: Request,
   context: { params: Promise<{ userId: string }> },
 ) => {
-  const authenticatedUserId = await requireHostedCloudflareCallbackRequest(request, {
-    maxBodyBytes: HOSTED_ORCHESTRATION_RECONCILIATION_FACTS_CALLBACK_BODY_LIMIT_BYTES,
-  });
-  const routeUserId = await resolveDecodedRouteParam(context.params, "userId");
-  assertHostedOrchestrationUserMatches({
-    authenticatedUserId,
-    routeUserId,
-  });
+  const startedAt = Math.round(performance.now());
+  let stageStartedAt = startedAt;
+  let timingStage: HostedRuntimeReconciliationTimingStage = "authentication";
+  const stageDurationsMs: Partial<Record<HostedRuntimeReconciliationTimingStage, number>> = {};
+  const reportStage = (stage: HostedRuntimeReconciliationTimingStage): void => {
+    const now = Math.round(performance.now());
+    stageDurationsMs[timingStage] = (stageDurationsMs[timingStage] ?? 0)
+      + now - stageStartedAt;
+    timingStage = stage;
+    stageStartedAt = now;
+  };
 
-  const factsRequest = parseHostedRuntimeReconciliationFactsRequest({
-    userId: routeUserId,
-  });
-
-  let failureStage: HostedRuntimeReconciliationFactsProcessingStage =
-    "canonical_access_workspace";
-  let facts: Awaited<
-    ReturnType<typeof readHostedRuntimeReconciliationFactsWithVisibleAccess>
-  >;
   try {
-    facts = await readHostedRuntimeReconciliationFactsWithVisibleAccess(
-      factsRequest,
-      (stage) => {
-        failureStage = stage;
-      },
-    );
-  } catch (error) {
-    emitHostedRuntimeReconciliationFailure({
-      error,
-      stage: failureStage,
+    const authenticatedUserId = await requireHostedCloudflareCallbackRequest(request, {
+      maxBodyBytes: HOSTED_ORCHESTRATION_RECONCILIATION_FACTS_CALLBACK_BODY_LIMIT_BYTES,
     });
-    throw error;
-  }
+    reportStage("request_validation");
+    const routeUserId = await resolveDecodedRouteParam(context.params, "userId");
+    assertHostedOrchestrationUserMatches({
+      authenticatedUserId,
+      routeUserId,
+    });
 
-  return jsonOk(projectHostedRuntimeReconciliationFactsWireResponse(facts));
+    const factsRequest = parseHostedRuntimeReconciliationFactsRequest({
+      userId: routeUserId,
+    });
+
+    let failureStage: HostedRuntimeReconciliationFactsProcessingStage =
+      "canonical_access_workspace";
+    reportStage(failureStage);
+    let facts: Awaited<
+      ReturnType<typeof readHostedRuntimeReconciliationFactsWithVisibleAccess>
+    >;
+    try {
+      facts = await readHostedRuntimeReconciliationFactsWithVisibleAccess(
+        factsRequest,
+        (stage) => {
+          failureStage = stage;
+          reportStage(stage);
+        },
+      );
+    } catch (error) {
+      emitHostedRuntimeReconciliationFailure({
+        error,
+        stage: failureStage,
+      });
+      throw error;
+    }
+
+    reportStage("response_projection");
+    return jsonOk(projectHostedRuntimeReconciliationFactsWireResponse(facts));
+  } finally {
+    try {
+      reportStage(timingStage);
+      console.info("Hosted runtime reconciliation facts timing.", {
+        durationMs: stageStartedAt - startedAt,
+        schema: HOSTED_RUNTIME_RECONCILIATION_TIMING_LOG_SCHEMA,
+        stageDurationsMs,
+      });
+    } catch {
+      // Timing telemetry must never replace the reconciliation result or failure.
+    }
+  }
 });
 
 function assertHostedOrchestrationUserMatches(input: {

--- a/apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service-wake.ts
@@ -193,6 +193,12 @@ async function recordHostedDirectEnsureWakeTimingBestEffort(timingRecord: {
         timingRecord.timing.directEnsureRequestStartedAtEpochMs,
       directEnsureResponseReceivedAtEpochMs:
         timingRecord.timing.directEnsureResponseReceivedAtEpochMs,
+      ...(timingRecord.timing.directEnsureAuthDurationMs === undefined ? {} : {
+        directEnsureAuthDurationMs: timingRecord.timing.directEnsureAuthDurationMs,
+      }),
+      ...(timingRecord.timing.directEnsureHandlerDurationMs === undefined ? {} : {
+        directEnsureHandlerDurationMs: timingRecord.timing.directEnsureHandlerDurationMs,
+      }),
       directEnsureOrchestrationAttemptId:
         timingRecord.timing.orchestrationAttemptId,
       directEnsureResultKind: timingRecord.timing.directEnsureResultKind,

--- a/apps/web/src/lib/hosted-orchestration/runtime-reconciliation-facts.ts
+++ b/apps/web/src/lib/hosted-orchestration/runtime-reconciliation-facts.ts
@@ -315,17 +315,11 @@ export async function readHostedRuntimeReconciliationFacts(
   });
 
   if (usageGateRequired) {
-    const [gate, selectedCustomInference] = await Promise.all([
-      resolveHostedRuntimeAiUsageGate({
-        mode: input.usageGateMode ?? "mutating",
-        now,
-        userId: input.userId,
-      }),
-      readSelectedHostedInferenceConnectionOverride({
-        memberId: input.userId,
-        prisma,
-      }),
-    ]);
+    const gate = await resolveHostedRuntimeAiUsageGate({
+      mode: input.usageGateMode ?? "mutating",
+      now,
+      userId: input.userId,
+    });
 
     if (gate.status === "health_data_consent_withdrawn") {
       reportStage?.("canonical_projection");
@@ -344,7 +338,13 @@ export async function readHostedRuntimeReconciliationFacts(
       return facts;
     }
 
-    if (gate.status === "denied" && !selectedCustomInference) {
+    if (
+      gate.status === "denied"
+      && !(await readSelectedHostedInferenceConnectionOverride({
+        memberId: input.userId,
+        prisma,
+      }))
+    ) {
       let noticeRetryAt: Date | null = null;
       if ((input.usageGateMode ?? "mutating") === "mutating") {
         if (freshConversationMailboxLag) {

--- a/apps/web/test/hosted-onboarding-webhook-wake-direct-ensure.test.ts
+++ b/apps/web/test/hosted-onboarding-webhook-wake-direct-ensure.test.ts
@@ -53,6 +53,8 @@ type DirectEnsureInput = {
     & {
       directEnsureRequestStartedAtEpochMs: number;
       directEnsureResponseReceivedAtEpochMs: number;
+      directEnsureAuthDurationMs?: number;
+      directEnsureHandlerDurationMs?: number;
       orchestrationAttemptId: string;
       tokenAcquiredAtEpochMs: number;
       tokenAcquireStartedAtEpochMs: number;
@@ -124,6 +126,8 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
     mocks.ensureRuntimeProcessing.mockImplementationOnce(async (input: DirectEnsureInput) => {
       wakeOrder.push("direct");
       input.onTiming({
+        directEnsureAuthDurationMs: 0,
+        directEnsureHandlerDurationMs: 42,
         directEnsureAction: "woken",
         tokenAcquireStartedAtEpochMs: 1_777_000_000_000,
         tokenAcquiredAtEpochMs: 1_777_000_000_010,
@@ -213,6 +217,8 @@ describe("maybeHandoffHostedExecutionWebhookWake direct ensure fast path", () =>
           tokenAcquiredAtEpochMs: 1_777_000_000_010,
           directEnsureRequestStartedAtEpochMs: 1_777_000_000_012,
           directEnsureResponseReceivedAtEpochMs: 1_777_000_000_120,
+          directEnsureAuthDurationMs: 0,
+          directEnsureHandlerDurationMs: 42,
           directEnsureOrchestrationAttemptId: expect.stringMatching(
             /^web-ingress-[0-9a-f-]{36}$/u,
           ),

--- a/apps/web/test/hosted-orchestration-reconciliation-facts-timing.test.ts
+++ b/apps/web/test/hosted-orchestration-reconciliation-facts-timing.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { hostedOnboardingError } from "../src/lib/hosted-onboarding/errors";
+
+type ReadFacts = typeof import(
+  "../src/lib/hosted-orchestration/visible-runtime-reconciliation"
+).readHostedRuntimeReconciliationFactsWithVisibleAccess;
+type ReconciliationRoute = typeof import(
+  "../app/api/internal/hosted-orchestration/users/[userId]/reconciliation-facts/route"
+);
+
+const MEMBER_ID = "member_timing_fixture";
+const TIMING_MESSAGE = "Hosted runtime reconciliation facts timing.";
+const TIMING_SCHEMA = "murph.hosted-runtime.reconciliation-facts.timing.v1";
+const FACTS: Awaited<ReturnType<ReadFacts>> = {
+  blocked: null,
+  mailboxLag: [],
+  workspace: null,
+};
+
+const mocks = vi.hoisted(() => ({
+  requireHostedCloudflareCallbackRequest: vi.fn(),
+  readFacts: vi.fn<ReadFacts>(),
+}));
+
+vi.mock("@/src/lib/hosted-execution/cloudflare-callback-auth", () => ({
+  requireHostedCloudflareCallbackRequest: mocks.requireHostedCloudflareCallbackRequest,
+}));
+vi.mock("@/src/lib/hosted-orchestration/visible-runtime-reconciliation", () => ({
+  readHostedRuntimeReconciliationFactsWithVisibleAccess: mocks.readFacts,
+}));
+
+let route: ReconciliationRoute;
+let elapsedMs = 0;
+
+beforeAll(async () => {
+  route = await import(
+    "../app/api/internal/hosted-orchestration/users/[userId]/reconciliation-facts/route"
+  );
+});
+
+beforeEach(() => {
+  elapsedMs = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => elapsedMs);
+  vi.spyOn(console, "info").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  mocks.requireHostedCloudflareCallbackRequest.mockReset().mockImplementation(async () => {
+    elapsedMs += 20;
+    return MEMBER_ID;
+  });
+  mocks.readFacts.mockReset().mockResolvedValue(FACTS);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("reconciliation facts route timing", () => {
+  it("accounts for authentication and repeated canonical stages without changing the response", async () => {
+    mocks.readFacts.mockImplementation(async (_request, reportStage) => {
+      reportStage?.("canonical_access_workspace");
+      elapsedMs += 30;
+      reportStage?.("canonical_consent");
+      elapsedMs += 40;
+      reportStage?.("canonical_projection");
+      elapsedMs += 5;
+      reportStage?.("canonical_mailbox");
+      elapsedMs += 60;
+      reportStage?.("canonical_projection");
+      elapsedMs += 7;
+      reportStage?.("canonical_mailbox");
+      elapsedMs += 80;
+      reportStage?.("canonical_projection");
+      elapsedMs += 3;
+      reportStage?.("canonical_usage");
+      elapsedMs += 100;
+      reportStage?.("canonical_projection");
+      elapsedMs += 2;
+      return FACTS;
+    });
+
+    const response = await requestFacts();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(await response.json()).toEqual(FACTS);
+    expect(mocks.requireHostedCloudflareCallbackRequest).toHaveBeenCalledWith(
+      expect.any(Request),
+      { maxBodyBytes: 0 },
+    );
+    expect(console.info).toHaveBeenCalledExactlyOnceWith(TIMING_MESSAGE, {
+      durationMs: 347,
+      schema: TIMING_SCHEMA,
+      stageDurationsMs: {
+        authentication: 20,
+        request_validation: 0,
+        canonical_access_workspace: 30,
+        canonical_consent: 40,
+        canonical_projection: 17,
+        canonical_mailbox: 140,
+        canonical_usage: 100,
+        response_projection: 0,
+      },
+    });
+  });
+
+  it("records rejected authentication without reading facts or logging request contents", async () => {
+    mocks.requireHostedCloudflareCallbackRequest.mockImplementation(async () => {
+      elapsedMs += 42;
+      throw hostedOnboardingError({
+        code: "CALLBACK_AUTH_REJECTED",
+        httpStatus: 401,
+        message: "Synthetic private authentication failure.",
+      });
+    });
+
+    const response = await requestFacts();
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({
+      error: { code: "CALLBACK_AUTH_REJECTED" },
+    });
+    expect(mocks.readFacts).not.toHaveBeenCalled();
+    expect(console.info).toHaveBeenCalledExactlyOnceWith(TIMING_MESSAGE, {
+      durationMs: 42,
+      schema: TIMING_SCHEMA,
+      stageDurationsMs: { authentication: 42 },
+    });
+  });
+
+  it("preserves the user-binding rejection before facts are read", async () => {
+    const response = await requestFacts("member_other_fixture");
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { code: "HOSTED_ORCHESTRATION_USER_MISMATCH" },
+    });
+    expect(mocks.readFacts).not.toHaveBeenCalled();
+    expect(console.info).toHaveBeenCalledExactlyOnceWith(TIMING_MESSAGE, {
+      durationMs: 20,
+      schema: TIMING_SCHEMA,
+      stageDurationsMs: { authentication: 20, request_validation: 0 },
+    });
+  });
+
+  it("closes the failing canonical stage and preserves existing failure classification", async () => {
+    mocks.readFacts.mockImplementation(async (_request, reportStage) => {
+      elapsedMs += 30;
+      reportStage?.("canonical_mailbox");
+      elapsedMs += 50;
+      throw new TypeError("Synthetic private mailbox failure.");
+    });
+
+    const response = await requestFacts();
+
+    expect(response.status).toBe(400);
+    expect(console.error).toHaveBeenCalledWith(
+      "Hosted runtime reconciliation facts failed.",
+      {
+        errorClass: "type_error",
+        schema: "murph.hosted-runtime.reconciliation-facts.failure.v1",
+        stage: "canonical_mailbox",
+      },
+    );
+    expect(console.info).toHaveBeenCalledExactlyOnceWith(TIMING_MESSAGE, {
+      durationMs: 100,
+      schema: TIMING_SCHEMA,
+      stageDurationsMs: {
+        authentication: 20,
+        request_validation: 0,
+        canonical_access_workspace: 30,
+        canonical_mailbox: 50,
+      },
+    });
+  });
+
+  it.each(["success", "failure"] as const)(
+    "does not replace the %s response when timing logging throws",
+    async (outcome) => {
+      vi.mocked(console.info).mockImplementation(() => {
+        throw new Error("Synthetic timing sink failure.");
+      });
+      if (outcome === "failure") {
+        mocks.readFacts.mockRejectedValue(hostedOnboardingError({
+          code: "FACTS_UNAVAILABLE",
+          httpStatus: 503,
+          message: "Synthetic facts unavailable.",
+        }));
+      }
+
+      const response = await requestFacts();
+
+      expect(response.status).toBe(outcome === "success" ? 200 : 503);
+      expect(await response.json()).toEqual(outcome === "success"
+        ? FACTS
+        : expect.objectContaining({ error: expect.objectContaining({ code: "FACTS_UNAVAILABLE" }) }));
+    },
+  );
+});
+
+async function requestFacts(userId = MEMBER_ID): Promise<Response> {
+  return await route.GET(
+    new Request(
+      `https://join.example.test/api/internal/hosted-orchestration/users/${userId}/reconciliation-facts`,
+    ),
+    { params: Promise.resolve({ userId }) },
+  );
+}

--- a/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
+++ b/apps/web/test/hosted-orchestration-reconciliation-facts.test.ts
@@ -437,7 +437,9 @@ describe("hosted orchestration reconciliation facts", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(consoleInfoSpy).toHaveBeenCalledTimes(1);
+    expect(consoleInfoSpy.mock.calls.filter(
+      ([message]: readonly unknown[]) => message === "Hosted runtime reconciliation facts.",
+    )).toHaveLength(1);
     expect(consoleInfoSpy).toHaveBeenCalledWith(
       "Hosted runtime reconciliation facts.",
       {
@@ -1000,6 +1002,55 @@ describe("hosted orchestration reconciliation facts", () => {
     expect(response.status).toBe(200);
     expect(facts.blocked).toBeNull();
     expect(mocks.resolveHostedRuntimeAiUsageGate).not.toHaveBeenCalled();
+  });
+
+  it.each(["allowed", "health_data_consent_withdrawn"] as const)(
+    "does not depend on custom inference lookup when usage admission is %s",
+    async (status) => {
+      mocks.readHostedMailboxMaxSeqByLane.mockResolvedValue([
+        { lane: "conversation", maxSeq: "1" },
+      ]);
+      mocks.resolveHostedRuntimeAiUsageGate.mockResolvedValue({ status });
+      mocks.readSelectedHostedInferenceConnectionOverride.mockRejectedValue(
+        new Error("Unavailable custom inference selection."),
+      );
+
+      const response = await reconciliationRoute.GET(requestForFacts(), routeContext());
+      const facts = parseHostedRuntimeReconciliationFacts(await response.json());
+
+      expect(response.status).toBe(200);
+      expect(facts.blocked?.reason ?? null).toBe(
+        status === "allowed" ? null : "health_data_consent_withdrawn",
+      );
+      expect(mocks.resolveHostedRuntimeAiUsageGate).toHaveBeenCalledWith({
+        mode: "mutating",
+        now: new Date(FIXED_NOW),
+        userId: MEMBER_ID,
+      });
+      expect(mocks.readSelectedHostedInferenceConnectionOverride).not.toHaveBeenCalled();
+      expect(mocks.tryMarkHostedMailboxConversationAiUsageDenied).not.toHaveBeenCalled();
+    },
+  );
+
+  it("fails closed without issuing a usage notice when a denied override lookup fails", async () => {
+    mocks.readHostedMailboxMaxSeqByLane.mockResolvedValue([
+      { lane: "conversation", maxSeq: "1" },
+    ]);
+    mocks.resolveHostedRuntimeAiUsageGate.mockResolvedValue({
+      decision: buildUsageLimitExceededGateDecision(),
+      status: "denied",
+    });
+    mocks.readSelectedHostedInferenceConnectionOverride.mockRejectedValue(
+      new Error("Unavailable custom inference selection."),
+    );
+
+    const response = await reconciliationRoute.GET(requestForFacts(), routeContext());
+
+    expect(response.status).toBe(500);
+    expect(mocks.readSelectedHostedInferenceConnectionOverride).toHaveBeenCalledOnce();
+    expect(mocks.tryMarkHostedMailboxConversationAiUsageDenied).not.toHaveBeenCalled();
+    expect(mocks.sendClaimedHostedAiUsageLimitNoticeToLinqChat).not.toHaveBeenCalled();
+    expect(mocks.sendClaimedHostedAiUsageLimitNoticeToTelegramThread).not.toHaveBeenCalled();
   });
 
   it("admits member-funded custom core inference when managed usage is denied", async () => {

--- a/apps/web/test/hosted-runtime-latency-store.test.ts
+++ b/apps/web/test/hosted-runtime-latency-store.test.ts
@@ -1100,6 +1100,8 @@ describe("hosted runtime latency dashboard store", () => {
           tokenAcquiredAtEpochMs: 1_777_000_000_010,
           directEnsureRequestStartedAtEpochMs: 1_777_000_000_012,
           directEnsureResponseReceivedAtEpochMs: 1_777_000_000_120,
+          directEnsureAuthDurationMs: 0,
+          directEnsureHandlerDurationMs: 42,
         },
       },
       prisma,
@@ -1117,6 +1119,8 @@ describe("hosted runtime latency dashboard store", () => {
         tokenAcquiredAtEpochMs: 1_777_000_000_010,
         directEnsureRequestStartedAtEpochMs: 1_777_000_000_012,
         directEnsureResponseReceivedAtEpochMs: 1_777_000_000_120,
+        directEnsureAuthDurationMs: 0,
+        directEnsureHandlerDurationMs: 42,
       },
     });
     expect(prisma.readTraceInsertSql()).toContain("ON CONFLICT (mailbox_item_id) DO NOTHING");

--- a/packages/cloudflare-hosted-control/src/client.ts
+++ b/packages/cloudflare-hosted-control/src/client.ts
@@ -13,7 +13,9 @@ import {
   HOSTED_EXECUTION_ENVIRONMENT_VOICE_MAX_BYTES,
   type HostedExecutionEnvironmentVoiceContentType,
   HOSTED_EXECUTION_USER_ID_HEADER,
+  HOSTED_RUNTIME_ENSURE_PROCESSING_AUTH_DURATION_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_DIRECT_REQUEST_STARTED_AT_MS_HEADER,
+  HOSTED_RUNTIME_ENSURE_PROCESSING_HANDLER_DURATION_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_TIMEOUT_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_TOKEN_ACQUIRED_AT_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_TOKEN_ACQUIRE_STARTED_AT_MS_HEADER,
@@ -326,6 +328,8 @@ export type CloudflareHostedControlRuntimeEnsureProcessingResponse =
   | CloudflareHostedControlRuntimeEnsureProcessingAcceptedAck;
 
 interface CloudflareHostedControlRuntimeEnsureProcessingTimingBase {
+  directEnsureAuthDurationMs?: number;
+  directEnsureHandlerDurationMs?: number;
   directEnsureRequestStartedAtEpochMs: number;
   directEnsureResponseReceivedAtEpochMs: number;
   orchestrationAttemptId: string;
@@ -2412,8 +2416,18 @@ async function requestHostedExecutionAuthorizedJson<TResponse>(input: {
     && input.runtimeEnsureProcessingOrchestrationAttemptId !== undefined
     && input.readRuntimeEnsureProcessingTimingResult !== undefined
   ) {
+    const directEnsureAuthDurationMs = readRuntimeEnsureProcessingDurationHeader(
+      response.headers,
+      HOSTED_RUNTIME_ENSURE_PROCESSING_AUTH_DURATION_MS_HEADER,
+    );
+    const directEnsureHandlerDurationMs = readRuntimeEnsureProcessingDurationHeader(
+      response.headers,
+      HOSTED_RUNTIME_ENSURE_PROCESSING_HANDLER_DURATION_MS_HEADER,
+    );
     try {
       input.onRuntimeEnsureProcessingTiming?.({
+        directEnsureAuthDurationMs,
+        directEnsureHandlerDurationMs,
         directEnsureRequestStartedAtEpochMs,
         directEnsureResponseReceivedAtEpochMs,
         orchestrationAttemptId:
@@ -2428,6 +2442,18 @@ async function requestHostedExecutionAuthorizedJson<TResponse>(input: {
   }
 
   return parsed;
+}
+
+function readRuntimeEnsureProcessingDurationHeader(
+  headers: Headers,
+  name: string,
+): number | undefined {
+  const value = headers.get(name);
+  if (value === null || !/^\d{1,16}$/u.test(value)) {
+    return undefined;
+  }
+  const durationMs = Number(value);
+  return Number.isSafeInteger(durationMs) ? durationMs : undefined;
 }
 
 function createHostedExecutionRequestSignal(input: {

--- a/packages/cloudflare-hosted-control/test/client.test.ts
+++ b/packages/cloudflare-hosted-control/test/client.test.ts
@@ -5,7 +5,9 @@ import {
   HOSTED_BROWSER_VAULT_REPLICA_METRIC_BUCKET_SET_REF_SCHEMA,
   HOSTED_BROWSER_VAULT_REPLICA_SHARD_SET_REF_SCHEMA,
   HOSTED_EXECUTION_USER_ID_HEADER,
+  HOSTED_RUNTIME_ENSURE_PROCESSING_AUTH_DURATION_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_DIRECT_REQUEST_STARTED_AT_MS_HEADER,
+  HOSTED_RUNTIME_ENSURE_PROCESSING_HANDLER_DURATION_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_TIMEOUT_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_TOKEN_ACQUIRED_AT_MS_HEADER,
   HOSTED_RUNTIME_ENSURE_PROCESSING_TOKEN_ACQUIRE_STARTED_AT_MS_HEADER,
@@ -302,6 +304,11 @@ describe("createCloudflareHostedControlClient", () => {
       kind: "runtime_processing_accepted",
       recommendedRecheckAt: "2026-07-02T00:03:00.000Z",
       runtimeAttemptId: "runtime-attempt-test",
+    }, {
+      headers: {
+        [HOSTED_RUNTIME_ENSURE_PROCESSING_AUTH_DURATION_MS_HEADER]: "13",
+        [HOSTED_RUNTIME_ENSURE_PROCESSING_HANDLER_DURATION_MS_HEADER]: "42",
+      },
     })) as typeof fetch;
     const client = createCloudflareHostedControlClient({
       baseUrl: "https://runner.example.test",
@@ -356,6 +363,8 @@ describe("createCloudflareHostedControlClient", () => {
     expect(init.signal).toBe(abortController.signal);
     expect(onTiming).toHaveBeenCalledWith({
       directEnsureAction: "woken",
+      directEnsureAuthDurationMs: 13,
+      directEnsureHandlerDurationMs: 42,
       directEnsureRequestStartedAtEpochMs: Date.parse("2026-07-06T12:00:00.010Z"),
       directEnsureResponseReceivedAtEpochMs: Date.parse("2026-07-06T12:00:00.010Z"),
       directEnsureResultKind: "runtime_processing_accepted",
@@ -514,6 +523,88 @@ describe("createCloudflareHostedControlClient", () => {
     });
   });
 
+  it("accepts zero and the largest safe integer as direct ensure durations", async () => {
+    const onTiming = vi.fn();
+    const client = createCloudflareHostedControlClient({
+      baseUrl: "https://runner.example.test",
+      fetchImpl: vi.fn(async () => createJsonResponse({ accepted: true }, {
+        headers: {
+          [HOSTED_RUNTIME_ENSURE_PROCESSING_AUTH_DURATION_MS_HEADER]: "0",
+          [HOSTED_RUNTIME_ENSURE_PROCESSING_HANDLER_DURATION_MS_HEADER]:
+            String(Number.MAX_SAFE_INTEGER),
+        },
+        status: 202,
+      })) as typeof fetch,
+      getBearerToken: async () => "token-123",
+    });
+
+    await expect(client.ensureRuntimeProcessing({
+      onTiming,
+      orchestrationAttemptId: "web-ingress-attempt-test",
+      userId: "user_123",
+    })).resolves.toEqual({ accepted: true });
+
+    expect(onTiming).toHaveBeenCalledWith(expect.objectContaining({
+      directEnsureAuthDurationMs: 0,
+      directEnsureHandlerDurationMs: Number.MAX_SAFE_INTEGER,
+      directEnsureResultKind: "legacy_accepted",
+    }));
+  });
+
+  it.each([
+    null,
+    "",
+    "-1",
+    "1.5",
+    "NaN",
+    "Infinity",
+    "1e3",
+    "+1",
+    "0x10",
+    "9007199254740992",
+    "12ms",
+  ])("ignores an invalid or absent direct ensure duration independently: %s", async (invalidValue) => {
+    const durationHeaders = [
+      [HOSTED_RUNTIME_ENSURE_PROCESSING_AUTH_DURATION_MS_HEADER, "directEnsureAuthDurationMs"],
+      [HOSTED_RUNTIME_ENSURE_PROCESSING_HANDLER_DURATION_MS_HEADER, "directEnsureHandlerDurationMs"],
+    ] as const;
+
+    for (const [invalidHeader, invalidField] of durationHeaders) {
+      const onTiming = vi.fn();
+      const headers = new Headers();
+      for (const [header] of durationHeaders) {
+        if (header !== invalidHeader) {
+          headers.set(header, "17");
+        } else if (invalidValue !== null) {
+          headers.set(header, invalidValue);
+        }
+      }
+      const client = createCloudflareHostedControlClient({
+        baseUrl: "https://runner.example.test",
+        fetchImpl: vi.fn(async () => createJsonResponse({ accepted: true }, {
+          headers,
+          status: 202,
+        })) as typeof fetch,
+        getBearerToken: async () => "token-123",
+      });
+
+      await expect(client.ensureRuntimeProcessing({
+        onTiming,
+        orchestrationAttemptId: "web-ingress-attempt-test",
+        userId: "user_123",
+      })).resolves.toEqual({ accepted: true });
+
+      expect(onTiming).toHaveBeenCalledOnce();
+      const timing = onTiming.mock.calls[0]?.[0];
+      expect(timing?.[invalidField]).toBeUndefined();
+      for (const [header, field] of durationHeaders) {
+        if (header !== invalidHeader) {
+          expect(timing).toHaveProperty(field, 17);
+        }
+      }
+    }
+  });
+
   it("reports retry_later timing only after the response parses", async () => {
     const onTiming = vi.fn();
     const client = createCloudflareHostedControlClient({
@@ -547,6 +638,11 @@ describe("createCloudflareHostedControlClient", () => {
       baseUrl: "https://runner.example.test",
       fetchImpl: vi.fn(async () => createJsonResponse({
         error: "payload-shaped diagnostic must not be recorded",
+      }, {
+        headers: {
+          [HOSTED_RUNTIME_ENSURE_PROCESSING_AUTH_DURATION_MS_HEADER]: "13",
+          [HOSTED_RUNTIME_ENSURE_PROCESSING_HANDLER_DURATION_MS_HEADER]: "42",
+        },
       })) as typeof fetch,
       getBearerToken: async () => "token-123",
     });

--- a/packages/hosted-execution/src/contracts.ts
+++ b/packages/hosted-execution/src/contracts.ts
@@ -1180,6 +1180,10 @@ export const HOSTED_RUNTIME_ENSURE_PROCESSING_TOKEN_ACQUIRED_AT_MS_HEADER =
   "x-hosted-runtime-ensure-processing-token-acquired-at-ms";
 export const HOSTED_RUNTIME_ENSURE_PROCESSING_DIRECT_REQUEST_STARTED_AT_MS_HEADER =
   "x-hosted-runtime-ensure-processing-direct-request-started-at-ms";
+export const HOSTED_RUNTIME_ENSURE_PROCESSING_AUTH_DURATION_MS_HEADER =
+  "x-hosted-runtime-ensure-processing-auth-duration-ms";
+export const HOSTED_RUNTIME_ENSURE_PROCESSING_HANDLER_DURATION_MS_HEADER =
+  "x-hosted-runtime-ensure-processing-handler-duration-ms";
 
 export function assertHostedRuntimeProcessingTimeoutMs(
   value: number,

--- a/packages/hosted-execution/src/parsers/runtime-control.ts
+++ b/packages/hosted-execution/src/parsers/runtime-control.ts
@@ -6823,6 +6823,16 @@ function parseHostedRuntimeLatencyPhaseBreakdown(
         "directEnsureResponseReceivedAtEpochMs",
         orchestrationLabel,
       ),
+      ...requireOptionalNonNegativeInteger(
+        orchestration,
+        "directEnsureAuthDurationMs",
+        orchestrationLabel,
+      ),
+      ...requireOptionalNonNegativeInteger(
+        orchestration,
+        "directEnsureHandlerDurationMs",
+        orchestrationLabel,
+      ),
       ...requireOptionalDirectEnsureOrchestrationAttemptId(
         orchestration,
         "directEnsureOrchestrationAttemptId",

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -2380,6 +2380,10 @@ export interface HostedRuntimeLatencyPhaseBreakdown {
     tokenAcquiredAtEpochMs?: number;
     directEnsureRequestStartedAtEpochMs?: number;
     directEnsureResponseReceivedAtEpochMs?: number;
+    // These durations belong to this direct HTTP response; generic orchestration
+    // spans can instead describe a competing Temporal wake.
+    directEnsureAuthDurationMs?: number;
+    directEnsureHandlerDurationMs?: number;
     directEnsureOrchestrationAttemptId?: string;
     directEnsureResultKind?:
       | "legacy_accepted"
@@ -2799,6 +2803,8 @@ export const HOSTED_RUNTIME_LATENCY_PHASE_BREAKDOWN_LEAF_KEYS: Record<
     "tokenAcquiredAtEpochMs",
     "directEnsureRequestStartedAtEpochMs",
     "directEnsureResponseReceivedAtEpochMs",
+    "directEnsureAuthDurationMs",
+    "directEnsureHandlerDurationMs",
     "directEnsureOrchestrationAttemptId",
     "directEnsureResultKind",
     "directEnsureAction",

--- a/packages/hosted-execution/test/hosted-runtime-control.test.ts
+++ b/packages/hosted-execution/test/hosted-runtime-control.test.ts
@@ -1652,6 +1652,8 @@ describe("hosted runtime control contracts", () => {
         tokenAcquiredAtEpochMs: 1_777_000_000_012,
         directEnsureRequestStartedAtEpochMs: 1_777_000_000_013,
         directEnsureResponseReceivedAtEpochMs: 1_777_000_000_014,
+        directEnsureAuthDurationMs: 0,
+        directEnsureHandlerDurationMs: 42,
         directEnsureOrchestrationAttemptId:
           "web-ingress-123e4567-e89b-42d3-a456-426614174000",
         directEnsureResultKind: "runtime_processing_accepted",
@@ -1992,6 +1994,10 @@ describe("hosted runtime control contracts", () => {
       { temporalActivityStartedAtEpochMs: 1, requestUrl: 1 }, // unknown sub key
       { tokenAcquireStartedAtEpochMs: -1 }, // web-side negative leaf
       { directEnsureResponseReceivedAtEpochMs: 1.5 }, // web-side non-integer leaf
+      { directEnsureAuthDurationMs: -1 },
+      { directEnsureAuthDurationMs: "42" },
+      { directEnsureHandlerDurationMs: Number.POSITIVE_INFINITY },
+      { directEnsureHandlerDurationMs: Number.MAX_SAFE_INTEGER + 1 },
       { directEnsureOrchestrationAttemptId: "web-ingress-not-a-uuid" }, // correlation id must be bounded
       { shellPrewarmOrchestrationAttemptId: "web-prewarm-not-a-uuid" }, // prewarm correlation ids have their own exact prefix and shape
       { shellPrewarmExpectedOrchestrationAttemptId: "web-ingress-123e4567-e89b-42d3-a456-426614174000" }, // direct-wake ids cannot enter the prewarm channel


### PR DESCRIPTION
## Why and outcome

Allowed runtime reconciliation queried custom inference settings that only affect a denied managed allowance. A failure in that unused lookup could reject an otherwise allowed wake. Read it only after denial, preserving authoritative usage admission, consent withdrawal, custom funding, and usage notices.

Measure the remaining wake delay at its existing owners: Web facts stages and authentication/handler durations from the exact direct Worker response. Coalesced runtime traces can otherwise mix Web and Temporal timestamps. These diagnostics add no awaited work or remote calls; production latency improvement is not yet measured.

## Product UX

- Effort: Not applicable; internal wake processing and diagnostics.
- Result: Ready; focused proof and parent review passed.
- Walkthrough: Existing message, access, consent, custom inference and notice behavior retained. No UI or message-copy changes.

## Evidence

- Direct: The new irrelevant-lookup failure regression fails at base and passes after the change. Denied lookup failure remains closed without a notice; existing custom-funded and denied-notice cases pass.
- Coverage: 264 focused cases across Web reconciliation/timing (71), Web direct recorder/store (58), hosted-execution contracts (38), control client (75), and Worker runtime control (22).
- Checks: Web, Cloudflare, hosted-execution and control-client typechecks pass. Scoped route lint and diff/privacy checks pass. ReviewGPT passed on `ddf7e5e7bc661cb3efbe3b396804683c83f1679b` with matching exact-response gpt-6-pro metadata and more than 301 seconds of attached waiting; candidate CI passed. Final head `2188d88b11da8e0b04a62d077d0bddb9891efa18` only closes the execution plan; production source and tests are unchanged, and final-head CI passed with 33 successful checks and two intentionally skipped checks.
- Timing proof: Repeated stages aggregate correctly; failures and logging failures retain responses. Optional headers retain old-client/old-Worker compatibility; malformed durations never reject processing.

## Non-obvious affected surfaces

Direct timing fields pass through the existing shared leaf allowlist/parser and Web trace recorder. Tests cover zero, absent, malformed, nonfinite and unsafe-integer values, plus callback-signed responses without the OIDC-only headers.

## Architecture and reuse

- Existing systems reused: Web reconciliation/usage owners, route stage callback, direct control response, timing callback, and existing latency trace.
- New logic: Denied-only override lookup and bounded numeric timing projection.
- New abstractions: One local numeric-header parser; no new lifecycle or state owner.
- Complexity intentionally avoided: No queues, caches, retries, configuration, dependencies, billing-policy fork, or Temporal workflow command changes.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base origin/main`.
- Hotspots: Existing reconciliation/facts emitter (33/23), control request/browser parser (21/22), group contract parsers (83/22/149), and automation timing inspector (25) remain unchanged in complexity.
- Agent judgment: The unused read is removed; remaining guarded admission and parsing branches encode current behavior. Splitting them solely for the metric would add indirection.

## Hot reply path impact

- Path status: Touched before runtime wake.
- Database calls: Custom-override Prisma lookup goes from one to zero on allowed or consent-withdrawn usage results. Denied results retain at most one lookup, now after the gate rather than concurrent with it. Selected cardinality remains one member and its singular relations; no collection fanout or new transaction. Existing database timeout/retry behavior is unchanged.
- Network/provider calls: None added. Existing Temporal facts GET and direct ensure request remain unchanged.
- Other awaited latency: None added. Timing is synchronous numeric bookkeeping plus one best-effort existing-platform log per facts request. No new retry/fallback.
- Before/after proof: Regression tests prove unused-lookup independence. A removed parallel read does not establish a fixed millisecond saving; the denied path deliberately serializes its required lookup.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no instructions, tool/schema/generated guidance, history, model configuration or other provider-visible input changes. Full-input token measurement was not run because only wake admission reads and diagnostics changed.

ReviewGPT first-reviewed head: ddf7e5e7bc661cb3efbe3b396804683c83f1679b
ReviewGPT context sensitivity: sensitive
Classification reason: Hosted execution, admission and cross-app diagnostic boundaries.

## Deployment concerns

- Deployment: applicable
- Supported skew: New Web accepts missing headers from an old Worker; old Web ignores headers from a new Worker. Facts JSON and Temporal commands are unchanged.
- Safe order: Protected Web release before a protected Worker-only release (`container_rollout=worker-only`); existing member images remain selected. No private Temporal worker change or migration required.
- Rollback floor: Existing receiver JSON contract; optional headers introduce no new floor.
- Expected exposure: Existing facts requests and OIDC direct wakes; no new requests or persisted authority.
- Reversibility: Ordinary source revert; existing trace fields are optional diagnostics.
- Convergence proof: Consumer tests cover absent/malformed headers; producer tests retain JSON/status and omit headers for callback-signed requests.
- Post-deploy checks: Observe warm member turns, compare accepted-to-provider latency, inspect numeric facts stages and same-request direct durations. Do not infer transport spans from competing wake timestamps.

## Change-shape breakdown

Classification rule: Runtime files are source, test paths are tests, and agent documentation/plans are docs. No binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 150 | 43 |
| Tests / fixtures | 389 | 1 |
| Docs | 92 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **631** | **44** |

## Changelog

- Changelog: not applicable
- Reason: Internal diagnostic attribution and removal of an unused query dependency; no member-visible performance improvement is claimed before production measurement.
