### PR TITLE
perf(device-sync): remove redundant historical source reads

### DIFF
--- a/.agents/friction-log/20260909121416-reviewgpt-cannot-capture/friction.md
+++ b/.agents/friction-log/20260909121416-reviewgpt-cannot-capture/friction.md
@@ -1,0 +1,26 @@
+---
+title: 'ReviewGPT cannot capture a submitted review with a WEB-prefixed conversation URL'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+After the repository review command submits an attached audit, retain the exact owned conversation and continue response capture, or provide a supported recovery command without resending.
+
+## Current Behavior
+
+The command reports that auto-send committed but it cannot prove one accepted conversation URL. The owned browser page contains the exact submitted review and shows Pro thinking at a `/c/WEB:<uuid>` URL. The waited command exits before capturing a response.
+
+## Possible Solution
+
+Teach the review package to distinguish an accepted transient conversation from an unsent draft and preserve enough exact-target metadata to resume capture safely.
+
+## Minimal Reproducible Example
+
+Run `pnpm --silent review:gpt pr-review --wait` on an eligible synthetic PR. If ChatGPT retains the submitted turn at a WEB-prefixed conversation URL, the review wrapper exits after submission instead of waiting.
+
+## Context
+
+The required review gate is unavailable despite successful staging and submission. Retrying by resending could duplicate an accepted audit. No production data or credentials are required to reproduce the browser URL handling issue.
+
+Recovery succeeded after the transient URL resolved: exporting the same exact conversation captured the completed audit. The caller still had to recover and attest the result manually because the original waited process had already exited.

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1990,6 +1990,12 @@ Last verified: 2026-09-04
   new successors never write the envelope or consult its completed-resource
   names. Every partial continuation preserves `lastSyncCompletedAt`; only
   terminal current full work may advance it.
+- Extended historical Junction resource jobs reject locally known stale source
+  epochs before provider inventory discovery. Inventory discovery reads connection
+  capabilities, not health samples. One fresh post-discovery source snapshot
+  governs both local projection and admission before the health-data request;
+  it also catches revocations newer than the hydrated local state. Import and
+  post-import progress retain their existing fresh source checks.
 - Junction summary and workout import preparation share their fresh post-provider
   source read with historical evidence evaluation through pure admission helpers.
   Empty historical segments retain their post-fetch authority without a second

--- a/agent-docs/exec-plans/active/2026-09-09-device-source-authorization.md
+++ b/agent-docs/exec-plans/active/2026-09-09-device-source-authorization.md
@@ -1,65 +1,41 @@
-# Reuse source authority after provider discovery
+# Remove unnecessary historical source-authority requests
 
 Status: active
 Created: 2026-09-09
 Updated: 2026-09-09
 
-## Goal
+## Goal and scope
 
-Remove repeated hosted source-authority requests without weakening disconnect or reconnect fencing.
-
-## Success criteria
-
-- Extended historical resource jobs share the fresh post-discovery source snapshot between local projection and admission.
-- Synthetic maximum-source coverage proves one fewer source read per eligible job.
-- Epoch changes before discovery, after discovery, after data fetch, and after import retain their existing fences.
-- Focused tests, typecheck, complexity review, and the applicable final review pass.
-
-## Scope
-
-- In scope: Junction source projection and extended historical resource admission, regression proof.
-- Out of scope: whole-pass authorization caching, new runtime cancellation protocols, production deployment.
-
-## Constraints
-
-- Keep existing source authority and SQLite observation ownership.
-- No TTL, dependencies, services, persistence, or configuration.
-- Keep private operational evidence out of repository artifacts.
-
-## Risks and mitigations
-
-1. Revocation during a provider request or import could make retained authority stale.
-   Mitigation: retain fresh reads after those external boundaries; reuse only across local projection.
-2. Source aliases and lifecycle epochs could diverge from provider inventory.
-   Mitigation: admission uses the same authoritative source snapshot as projection, not provider inventory.
-3. A read-count improvement could be mistaken for a production traffic percentage.
-   Mitigation: report the synthetic per-job delta separately; production reduction requires deployment and matched observation.
-
-## Tasks
-
-1. [x] Trace snapshot callers, source lifecycle writers, and runtime cancellation ownership.
-2. [x] Reject whole-pass caching: source revocation is not independently enforced at canonical import, and cancellation would require a new cross-service protocol.
-3. [x] Reuse fresh post-discovery authority for local projection and immediate admission.
-4. [x] Run focused regression tests and typecheck; review source identity and no-storage fallbacks.
-5. [ ] Review diff and complexity; complete the scoped commit and applicable PR review.
+Reduce hosted source-authority requests during extended historical Junction jobs while preserving health-data admission and lifecycle fencing. Changes stay in the existing provider and reliability owner. Production deployment is outside this task.
 
 ## Decisions
 
-- Prefer a smaller request reduction over an invalidation protocol spanning Web, Worker, and warm runners.
-- Preserve pre-discovery, post-fetch, and post-import authority checks.
-- No public changelog: internal request-count optimization with unchanged member behavior.
+- Reject whole-pass authorization caching: canonical import does not independently enforce source revocation, and reliable invalidation would add a cross-service protocol.
+- Use hydrated account sources to reject locally known stale epochs before inventory discovery. Inventory lists connections and capabilities, not health samples.
+- After discovery, share one fresh source snapshot between local projection and admission before health-data retrieval.
+- Retain fresh reads after health-data fetches and canonical imports. Do not add TTLs, services, configuration, dependencies, or persistent state.
+- Keep private operational evidence outside repository artifacts. Per-job proof is not a production traffic forecast.
+- No public changelog: internal request reduction preserves member behavior.
+
+## Risks and proof
+
+- A remote revocation newer than local hydration may permit an inventory listing; the post-discovery check still blocks health-data retrieval. Locally known superseded epochs still skip inventory.
+- Projection copies the supplied source array and performs synchronous local SQLite writes in production. No external operation separates the shared source read from immediate admission.
+- Alias identity, empty segments, retryable failure, old epochs, post-fetch disconnect, and post-import completion fences remain covered.
+- Failure injection now follows the actual fetch boundary instead of depending on obsolete read ordinals.
+
+## Tasks
+
+1. [x] Trace snapshot callers, lifecycle writers, canonical import, and runtime cancellation.
+2. [x] Remove the remote pre-discovery read and duplicate post-discovery read.
+3. [x] Update the reliability owner and regression assertions.
+4. [x] Run focused verification and parent candidate review.
+5. [ ] Complete the scoped commit, PR checks, final review, and plan closure.
 
 ## Verification
 
-- Focused Junction historical-backfill and source-admission tests.
-- Device-syncd typecheck.
-- Complexity diff and parent candidate review.
-
-## Results
-
-- Focused Vitest run: 155 tests passed across historical backfill, admission reads, timeseries source reuse, and provider identity.
-- Maximum-source historical import uses four authority reads instead of five; the empty-segment retry path uses three instead of four.
-- Failure injection now follows the actual provider-fetch boundary rather than an obsolete read ordinal.
+- Focused Vitest: 155 passed across historical backfill, admission reads, timeseries reuse, and provider identity.
+- Synthetic historical import: five source reads become three; empty-segment retry: four become two.
 - Device-syncd typecheck and diff whitespace checks passed.
-- Complexity guard passed: unchanged aggregate debt, maximum function score reduced from 145 to 143. The changed projection function remains a hotspot at 47; broader provider restructuring is outside this request.
-- Parent review confirmed source reads remain live across provider/import boundaries and production projection uses synchronous SQLite writes. No Web, Worker, or persisted protocol changes.
+- Complexity guard passed: aggregate debt unchanged at 406, maximum score reduced from 145 to 143. Changed hotspots are resource execution at 143 and source projection at 47; broader provider restructuring is outside scope.
+- Parent review confirmed the existing authority owner and fresh external-boundary checks remain intact. No Web, Worker, or persisted protocol changes.

--- a/agent-docs/exec-plans/active/2026-09-09-device-source-authorization.md
+++ b/agent-docs/exec-plans/active/2026-09-09-device-source-authorization.md
@@ -1,0 +1,65 @@
+# Reuse source authority after provider discovery
+
+Status: active
+Created: 2026-09-09
+Updated: 2026-09-09
+
+## Goal
+
+Remove repeated hosted source-authority requests without weakening disconnect or reconnect fencing.
+
+## Success criteria
+
+- Extended historical resource jobs share the fresh post-discovery source snapshot between local projection and admission.
+- Synthetic maximum-source coverage proves one fewer source read per eligible job.
+- Epoch changes before discovery, after discovery, after data fetch, and after import retain their existing fences.
+- Focused tests, typecheck, complexity review, and the applicable final review pass.
+
+## Scope
+
+- In scope: Junction source projection and extended historical resource admission, regression proof.
+- Out of scope: whole-pass authorization caching, new runtime cancellation protocols, production deployment.
+
+## Constraints
+
+- Keep existing source authority and SQLite observation ownership.
+- No TTL, dependencies, services, persistence, or configuration.
+- Keep private operational evidence out of repository artifacts.
+
+## Risks and mitigations
+
+1. Revocation during a provider request or import could make retained authority stale.
+   Mitigation: retain fresh reads after those external boundaries; reuse only across local projection.
+2. Source aliases and lifecycle epochs could diverge from provider inventory.
+   Mitigation: admission uses the same authoritative source snapshot as projection, not provider inventory.
+3. A read-count improvement could be mistaken for a production traffic percentage.
+   Mitigation: report the synthetic per-job delta separately; production reduction requires deployment and matched observation.
+
+## Tasks
+
+1. [x] Trace snapshot callers, source lifecycle writers, and runtime cancellation ownership.
+2. [x] Reject whole-pass caching: source revocation is not independently enforced at canonical import, and cancellation would require a new cross-service protocol.
+3. [x] Reuse fresh post-discovery authority for local projection and immediate admission.
+4. [x] Run focused regression tests and typecheck; review source identity and no-storage fallbacks.
+5. [ ] Review diff and complexity; complete the scoped commit and applicable PR review.
+
+## Decisions
+
+- Prefer a smaller request reduction over an invalidation protocol spanning Web, Worker, and warm runners.
+- Preserve pre-discovery, post-fetch, and post-import authority checks.
+- No public changelog: internal request-count optimization with unchanged member behavior.
+
+## Verification
+
+- Focused Junction historical-backfill and source-admission tests.
+- Device-syncd typecheck.
+- Complexity diff and parent candidate review.
+
+## Results
+
+- Focused Vitest run: 155 tests passed across historical backfill, admission reads, timeseries source reuse, and provider identity.
+- Maximum-source historical import uses four authority reads instead of five; the empty-segment retry path uses three instead of four.
+- Failure injection now follows the actual provider-fetch boundary rather than an obsolete read ordinal.
+- Device-syncd typecheck and diff whitespace checks passed.
+- Complexity guard passed: unchanged aggregate debt, maximum function score reduced from 145 to 143. The changed projection function remains a hotspot at 47; broader provider restructuring is outside this request.
+- Parent review confirmed source reads remain live across provider/import boundaries and production projection uses synchronous SQLite writes. No Web, Worker, or persisted protocol changes.

--- a/agent-docs/exec-plans/completed/2026-09-09-device-source-authorization.md
+++ b/agent-docs/exec-plans/completed/2026-09-09-device-source-authorization.md
@@ -1,6 +1,6 @@
 # Remove unnecessary historical source-authority requests
 
-Status: active
+Status: completed
 Created: 2026-09-09
 Updated: 2026-09-09
 
@@ -30,7 +30,7 @@ Reduce hosted source-authority requests during extended historical Junction jobs
 2. [x] Remove the remote pre-discovery read and duplicate post-discovery read.
 3. [x] Update the reliability owner and regression assertions.
 4. [x] Run focused verification and parent candidate review.
-5. [ ] Complete the scoped commit, PR checks, final review, and plan closure.
+5. [x] Complete parent and final review, prepare the scoped closure commit, and route final-head CI.
 
 ## Verification
 
@@ -39,3 +39,11 @@ Reduce hosted source-authority requests during extended historical Junction jobs
 - Device-syncd typecheck and diff whitespace checks passed.
 - Complexity guard passed: aggregate debt unchanged at 406, maximum score reduced from 145 to 143. Changed hotspots are resource execution at 143 and source projection at 47; broader provider restructuring is outside scope.
 - Parent review confirmed the existing authority owner and fresh external-boundary checks remain intact. No Web, Worker, or persisted protocol changes.
+
+## Completion evidence
+
+- Final ReviewGPT: PASS on runtime candidate `610a0914608d`, no qualifying findings. Recovered the exact submitted turn after a temporary conversation-URL capture failure; package model attestation passed with GPT-6 Pro DOM metadata and the browser-reported 8m 27s duration. Reviewer verified snapshot hashes and source-admission boundaries.
+- CI exposed two unchanged attachment fixtures whose fixed timestamps crossed retention. Pinning only their Date clock preserves the production policy; all 69 mailbox import tests and assistant-runtime typecheck pass. This isolated test correction and completion documentation do not change the reviewed runtime candidate.
+- Recorded the review capture defect through Frog, including same-thread recovery.
+- Final-head CI remains a separate PR gate; no merge or deployment is claimed by plan closure.
+Completed: 2026-09-09

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
@@ -106,6 +106,7 @@ if (!TEST_ASSISTANT_TARGET) {
 const tempRoots: string[] = [];
 
 afterEach(async () => {
+  vi.useRealTimers();
   await Promise.all(
     tempRoots.splice(0).map((root) =>
       rm(root, {
@@ -775,6 +776,8 @@ describe("hosted mailbox conversation import adapter", () => {
   });
 
   test("admits an audio attachment exactly once after its parser retry settles", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-08-26T12:00:00.000Z"));
     const parentRoot = await mkdtemp(path.join(tmpdir(), "murph-hosted-input-audio-parser-retry-"));
     tempRoots.push(parentRoot);
     const vaultRoot = path.join(parentRoot, "vault");
@@ -5280,6 +5283,8 @@ describe("hosted mailbox conversation import adapter", () => {
   });
 
   test("keeps projection-exempt group email attachments restart-replyable", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-08-26T12:00:00.000Z"));
     const parentRoot = await mkdtemp(path.join(tmpdir(), "murph-hosted-email-group-raw-sweep-"));
     tempRoots.push(parentRoot);
     const vaultRoot = path.join(parentRoot, "vault");

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -2961,10 +2961,11 @@ export function createJunctionDeviceSyncProvider(
             && sourceProviderSlug
             && sourceLifecycleEpoch !== null
           ) {
-            currentSourceAdmission = await resolveJunctionCurrentSourceAdmission(
-              context,
+            currentSourceAdmission = resolveJunctionCurrentSourceAdmissionFromSources(
+              context.account.sources ?? [],
               sourceProviderSlug,
-              sourceLifecycleEpoch ?? undefined,
+              context.connectionSourceAdmissionMode !== "listed_only",
+              sourceLifecycleEpoch,
             );
             if (currentSourceAdmission === "fenced") {
               return {};

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -2970,17 +2970,22 @@ export function createJunctionDeviceSyncProvider(
               return {};
             }
           }
-          sourceProviders = await loadAndProjectSourceProviders();
           if (extendedHistoricalBackfill && sourceProviderSlug) {
-            sourceIdentityAuthority = context.listConnectionSources
-              ? await context.listConnectionSources()
-              : context.account.sources ?? [];
+            sourceProviders = await loadSourceProviders();
+            sourceIdentityAuthority = await readJunctionImportSources(context);
+            // Projection only writes local source observations. Reuse its fresh
+            // authority for admission before the next provider request.
+            await projectJunctionSources(context, sourceProviders, {
+              admissionSources: sourceIdentityAuthority,
+            });
             currentSourceAdmission = resolveJunctionCurrentSourceAdmissionFromSources(
               sourceIdentityAuthority,
               sourceProviderSlug,
               context.connectionSourceAdmissionMode !== "listed_only",
               sourceLifecycleEpoch ?? undefined,
             );
+          } else {
+            sourceProviders = await loadAndProjectSourceProviders();
           }
         } catch (error) {
           if (
@@ -12595,6 +12600,7 @@ async function projectJunctionSources(
   context: ProviderJobContext,
   providers: readonly JunctionProviderConnection[],
   options: {
+    admissionSources?: readonly JunctionImportAdmissionSource[];
     historicalBackfillCompletedProviderSlug?: string;
     preserveHistoricalReconnect?: boolean;
     preserveHistoricalReconnectProviderSlugs?: readonly string[];
@@ -12639,13 +12645,15 @@ async function projectJunctionSources(
       httpStatus: 502,
     });
   }
-  const existingSources = context.listConnectionSources
-    ? [...await context.listConnectionSources()]
-    : [];
+  const existingSources = options.admissionSources
+    ? [...options.admissionSources]
+    : context.listConnectionSources
+      ? [...await context.listConnectionSources()]
+      : [];
   const admissionSources: readonly JunctionImportAdmissionSource[] =
-    context.listConnectionSources
+    options.admissionSources ?? (context.listConnectionSources
       ? existingSources
-      : context.account.sources ?? [];
+      : context.account.sources ?? []);
   for (const source of projectedSources) {
     const listedOnly = context.connectionSourceAdmissionMode === "listed_only";
     if (

--- a/packages/device-syncd/test/junction-blood-pressure-backfill.test.ts
+++ b/packages/device-syncd/test/junction-blood-pressure-backfill.test.ts
@@ -2182,10 +2182,10 @@ test("maximum-cardinality schedule-time history queries 396 keys once and offers
 });
 
 test.each([
-  ["before provider discovery", 0, 0, 0],
+  ["before provider discovery", 1, 0, 0],
   ["after provider discovery", 1, 0, 0],
   ["after timeseries fetch", 1, 1, 0],
-] as const)("an old source epoch is fenced %s", async (
+] as const)("a remote epoch change %s is fenced before health-data fetch or import", async (
   boundary,
   expectedProviderListRequests,
   expectedTimeseriesRequests,
@@ -2475,12 +2475,7 @@ test("maximum source projection uses one shared snapshot while retaining exact-s
     toJobRecord(job, 260),
   );
 
-  assert.deepEqual(sourceReads, [
-    targetSlug,
-    "*",
-    "*",
-    targetSlug,
-  ]);
+  assert.deepEqual(sourceReads, ["*", "*", targetSlug]);
   assert.equal(providerListRequests.count, 1);
   assert.equal(requests.length, 1);
   assert.equal(importCalls, 1);
@@ -4136,14 +4131,12 @@ test("retryable post-fetch failures preserve raw evidence and replay the anchore
       message: `Temporary hosted device-sync ${boundary} failure.`,
       retryable: true,
     });
-    let sourceStateReads = 0;
     const failed = await requireValue(provider.jobExecutor).executeJob(
       createJobContext({
         ...(boundary === "source-state"
           ? {
               listConnectionSources: async () => {
-                sourceStateReads += 1;
-                if (sourceStateReads <= 3) {
+                if (requests.length === 0) {
                   return [];
                 }
                 throw failure;
@@ -4278,7 +4271,7 @@ test("an empty successful segment retries when its post-fetch source reread fail
       && error.retryable === true,
   );
 
-  assert.equal(sourceStateReads, 3);
+  assert.equal(sourceStateReads, 2);
   assert.equal(
     requests.filter((request) => request.resource === "blood_pressure").length,
     1,

--- a/packages/device-syncd/test/junction-blood-pressure-backfill.test.ts
+++ b/packages/device-syncd/test/junction-blood-pressure-backfill.test.ts
@@ -2479,7 +2479,6 @@ test("maximum source projection uses one shared snapshot while retaining exact-s
     targetSlug,
     "*",
     "*",
-    "*",
     targetSlug,
   ]);
   assert.equal(providerListRequests.count, 1);
@@ -4265,7 +4264,7 @@ test("an empty successful segment retries when its post-fetch source reread fail
       createJobContext({
         listConnectionSources: async () => {
           sourceStateReads += 1;
-          if (sourceStateReads <= 3) {
+          if (requests.length === 0) {
             return [];
           }
           throw failure;
@@ -4279,7 +4278,7 @@ test("an empty successful segment retries when its post-fetch source reread fail
       && error.retryable === true,
   );
 
-  assert.equal(sourceStateReads, 4);
+  assert.equal(sourceStateReads, 3);
   assert.equal(
     requests.filter((request) => request.resource === "blood_pressure").length,
     1,


### PR DESCRIPTION
## Why and outcome

Extended historical Junction jobs make an unnecessary remote source check before inventory discovery and then repeat a source read around local projection. Use hydrated authority to reject locally known stale jobs, then share the fresh post-discovery snapshot between projection and admission. This removes two remote reads per eligible job.

Keep fresh authority checks after discovery and before health-data fetches, after those fetches, and after canonical imports. This change does not cache authorization across a sync pass.

## Product UX

- Effort: Not applicable — internal sync request reduction with unchanged member behavior.
- Result: Ready.
- Walkthrough: Existing disconnect, reconnect epoch, imported-data, empty-data, retry, alias, and local fallback paths retain their admission rules. Whole-pass caching was rejected because revocation would require a new cross-service invalidation protocol.

## Evidence

- Direct: `pnpm --filter @murphai/device-syncd exec vitest run --config vitest.config.ts --no-coverage test/junction-blood-pressure-backfill.test.ts test/junction-admission-source-reads.test.ts test/junction-timeseries-source-reuse.test.ts test/junction-provider-identity.test.ts` — 155 passed.
- Coverage: Synthetic maximum-source import proves five source reads become three; empty-segment retry proves four become two. Existing tests reject locally stale epochs before discovery and catch remote revocations before health-data fetch, after data fetch, and after import; identity and adjacent import tests cover aliases and fallback behavior.
- `pnpm --filter @murphai/device-syncd typecheck` — passed.
- `git diff --check` — passed.
- An initial package invocation accidentally ran the full package: 1,380 passed and one read-ordinal fixture failed. Two retry fixtures now inject failure at the actual post-fetch boundary; the final focused rerun above passes.
- Final ReviewGPT: PASS on `610a0914608d`, with no qualifying findings. Recovered the exact submitted turn after its transient URL resolved; the package attestation accepts the GPT-6 Pro response metadata, and the browser reports 8m 27s. Snapshot integrity and authority boundaries were checked.
- Final-head CI is recorded in the PR checks. No production request reduction has been measured after deployment.
- CI exposed two unchanged attachment fixtures whose fixed timestamps crossed media retention. Pinning only Date in those two tests preserves the policy: all 69 mailbox import tests and assistant-runtime typecheck pass. This isolated fixture correction and completion documentation do not change the reviewed runtime implementation; no further substantive review is required under the isolated-proof exemption.

## Non-obvious affected surfaces

An isolated CI fixture correction pins the Date clock for two attachment tests that aged across retention; production retention is unchanged. All 69 mailbox conversation import tests pass.

Local source projection copies the supplied authority array before updating observations. Its production store writes synchronously to SQLite; no new external operation separates the shared read from admission. Local fallback and provider alias behavior are covered by the focused suites.

## Architecture and reuse

- Existing systems reused: Existing Junction inventory loader, source reader, projection function, and source lifecycle admission checks.
- New logic: Use hydrated sources for the pre-inventory check. Supply the fresh post-discovery authority to local projection and immediate admission.
- New abstractions: None; one optional input to the existing projection function.
- Complexity intentionally avoided: TTL cache, persistent state, dependencies, configuration, cross-service cancellation or invalidation protocol.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`; aggregate debt 406 → 406, maximum 145 → 143.
- Hotspots: Changed functions are `executeResourceJob` (143) and `projectJunctionSources` (47). The remaining reported hotspots have unchanged bodies: `executeJob`, `executeFullJobTimeseriesContinuation`, `importTimeseriesPreciseSnapshots`, `withJunctionExtendedTimeseriesBackfillFollowUp`, `recordAcceptedJunctionFitbitCoverage`, `evaluateJunctionHistoricalBackfillCoverage`, `junctionTimeseriesRecordValueIdentity`, `importJunctionWorkoutStreamWindow`, `isBlockedJunctionSourceAvailabilityKey`, `buildJunctionWebhookWindow`, `importJunctionTimeseriesResourceSnapshot`, `importTimeseriesDailyAggregateSnapshots`, `selectJunctionElectrocardiogramRecordingCandidates`, `classifyClearOptionalJunctionResourceCode`, `extractJunctionWebhookSourceProviderSlugFallback`, and the record-identity callback.
- Agent judgment: This removes a remote operation at the existing owner. Broader restructuring of the provider would exceed the measured problem; whole-pass caching would add disproportionate coordination machinery.

## Hot reply path impact

- Path status: No new foreground work; only historical device-sync resource admission changes.
- Database calls: None added; projection continues existing local SQLite writes.
- Network/provider calls: Two hosted source snapshot requests removed per eligible job. A revocation newer than hydration can permit one inventory listing, but the fresh post-discovery check blocks health-data retrieval. Locally known stale jobs still avoid inventory.
- Other awaited latency: None added.
- Before/after proof: Synthetic five-to-three and four-to-two source-read assertions; no production latency claim.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no assembled instructions, tool schemas, generated guidance, message history, or provider-visible request assembly changed. Input token measurement was not run.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing Web snapshots and Worker protocols are unchanged; old and new runners use the same schema and authority source.
- Safe order: Ordinary runtime rollout; no coordinated Web or Worker change required.
- Rollback floor: Previous runtime remains compatible with unchanged snapshots and persisted records.
- Expected exposure: Request reduction applies only to eligible jobs executed by the updated runtime.
- Reversibility: Reverting restores the extra read without a data migration.
- Convergence proof: Protocol shapes and consumers are unchanged; no capability negotiation is introduced.
- Post-deploy checks: Confirm runtime release convergence, compare bounded snapshot request counts with eligible job volume, and check source-state failures. Deployment is outside this PR task.

## Change-shape breakdown

Classification rule: package src is source, package test is tests, and execution plan, reliability guidance, and Frog report are docs. No binaries or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 21 | 12 |
| Tests / fixtures | 11 | 14 |
| Docs | 81 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | 113 | **26** |

## Changelog

- Changelog: not applicable
- Reason: Internal request-count optimization preserves member behavior.

ReviewGPT context sensitivity: sensitive
Classification reason: Source authorization read ordering and hosted health-data admission.

ReviewGPT first-reviewed head: 610a0914608dd4117368b1ffd56680d67beef7fa
