### PR TITLE
fix(runtime): retire admitted companion dirty hints

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-09-runtime-mailbox-recovery-rollout.md
+++ b/agent-docs/exec-plans/active/2026-09-09-runtime-mailbox-recovery-rollout.md
@@ -111,3 +111,20 @@ Keep the same sixteen-value limit and fixed-value allowlist; disclose no payload
 values and change no scheduling or acknowledgement behavior. Six synthetic
 shape cases fail before this addition. Direct checkpoint, invocation, and log
 wire-parser coverage must pass before exact-head review, CI, and deployment.
+
+## Companion dirty-hint recovery
+
+The companion metadata and RMSSD producers persist work through the same dirty
+state and payload owner as webhook imports, but label their hints with two
+distinct reasons. The mailbox plain-hint predicate accepts neither reason, so
+an admitted retained owner leaves these otherwise redundant hints queued behind
+its next retry. Four checkpoint/restore regressions reproduce that difference
+with the two canonical producer reasons, acknowledgement retry, and a newer
+dirty revision; the ordinary hint controls pass.
+
+Recognize those two existing reasons in the shared plain-hint reason predicate
+and use that predicate in diagnostics. Preserve explicit jobs, scopes, revoke
+warnings, unknown reasons, epoch barriers, active retry work, and checkpoint
+acknowledgement. Do not infer incident recovery from this synthetic proof: verify
+the diagnostic release against the original cohort and then verify the reviewed
+fix after its protected deployment. The overall recovery plan remains active.

--- a/apps/web/changelog/entries/2026-09-09/companion-sync-clears-duplicate-requests.json
+++ b/apps/web/changelog/entries/2026-09-09/companion-sync-clears-duplicate-requests.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-09",
+  "order": 200,
+  "item": {
+    "id": "companion-sync-clears-duplicate-requests",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Companion sync clears duplicate requests",
+    "summary": "Companion health updates no longer leave duplicate sync requests waiting behind older device retries.",
+    "details": "Pending device jobs keep their retry history, and newer health updates stay queued until they are safely processed.",
+    "relevanceTags": ["device-sync", "reliability"],
+    "sourcePullRequests": [3095]
+  }
+}

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox-diagnostics.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox-diagnostics.ts
@@ -1,5 +1,6 @@
 import {
   isHostedPlainDeviceSyncWakeHint,
+  isHostedPlainDeviceSyncWakeHintReason,
   systemMailboxItemIsDue,
   type HostedSystemMailboxState,
   type HostedSystemMailboxPendingItem,
@@ -80,8 +81,7 @@ function describeNonScheduledHint(head: HostedSystemMailboxPendingItem): Record<
     headHasJobs: (wake.hint?.jobs?.length ?? 0) > 0,
     headScopesPresent: wake.hint?.scopes !== undefined,
     headRevokeWarningPresent: wake.hint?.revokeWarning != null,
-    headHintReasonSupported: wake.hint?.reason == null
-      || wake.hint.reason === "webhook_dirty_transition",
+    headHintReasonSupported: isHostedPlainDeviceSyncWakeHintReason(wake.hint?.reason),
     headRecordPresent: head.postCheckpointRecord !== null,
   };
 }

--- a/packages/assistant-runtime/src/hosted-runtime/system-mailbox-state.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/system-mailbox-state.ts
@@ -795,10 +795,19 @@ export function isHostedPlainDeviceSyncWakeHint(item: HostedSystemMailboxPending
     && item.deviceSyncContinuationOwner !== true
     && wake.kind === "device-sync.wake"
     && (wake.reason === "webhook_hint" || wake.reason === "reconcile_due")
-    && (wake.hint?.reason == null || wake.hint.reason === "webhook_dirty_transition")
+    && isHostedPlainDeviceSyncWakeHintReason(wake.hint?.reason)
     && (wake.hint?.jobs?.length ?? 0) === 0
     && wake.hint?.scopes === undefined
     && wake.hint?.revokeWarning == null;
+}
+
+export function isHostedPlainDeviceSyncWakeHintReason(reason: string | null | undefined): boolean {
+  // These producers store their work in canonical dirty state, which the
+  // retained connection owner fetches on its admitted pass.
+  return reason == null
+    || reason === "webhook_dirty_transition"
+    || reason === "companion_health_metadata"
+    || reason === "companion_hrv_rmssd";
 }
 
 export function isHostedRetainedDeviceScheduledAdmission(

--- a/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-system-mailbox-notification.test.ts
@@ -4348,7 +4348,11 @@ describe("hosted system mailbox notification execution context", () => {
     }
   });
 
-  it.each([false, true])("drains admitted wake hints across checkpoint restore (new dirty revision: %s)", async (newerDirtyRevision) => {
+  it.each([false, true].flatMap((newerDirtyRevision) =>
+    [undefined, "companion_health_metadata", "companion_hrv_rmssd"].map((hintReason) =>
+      ({ newerDirtyRevision, hintReason })
+    )
+  ))("drains admitted wake hints across checkpoint restore (new dirty revision: $newerDirtyRevision, reason: $hintReason)", async ({ newerDirtyRevision, hintReason }) => {
     const workspace = await createHostedRuntimeWorkspace("murph-hosted-system-mailbox-");
     const connectionId = "dsc_synthetic_retained_drain";
     const retryAt = "2026-04-28T00:00:00.000Z";
@@ -4382,7 +4386,8 @@ describe("hosted system mailbox notification execution context", () => {
           connectionId, eventId: `device-sync.wake:synthetic-hint-${index}`,
           expectedConnectedAt, occurredAt: FIXED_NOW, provider: "junction",
           reason, userId: "member_123",
-          ...(reason === "reconcile_due" ? { hint: { nextReconcileAt: FIXED_NOW } } : {}),
+          hint: reason === "reconcile_due" ? { nextReconcileAt: FIXED_NOW }
+            : { reason: hintReason },
         });
         await enqueueHostedSystemMailboxItem({
           item: createResolvedDeviceSyncItem({ dedupeKey: wake.eventId,
@@ -4661,7 +4666,7 @@ describe("hosted system mailbox notification execution context", () => {
   });
 
   it.each([
-    "epoch", "manual", "jobs", "attempted", "recording", "disconnect",
+    "epoch", "manual", "jobs", "scopes", "revoke", "unknown_reason", "attempted", "recording", "disconnect",
     "reauthorization", "connected", "future_schedule", "equal_schedule", "undated_schedule", "unbound_owner", "other_connection",
   ])("preserves %s work when a retained device owner admits hints", async (boundary) => {
     const workspace = await createHostedRuntimeWorkspace("murph-hosted-system-mailbox-");
@@ -4679,6 +4684,9 @@ describe("hosted system mailbox notification execution context", () => {
     if (boundary === "epoch") candidate.expectedConnectedAt = "2026-04-02T00:00:00.000Z";
     if (boundary === "manual") { candidate.reason = "reconcile_due"; candidate.hint = { reason: "manual_reconcile" }; }
     if (boundary === "jobs") candidate.hint = { jobs: [{ kind: "resource", dedupeKey: "synthetic-distinct-job" }] };
+    if (boundary === "scopes") candidate.hint = { reason: "companion_health_metadata", scopes: [] };
+    if (boundary === "revoke") candidate.hint = { reason: "companion_hrv_rmssd", revokeWarning: { code: "synthetic_warning", message: "Synthetic warning" } };
+    if (boundary === "unknown_reason") candidate.hint = { reason: "synthetic_unrecognized_reason" };
     if (boundary === "disconnect") candidate.reason = "disconnected";
     if (boundary === "reauthorization") candidate.reason = "reauthorization_required";
     if (boundary === "connected") candidate.reason = "connected";

--- a/packages/assistant-runtime/test/system-mailbox-diagnostics.test.ts
+++ b/packages/assistant-runtime/test/system-mailbox-diagnostics.test.ts
@@ -70,12 +70,14 @@ describe("mailbox blocker diagnostics", () => {
     },
   );
 
-  it.each(["plain", "jobs", "scopes", "revoke", "reason", "record"])(
+  it.each(["plain", "companion-metadata", "companion-hrv", "jobs", "scopes", "revoke", "reason", "record"])(
     "identifies non-scheduled hint shape without exposing values (%s)", (condition) => {
       const head = device("2");
       if (head.wake.kind !== "device-sync.wake") throw new Error("Invalid synthetic fixture");
       head.wake.reason = "webhook_hint";
       head.wake.hint = { reason: "webhook_dirty_transition" };
+      if (condition === "companion-metadata") head.wake.hint.reason = "companion_health_metadata";
+      if (condition === "companion-hrv") head.wake.hint.reason = "companion_hrv_rmssd";
       if (condition === "jobs") head.wake.hint.jobs = [{ kind: "synthetic-private-job" }];
       if (condition === "scopes") head.wake.hint.scopes = [];
       if (condition === "revoke") head.wake.hint.revokeWarning = {
@@ -91,7 +93,7 @@ describe("mailbox blocker diagnostics", () => {
         continuationSeqs: [], firstPendingSeq: "2", now: NOW, state,
       });
       expect(result).toEqual(expect.arrayContaining([
-        `headPlainHint=${condition === "plain"}`,
+        `headPlainHint=${condition === "plain" || condition.startsWith("companion-")}`,
         `headHasJobs=${condition === "jobs"}`,
         `headScopesPresent=${condition === "scopes"}`,
         `headRevokeWarningPresent=${condition === "revoke"}`,


### PR DESCRIPTION
## Why and outcome

Companion health metadata and RMSSD producers persist their work in canonical dirty state but emit two hint reasons missing from the mailbox plain-hint predicate. An admitted retained owner can fetch that work while redundant mailbox hints remain queued behind its next retry.

Recognize those two existing producer reasons through a shared predicate also used by diagnostics. Existing checks still preserve explicit jobs, scopes, revoke warnings, unknown reasons, connection epochs, and checkpoint acknowledgement. This proves and fixes the producer/consumer mismatch; recovery of the incident cohort requires separate live verification.

## Product UX

- Effort: Patch — companion background-sync recovery.
- Result: Ready.
- Walkthrough: Ordinary and both companion dirty hints drain when a valid retained owner admits their work. A failed acknowledgement stays recording across restore, a newer dirty revision keeps its immediate continuation, and exact historical jobs retain their retry state. Substantive or unrelated events remain queued. No difference from the recovery plan.

## Evidence

- Direct: Four companion checkpoint/restore cases fail against base while ordinary controls pass. All six cases pass at head, including acknowledgement failure and a newer dirty revision.
- Coverage: 328 runtime tests pass across mailbox notification, diagnostics, device-sync runtime, and workspace system-mailbox entrypoint suites. Eighteen existing companion producer tests pass in device-sync-hosted-wake.test.ts.
- Runtime and Web typechecks, ten changelog rendering tests, docs drift, diff whitespace, and complexity pass.
- Source trace: persistHostedDeviceSyncCompanionResource writes canonical dirty resources and emits companion_health_metadata or companion_hrv_rmssd. applyHostedPendingDirtyDeviceSyncState fetches by connection without filtering by those hint reasons. The existing admitted owner therefore owns the actual work.
- Exact-head ReviewGPT PASS: https://chatgpt.com/c/6aa113bc-b78c-83ea-a486-385ded5f7cc0. Verified gpt-6-pro response hash 4b637cef14e905ea63817b3cced22077be8ed61e7efb9632934dd2d2a1637aa8; no qualifying findings.
- Exact-head required CI passes: https://github.com/cobuildwithus/murph/actions/runs/34327316956 and https://github.com/cobuildwithus/murph/actions/runs/34327316981. Production attribution and recovery are not inferred from tests.

## Non-obvious affected surfaces

Diagnostics now use the same reason predicate as retirement, avoiding contradictory flags. Scheduled cadence handling, manual reconcile, unknown reasons, explicit jobs, scopes, revoke warnings, epoch barriers, and post-checkpoint records retain their existing boundaries.

## Architecture and reuse

- Existing systems reused: Canonical dirty state, retained continuation ownership, existing mailbox compaction and acknowledgement, and fixed diagnostics.
- New logic: Admit two existing producer reasons as plain hints.
- New abstractions: One shared pure reason predicate replaces the duplicated reason check in diagnostics; no new state owner.
- Complexity intentionally avoided: No queue, scheduler, migration, manual acknowledgement, provider call, or payload copy.

## Complexity impact

- Guard: pass — pnpm complexity:diff; debt unchanged.
- Hotspots: Existing parseHostedSystemMailboxRecordRequest remains 25 and is untouched. Its explicit record-kind parsing is unrelated to this correction.
- Agent judgment: A shared four-condition reason predicate is the smallest correction without allowing arbitrary future reasons or duplicating the allowlist.

## Hot reply path impact

- Path status: Existing synchronous mailbox classification only.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None.
- Before/after proof: Existing execution and acknowledgement call counts remain asserted in composed regressions; retained jobs are unchanged.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no instructions, tools, generated guidance, history, or provider-visible input changes. No input measurement required.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: Existing production anchor is reachable; ten changelog-page tests pass.
- Coverage: Content-only entry rendered through the unchanged archive component; no visual or layout changes.

ReviewGPT first-reviewed head: a6179b5f2aa669c452330883d2d2b2bcc5756fa3
ReviewGPT context sensitivity: sensitive
Classification reason: Runtime mailbox ordering, durable ownership, and checkpoint acknowledgement boundary.

## Deployment concerns

- Deployment: applicable
- Supported skew: No wire or state shape changes. Existing Web readers and old/new runners accept the same events and diagnostics; old runners may retain redundant hints longer.
- Safe order: ReviewGPT and required CI must pass, then use the protected full runtime deployment.
- Rollback floor: Existing durable jobs, dirty revisions, and acknowledgement records remain authoritative and readable.
- Expected exposure: Mixed runners may differ in hint retirement until the release converges.
- Reversibility: A later reviewed release can restore prior classification without data migration; the original actual work remains under canonical ownership.
- Convergence proof: Verify protected deployment receipt and admitted source SHA in runtime invocation logs.
- Post-deploy checks: Confirm pending-head diagnostic attribution, original mailbox targets, retained-work progress, and bounded error aggregates.

## Change-shape breakdown

Classification rule: Runtime modules are source; synthetic regressions are tests; active plan and changelog copy are docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 12 | 3 |
| Tests / fixtures | 15 | 5 |
| Docs | 31 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **58** | **8** |

## Changelog

- Changelog: updated
- Items: 2026-09-09 · companion-sync-clears-duplicate-requests
