### PR TITLE
refactor(cloudflare): remove redundant runner handoff waits and RPCs

### DIFF
--- a/.agents/friction-log/20260909125627-browser-vault-overflow/friction.md
+++ b/.agents/friction-log/20260909125627-browser-vault-overflow/friction.md
@@ -1,0 +1,20 @@
+---
+title: 'Browser vault overflow test exhausts microtask-only wait in CI'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The browser-vault overflow experiment regression should await its observable loaded state reliably in both isolated and sharded Web test runs.
+
+## Current Behavior
+
+The Web test shard failed `overflow experiment routes derive demand from the immutable legacy outcome` in `apps/web/test/browser-vault-context.test.tsx` while waiting for its exact experiment probe to load. The same unchanged test passed in isolation on the same PR head. The shared `waitForCondition` helper stops after 20 `act`/microtask turns instead of an elapsed asynchronous completion deadline. Timing sensitivity is suspected; a deterministic cause has not yet been reproduced locally.
+
+## Minimal Reproducible Example
+
+Compare the failed Release Web tests (2/4) job in PR #3104 with `pnpm --dir apps/web test -- browser-vault-context.test.tsx -t 'overflow experiment routes derive demand from the immutable legacy outcome'` on its reviewed head. The test and browser-vault runtime are unchanged in that PR.
+
+## Context
+
+An unrelated runner lifecycle simplification was delayed by this test failure. Preserve the probe and two-request assertions when improving its asynchronous waiting; do not add retries to production behavior.

--- a/agent-docs/SECURITY.md
+++ b/agent-docs/SECURITY.md
@@ -1506,9 +1506,14 @@ locally readable.
   fact. The container's immutable binding is the sole opaque-name-to-member mapping
   for both warm and cold allocations. Legacy ENAM targets preserve their original
   region and namespace; new global targets must never be parsed as member names.
-  Before provider credential minting, invocation, wake, or cleanup, the
-  per-member owner must re-read that binding and require the exact member,
-  release, region, and slot. A claimed slot is never reusable across members;
+  Before provider credential minting, the per-member owner must verify the exact
+  member, release, region, and slot. Fenced preparation may reuse the immutable
+  binding receipt from allocation or retained-slot resolution in that same
+  request; otherwise it reads the binding. Invocation and wake still authorize
+  the live binding inside the slot owner. Cleanup sends the exact slot and member
+  to that owner, which validates them before retirement and acknowledges only
+  after native destruction and durable identity scrubbing. A successful
+  acknowledgement needs no binding readback. A claimed slot is never reusable across members;
   terminal retirement destroys the container and scrubs claim/member identity.
   Codex standby preflight uses a disposable content-free home and must not make
   a provider request or retain a resident member-configured App Server.

--- a/agent-docs/exec-plans/active/2026-09-09-runner-handoff-simplify.md
+++ b/agent-docs/exec-plans/active/2026-09-09-runner-handoff-simplify.md
@@ -59,7 +59,8 @@ tests pass. Cloudflare typecheck and complexity diff pass (complexity debt 75 to
 69; existing unrelated hotspots unchanged). Ten changelog rendering tests pass.
 Web typecheck passes. The network-call pass also passes 270 composed fleet,
 consent, cleanup, and UserRunner tests; the final lifecycle/recovery run passes 359 tests. Cloudflare typecheck passes
-after the final TypeScript edit. PR metadata, ReviewGPT, and required CI remain.
+after the final TypeScript edit. PR #3104 is open with complete evidence and a linked changelog entry.
+ReviewGPT and required CI remain.
 
 Product UX: Ready at the adapter boundary. Warm retention, native stopped-slot
 retirement, immutable binding, delayed destroy, failed destroy, cleanup deadlines,

--- a/agent-docs/exec-plans/active/2026-09-09-runner-handoff-simplify.md
+++ b/agent-docs/exec-plans/active/2026-09-09-runner-handoff-simplify.md
@@ -1,0 +1,67 @@
+# Simplify runner destruction and standby handoff
+
+## Outcome and invariants
+
+Reduce container handoff machinery while preserving one member-bound execution
+owner, exact-generation cleanup, bounded failure, and durable retirement before
+another target can be allocated. No new service, configuration, schema, or state.
+
+## Owner and evidence
+
+`RunnerContainer` owns native lifecycle operations; `UserRunner` owns target
+reservation and the runtime write fence. The pinned Containers SDK delegates
+`destroy()` directly to the native destruction promise. Cloudflare documents that
+promise as completing when destruction finishes. The current adapter also polls
+cached SDK status and races stop notifications, creating a redundant settlement
+owner that can outlive native destruction. Prove this with synthetic stale-status
+and delayed-native-completion cases before changing source.
+
+## Changes and protected boundaries
+
+- Delete the redundant destruction status poller and its observer bookkeeping.
+- Await native destruction within the existing cleanup deadline; retain exact
+  generation checks and fail closed on rejection or timeout.
+- Keep pending-target reconciliation, immutable member binding, admission,
+  readiness, and write-fence ownership at their existing boundaries.
+- Reuse the retained-slot resolution receipt in fenced preparation. Remove
+  binding readbacks after successful retirement in cleanup and bind recovery.
+  Keep recovery reads for ambiguous failures and live callee authorization.
+- Update lifecycle tests and the durable runtime and security owner documentation.
+- No Web or Temporal wire changes. Old and new containers share existing RPCs
+  and persisted records; no migration or rollout-order dependency is introduced.
+
+## Product UX (Patch)
+
+Outcome: a container handoff does not wait for stale status after native cleanup.
+Reaches: fresh conversation startup, retained warm containers, and failure cleanup.
+Proof: composed container/standby lifecycle tests for success, stale callbacks,
+foreign ownership, destruction failure, and timeout. Deployed latency measurement
+remains a post-deploy check; local evidence makes no end-to-end timing promise.
+
+## Verification and completion
+
+- Focused runner-container, standby, and real Containers SDK lifecycle tests.
+- Cloudflare typecheck and complexity diff; inspect full diff for safety/privacy.
+- Scoped commit, draft PR, candidate review, Ready, ReviewGPT alongside required CI.
+- Record final proof and close this plan before handoff.
+
+## Progress
+
+Implementation and parent candidate review complete for the original lifecycle
+scope; the network-call pass additionally removes three redundant binding RPCs. Removed destruction polling,
+stop-observer bookkeeping, redundant synchronous guards, and a redundant error
+wrapper. Native stopped-state checks avoid both cached status reads on retained
+retirement. The stale-status regression failed before the source change and now
+passes. No additional authority, persisted fields, services, or dependencies.
+
+Focused proof: 235 runner-container tests, 50 standby tests, and seven pinned-SDK
+tests pass. Cloudflare typecheck and complexity diff pass (complexity debt 75 to
+69; existing unrelated hotspots unchanged). Ten changelog rendering tests pass.
+Web typecheck passes. The network-call pass also passes 270 composed fleet,
+consent, cleanup, and UserRunner tests; the final lifecycle/recovery run passes 359 tests. Cloudflare typecheck passes
+after the final TypeScript edit. PR metadata, ReviewGPT, and required CI remain.
+
+Product UX: Ready at the adapter boundary. Warm retention, native stopped-slot
+retirement, immutable binding, delayed destroy, failed destroy, cleanup deadlines,
+replacement generations, abort, and smoke paths are exercised. Live timing and
+provider delivery are post-deploy proof, not claimed by these local tests.

--- a/agent-docs/exec-plans/completed/2026-09-09-runner-handoff-simplify.md
+++ b/agent-docs/exec-plans/completed/2026-09-09-runner-handoff-simplify.md
@@ -60,9 +60,23 @@ tests pass. Cloudflare typecheck and complexity diff pass (complexity debt 75 to
 Web typecheck passes. The network-call pass also passes 270 composed fleet,
 consent, cleanup, and UserRunner tests; the final lifecycle/recovery run passes 359 tests. Cloudflare typecheck passes
 after the final TypeScript edit. PR #3104 is open with complete evidence and a linked changelog entry.
-ReviewGPT and required CI remain.
+ReviewGPT round 1 passed on `5ac681765e2320b2b2b0fd39f5f3ead638c702cc`.
+The full-patch review took approximately six minutes in the Vonneumann lane.
+The captured response hash matches its concrete `gpt-6-pro` model evidence and
+committed user turn; the completion marker and all 14 patch blob hashes were
+verified. The review covered native lifecycle, binding, consent, and deletion
+owners and found no qualifying bugs or Complexity Collapse. No accepted
+findings remain. The final documentation-only closure needs no new model round.
+
+Initial CI passed the changed Cloudflare owner; an unchanged browser-vault UI
+test timed out in the Web shard and passes in isolation on the same head.
+Frog records the test-wait evidence without changing unrelated product code.
+Final exact-head CI status is maintained on PR #3104 after this plan closure.
 
 Product UX: Ready at the adapter boundary. Warm retention, native stopped-slot
 retirement, immutable binding, delayed destroy, failed destroy, cleanup deadlines,
 replacement generations, abort, and smoke paths are exercised. Live timing and
 provider delivery are post-deploy proof, not claimed by these local tests.
+Status: completed
+Updated: 2026-09-09
+Completed: 2026-09-09

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1727,9 +1727,13 @@ the same retry rule, including when the retry arrives through Temporal.
 Replenishment, readiness re-proving, orphan retirement, and stale-release drain
 remain outside the accepted-message path. A claimed slot is never rebound or
 returned to ready. Group chats do not own standby lifecycle; the member's
-`UserRunner` remains the allocation and stop-target owner. Slot invocation,
-provider-credential minting, withdrawal, account deletion, and retirement all
-re-read the exact durable binding; a member mismatch fails closed. A successful
+`UserRunner` remains the allocation and stop-target owner. Fenced preparation
+reuses the exact immutable binding receipt from allocation or retained resolution
+within that request, or reads it when no receipt exists. Invocation and wake
+authorize the live bound member inside the slot owner. Withdrawal and account
+deletion send that owner the exact slot/member target; the owner validates it and
+acknowledges only after native destruction and durable retirement. Callers need no
+binding readback after this acknowledgement. A member mismatch fails closed. A successful
 fresh-start acceptance records the closed standby allocation outcome, bounded
 reason, and elapsed milliseconds in the existing orchestration latency phase
 breakdown and structured log. The selection log records the same metadata
@@ -3041,9 +3045,13 @@ upstream five-second default.
 Container readiness receives at most 15 wall-clock seconds, including time
 queued for the container lifecycle lock. Once readiness-triggered cleanup starts, the RPC
 allows one absolute five-second fail-closed cleanup deadline shared by the
-pre-destroy state read and destroy settlement, and its caller-side guard keeps
-a separate one-second margin. If the container RPC settles
-with a timeout or transport failure, the fresh fence is compare-cleared as
+pre-destroy state read and native destruction promise, and its caller-side guard
+keeps a separate one-second margin. Native destruction completion is the stop
+receipt; cached SDK lifecycle status and a delayed `onStop` callback are not
+additional settlement gates. A definitely stopped native container skips both
+status reads and destruction during retained-target retirement. The slot's
+existing retirement fence and exact-generation checks remain authoritative.
+If the container RPC settles with a timeout or transport failure, the fresh fence is compare-cleared as
 before. If cleanup remains unsettled at its deadline or only the outer guard
 elapses, Cloudflare preserves the fresh fence: the lifecycle RPC has not proved
 that cleanup is safe, and the existing startup-grace convergence path remains

--- a/apps/cloudflare/README.md
+++ b/apps/cloudflare/README.md
@@ -676,17 +676,29 @@ binding workspace facts. It also overlaps immutable slot-binding verification
 with runner-secret and snapshot-restore preparation. Launch still requires the
 exact active write fence, verified member binding, usage admission and container
 readiness. Warm active-runtime wakes do not start these fresh preparation reads.
-Fresh allocation carries its verified immutable binding result into that same
-request's fenced preparation, avoiding a second binding RPC. The receipt is
+Fresh allocation and retained-slot resolution carry their verified immutable
+binding result into that same request's fenced preparation, avoiding a second
+binding RPC. The receipt is
 validated against the selected slot, member, claim format, region and release;
-it is neither persisted nor sent to the container. Retained/direct preparation
-still reads binding evidence, and the container still checks its live bound
-member at launch. Exact bind-response recovery can reuse its verified result.
+it is neither persisted nor sent to the container. Direct preparation without a
+receipt still reads binding evidence, and the container still checks its live
+bound member at launch. Exact bind-response recovery can reuse its verified result.
+Retirement validates the exact target inside the slot owner and acknowledges only
+after destruction and durable identity scrubbing; callers do not reread the binding
+after that acknowledgement. Ambiguous failed binding still requires recovery evidence.
 The individual read timings overlap allocation and each other; they are not
 additive slices of `runtimeInvocationPreparationElapsedMs`, which measures the
 remaining fenced preparation call.
 
 ## Runner Container Lifecycle
+
+Native `destroy()` completion is the destruction receipt. Cleanup keeps its
+existing timeout and exact-generation checks, but does not poll cached SDK status
+or wait for a later `onStop` hook after that promise resolves. A native
+`running === false` observation lets retained-slot reconciliation retire an
+already-stopped target without another status read or destruction request.
+The immutable slot still enters retirement before cleanup and is scrubbed only
+after stop proof; ambiguous or failed cleanup keeps the existing target pinned.
 
 The native Cloudflare container is a warm per-user shell. Startup readiness is
 allowed up to 15 wall-clock seconds, including lifecycle-lock queue time. Once

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -32,7 +32,6 @@ import {
   buildHostedRunnerContainerCaEnv,
 } from "./runner-container-ca-env.ts";
 import {
-  hostedRunnerSlotBindingMatchesTarget,
   isHostedRunnerSlotName,
   isHostedRunnerTargetName,
   isHostedStandbySlotName,
@@ -677,7 +676,6 @@ export class RunnerContainer extends Container {
   private lastDestroyRequest: RunnerContainerDestroyRequestRecord | null = null;
   private recentReadinessProof: RunnerContainerReadinessProof | null = null;
   private stopGeneration = 0;
-  private stopObservers = new Set<() => void>();
   private warmShellInvalidatedByUnsettledDestroy = false;
   private pointerlessWakeBlockingLifecycleCount = 0;
   private pendingCompletionCleanup: RunnerContainerPendingCompletionCleanup | null = null;
@@ -1758,8 +1756,9 @@ export class RunnerContainer extends Container {
     // Keep the native status proof and activity renewal under one lifecycle
     // lock so idle expiry cannot stop the container between them.
     return await this.withLifecycleLock(async () => {
+      if (this.isPlatformContainerDefinitelyStopped()) return "stopped";
       const status = await readRunnerContainerStatus(this);
-      if (this.isPlatformContainerDefinitelyStopped() || isRunnerContainerStopped(status)) {
+      if (isRunnerContainerStopped(status)) {
         return "stopped";
       }
       if (
@@ -3167,6 +3166,12 @@ export class RunnerContainer extends Container {
     failClosed?: boolean;
     reason: RunnerContainerDestroyReason;
   }): Promise<boolean> {
+    if (this.isPlatformContainerDefinitelyStopped()) {
+      if (this.readContainerCleanupOwnership(input.expectedStart) === "current") {
+        this.recordCurrentContainerStopped();
+      }
+      return true;
+    }
     const failClosed = Boolean(input.failClosed);
     const context = this.currentLogContext;
     const statusDeadlineAtMs = input.cleanupDeadlineAtMs
@@ -3219,16 +3224,7 @@ export class RunnerContainer extends Container {
     ) {
       return true;
     }
-    const ownershipBeforeRequest = this.readContainerCleanupOwnership(
-      input.expectedStart,
-      stateBeforeDestroy,
-    );
-    if (ownershipBeforeRequest !== "current") {
-      return ownershipBeforeRequest === "superseded";
-    }
-
     const destroyStartedAt = Date.now();
-    const stopGenerationBeforeDestroy = this.stopGeneration;
     this.lastDestroyRequest = {
       failClosed,
       reason: input.reason,
@@ -3248,95 +3244,30 @@ export class RunnerContainer extends Container {
       userId: context?.userId,
     });
 
-    if (
-      input.expectedInteractionGeneration !== undefined
-      && this.containerInteractionGeneration !== input.expectedInteractionGeneration
-    ) {
-      return true;
-    }
-    const ownershipBeforeDestroy = this.readContainerCleanupOwnership(
-      input.expectedStart,
-      stateBeforeDestroy,
-    );
-    if (ownershipBeforeDestroy !== "current") {
-      return ownershipBeforeDestroy === "superseded";
-    }
     this.pointerlessWakeBlockingLifecycleCount += 1;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     try {
-      const destroyRequest = this.destroy().then(
-        () => ({ kind: "destroy-resolved" as const }),
-        (error: unknown) => ({ error, kind: "destroy-rejected" as const }),
-      );
-      const destroySettle = this.waitForDestroyedContainerStopped({
-        ...(input.cleanupDeadlineAtMs === undefined
-          ? {}
-          : { cleanupDeadlineAtMs: input.cleanupDeadlineAtMs }),
-        destroyStartedAt,
-        expectedStart: input.expectedStart,
-        failClosed,
-        statusBeforeDestroy,
-        stopGenerationBeforeDestroy,
-      }).then(
-        (settled) => ({ kind: "settle-finished" as const, settled }),
-        (error: unknown) => ({ error, kind: "settle-rejected" as const }),
-      );
-      const firstDestroyOutcome = await Promise.race([
-        destroyRequest,
-        destroySettle,
+      // The SDK delegates to native destroy(), whose promise is the stop receipt.
+      // Cached getState()/onStop bookkeeping may lag it and is not a second gate.
+      await Promise.race([
+        this.destroy(),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(() => {
+            reject(new Error("Hosted runner container destruction timed out."));
+          }, Math.max(1, (input.cleanupDeadlineAtMs
+            ?? destroyStartedAt + RUNNER_DESTROY_SETTLE_TIMEOUT_MS) - Date.now()));
+        }),
       ]);
-
-      if (firstDestroyOutcome.kind === "destroy-rejected") {
-        if (this.readContainerCleanupOwnership(input.expectedStart) === "superseded") {
-          return true;
-        }
-        const error = firstDestroyOutcome.error;
-        if (isSettledRunnerContainerDestroyRaceError(error)) {
-          return true;
-        }
-        emitRunnerContainerLifecycleFailure({
-          destroyLatencyMs: Date.now() - destroyStartedAt,
-          error,
-          failClosed,
-          context,
-          message: "Hosted execution container destroy request failed.",
-          statusBeforeDestroy,
-          stage: "destroy",
-        });
-        if (failClosed) {
-          throw new Error("Hosted runner container failed to destroy cleanly.", { cause: error });
-        }
-        return false;
+      if (this.readContainerCleanupOwnership(input.expectedStart) === "superseded") {
+        return true;
       }
-
-      const settledOutcome = firstDestroyOutcome.kind === "destroy-resolved"
-        ? await destroySettle
-        : firstDestroyOutcome;
-      if (settledOutcome.kind === "settle-rejected") {
-        if (this.readContainerCleanupOwnership(input.expectedStart) === "superseded") {
-          return true;
-        }
-        if (failClosed) {
-          throw settledOutcome.error;
-        }
-        return false;
-      }
-
-      const settled = settledOutcome.settled;
-      if (!settled.ok) {
-        return false;
-      }
+      this.recordCurrentContainerStopped();
       emitHostedExecutionStructuredLog({
         component: "container",
         details: {
           destroyLatencyMs: Date.now() - destroyStartedAt,
-          destroySettleLatencyMs: settled.settleLatencyMs,
-          destroySettleTimeoutMs: RUNNER_DESTROY_SETTLE_TIMEOUT_MS,
           failClosed,
           lifecycleStage: "destroyed",
-          observedStatusesAfterDestroy: settled.observedStatuses,
-          settleReason: settled.settleReason,
-          statusAfterDestroy: settled.statusAfterDestroy,
-          stopObservedAfterDestroy: settled.stopObservedAfterDestroy,
           statusBeforeDestroy,
         },
         message: "Hosted execution container destroy completed.",
@@ -3344,138 +3275,30 @@ export class RunnerContainer extends Container {
         userId: context?.userId,
       });
       return true;
-    } finally {
-      this.pointerlessWakeBlockingLifecycleCount -= 1;
-    }
-  }
-
-  private async waitForDestroyedContainerStopped(input: {
-    cleanupDeadlineAtMs?: number;
-    destroyStartedAt: number;
-    expectedStart?: RunnerContainerCurrentStart | null;
-    failClosed: boolean;
-    statusBeforeDestroy: string | null;
-    stopGenerationBeforeDestroy: number;
-  }): Promise<
-    | {
-        ok: true;
-        observedStatuses: string[];
-        settleReason: "onStop" | "status" | "superseded";
-        settleLatencyMs: number;
-        statusAfterDestroy: string | null;
-        stopObservedAfterDestroy: boolean;
-      }
-    | {
-        ok: false;
-      }
-  > {
-    const context = this.currentLogContext;
-    const cleanupDeadlineAtMs = input.cleanupDeadlineAtMs
-      ?? Date.now() + RUNNER_DESTROY_SETTLE_TIMEOUT_MS;
-    const observedStatuses: string[] = [];
-    let lastError: unknown = null;
-    let statusAfterDestroy: string | null = null;
-    const supersededResult = () => ({
-      ok: true as const,
-      observedStatuses,
-      settleLatencyMs: Date.now() - input.destroyStartedAt,
-      settleReason: "superseded" as const,
-      statusAfterDestroy,
-      stopObservedAfterDestroy: false,
-    });
-
-    while (true) {
+    } catch (error) {
       if (this.readContainerCleanupOwnership(input.expectedStart) === "superseded") {
-        return supersededResult();
+        return true;
       }
-      if (this.stopGeneration > input.stopGenerationBeforeDestroy) {
-        return {
-          ok: true,
-          observedStatuses,
-          settleLatencyMs: Date.now() - input.destroyStartedAt,
-          settleReason: "onStop",
-          statusAfterDestroy,
-          stopObservedAfterDestroy: true,
-        };
+      if (isMissingRunnerContainerError(error)) {
+        this.recordCurrentContainerStopped();
+        return true;
       }
-
-      let remainingMs = cleanupDeadlineAtMs - Date.now();
-      if (remainingMs <= 0) {
-        const error = lastError
-          ? new Error("Hosted runner container did not report stopped after destroy.", {
-              cause: lastError,
-            })
-          : new Error("Hosted runner container did not report stopped after destroy.");
-        emitHostedExecutionStructuredLog({
-          component: "container",
-          details: {
-            destroyLatencyMs: Date.now() - input.destroyStartedAt,
-            destroySettleTimeoutMs: RUNNER_DESTROY_SETTLE_TIMEOUT_MS,
-            failClosed: input.failClosed,
-            lifecycleStage: "destroy-settle",
-            observedStatusesAfterDestroy: observedStatuses,
-            statusAfterDestroy,
-            statusBeforeDestroy: input.statusBeforeDestroy,
-          },
-          error,
-          level: input.failClosed ? "error" : "warn",
-          message: "Hosted execution container destroy did not settle to stopped.",
-          phase: "failed",
-          userId: context?.userId,
-        });
-        if (input.failClosed) {
-          throw error;
-        }
-        return { ok: false };
+      emitRunnerContainerLifecycleFailure({
+        destroyLatencyMs: Date.now() - destroyStartedAt,
+        error,
+        failClosed,
+        context,
+        message: "Hosted execution container destroy request failed.",
+        statusBeforeDestroy,
+        stage: "destroy",
+      });
+      if (failClosed) {
+        throw new Error("Hosted runner container failed to destroy cleanly.", { cause: error });
       }
-
-      try {
-        const stateAfterDestroy = await readRunnerContainerStateWithTimeout(
-          this,
-          Math.min(RUNNER_WAIT_INTERVAL_MS, remainingMs),
-        );
-        statusAfterDestroy = readContainerStatus(stateAfterDestroy);
-        appendObservedRunnerContainerStatus(observedStatuses, statusAfterDestroy);
-        const ownershipAfterDestroy = this.readContainerCleanupOwnership(
-          input.expectedStart,
-          stateAfterDestroy,
-        );
-        if (ownershipAfterDestroy === "superseded") {
-          return supersededResult();
-        }
-        if (ownershipAfterDestroy === "ambiguous") {
-          return { ok: false };
-        }
-        if (
-          isRunnerContainerStopped(statusAfterDestroy)
-          && !this.isPlatformContainerDefinitelyRunning()
-        ) {
-          this.recordCurrentContainerStopped();
-          return {
-            ok: true,
-            observedStatuses,
-            settleReason: "status",
-            settleLatencyMs: Date.now() - input.destroyStartedAt,
-            statusAfterDestroy,
-            stopObservedAfterDestroy: this.stopGeneration > input.stopGenerationBeforeDestroy,
-          };
-        }
-      } catch (error) {
-        if (this.readContainerCleanupOwnership(input.expectedStart) === "superseded") {
-          return supersededResult();
-        }
-        lastError = error;
-        appendObservedRunnerContainerStatus(observedStatuses, "status_error");
-      }
-
-      remainingMs = cleanupDeadlineAtMs - Date.now();
-      if (remainingMs <= 0) {
-        continue;
-      }
-      await this.waitForStopOrDelay(
-        input.stopGenerationBeforeDestroy,
-        Math.min(RUNNER_WAIT_INTERVAL_MS, remainingMs),
-      );
+      return false;
+    } finally {
+      clearTimeout(timeout);
+      this.pointerlessWakeBlockingLifecycleCount -= 1;
     }
   }
 
@@ -3549,44 +3372,6 @@ export class RunnerContainer extends Container {
       throw new RunnerContainerCleanupUnsettledError(error);
     }
     throw new RunnerContainerCleanupUnsettledError(input.cause);
-  }
-
-  private async waitForStopOrDelay(
-    observedStopGeneration: number,
-    delayMs: number,
-  ): Promise<void> {
-    if (this.stopGeneration > observedStopGeneration) {
-      return;
-    }
-
-    await new Promise<void>((resolve) => {
-      let settled = false;
-      let timeout: ReturnType<typeof setTimeout> | null = null;
-      const finish = () => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        if (timeout) {
-          clearTimeout(timeout);
-        }
-        this.stopObservers.delete(finish);
-        resolve();
-      };
-      this.stopObservers.add(finish);
-      timeout = setTimeout(finish, delayMs);
-      if (this.stopGeneration > observedStopGeneration) {
-        finish();
-      }
-    });
-  }
-
-  private resolveStopObservers(): void {
-    const observers = [...this.stopObservers];
-    this.stopObservers.clear();
-    for (const observer of observers) {
-      observer();
-    }
   }
 
   private startRunnerActivityRenewal(): () => void {
@@ -3783,8 +3568,7 @@ export class RunnerContainer extends Container {
   private recordCurrentContainerStopped(): boolean {
     const currentGenerationObserved = this.currentContainerStart !== null
       || this.recentReadinessProof !== null
-      || this.lastDestroyRequest !== null
-      || this.stopObservers.size > 0;
+      || this.lastDestroyRequest !== null;
     if (!currentGenerationObserved) {
       return false;
     }
@@ -3796,7 +3580,6 @@ export class RunnerContainer extends Container {
     this.lastActivityObservedAtMs = null;
     this.lastActivityObservedStage = null;
     this.lastDestroyRequest = null;
-    this.resolveStopObservers();
     return true;
   }
 
@@ -4763,19 +4546,16 @@ export async function destroyHostedExecutionContainer(input: {
     const runnerContainerName = input.runnerContainerName ?? input.userId;
     const container = input.runnerContainerNamespace.getByName(runnerContainerName);
     if (isHostedRunnerTargetName(runnerContainerName)) {
-      if (!container.readStandbySlotBinding || !container.retireStandbySlot) {
+      if (!container.retireStandbySlot) {
         throw new Error("Hosted standby runner cleanup RPC is unavailable.");
       }
-      await container.retireStandbySlot({
+      // The addressed owner validates member/slot authority and acknowledges
+      // only after native destruction and durable retirement have completed.
+      const receipt = await container.retireStandbySlot({
         target: { slotName: runnerContainerName, userId: input.userId },
       });
-      const retired = await container.readStandbySlotBinding();
-      if (
-        !hostedRunnerSlotBindingMatchesTarget(retired, runnerContainerName)
-        || retired.state !== "retired"
-        || retired.claimId !== null || retired.userId !== null
-      ) {
-        throw new Error("Hosted runner cleanup did not prove exact terminal retirement.");
+      if (receipt?.retired !== true) {
+        throw new Error("Hosted runner cleanup did not acknowledge terminal retirement.");
       }
     } else {
       await container.destroyInstance();
@@ -5568,10 +5348,6 @@ function readStrictPositiveIntegerEnv(raw: string): number {
 function isMissingRunnerContainerError(error: unknown): boolean {
   const message = readErrorMessage(error);
   return message !== null && message.includes("No such container");
-}
-
-function isSettledRunnerContainerDestroyRaceError(error: unknown): boolean {
-  return isMissingRunnerContainerError(error);
 }
 
 function readErrorMessage(error: unknown): string | null {

--- a/apps/cloudflare/src/user-runner/runtime-invocation.ts
+++ b/apps/cloudflare/src/user-runner/runtime-invocation.ts
@@ -1180,8 +1180,8 @@ export class RuntimeInvocationService {
       }
       const readBinding = async () =>
         await requireHostedRunnerSlotLifecycle(namespace.getByName(runnerContainerName)).readStandbySlotBinding();
-      // Fresh allocation already checked this immutable binding. Reuse only
-      // its request-local receipt; direct and retained starts still read it.
+      // Allocation or retained-slot resolution already checked this binding.
+      // Reuse that request-local receipt; direct starts without one still read it.
       // The container independently authorizes its live binding at launch.
       const binding = input.verifiedSlotBinding ?? (input.commandBudget
         ? await runRuntimeProcessingCommandStep({

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -1012,10 +1012,11 @@ export class RuntimeProcessingController {
             runnerContainerName: pending,
             userId,
           });
-          if (retained === "ready") {
+          if (typeof retained !== "string") {
             return {
               kind: "ready",
               runnerContainerName: pending,
+              verifiedSlotBinding: retained,
               standbyAllocationOutcome: "retained",
               standbyAllocationReason: "retained",
             };
@@ -1197,7 +1198,7 @@ export class RuntimeProcessingController {
     if (recovery.kind !== "completed" || !hostedRunnerSlotBindingMatchesTarget(recovery.value, slotName)) {
       return retry();
     }
-    let binding: HostedStandbySlotBinding = recovery.value;
+    const binding = recovery.value;
     if (binding.state === "bound" && boundExactly(binding)) {
       // Same allocating request, same random claim: a just-bound cold target
       // may start. This exception is never used by later pending recovery.
@@ -1205,17 +1206,11 @@ export class RuntimeProcessingController {
     }
     if (binding.state === "unbound") {
       const retirement = await settle(() => slot.retireStandbySlot({}));
-      if (retirement.kind !== "completed") return retry();
-      const receipt = await settle(() => slot.readStandbySlotBinding());
-      if (receipt.kind !== "completed") return retry();
-      binding = receipt.value;
+      if (retirement.kind !== "completed" || retirement.value?.retired !== true) return retry();
+    } else if (binding.state !== "retired") {
+      // Foreign, retiring, malformed and unavailable evidence stays pinned.
+      return retry();
     }
-    // Foreign, retiring, malformed and unavailable evidence all stay pinned.
-    // The retirement RPC's boolean is not a terminal receipt for this identity.
-    if (
-      !hostedRunnerSlotBindingMatchesTarget(binding, slotName)
-      || binding.state !== "retired"
-    ) return retry();
     await this.input.stateStore.clearStoppedRunnerContainerForUserControl({
       runnerContainerName: slotName,
       userId: runtimeInput.userId,
@@ -1232,7 +1227,7 @@ export class RuntimeProcessingController {
     commandBudget: RuntimeProcessingCommandBudget;
     runnerContainerName: string;
     userId: string;
-  }): Promise<"cleared" | "ready" | "retry"> {
+  }): Promise<HostedStandbySlotBinding | "cleared" | "retry"> {
     const currentReleaseId = resolveHostedRunnerReleaseId(this.input.runnerRuntimeEnvSource);
     const identity = readHostedRunnerTargetIdentity(input.runnerContainerName);
     if (!identity) return "retry";
@@ -1252,7 +1247,7 @@ export class RuntimeProcessingController {
     if (binding.state === "bound") {
       return isSupportedHostedRunnerRelease(this.input.runnerRuntimeEnvSource, binding.releaseId)
         && binding.userId === input.userId
-        && isHostedStandbyClaimId(binding.claimId) ? "ready" : "retry";
+        && isHostedStandbyClaimId(binding.claimId) ? binding : "retry";
     }
     if (binding.state !== "retired" || binding.claimId !== null || binding.userId !== null) return "retry";
     const cleared = await this.input.stateStore.clearStoppedRunnerContainerForUserControl({

--- a/apps/cloudflare/test/containers-helper-readiness.test.ts
+++ b/apps/cloudflare/test/containers-helper-readiness.test.ts
@@ -33,6 +33,26 @@ describe("patched Cloudflare container readiness probes", () => {
     vi.useRealTimers();
   });
 
+  it("uses native destruction completion independently of cached SDK status", async () => {
+    let finishNativeDestroy: () => void = () => { throw new Error("Destroy not started"); };
+    const nativeDestroy = vi.fn(() => new Promise<void>((resolve) => {
+      finishNativeDestroy = resolve;
+    }));
+    const runner: Container = Object.create(Container.prototype);
+    Object.defineProperty(runner, "container", { value: { destroy: nativeDestroy } });
+    const cachedStatus = vi.spyOn(runner, "getState")
+      .mockRejectedValue(new Error("Cached state unavailable"));
+    let completed = false;
+    const destruction = runner.destroy().then(() => { completed = true; });
+    await Promise.resolve();
+    expect(nativeDestroy).toHaveBeenCalledOnce();
+    expect(completed).toBe(false);
+    finishNativeDestroy();
+    await destruction;
+    expect(completed).toBe(true);
+    expect(cachedStatus).not.toHaveBeenCalled();
+  });
+
   it("cuts the production-shaped sticky-probe path by more than two seconds", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-30T12:00:00.000Z"));

--- a/apps/cloudflare/test/runner-container.test.ts
+++ b/apps/cloudflare/test/runner-container.test.ts
@@ -2114,6 +2114,7 @@ describe("RunnerContainer", () => {
       const destroyStarted = createDeferred<void>();
       const destroy = vi.fn(async () => {
         destroyStarted.resolve(undefined);
+        await new Promise<void>(() => undefined);
       });
       const startAndWaitForPorts = vi.fn(async () => {
         status = "running";
@@ -2988,7 +2989,9 @@ describe("RunnerContainer", () => {
         if (expectedDestroyCalls === 1) {
           await destroyIssued.promise;
         }
-        await vi.waitFor(() => expect(statusReads).toBe(gatedStatusRead));
+        if (expectedDestroyCalls === 0) {
+          await vi.waitFor(() => expect(statusReads).toBe(gatedStatusRead));
+        }
 
         nowMs += 1_000;
         const replacementStartedAtMs = nowMs;
@@ -4842,7 +4845,7 @@ describe("RunnerContainer", () => {
     vi.useFakeTimers();
 
     try {
-      const destroy = vi.fn(async () => {});
+      const destroy = vi.fn(() => new Promise<void>(() => undefined));
       const getState = vi.fn(async () => ({
         lastChange: Date.now(),
         status: "running",
@@ -4912,7 +4915,7 @@ describe("RunnerContainer", () => {
 
     try {
       let hangNextStatusRead = false;
-      const destroy = vi.fn(async () => {});
+      const destroy = vi.fn(() => new Promise<void>(() => undefined));
       const getState = vi.fn(async () => {
         if (hangNextStatusRead) {
           await new Promise<void>(() => undefined);
@@ -5019,8 +5022,6 @@ describe("RunnerContainer", () => {
         component: "container",
         details: expect.objectContaining({
           lifecycleStage: "destroyed",
-          settleReason: "onStop",
-          stopObservedAfterDestroy: true,
         }),
         message: "Hosted execution container destroy completed.",
         phase: "container.ready",
@@ -7212,7 +7213,7 @@ describe("RunnerContainer", () => {
     },
   );
 
-  it("requires exact abort and observed stop when control-plane status is stale", async () => {
+  it("requires exact abort and native destruction when control-plane status is stale", async () => {
     const request = createRunnerRequest("evt_missing_pointer_stale_stopped_status");
     const containerFetch = vi.fn(async (url: string, init?: RequestInit) => {
       if (url.endsWith("/internal/workspace-invocation/abort")) {
@@ -7225,7 +7226,8 @@ describe("RunnerContainer", () => {
       }
       throw new Error(`Unexpected runner request URL: ${url}`);
     });
-    const destroy = vi.fn(async () => {});
+    const nativeStop = createDeferred<void>();
+    const destroy = vi.fn(() => nativeStop.promise);
     const { container } = createContainerDouble({
       containerFetch,
       destroy,
@@ -7246,7 +7248,7 @@ describe("RunnerContainer", () => {
     expect(containerFetch).toHaveBeenCalledOnce();
     expect(abortSettled).toBe(false);
 
-    container.onStop({ exitCode: 0, reason: "exit" });
+    nativeStop.resolve(undefined);
     await expect(abort).resolves.toBe("accepted");
   });
 
@@ -8290,31 +8292,16 @@ describe("RunnerContainer", () => {
     }
   });
 
-  it("waits for a destroyed warm shell to report stopped before cold restart", async () => {
+  it("waits for native destruction before cold restart", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-08T00:00:00.000Z"));
 
     try {
-      const settleRunningObserved = createDeferred<void>();
+      const nativeStop = createDeferred<void>();
       let healthChecks = 0;
-      let statusReads = 0;
-      const getState = vi.fn(async () => {
-        statusReads += 1;
-        if (statusReads === 3) {
-          settleRunningObserved.resolve();
-          return {
-            lastChange: Date.now(),
-            status: "running",
-          };
-        }
-
-        return {
-          lastChange: Date.now(),
-          status: statusReads < 3 ? "running" : "stopped",
-        };
-      });
+      const getState = vi.fn(async () => ({ lastChange: Date.now(), status: "running" }));
       const { container, destroy, startAndWaitForPorts } = createContainerDouble({
-        destroy: vi.fn(async () => {}),
+        destroy: vi.fn(() => nativeStop.promise),
         getState,
         initialStatus: "running",
         startAndWaitForPorts: vi.fn(async () => {}),
@@ -8354,23 +8341,17 @@ describe("RunnerContainer", () => {
         userId: "member_123",
       });
 
-      await settleRunningObserved.promise;
+      await vi.advanceTimersByTimeAsync(1);
+      expect(destroy).toHaveBeenCalledOnce();
       expect(startAndWaitForPorts).not.toHaveBeenCalled();
 
-      await vi.advanceTimersByTimeAsync(250);
+      nativeStop.resolve(undefined);
+      await vi.advanceTimersByTimeAsync(1);
       await expect(invokePromise).resolves.toEqual(createRunnerResult());
 
       expect(destroy).toHaveBeenCalledTimes(1);
       expect(startAndWaitForPorts).toHaveBeenCalledTimes(1);
-      const destroyCompletedLog = mocks.emitHostedExecutionStructuredLog.mock.calls
-        .map(([log]) => log)
-        .find((log) => log.message === "Hosted execution container destroy completed.");
-      expect(destroyCompletedLog?.details).toEqual(expect.objectContaining({
-        destroySettleTimeoutMs: 5_000,
-        lifecycleStage: "destroyed",
-        observedStatusesAfterDestroy: ["running", "stopped"],
-        statusAfterDestroy: "stopped",
-      }));
+      expect(getState).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }
@@ -9219,6 +9200,23 @@ describe("RunnerContainer", () => {
     expect(destroy).toHaveBeenCalledTimes(1);
   });
 
+  it("finishes native destruction without waiting for cached lifecycle status", async () => {
+    vi.useFakeTimers();
+    try {
+      const getState = vi.fn(async () => ({ lastChange: Date.now(), status: "running" }));
+      const { container, destroy } = createContainerDouble({ getState, initialStatus: "running" });
+      let settled = false;
+      const result = container.destroyInstance().then(() => { settled = true; });
+      await vi.advanceTimersByTimeAsync(1);
+      expect(destroy).toHaveBeenCalledOnce();
+      expect(settled).toBe(true);
+      await result;
+      expect(getState).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("waits for explicit destroy to resolve through the native container lifecycle", async () => {
     vi.useFakeTimers();
 
@@ -9315,54 +9313,6 @@ describe("RunnerContainer", () => {
     }
   });
 
-  it("fails closed when destroy resolves but the container never reports stopped", async () => {
-    vi.useFakeTimers();
-
-    try {
-      let status: "running" | "destroying" = "running";
-      const destroy = vi.fn(async () => {
-        status = "destroying";
-        await new Promise<void>((resolve) => setTimeout(resolve, 250));
-      });
-      const getState = vi.fn(async () => ({
-        lastChange: Date.now(),
-        status,
-      }));
-      const { container } = createContainerDouble({
-        destroy,
-        getState,
-        initialStatus: "running",
-      });
-
-      const destroyPromise = container.destroyInstance().catch((error: unknown) => error);
-      await vi.advanceTimersByTimeAsync(5_500);
-
-      await expect(destroyPromise).resolves.toMatchObject({
-        message: "Hosted runner container did not report stopped after destroy.",
-      });
-      expect(destroy).toHaveBeenCalledTimes(1);
-      expect(getState.mock.calls.length).toBeGreaterThan(1);
-      expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
-        expect.objectContaining({
-          component: "container",
-          details: expect.objectContaining({
-            destroySettleTimeoutMs: 5_000,
-            failClosed: true,
-            lifecycleStage: "destroy-settle",
-            observedStatusesAfterDestroy: ["destroying"],
-            statusAfterDestroy: "destroying",
-            statusBeforeDestroy: "running",
-          }),
-          level: "error",
-          message: "Hosted execution container destroy did not settle to stopped.",
-          phase: "failed",
-        }),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   it("fails closed when the destroy request itself never settles", async () => {
     vi.useFakeTimers();
 
@@ -9384,21 +9334,21 @@ describe("RunnerContainer", () => {
       await vi.advanceTimersByTimeAsync(5_500);
 
       await expect(destroyPromise).resolves.toMatchObject({
-        message: "Hosted runner container did not report stopped after destroy.",
+        message: "Hosted runner container failed to destroy cleanly.",
+        cause: { message: "Hosted runner container destruction timed out." },
       });
       expect(destroy).toHaveBeenCalledTimes(1);
-      expect(getState.mock.calls.length).toBeGreaterThan(1);
+      expect(getState).toHaveBeenCalledOnce();
       expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
         expect.objectContaining({
           component: "container",
           details: expect.objectContaining({
-            destroySettleTimeoutMs: 5_000,
             failClosed: true,
-            lifecycleStage: "destroy-settle",
+            lifecycleStage: "destroy",
             statusBeforeDestroy: "running",
           }),
           level: "error",
-          message: "Hosted execution container destroy did not settle to stopped.",
+          message: "Hosted execution container destroy request failed.",
           phase: "failed",
         }),
       );
@@ -9441,62 +9391,6 @@ describe("RunnerContainer", () => {
             lifecycleStage: "status",
           }),
           message: "Hosted execution container failed while checking its lifecycle state.",
-          phase: "failed",
-        }),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("fails closed when destroy settle status reads never settle", async () => {
-    vi.useFakeTimers();
-
-    try {
-      const destroy = vi.fn(async () => {});
-      let statusReadCount = 0;
-      const getState = vi.fn(async () => {
-        statusReadCount += 1;
-        if (statusReadCount === 1) {
-          return {
-            lastChange: Date.now(),
-            status: "running",
-          };
-        }
-
-        await new Promise<void>(() => undefined);
-        return {
-          lastChange: Date.now(),
-          status: "destroying",
-        };
-      });
-      const { container } = createContainerDouble({
-        destroy,
-        getState,
-        initialStatus: "running",
-      });
-
-      const destroyPromise = container.destroyInstance().catch((error: unknown) => error);
-      await vi.advanceTimersByTimeAsync(5_500);
-
-      await expect(destroyPromise).resolves.toMatchObject({
-        message: "Hosted runner container did not report stopped after destroy.",
-      });
-      expect(destroy).toHaveBeenCalledTimes(1);
-      expect(getState.mock.calls.length).toBeGreaterThan(1);
-      expect(mocks.emitHostedExecutionStructuredLog).toHaveBeenCalledWith(
-        expect.objectContaining({
-          component: "container",
-          details: expect.objectContaining({
-            destroySettleTimeoutMs: 5_000,
-            failClosed: true,
-            lifecycleStage: "destroy-settle",
-            observedStatusesAfterDestroy: ["status_error"],
-            statusAfterDestroy: null,
-            statusBeforeDestroy: "running",
-          }),
-          level: "error",
-          message: "Hosted execution container destroy did not settle to stopped.",
           phase: "failed",
         }),
       );
@@ -9556,7 +9450,7 @@ describe("RunnerContainer", () => {
   });
 
   it("fails closed before reusing a warm shell after best-effort cleanup does not settle", async () => {
-    const destroy = vi.fn(async () => {});
+    const destroy = vi.fn(() => new Promise<void>(() => undefined));
     const containerFetch = vi.fn(async (url: string) => {
       if (url.endsWith("/health")) {
         return new Response(JSON.stringify(createRunnerHealthResult()), {
@@ -9602,7 +9496,7 @@ describe("RunnerContainer", () => {
       await vi.advanceTimersByTimeAsync(5_500);
 
       await expect(invokeResult).resolves.toMatchObject({
-        message: "Hosted runner container did not report stopped after destroy.",
+        message: "Hosted runner container failed to destroy cleanly.",
       });
     } finally {
       vi.useRealTimers();

--- a/apps/cloudflare/test/runner-fleet-lifecycle.test.ts
+++ b/apps/cloudflare/test/runner-fleet-lifecycle.test.ts
@@ -312,11 +312,22 @@ describe("native warm retention and terminal retirement", () => {
     assert.equal(calls.start, 0);
   });
 
-  it("never accepts a boolean retirement response in place of an exact terminal receipt", async () => {
-    const { container } = runnerHarness();
+  it("awaits native stop and durable retirement without a binding readback", async () => {
+    const stopped = deferred<void>();
+    const { container, sql } = runnerHarness({ running: true, destroy: () => stopped.promise });
     await container.bindStandbySlot(claimInput());
-    Object.assign(container, { async retireStandbySlot() { return { retired: true }; } });
-    assert.equal((await destroyHostedExecutionContainer({ runnerContainerNamespace: { getByName: () => container }, runnerContainerName: GLOBAL_SLOT, userId: MEMBER })).ok, false);
+    const readBinding = vi.spyOn(container, "readStandbySlotBinding");
+    const store = new RunnerSlotBindingStore(sql);
+    let settled = false;
+    const cleanup = destroyHostedExecutionContainer({ runnerContainerNamespace: { getByName: () => container }, runnerContainerName: GLOBAL_SLOT, userId: MEMBER });
+    void cleanup.then(() => { settled = true; });
+    await vi.waitFor(() => assert.equal(store.read().state, "retiring"));
+    assert.equal(settled, false);
+    stopped.resolve();
+    assert.equal((await cleanup).ok, true);
+    assert.equal(store.read().state, "retired");
+    assert.equal(store.read().userId, null);
+    assert.equal(readBinding.mock.calls.length, 0);
   });
 
   it("rejects new inventory preparation and new binding in the legacy class", async () => {
@@ -730,6 +741,7 @@ describe("fleet allocation policy and ambiguous-outcome recovery", () => {
     assert.equal(first.kind, "ready");
     if (first.kind !== "ready") throw new Error("expected allocation");
     const slot = h.slots.get(first.runnerContainerName)!;
+    slot.setNative(true);
     Object.assign(slot.container, { async getState() { throw new Error("native provider unavailable"); } });
     assert.equal((await h.resolve()).kind, "retry");
     assert.equal((await h.store.readState()).pendingRunnerContainerName, first.runnerContainerName);
@@ -786,6 +798,29 @@ describe("fleet allocation policy and ambiguous-outcome recovery", () => {
     if (replacement.kind !== "ready") throw new Error("expected replacement");
     assert.notEqual(replacement.runnerContainerName, pending);
     assert.equal((await h.slots.get(pending)!.container.readStandbySlotBinding()).state, "retired");
+  });
+
+  it("clears an unbound rejected allocation after retirement without a second binding RPC", async () => {
+    let reads = 0;
+    const h = allocationHarness({
+      mode: "off",
+      async bind(input) {
+        const slot = h.slots.get(input.slotName)!;
+        new RunnerSlotBindingStore(slot.sql).initialize(input);
+        throw new Error("Bind rejected before member assignment");
+      },
+      async read(_input, original) {
+        reads++;
+        if (reads > 1) throw new Error("Redundant retirement readback");
+        return original();
+      },
+    });
+    assert.equal((await h.resolve()).kind, "retry");
+    assert.equal(reads, 1);
+    assert.equal((await h.store.readState()).pendingRunnerContainerName, null);
+    assert.equal(h.slots.size, 1);
+    const slot = [...h.slots.values()][0]!;
+    assert.equal(new RunnerSlotBindingStore(slot.sql).read().state, "retired");
   });
 
   it("requires exact terminal identity before clearing rejected-bind recovery", async () => {

--- a/apps/cloudflare/test/runner-user-data-cleanup.test.ts
+++ b/apps/cloudflare/test/runner-user-data-cleanup.test.ts
@@ -293,7 +293,7 @@ describe("hosted runner user data cleanup", () => {
       ok: true,
     });
     expect(requestedRunnerContainerNames).toEqual([slotName, slotName]);
-    expect(readStandbySlotBinding).toHaveBeenCalledOnce();
+    expect(readStandbySlotBinding).not.toHaveBeenCalled();
     expect(retireStandbySlot).toHaveBeenCalledTimes(2);
     expect(destroyInstance).not.toHaveBeenCalled();
     expect(stateStore.runnerContainerName).toBeNull();

--- a/apps/cloudflare/test/standby-runner.test.ts
+++ b/apps/cloudflare/test/standby-runner.test.ts
@@ -221,10 +221,17 @@ describe("RunnerContainer slot lifecycle", () => {
     expect(harness.renewActivityTimeout).toHaveBeenCalledTimes(2);
 
     harness.setNativeStatus("stopped");
+    const cachedStatus = vi.spyOn(harness.container, "getState").mockClear()
+      .mockRejectedValue(new Error("cached status is unavailable"));
     await expect(harness.container.resolveRetainedStandbySlot(resolution))
       .resolves.toMatchObject({ claimId: null, state: "retired", userId: null });
     await expect(harness.container.readStandbySlotBinding()).resolves
       .toMatchObject({ claimId: null, state: "retired", userId: null });
+    expect(cachedStatus).not.toHaveBeenCalled();
+    expect(harness.destroy).not.toHaveBeenCalled();
+    await expect(harness.container.bindStandbySlot({
+      claimId, releaseId: RELEASE_ID, region: HOSTED_RUNNER_REGION, slotName, userId: "member_123",
+    })).rejects.toThrow();
   });
 
   it("keeps a claimed slot assigned for foreign users or ambiguous liveness", async () => {
@@ -1209,7 +1216,11 @@ function createStandbyContainerHarness(input: {
     return new Response(JSON.stringify({ ok: true }), { status: 200 });
   });
   const slotName = createHostedRunnerSlotName(RELEASE_ID);
-  const container = new RunnerContainer({ ...state, id: { name: slotName } }, {
+  const container = new RunnerContainer({
+    ...state,
+    id: { name: slotName },
+    container: { get running() { return nativeStatus !== "stopped"; } },
+  }, {
     CF_VERSION_METADATA: { id: RELEASE_ID },
     HOSTED_EXECUTION_RUNNER_BUNDLE_FINGERPRINT: BUNDLE_FINGERPRINT,
     HOSTED_EXECUTION_RUNNER_SOURCE_FINGERPRINT: SOURCE_FINGERPRINT,

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1003,7 +1003,41 @@ describe("HostedUserRunner execution coordination", () => {
     expect(readRunnerMeta(sql).active_attempt_id).toBeNull();
   });
 
-  it("releases consent withdrawal after retained standby invocation binding exhausts the command budget", async () => {
+  it("invokes a retained slot using its verified resolution without another binding RPC", async () => {
+    const slotName = `runner--v-release_1--${"d".repeat(32)}`;
+    const binding: HostedStandbySlotBinding = {
+      claimId: "standby-claim-12345678-1234-4123-8123-123456789abc",
+      releaseId: "release_1", region: "GLOBAL", slotName,
+      state: "bound", userId: TEST_USER_ID,
+    };
+    const readBinding = vi.fn(async () => { throw new Error("Redundant binding RPC"); });
+    const resolveRetained = vi.fn(async () => binding);
+    const harness = createRunnerHarness({
+      runnerRuntimeEnvSource: {
+        ...TEST_RUNNER_RUNTIME_ENV_SOURCE,
+        CF_VERSION_METADATA: { id: "release_1" },
+      },
+      runnerContainerStubForName(name, defaultStub) {
+        expect(name).toBe(slotName);
+        defaultStub.readStandbySlotBinding = readBinding;
+        defaultStub.resolveRetainedStandbySlot = resolveRetained;
+        return defaultStub;
+      },
+    });
+    await harness.runner.bindUser(TEST_USER_ID);
+    harness.sql.exec(
+      "UPDATE runner_meta SET active_runner_container_name = ? WHERE singleton = 1", slotName,
+    );
+    await expect(harness.runner.ensureRuntimeProcessingForUser({
+      userId: TEST_USER_ID, orchestrationAttemptId: "retained-start",
+    })).resolves.toMatchObject({ kind: "runtime_processing_accepted" });
+    await harness.flushWaitUntil();
+    expect(resolveRetained).toHaveBeenCalledOnce();
+    expect(readBinding).not.toHaveBeenCalled();
+    expect(harness.invoke).toHaveBeenCalledOnce();
+  });
+
+  it("releases consent withdrawal after retained standby resolution exhausts the command budget", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));
     let consentState: "granted" | "revoked" = "granted";
@@ -1030,11 +1064,11 @@ describe("HostedUserRunner execution coordination", () => {
       binding = { ...input, state: "bound" };
       return { ...input, bound: true as const };
     });
-    const resolveRetainedStandbySlot = vi.fn(async () => binding);
-    const invocationBindingRead = vi.fn(async () => {
+    const resolveRetainedStandbySlot = vi.fn(async () => {
       bindingReadStarted.resolve(undefined);
       return await new Promise<HostedStandbySlotBinding>(() => {});
     });
+    const invocationBindingRead = vi.fn(async () => binding);
     const retireStandbySlot = vi.fn(async (input: Parameters<NonNullable<HostedExecutionContainerStubLike["retireStandbySlot"]>>[0]) => {
       expect(input).toEqual({ target: { slotName, userId: TEST_USER_ID } });
       retirementStarted.resolve(undefined);
@@ -1107,7 +1141,7 @@ describe("HostedUserRunner execution coordination", () => {
       standbyCoordinatorNamespace,
     });
     await harness.runner.bindUser(TEST_USER_ID);
-    // Retained targets still require a fresh binding read during preparation.
+    // The required retained-owner resolution shares the command budget.
     harness.sql.exec(
       "UPDATE runner_meta SET active_runner_container_name = ? WHERE singleton = 1",
       slotName,
@@ -1157,8 +1191,8 @@ describe("HostedUserRunner execution coordination", () => {
     expect(claimReadyStandby).not.toHaveBeenCalled();
     expect(bindStandbySlot).not.toHaveBeenCalled();
     expect(resolveRetainedStandbySlot).toHaveBeenCalledOnce();
-    expect(invocationBindingRead).toHaveBeenCalledOnce();
-    expect(cleanupBindingRead).toHaveBeenCalledOnce();
+    expect(invocationBindingRead).not.toHaveBeenCalled();
+    expect(cleanupBindingRead).not.toHaveBeenCalled();
     expect(retireStandbySlot).toHaveBeenCalledOnce();
     expect(readActiveRunnerContainerNameForTest(harness.sql)).toBeNull();
   });
@@ -1270,7 +1304,7 @@ describe("HostedUserRunner execution coordination", () => {
     });
 
     expect(harness.runnerContainerNames).toEqual([slotName]);
-    expect(readStandbySlotBinding).toHaveBeenCalledOnce();
+    expect(readStandbySlotBinding).not.toHaveBeenCalled();
     expect(retireStandbySlot).toHaveBeenCalledOnce();
     expect(destroyInstance).not.toHaveBeenCalled();
     expect(readActiveRunnerContainerNameForTest(sql)).toBeNull();

--- a/apps/web/changelog/entries/2026-09-09/conversation-restart-wait.json
+++ b/apps/web/changelog/entries/2026-09-09/conversation-restart-wait.json
@@ -8,7 +8,12 @@
     "title": "Less waiting when a conversation restarts",
     "summary": "Murph can begin processing your next message sooner after a previous session has stopped.",
     "details": "Removes an extra wait during session cleanup while preserving recovery when a session cannot close safely.",
-    "relevanceTags": ["messaging", "reliability"],
-    "sourcePullRequests": []
+    "relevanceTags": [
+      "messaging",
+      "reliability"
+    ],
+    "sourcePullRequests": [
+      3104
+    ]
   }
 }

--- a/apps/web/changelog/entries/2026-09-09/conversation-restart-wait.json
+++ b/apps/web/changelog/entries/2026-09-09/conversation-restart-wait.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-09",
+  "order": 100,
+  "item": {
+    "id": "conversation-restart-wait",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Less waiting when a conversation restarts",
+    "summary": "Murph can begin processing your next message sooner after a previous session has stopped.",
+    "details": "Removes an extra wait during session cleanup while preserving recovery when a session cannot close safely.",
+    "relevanceTags": ["messaging", "reliability"],
+    "sourcePullRequests": []
+  }
+}


### PR DESCRIPTION
## Why and outcome

Runner handoff waited for cached lifecycle status after native destruction had already completed. It also reread immutable binding evidence immediately after the slot owner had verified it or acknowledged terminal retirement.

Use native destruction as the stop receipt, reuse the retained-resolution binding receipt, and remove retirement readbacks. This removes a poller, stop observers, and three redundant RPCs without adding state or dependencies.

## Product UX

- Effort: Patch.
- Result: Ready at the tested runtime boundary; deployed latency remains unmeasured.
- Walkthrough: Members starting another conversation turn avoid redundant handoff work. Warm retention, failure recovery, consent withdrawal, and account deletion preserve their ownership and cleanup requirements.

## Evidence

- Direct: 359 lifecycle/fleet/standby tests pass, including stale cached status after completed destruction, delayed native stop, rejected-bind recovery with a second read disabled, foreign ownership, and retirement fencing. 270 fleet/UserRunner/deletion tests passed before the final additional recovery test; retained invocation succeeds with its redundant binding RPC disabled. Seven tests exercise the pinned Containers SDK directly. Ten changelog rendering tests pass.
- Coverage: Actual lifecycle, binding store, SQLite state, controller, and invocation owners are exercised with narrow injected transport boundaries. Cloudflare and Web typechecks pass. This proves call removal and cleanup ordering, without claiming live provider latency.
- Commands: `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts <focused test files> --no-coverage --testTimeout=15000`; `pnpm exec vitest run --config apps/cloudflare/vitest.containers-helper.config.ts --no-coverage`; `pnpm --dir apps/cloudflare typecheck`; `pnpm --dir apps/web typecheck`; `pnpm --dir apps/web test -- changelog-page.test.tsx`.

- Review: ReviewGPT round 1 PASS on `5ac681765e2320b2b2b0fd39f5f3ead638c702cc`; concrete `gpt-6-pro` capture verified after approximately six minutes. No accepted findings. The later commit only closes this plan and records test friction; runtime source is identical.
- CI: The reviewed head passed full Cloudflare verification. One unchanged browser-vault test timed out in the Web shard and passed in an isolated local reproduction; Frog records the evidence. All final-head checks pass on `d07a894d1b493bf8522182c62239e556efa746f0` (32 successful, three intentional skips), including required release verification. The previously failing Web shard passes. Current-main merge-tree is clean.

## Non-obvious affected surfaces

Consent withdrawal and account deletion still await successful native stop and durable retirement; failure preserves the target and data. Abort, smoke readiness, delayed callbacks, replacement generations, timeout, and warm reuse retain lifecycle regression coverage. An unavailable cached status no longer blocks an explicitly stopped native container.

## Architecture and reuse

- Existing systems reused: Native container destruction, the lifecycle lock and deadline, immutable slot binding, durable retirement, UserRunner reservation, and the existing request-local verified binding receipt.
- New logic: Retained resolution returns its verified binding to preparation; cleanup trusts the addressed owner's terminal acknowledgement. Missing-container handling and timeout remain bounded.
- New abstractions: None. Remove stop observers, the destruction settlement poller, and a trivial error wrapper.
- Complexity intentionally avoided: No extra cache, scheduler, retry layer, schema, deployment flag, dependency, or credential path.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; runner-container debt 75 to 69. Other changed source files have unchanged debt.
- Hotspots: `wakeRuntime` 74, `ensureContainerReady` 30, `classifyHostedRunnerContainerErrorResponse` 24, `invokeHostedExecution` 21, `prepareWithInputs` 24, `prepareWorkspaceRunnerInvocation` 23, and `ensureExistingRuntimeProcessing` 25 are unchanged. Their admission, failure recovery, and readiness decisions establish different facts from the removed readbacks.
- Agent judgment: The redundant settlement owner and readbacks are removed. Collapsing the remaining recovery/readiness branches requires a separate demonstrated equivalence; it would expand this bounded change.

## Hot reply path impact

- Path status: Touched during startup and prior-target reconciliation.
- Database calls: None added or moved onto the path. Removes cached Durable Object lifecycle reads after destruction and for explicitly stopped native containers.
- Network/provider calls: None added. Removes one serial binding RPC per retained preparation, one per successful exact-target retirement, and one per unbound rejected-bind recovery. These are separate branches, not three calls guaranteed on every turn. Binding recovery after an ambiguous failure still reads once. No provider calls change.
- Other awaited latency: Removes destruction status polling and stop-observer waits. Native destruction remains awaited under the existing deadline; rejection/timeout fails closed. No added retries or fallback.
- Before/after proof: Stale-status regression failed before the destruction change and now completes after native destruction. Composed tests disable redundant binding RPCs and prove retained invocation and durable cleanup still succeed. Native stopped retirement performs zero cached status reads. Actual latency savings depend on the branch and deployment.

## Murph initial provider input impact

Not applicable for individual or group Murph: no prompts, tools, schemas, messages, or provider-input builders change.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Design proof

- Design page: [Changelog archive](https://www.withmurph.ai/screenshots/ops#changelog-archive).
- Evidence: Content-only entry uses the existing archive renderer; ten rendering tests pass and the production reference is reachable.
- Coverage: No component, layout, style, or interaction changes; follows the changelog content-only no-preview route.

ReviewGPT first-reviewed head: 5ac681765e2320b2b2b0fd39f5f3ead638c702cc
ReviewGPT context sensitivity: sensitive
Classification reason: Hosted execution cleanup, concurrency, and member-binding authority.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing Worker and container RPC shapes and durable records remain unchanged. The deployed retirement owner already acknowledges only after destruction and scrubbing; retained resolution already returns the complete binding.
- Safe order: Ordinary Cloudflare rollout; no Web or Temporal sequencing required.
- Rollback floor: Current base remains compatible with all records and RPCs produced by this patch.
- Expected exposure: Requests encountering cleanup or retained-slot startup during rollout use their owner's implementation.
- Reversibility: Reverting source restores redundant waits/readbacks without data migration; no rollout or rollback is performed by this PR.
- Convergence proof: Source inspection confirms unchanged RPC/store shapes and existing terminal acknowledgement ordering; actual pinned SDK test confirms destroy delegates to the native completion promise. Fleet tests cover prior-release warm retention, exact member authority, and retirement failure.
- Post-deploy checks: Compare bounded startup/typing latency distributions and cleanup failure aggregates; verify foreign-owner, duplicate-start, and retirement failures remain absent.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source; test files are tests; Markdown is docs; the authored changelog JSON is other. No binary or generated files. 

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 60 | 289 |
| Tests / fixtures | 156 | 162 |
| Docs | 141 | 14 |
| Config / tooling | 0 | 0 |
| Generated / other | 19 | 0 |
| **Total** | **376** | **465** |

## Changelog

- Changelog: updated
- Items: 2026-09-09 · conversation-restart-wait
