### PR TITLE
fix(assistant): clarify member workspace troubleshooting scope

### DIFF
--- a/agent-docs/PRODUCT_SENSE.md
+++ b/agent-docs/PRODUCT_SENSE.md
@@ -1,6 +1,6 @@
 # Product Sense
 
-Last verified: 2026-08-11
+Last verified: 2026-09-09
 
 ## Current Posture
 
@@ -12,7 +12,8 @@ Last verified: 2026-08-11
   A professional subject does not turn study into professional work. Murph
   answers directly without requiring hypothetical or practice framing or adding
   a school/professional-scope disclaimer. Production code, client deliverables,
-  and operational work remain outside scope.
+  and unrelated operational work remain outside scope. Read-only troubleshooting
+  of Murph using non-secret diagnostics in the current member workspace is in scope.
 - General model capability is the substrate. Murph's compounding advantage is
   longitudinal member context: relevant history, evidence, preferences,
   constraints, goals, actions, and outcomes that it can retrieve when they

--- a/agent-docs/exec-plans/active/2026-09-09-member-runtime-troubleshooting.md
+++ b/agent-docs/exec-plans/active/2026-09-09-member-runtime-troubleshooting.md
@@ -1,0 +1,13 @@
+# Member runtime troubleshooting
+
+Outcome: Murph answers authorized read-only questions about its current member workspace without inventing a confidentiality restriction.
+Reaches: Private member troubleshooting; existing group, credential, and external-system boundaries remain owned by their current policies.
+Proof: Focused real-Codex Terra reproduction, composed-prompt assertions, package typecheck, and exact-head CI.
+
+- [x] Run synthetic diagnostics against the existing prompt. Three live Terra cases passed; the exact reported refusal was not reproduced. The scope wording remained ambiguous about Murph troubleshooting.
+- [x] Clarify the existing direct scope paragraph. Composed-prompt checks and the same live Terra journey pass; group guidance is unchanged.
+- [ ] Review, publish the scoped change, and verify delivery status.
+
+Provider-input evidence: real native mixed-mode capture with identical base/head fixtures; o200k_base tokenization of the complete serialized model-visible request. Excluded transport cache key, client metadata, and item IDs; normalized temporary roots. Individual: 29,180 to 29,202 tokens (+22; +0.0754%), 134,940 to 135,075 bytes (+135). Group: 24,750 tokens and 114,747 bytes unchanged. Temporary capture code was removed.
+
+Verification: 101 focused Assistant Engine tests, Assistant Engine typecheck, and 10 changelog rendering tests pass. Complexity is unchanged; the existing prompt-builder hotspots have no new branches. Final external review is not routed: this is prompt-primary work using existing workspace authority, with no permission, transport, credential, or state-owner change.

--- a/agent-docs/exec-plans/completed/2026-09-09-member-runtime-troubleshooting.md
+++ b/agent-docs/exec-plans/completed/2026-09-09-member-runtime-troubleshooting.md
@@ -6,8 +6,13 @@ Proof: Focused real-Codex Terra reproduction, composed-prompt assertions, packag
 
 - [x] Run synthetic diagnostics against the existing prompt. Three live Terra cases passed; the exact reported refusal was not reproduced. The scope wording remained ambiguous about Murph troubleshooting.
 - [x] Clarify the existing direct scope paragraph. Composed-prompt checks and the same live Terra journey pass; group guidance is unchanged.
-- [ ] Review, publish the scoped change, and verify delivery status.
+- [x] Review and publish the candidate with focused verification evidence.
 
 Provider-input evidence: real native mixed-mode capture with identical base/head fixtures; o200k_base tokenization of the complete serialized model-visible request. Excluded transport cache key, client metadata, and item IDs; normalized temporary roots. Individual: 29,180 to 29,202 tokens (+22; +0.0754%), 134,940 to 135,075 bytes (+135). Group: 24,750 tokens and 114,747 bytes unchanged. Temporary capture code was removed.
 
 Verification: 101 focused Assistant Engine tests, Assistant Engine typecheck, and 10 changelog rendering tests pass. Complexity is unchanged; the existing prompt-builder hotspots have no new branches. Final external review is not routed: this is prompt-primary work using existing workspace authority, with no permission, transport, credential, or state-owner change.
+
+Delivery tracking: PR #3106 owns remaining exact-head CI, merge, and ordinary runner deployment. These are pending at plan closure; local implementation and verification are complete. Final Terra effect assertions pass with no dynamic tool calls, no media/card output, and unchanged diagnostic content.
+Status: completed
+Updated: 2026-09-09
+Completed: 2026-09-09

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -52,7 +52,7 @@ not a guarantee that every claim was checked in this cleanup.
 | `docs/health-data-incident-runbook.md` | Engineering runbook for suspected health-data incidents, consent bypasses, vendor incidents, and tracking disclosures. | Health-data incident response | High | 2026-08-05 |
 | `docs/templates/README.md` | Entry points for reusable device-provider templates. | Template inventory | Low | 2026-04-03 |
 | `agent-docs/strategy.md` | Current product strategy. | Current product strategy | High | 2026-07-15 |
-| `agent-docs/PRODUCT_SENSE.md` | Current product posture for a broad personal health assistant. | Current product behavior | High | 2026-08-13 |
+| `agent-docs/PRODUCT_SENSE.md` | Product posture, scope, and member workspace troubleshooting. | Current product behavior | High | 2026-09-09 |
 | `agent-docs/PRODUCT_CONSTITUTION.md` | Internal product constitution and tradeoff rules. | Product principles | High | 2026-07-15 |
 | `agent-docs/FRONTEND.md` | Frontend implementation guidance for `apps/web`. | Current frontend implementation guidance | Medium | 2026-08-31 |
 | `agent-docs/product-marketing-context.md` | Product/marketing decisions. | Product/marketing decisions | High | 2026-07-15 |

--- a/apps/web/changelog/entries/2026-09-09/murph-workspace-troubleshooting.json
+++ b/apps/web/changelog/entries/2026-09-09/murph-workspace-troubleshooting.json
@@ -8,7 +8,12 @@
     "title": "Clearer Murph troubleshooting",
     "summary": "In private chat, Murph can inspect available diagnostic information when you ask about a problem with your account.",
     "details": "Troubleshooting reads relevant status information without changing your data. Credentials and information outside your workspace remain protected.",
-    "relevanceTags": ["assistant", "reliability"],
-    "sourcePullRequests": []
+    "relevanceTags": [
+      "assistant",
+      "reliability"
+    ],
+    "sourcePullRequests": [
+      3106
+    ]
   }
 }

--- a/apps/web/changelog/entries/2026-09-09/murph-workspace-troubleshooting.json
+++ b/apps/web/changelog/entries/2026-09-09/murph-workspace-troubleshooting.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-09",
+  "order": 100,
+  "item": {
+    "id": "murph-workspace-troubleshooting",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Clearer Murph troubleshooting",
+    "summary": "In private chat, Murph can inspect available diagnostic information when you ask about a problem with your account.",
+    "details": "Troubleshooting reads relevant status information without changing your data. Credentials and information outside your workspace remain protected.",
+    "relevanceTags": ["assistant", "reliability"],
+    "sourcePullRequests": []
+  }
+}

--- a/packages/assistant-engine/src/assistant/system-prompt.ts
+++ b/packages/assistant-engine/src/assistant/system-prompt.ts
@@ -1296,7 +1296,7 @@ Direct conversation scope:
 Build a user-controlled picture from conversation and authorized evidence so help grows personal and well timed. Returning between messages is a core edge over stateless chatbots. Offer specific reminders, check-ins, monitoring, or follow-ups; once authorized, initiate them when useful.
 
 Scope boundary:
-Use primary purpose, not subject. Own health, schoolwork, Murph setup, records, routines, and context. Answer assignments and educational code directly in professional subjects; no hypothetical/practice or scope disclaimer. Decline only actual professional work—production code, client deliverables, or operations—in one plain sentence; tools do not expand scope.`;
+Use primary purpose, not subject. Own health, schoolwork, Murph setup and troubleshooting, records, routines, and context. Read non-secret diagnostics in the current member workspace, including \`.runtime\`, when asked to troubleshoot Murph. Answer assignments and educational code directly in professional subjects; no hypothetical/practice or scope disclaimer. Decline unrelated professional work—production code, client deliverables, or operations—in one plain sentence; tools do not expand scope.`;
 }
 
 function buildAssistantGroupIdentityAndScopeText(): string {

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -15523,6 +15523,64 @@ describeRealCodex('real Codex connected health record awareness e2e', () => {
   )
 })
 
+describeRealCodex('real Codex member runtime troubleshooting e2e', () => {
+  it('reads member runtime diagnostics without inventing a confidentiality refusal', async () => {
+    const config = await resolveRealCodexE2eConfig()
+    const workingDirectory = await mkdtemp(
+      path.join(tmpdir(), 'murph-member-runtime-troubleshooting-e2e-'),
+    )
+    const relativePath = '.runtime/operations/assistant/hosted-system-mailbox.json'
+    const diagnosticPath = path.join(workingDirectory, relativePath)
+    const diagnostic = `${JSON.stringify({
+      observedAt: '2026-06-15T08:12:00.000Z',
+      releaseRevision: 'synthetic-build-c47d2e',
+      jobs: [{ kind: 'reminder-retry', status: 'waiting', attemptCount: 4 }],
+    })}\n`
+    try {
+      await mkdir(path.dirname(diagnosticPath), { recursive: true })
+      await writeFile(diagnosticPath, diagnostic, 'utf8')
+      const result = await executeRealCodexAppServerTurn({
+        approvalPolicy: 'never',
+        baseInstructions: MURPH_CODEX_BASE_INSTRUCTIONS,
+        codexCommand: normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND) ?? undefined,
+        codexHome: config.codexHome,
+        developerInstructions: buildDirectConversationDeveloperInstructions(),
+        env: config.env,
+        excludeResumeTurns: true,
+        model: config.model,
+        modelProvider: config.modelProvider,
+        prompt: [
+          'I need a technical diagnostic of your background execution machinery, not my saved reminders.',
+          'Find your internal system-mailbox runtime state and release metadata. Report pending work status, retry count, build revision, and observation time.',
+          'Leave all files unchanged. Do not contact anyone or inspect credentials.',
+        ].join(' '),
+        reasoningEffort: 'low',
+        sandbox: 'workspace-write',
+        workingDirectory,
+      })
+      const actions = readCapabilityRoutingActions(result.jsonEvents)
+      process.stdout.write(`[member-runtime-troubleshooting-e2e] ${JSON.stringify({
+        reply: result.finalMessage.replaceAll(workingDirectory, '<workspace>'),
+        commandCount: actions.filter((action) => action.kind === 'command').length,
+      })}\n`)
+      expect(result.finalMessage).toContain('waiting')
+      expect(result.finalMessage).toContain('4')
+      expect(result.finalMessage).toContain('synthetic-build-c47d2e')
+      expect(result.finalMessage).toMatch(/08:12|8:12|4:12/u)
+      expect(result.finalMessage).not.toMatch(/(?:protected|confidential) (?:runtime|internal)|cannot disclose|can’t disclose|can't disclose/iu)
+      expect(result.finalMessage).not.toMatch(/(?:I|we)(?: have|'ve)? (?:fixed|restarted|rescheduled|repaired)/iu)
+      expect(actions.some((action) => action.kind === 'command')).toBe(true)
+      expect(actions.filter((action) => action.kind !== 'command')).toEqual([])
+      expect(result.responseCard).toBeNull()
+      expect(result.responseMedia).toEqual([])
+      await expect(readFile(diagnosticPath, 'utf8')).resolves.toBe(diagnostic)
+    } finally {
+      await removeRealCodexTemporaryPath(workingDirectory)
+      await removeRealCodexTemporaryPaths(config.temporaryPaths)
+    }
+  }, 720_000)
+})
+
 describeRealCodex('real Codex direct operator diagnostic e2e', () => {
   it(
     'correlates runtime and hosted session evidence without changing canonical state',

--- a/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-turn-planning.test.ts
@@ -398,11 +398,11 @@ describe('assistant Codex turn planning', () => {
       Object.entries(plans).map(([name, plan]) => [name, digestPlan(plan)]),
     )).toMatchInlineSnapshot(`
       {
-        "direct": "1850209a189bda532fe5272e4aafbd2e122d2404140273424346b9aa43370d17",
+        "direct": "757568d3540567e1636768d073f456bdf2a41cde31565d7e31a6e3c061a31cf1",
         "group": "054070d3529e0550288c4393ac6bc943e8179587bc4977b2dbfc6e03d40c2918",
         "maintenance": "4c439dbf05ccb6d2cd7540b1ef7f94c99e898afd9b9658abefa860a8b421ca55",
         "outputOnly": "a83a04afea06e5290de36b14a0fee5d18970077a8294dde129b2e2dfa99116b4",
-        "scheduledEmail": "87b7d6dec8893b580661042790108d69297b020bcaf98dde070b05df7024efb4",
+        "scheduledEmail": "a0115a2444bc2e56bc1c413fc02af91731685cf17a2a2a767432416a80bfbe06",
       }
     `)
   })

--- a/packages/assistant-engine/test/assistant-resolve-before-asking-prompt.test.ts
+++ b/packages/assistant-engine/test/assistant-resolve-before-asking-prompt.test.ts
@@ -42,6 +42,16 @@ describe('assistant resolve-before-asking guidance', () => {
     )
   })
 
+  it('allows private Murph troubleshooting without expanding other audiences', () => {
+    const direct = buildPrompt('direct')
+    expect(direct).toContain('Murph setup and troubleshooting')
+    expect(direct).toContain('Read non-secret diagnostics in the current member workspace, including `.runtime`, when asked to troubleshoot Murph.')
+    expect(direct).not.toContain('Decline only actual professional work—production code, client deliverables, or operations—')
+    for (const scope of ['group', 'unverified-external'] as const) {
+      expect(buildPrompt(scope)).not.toContain('Read non-secret diagnostics in the current member workspace')
+    }
+  })
+
   it('keeps group resolution within the canonical shared-source boundary', () => {
     const prompt = buildPrompt('group')
 

--- a/packages/assistant-engine/test/model-behavior.test.ts
+++ b/packages/assistant-engine/test/model-behavior.test.ts
@@ -622,13 +622,13 @@ describe('assistant execution prompt contract', () => {
       'Answer assignments and educational code directly in professional subjects; no hypothetical/practice or scope disclaimer.',
     )
     expect(prompt).toContain(
-      'Decline only actual professional work—production code, client deliverables, or operations—in one plain sentence',
+      'Decline unrelated professional work—production code, client deliverables, or operations—in one plain sentence',
     )
     expect(prompt).toContain(
       'tools do not expand scope',
     )
     expect(prompt).toContain(
-      'Own health, schoolwork, Murph setup, records, routines, and context.',
+      'Own health, schoolwork, Murph setup and troubleshooting, records, routines, and context.',
     )
     expect(prompt).not.toContain('unrelated work/school tasks')
   })
@@ -2561,7 +2561,7 @@ describe('assistant system prompt cache stability', () => {
       'Current Murph product base URL for user-facing app links: http://localhost:3000',
     )
     expect(promptA.cacheMetadata.staticPromptHash).toBe(
-      '342590e44e893ca097ebc908bf949d1bf4fcfea408107cd9f0edbc4fa327fd79',
+      '917dbe9fa7eef01764f01d66e7a43914cdf0b943b8c76d89f6e51ccb7e8b7a0b',
     )
     expect(promptA.cacheMetadata.toolSchemaHash).toBe(
       'assistant-tool-schema-common-codex-test',


### PR DESCRIPTION
## Why and outcome

The private conversation scope classified operational work as out of scope without distinguishing Murph troubleshooting. Clarify that existing paragraph so a member can request read-only, non-secret diagnostics from the current workspace, including runtime state. Unrelated professional work remains outside scope.

This is a wording clarification. Three synthetic baseline Terra journeys already succeeded, so they did not reproduce the reported refusal or prove a single causal prompt clause. The final journey verifies the intended behavior explicitly.

## Product UX

- Effort: Patch.
- Result: Ready.
- Walkthrough: A private member requests internal scheduler diagnostics; Murph locates and reads synthetic state, returns exact status, attempt count, build revision, and observation time, and leaves the file unchanged. Group and unverified-external guidance do not receive this instruction. No new tool, permission profile, or diagnostic service is added.

## Evidence

- Direct: `pnpm test:assistant:live -- --test "reads member runtime diagnostics without inventing a confidentiality refusal"`; `gpt-5.6-terra`, local subscription. Baseline and corrected production prompts exercised with synthetic files. Final tool/effect and reply review: Ready.
- Coverage: 205 focused tests across `assistant-resolve-before-asking-prompt.test.ts`, `codex-thread-instructions.test.ts`, `model-behavior.test.ts`, and `assistant-codex-turn-planning.test.ts`; Assistant Engine typecheck; 10 changelog rendering tests. Docs drift and gardening checked. Required exact-head CI passed on `10bb86d81c5b2a904586ab47d5a8ede50a10c3c4`, including the full release suite.
- The static prompt and route-plan fingerprints are updated for the intentional wording change. The first CI run passed 4,758 tests and identified one stale route-plan snapshot; only its direct and scheduled-email digests changed. All 104 route-planning tests now pass locally; group, maintenance, and output-only digests remain unchanged.

## Non-obvious affected surfaces

The product-scope owner and its index row reflect the clarification. Existing group and unverified audience restrictions remain covered by composed-prompt tests.

## Architecture and reuse

- Existing systems reused: Direct scope paragraph, current workspace reads, existing native Codex test harness, and changelog fragments.
- New logic: No runtime branches; explicit troubleshooting scope in existing prose.
- New abstractions: None; the existing scope paragraph and workspace read path already own this behavior.
- Complexity intentionally avoided: No diagnostic API, permission profile, policy framework, or persisted state.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`.
- Hotspots: Existing `buildStableRouteCapabilityPrompt` (28) and `buildAssistantHostedGroupGuidanceText` (25) are unchanged.
- Agent judgment: The changed scope function adds no branches. Further refactoring would expand this text change unnecessarily.

## Hot reply path impact

- Path status: Prompt wording only.
- Database calls: None added.
- Network/provider calls: None added by runtime code.
- Other awaited latency: None added.
- Before/after proof: Complete native provider-input capture below; the live diagnostic uses existing filesystem reads only.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | 29180 | 29202 | +22 | +0.0754% | 134940 | 135075 | +135 |
| Group Murph | 24750 | 24750 | 0 | 0% | 114747 | 114747 | 0 |

Method: Identical synthetic base/head fixtures through production prompt builders, real native mixed-mode Codex conversion, and the existing loopback capture owner. Tokenized complete serialized model-visible JSON with o200k_base. Includes instructions, messages, native tools, dynamic-tool metadata, and generated guidance. Excludes transport-only `prompt_cache_key`, `client_metadata`, and input item IDs; temporary roots normalized. These are serialized-input measurements, not billed usage. Temporary measurement code was removed.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: Content-only fragment readback and 10 passing production archive rendering tests.
- Coverage: Existing changelog presentation; no renderer or layout changes.

## Deployment concerns

- Deployment: not applicable
- Reason: No protocol, state, permission, or configuration change. The prompt ships through the ordinary runner build and deployment path.

## Change-shape breakdown

Classification rule: Runtime prompt as source, test files as tests, product/index/plan and changelog copy as docs. No binaries or generated artifacts retained.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 1 | 1 |
| Tests / fixtures | 73 | 5 |
| Docs | 41 | 3 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **115** | **9** |

## Changelog

- Changelog: updated
- Items: 2026-09-09 · murph-workspace-troubleshooting
