### PR TITLE
perf(device-sync): drop continuation-only source reads

### DIFF
--- a/.agents/friction-log/20260909134145-chromium-ci-bootstrap/friction.md
+++ b/.agents/friction-log/20260909134145-chromium-ci-bootstrap/friction.md
@@ -1,0 +1,26 @@
+---
+title: 'Chromium CI bootstrap fails on an unrelated Chrome package index'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The repository Chromium bootstrap should install Playwright's required operating-system dependencies without depending on unrelated third-party package indexes bundled into a hosted runner image.
+
+## Current Behavior
+
+The viewport workflow repeatedly stops during dependency installation when the Chrome APT repository publishes inconsistent package-index hashes. Browser tests never start, including on a retry of the same candidate.
+
+## Possible Solution
+
+Keep dependency installation scoped to the distribution repositories required by Playwright. Avoid refreshing unrelated third-party indexes during browser-test setup.
+
+## Minimal Reproducible Example
+
+1. Run the repository viewport workflow on a hosted Ubuntu runner whose image includes the third-party Chrome APT repository.
+2. During an inconsistent index publication, invoke `scripts/install-playwright-chromium.sh`.
+3. Dependency installation fails before Chromium download or the viewport assertions run.
+
+## Context
+
+This produces a failed browser check for backend-only candidates despite the failure occurring entirely in dependency bootstrap. A same-head retry reproduced the failure; no application source change was involved.

--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -1995,12 +1995,16 @@ Last verified: 2026-09-04
   capabilities, not health samples. One fresh post-discovery source snapshot
   governs both local projection and admission before the health-data request;
   it also catches revocations newer than the hydrated local state. Import and
-  post-import progress retain their existing fresh source checks.
+  terminal progress retain their existing fresh source checks. Intermediate
+  precise-history segments omit reads used only to queue an epoch-bound
+  continuation: empty segments skip the post-fetch read, while imported segments
+  skip the post-import read. Each continuation must pass fresh admission before
+  fetching health data; see `../docs/device-sync-hosted-control-plane.md`.
 - Junction summary and workout import preparation share their fresh post-provider
   source read with historical evidence evaluation through pure admission helpers.
-  Empty historical segments retain their post-fetch authority without a second
-  read; actual canonical imports still recheck authority afterward. Reads are
-  never reused across provider fetches, stream candidates, or job executions.
+  Terminal historical segments retain post-fetch authority and recheck after an
+  actual canonical import. Reads are never reused across provider fetches,
+  stream candidates, or job executions.
 - Junction workout streams stay inside that existing resource/day continuation
   owner. Before the workout index, the existing control-plane current-import
   admission predicate intersects with the current Junction provider inventory

--- a/agent-docs/exec-plans/active/2026-09-09-vercel-request-reduction.md
+++ b/agent-docs/exec-plans/active/2026-09-09-vercel-request-reduction.md
@@ -1,0 +1,59 @@
+# Remove unnecessary hosted control-plane requests
+
+Status: active
+Created: 2026-09-09
+Updated: 2026-09-09
+
+## Goal and protected boundary
+
+Remove avoidable hosted source reads while preserving source revocation,
+canonical import admission, terminal coverage, and foreground yielding.
+Production request reduction must be distinguished from synthetic call counts.
+
+## Implementation
+
+- Intermediate empty precise-history segments skip the post-fetch source read;
+  successful intermediate imports skip the post-import read. Both only queue
+  an existing epoch-bound continuation, which must pass fresh admission again.
+- Terminal segments retain their checks. No authorization cache, new service,
+  state owner, wire contract, checkpoint behavior, or history-depth change.
+- Replace the precise-import function's single-element resource list with a
+  scalar resource; delete its redundant loop, arity checks, and chunk helper.
+- Derive total source reads from all collected job timings in the existing
+  finished-pass log, before the slowest-job sample is selected. This adds no
+  requests and is measurement only.
+
+## Evidence and review
+
+- [x] Verify and merge the preceding source-read simplification.
+- [x] Obtain and inspect Pro's implementation patch against current source.
+- [x] Preserve continuation identity and source fences through SQLite restarts.
+- [x] Run 159 source-admission/reuse/provider tests and 16 focused service/store tests.
+- [x] Run the focused full-total versus sampled-timing regression.
+- [x] Pass device-syncd and assistant-runtime typechecks on the final code.
+- [x] Pass complexity diff: Junction debt 406 to 405; precise import 42 to 41;
+  maintenance debt remains 105. Other changed-file hotspots are unchanged.
+- [x] Parent candidate review: privacy, source ownership, terminal boundaries,
+  scalar-resource equivalence, restart fencing, and current wire compatibility.
+- [ ] Final exact-head ReviewGPT, required CI, final parent review, and merge.
+
+## Limits and release
+
+Synthetic consecutive segments prove one removed snapshot lookup per qualifying
+intermediate segment. Do not extrapolate slowest-job samples to the full workload
+or count already-merged savings twice. A matched deployed observation must confirm
+net request volume: saved time may allow a bounded pass to process more history.
+
+Runtime-only behavior and a diagnostic JSON field preserve existing Web/Worker
+contracts and persisted continuation payloads. Old and new runtimes can consume
+the same queued jobs. Deploy through the existing runtime release pipeline and
+confirm the serving revision before measuring source reads and total requests.
+
+The managed download rejected its own capture identity due to the existing
+rendered-text normalization issue tracked by repository Frog entry
+`20260826141410-reviewgpt-detached-wake`. Recovery verified exact user/assistant
+message IDs, response equivalence apart from the language badge, model, and the
+sole artifact before downloading. No prompt was resent.
+
+Changelog: internal request overhead and diagnostic accuracy; no new member-facing
+feature, action, or promised sync freshness change.

--- a/agent-docs/exec-plans/completed/2026-09-09-vercel-request-reduction.md
+++ b/agent-docs/exec-plans/completed/2026-09-09-vercel-request-reduction.md
@@ -1,6 +1,6 @@
 # Remove unnecessary hosted control-plane requests
 
-Status: active
+Status: completed
 Created: 2026-09-09
 Updated: 2026-09-09
 
@@ -35,7 +35,11 @@ Production request reduction must be distinguished from synthetic call counts.
   maintenance debt remains 105. Other changed-file hotspots are unchanged.
 - [x] Parent candidate review: privacy, source ownership, terminal boundaries,
   scalar-resource equivalence, restart fencing, and current wire compatibility.
-- [ ] Final exact-head ReviewGPT, required CI, final parent review, and merge.
+- [x] Final ReviewGPT PASS on `b5f0be51ac68b2ed47f3c69a2071ce28490891b0`;
+  model attestation and exact-turn capture verified. No qualifying findings.
+- [x] Final parent review confirms the scoped implementation and verification.
+- Release gate: required CI on the final documentation-completion head and an
+  authorized merge remain pending at plan closure. No runtime edits follow review.
 
 ## Limits and release
 
@@ -57,3 +61,10 @@ sole artifact before downloading. No prompt was resent.
 
 Changelog: internal request overhead and diagnostic accuracy; no new member-facing
 feature, action, or promised sync freshness change.
+
+The optional viewport check failed twice during dependency bootstrap because an
+unrelated third-party APT index was inconsistent. Tests did not start. Required
+release checks remain the merge gate; the bootstrap defect is recorded in Frog.
+The production bucket-level request target remains an external measurement gap,
+not a passing result of this implementation plan.
+Completed: 2026-09-09

--- a/docs/device-sync-hosted-control-plane.md
+++ b/docs/device-sync-hosted-control-plane.md
@@ -78,6 +78,22 @@ Local `device-syncd` remains responsible for:
 - normalization and import through `@murphai/importers`
 - all canonical vault writes for wearable data
 
+### Historical source admission
+
+An intermediate Junction precise-history segment that fetched no rows does not
+read source authority again merely to enqueue its continuation. A nonempty
+segment still reads fresh authority after the provider fetch and before canonical
+import, but does not reread it after import merely to enqueue the next segment.
+Neither path publishes terminal history coverage. Continuations preserve their
+source lifecycle epoch, dedupe identity, original window and unresolved evidence;
+they must pass source admission again before fetching the next health segment.
+This holds for local SQLite sources and hosted Web-backed source reads.
+
+Terminal segments retain post-fetch and, when an import occurs, post-import
+source checks. Hosted apply still enforces observed connection/source versions
+and disconnect fences; local completion still uses the existing fenced job/store
+transaction.
+
 ## Trust boundary
 
 ### Hosted boundary

--- a/packages/assistant-runtime/src/hosted-runtime/device-sync-maintenance.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/device-sync-maintenance.ts
@@ -1616,6 +1616,10 @@ function writeHostedDeviceSyncPassLifecycleLog(input: {
               pendingRunningJobCountBefore: queueSnapshotBefore?.runningJobCount ?? null,
               queueSnapshotAfterPresent: queueSnapshotAfter !== null,
               queueSnapshotBeforePresent: queueSnapshotBefore !== null,
+              deviceSyncConnectionSourceReadCount: input.jobTimingDiagnostics.reduce(
+                (total, diagnostic) => total + diagnostic.connectionSourceReadCount,
+                0,
+              ),
               deviceSyncJobTimingCount: input.jobTimingDiagnostics.length,
               deviceSyncJobTimingSampleLimit: HOSTED_DEVICE_SYNC_JOB_TIMING_SAMPLE_LIMIT,
               deviceSyncJobTimingSummaries: jobTimingSummary.summaries,

--- a/packages/assistant-runtime/test/hosted-runtime-linq-audio-e2e.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-linq-audio-e2e.test.ts
@@ -29,7 +29,7 @@ import {
 import {
   saveAssistantAutomationState,
 } from "@murphai/assistant-engine/assistant-state";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   createHostedRuntimeEffectsPortStub,
@@ -86,7 +86,12 @@ import {
 } from "../src/hosted-runtime/events/conversation.ts";
 
 describe("hosted Linq audio conversation ingestion", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
   it("retries without advancing mailbox progress when stop aborts after the parser drain", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-08-26T17:30:00.000Z"));
     const workspaceRoot = await mkdtemp(path.join(tmpdir(), "murph-hosted-linq-audio-abort-"));
     const vaultRoot = path.join(workspaceRoot, "vault");
     const fakeFfmpeg = path.join(workspaceRoot, "fake-ffmpeg");

--- a/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-maintenance.test.ts
@@ -6946,7 +6946,7 @@ describe("runHostedDeviceSyncWakeLane", () => {
     ]);
   });
 
-  it("emits only the 16 slowest device-sync job timings in descending order", async () => {
+  it("totals all source reads while emitting only the 16 slowest job timings", async () => {
     const logRequests: HostedRuntimeLogRequest[] = [];
     const elapsedMsByClaim = [
       3_000,
@@ -6982,7 +6982,7 @@ describe("runHostedDeviceSyncWakeLane", () => {
         at: "2026-04-08T00:00:45.000Z",
         attempts: 1,
         canonicalProgressCommitted: true as const,
-        connectionSourceReadCount: 0,
+        connectionSourceReadCount: elapsedMs / 1_000,
         connectionSourceReadElapsedMs: 0,
         credentialRefreshCount: 0,
         credentialRefreshElapsedMs: 0,
@@ -7052,6 +7052,7 @@ describe("runHostedDeviceSyncWakeLane", () => {
       Record<string, boolean | number | string | null>
     >;
     expect(finishedEntry?.redactedJson).toEqual(expect.objectContaining({
+      deviceSyncConnectionSourceReadCount: 171,
       deviceSyncJobTimingCount: 18,
       deviceSyncJobTimingSampleLimit: 16,
       deviceSyncJobTimingTruncated: true,

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -3243,7 +3243,7 @@ export function createJunctionDeviceSyncProvider(
           window.windowStart,
           window.windowEnd,
           skippedOptionalResources,
-          [effectiveResource],
+          effectiveResource,
           sourceProviderSlug,
           {
             dateQueryFormat: extendedHistoricalPolicy?.completion === "daily_aggregate"
@@ -4292,12 +4292,12 @@ export function createJunctionDeviceSyncProvider(
     windowStart: string,
     windowEnd: string,
     skippedOptionalResources: JunctionSkippedOptionalResource[],
-    resources: readonly string[],
+    resource: string,
     sourceProviderSlug?: string | null,
     options: JunctionPreciseTimeseriesImportOptions = {},
     historicalResourceJobWorkBudget?: JunctionHistoricalResourceJobWorkBudget,
   ): Promise<JunctionPreciseTimeseriesImportResult> {
-    const accumulatedTimeseries: Record<string, unknown[]> = {};
+    let accumulatedRecords: unknown[] = [];
     let acceptedProviderRecordCount = 0;
     let executionWindowEnd: string | null = null;
     let executionWindowStart: string | null = null;
@@ -4310,14 +4310,10 @@ export function createJunctionDeviceSyncProvider(
     let providerRecordsExamined = false;
     let postFetchSourceAdmission: JunctionCurrentSourceAdmission | undefined;
 
-    if (resources.length !== 1) {
-      throw new TypeError("Precise Junction timeseries imports require exactly one resource.");
-    }
-    const resource = resources[0]!;
     const preciseWindows = buildPreciseTimeseriesWindows(
       windowStart,
       windowEnd,
-      resolveJunctionTimeseriesImportChunkMs(resources),
+      resolveJunctionTimeseriesFetchChunkMs(resource),
     );
     for (const [index, window] of preciseWindows.entries()) {
       if (context.shouldYield?.()) {
@@ -4336,7 +4332,7 @@ export function createJunctionDeviceSyncProvider(
       }
 
       const skippedResourceCountBeforeFetch = skippedOptionalResources.length;
-      let timeseries: Record<string, unknown[]>;
+      let records: unknown[];
       try {
         const fetched = await fetchTimeseriesResourceInChunks(
           context,
@@ -4347,13 +4343,13 @@ export function createJunctionDeviceSyncProvider(
           sourceProviderSlug,
           { dateQueryFormat: options.dateQueryFormat ?? "datetime" },
         );
-        timeseries = { [resource]: fetched.records };
+        records = fetched.records;
       } catch (error) {
         if (
           options.preservePartialRetryableFailure === true
           && (
             options.historicalProviderRecordsSeen === true
-            || hasJunctionSnapshotRecords(accumulatedTimeseries)
+            || accumulatedRecords.length > 0
           )
           && (
             isRetryableDeviceSyncFailure(error)
@@ -4373,12 +4369,7 @@ export function createJunctionDeviceSyncProvider(
 
       executionWindowStart ??= window.windowStart;
       executionWindowEnd = window.windowEnd;
-      for (const [resource, records] of Object.entries(timeseries)) {
-        accumulatedTimeseries[resource] = [
-          ...(accumulatedTimeseries[resource] ?? []),
-          ...records,
-        ];
-      }
+      accumulatedRecords = accumulatedRecords.concat(records);
       if (
         options.preservePartialRetryableFailure === true
         && index < preciseWindows.length - 1
@@ -4389,17 +4380,27 @@ export function createJunctionDeviceSyncProvider(
       }
     }
 
-    const dedupedTimeseries = dedupeJunctionTimeseriesSnapshotRecords(accumulatedTimeseries);
+    const dedupedTimeseries = dedupeJunctionTimeseriesSnapshotRecords({
+      [resource]: accumulatedRecords,
+    });
     const providerRecordCount = countJunctionSnapshotRecords(dedupedTimeseries);
     let unresolvedProviderRecordIdentities: readonly string[] = [];
     let unresolvedProviderRecordCount = providerRecordCount;
     let unresolvedProviderRecordsWithoutStableIdentity = providerRecordCount > 0;
-    const requiresBloodPressureRecordResolution = resources.includes("blood_pressure");
+    const requiresBloodPressureRecordResolution = resource === "blood_pressure";
     const successfulImportTerminatesDeliveredRows =
-      resources.length === 1
-      && doesJunctionImportReceiptResolveDeliveredRows(resources[0] ?? "");
+      doesJunctionImportReceiptResolveDeliveredRows(resource);
 
-    if (executionWindowStart && executionWindowEnd) {
+    // An intermediate historical segment only schedules an epoch-bound
+    // continuation. It neither completes coverage nor authorizes the next
+    // import; the continuation must pass fresh source admission again.
+    const continuesHistoricalWindow =
+      options.preservePartialRetryableFailure === true && yieldedAt !== null;
+    if (
+      executionWindowStart
+      && executionWindowEnd
+      && (providerRecordCount > 0 || !continuesHistoricalWindow)
+    ) {
       const identifyFetchedProviderRecords = (
         sourceIdentities: readonly JunctionAccountSourceIdentity[],
       ) =>
@@ -4544,11 +4545,13 @@ export function createJunctionDeviceSyncProvider(
               canonicalEventCount >= providerRecordCount ? 0 : providerRecordCount;
             unresolvedProviderRecordsWithoutStableIdentity = unresolvedProviderRecordCount > 0;
           }
-          // Import introduces another asynchronous boundary; empty segments
-          // retain the post-fetch read instead of fetching it twice.
+          // Recheck after import before terminal coverage, not merely to
+          // enqueue another epoch-bound segment. The pre-import read above
+          // remains fresh for every nonempty segment.
           if (
             sourceProviderSlug
             && options.sourceStatusRequirement === "connected"
+            && !continuesHistoricalWindow
           ) {
             postFetchSourceAdmission = await resolveJunctionCurrentSourceAdmission(
               context,
@@ -10091,16 +10094,6 @@ function buildPreciseTimeseriesWindows(
 function resolveJunctionTimeseriesFetchChunkMs(resource: string): number {
   const fetchChunkDays = resolveJunctionTimeseriesResourcePolicy(resource)?.fetchChunkDays ?? 1;
   return Math.max(1, fetchChunkDays) * TIMESERIES_CHUNK_MS;
-}
-
-function resolveJunctionTimeseriesImportChunkMs(resources: readonly string[]): number {
-  if (resources.length === 0) {
-    return TIMESERIES_CHUNK_MS;
-  }
-  return resources.reduce(
-    (smallest, resource) => Math.min(smallest, resolveJunctionTimeseriesFetchChunkMs(resource)),
-    Number.POSITIVE_INFINITY,
-  );
 }
 
 function floorUtcDayTimestamp(timestamp: string): string {

--- a/packages/device-syncd/test/junction-blood-pressure-backfill.test.ts
+++ b/packages/device-syncd/test/junction-blood-pressure-backfill.test.ts
@@ -416,6 +416,7 @@ function createProvider(input: {
   bloodPressureRecords?: readonly Record<string, unknown>[];
   includeNote?: boolean;
   noteRecords?: readonly Record<string, unknown>[];
+  onTimeseriesResponse?: () => void;
   timeseriesRecords?: Readonly<Record<string, readonly Record<string, unknown>[]>>;
   bloodPressureRequestFailure?: {
     active: boolean;
@@ -586,6 +587,7 @@ function createProvider(input: {
           : resource === "note"
             ? noteRecords
             : timeseriesRecords;
+        input.onTimeseriesResponse?.();
         return createJsonResponse(
           records.length > 0
             ? {
@@ -2204,8 +2206,8 @@ test.each([
     requests,
     timeseriesRecords: {
       caffeine: [{
-        end: "2026-06-10T08:05:00.000Z",
-        start: "2026-06-10T08:00:00.000Z",
+        end: "2025-12-13T08:05:00.000Z",
+        start: "2025-12-13T08:00:00.000Z",
         unit: "g",
         value: 0.08,
       }],
@@ -2454,7 +2456,6 @@ test("maximum source projection uses one shared snapshot while retaining exact-s
     ).find((candidate) => candidate !== undefined)),
     EXTENDED_HISTORY_EXECUTION_FIXTURE_DAYS,
   );
-  const targetSlug = String(job.payload?.sourceProviderSlug);
   const sourceReads: string[] = [];
   let importCalls = 0;
 
@@ -2475,7 +2476,7 @@ test("maximum source projection uses one shared snapshot while retaining exact-s
     toJobRecord(job, 260),
   );
 
-  assert.deepEqual(sourceReads, ["*", "*", targetSlug]);
+  assert.deepEqual(sourceReads, ["*", "*"]);
   assert.equal(providerListRequests.count, 1);
   assert.equal(requests.length, 1);
   assert.equal(importCalls, 1);
@@ -4201,7 +4202,7 @@ test("retryable post-fetch failures preserve raw evidence and replay the anchore
   }
 });
 
-test.each([false, true])("historical source reads follow actual import work (records: %s)", async (hasRecords) => {
+test.each([false, true])("terminal historical segments retain fresh source checks (records: %s)", async (hasRecords) => {
   const requests: TimeseriesRequest[] = [];
   const provider = createProvider({
     bloodPressureRecords: hasRecords ? [{
@@ -4240,10 +4241,181 @@ test.each([false, true])("historical source reads follow actual import work (rec
   assert.equal(result.scheduledJobs?.length ?? 0, hasRecords ? 0 : 1);
 });
 
-test("an empty successful segment retries when its post-fetch source reread fails", async () => {
+test.each([false, true])("intermediate history only reads authority for admission and import (records: %s)", async (hasRecords) => {
+  // Traverse distinct daily continuations rather than replaying a duplicate job.
+  const segmentCount = 128;
+  const records: Record<string, unknown>[] = hasRecords ? [{
+    id: "synthetic-history-reading",
+    timestamp: "2026-05-12T08:30:00.000Z",
+    systolic: 120,
+    diastolic: 78,
+  }] : [];
+  const requests: TimeseriesRequest[] = [];
+  const provider = createProvider({ bloodPressureRecords: records, requests });
+  const original = withHistoricalFixtureDays(
+    createScheduledBloodPressureJob(provider),
+    segmentCount + 1,
+  );
+  const source = createSourceSummary("omron");
+  let sourceReads = 0;
+  let imports = 0;
+  let nextJob = original;
+  for (let index = 0; index < segmentCount; index += 1) {
+    const windowStart = String(nextJob.payload?.windowStart);
+    if (hasRecords) {
+      records[0]!.id = `synthetic-history-reading-${index}`;
+      records[0]!.timestamp = `${windowStart.slice(0, 10)}T08:30:00.000Z`;
+    }
+    const result = await requireValue(provider.jobExecutor).executeJob(
+      createJobContext({
+        account: createAccount({ sources: [source] }),
+        connectionSourceAdmissionMode: "listed_only",
+        listConnectionSources: async () => {
+          sourceReads += 1;
+          return [source];
+        },
+        importSnapshot: async (snapshot) => {
+          imports += 1;
+          return importWithRealJunctionNormalizer(snapshot);
+        },
+      }),
+      toJobRecord(nextJob, index),
+    );
+    assert.equal(result.metadataPatch, undefined);
+    nextJob = findBloodPressureJob(result.scheduledJobs ?? []);
+    assert.equal(nextJob.dedupeKey, original.dedupeKey);
+    assert.equal(nextJob.payload?.sourceLifecycleEpoch, original.payload?.sourceLifecycleEpoch);
+    assert.equal(nextJob.payload?.historicalWindowStart, original.payload?.historicalWindowStart);
+    assert.equal(nextJob.payload?.windowEnd, original.payload?.windowEnd);
+    assert.equal(nextJob.payload?.windowStart, new Date(
+      Date.parse(windowStart) + 24 * 60 * 60_000,
+    ).toISOString());
+    assert.equal(nextJob.payload?.historicalRecordsSeen, hasRecords);
+  }
+  assert.equal(requests.length, segmentCount);
+  assert.equal(imports, hasRecords ? segmentCount : 0);
+  assert.equal(sourceReads, segmentCount * (hasRecords ? 2 : 1));
+});
+
+test.each(["local", "hosted"] as const)(
+  "%s intermediate continuations survive restart but cannot cross a source fence or reconnect",
+  async (authority) => {
+    for (const hasRecords of [false, true]) {
+      for (const change of ["disconnect", "reconnect"] as const) {
+        const tempDir = await makeTempDirectory("murph-history-source-admission");
+        const databasePath = path.join(tempDir, "state.sqlite");
+        let store = new SqliteDeviceSyncStore(databasePath);
+        try {
+          const account = store.upsertAccount({
+            connectedAt: NOW,
+            credential: {
+              credentialMetadata: {},
+              kind: "provider_config",
+              providerConfigKey: "junction",
+            },
+            externalAccountId: "junction-user-1",
+            provider: "junction",
+            scopes: [],
+            status: "active",
+          });
+          let liveSource = store.upsertConnectionSource({
+            ...createSourceSummary("omron"),
+            connectionId: account.id,
+            sourceInstanceKey: "junction-source-omron",
+          });
+          const changeAuthority = () => {
+            liveSource = {
+              ...liveSource,
+              lifecycleEpoch: change === "reconnect" ? 2 : 1,
+              lastErrorCode: change === "disconnect"
+                ? DEVICE_SYNC_SOURCE_DISCONNECT_IN_PROGRESS_ERROR_CODE
+                : null,
+            };
+            if (authority === "local") store.upsertConnectionSource(liveSource);
+          };
+          const requests: TimeseriesRequest[] = [];
+          let imports = 0;
+          const provider = createProvider({
+            bloodPressureRecords: hasRecords ? [{
+              id: "synthetic-reading-before-source-change",
+              timestamp: "2026-05-12T08:30:00.000Z",
+              systolic: 120,
+              diastolic: 78,
+            }] : [],
+            onTimeseriesResponse: () => {
+              if (!hasRecords) changeAuthority();
+            },
+            requests,
+          });
+          const context = (): ProviderJobContext => ({
+            ...createJobContext({
+              account: {
+                ...createAccount({
+                  sources: requireValue(store.getAccountById(account.id)).sources,
+                }),
+                id: account.id,
+              },
+              connectionSourceAdmissionMode: authority === "hosted"
+                ? "listed_only"
+                : "discover_unlisted",
+              importSnapshot: async (snapshot) => {
+                imports += 1;
+                const receipt = await importWithRealJunctionNormalizer(snapshot);
+                changeAuthority();
+                return receipt;
+              },
+              listConnectionSources: async () => authority === "hosted"
+                ? [liveSource]
+                : store.listConnectionSources({ connectionId: account.id }),
+            }),
+            upsertConnectionSource: (input) => store.upsertConnectionSource({
+              ...input,
+              connectionId: account.id,
+            }, { preserveDisconnected: true }),
+          });
+          const original = createScheduledBloodPressureJob(provider);
+          const first = await requireValue(provider.jobExecutor).executeJob(
+            context(),
+            { ...toJobRecord(original, 0), accountId: account.id },
+          );
+          assert.equal(first.metadataPatch, undefined);
+          const continuation = findBloodPressureJob(first.scheduledJobs ?? []);
+          const queued = store.enqueueJob({
+            ...continuation,
+            accountId: account.id,
+            provider: "junction",
+          });
+          store.close();
+          store = new SqliteDeviceSyncStore(databasePath);
+          const restored = requireValue(store.getJobById(queued.id));
+          assert.deepEqual(restored.payload, continuation.payload);
+          assert.equal(restored.dedupeKey, original.dedupeKey);
+          assert.equal(restored.payload.sourceLifecycleEpoch, 1);
+          const fenced = await requireValue(provider.jobExecutor).executeJob(context(), restored);
+          assert.equal(requests.length, 1);
+          assert.equal(imports, hasRecords ? 1 : 0);
+          assert.equal(fenced.metadataPatch, undefined);
+          assert.equal(fenced.scheduledJobs, undefined);
+          if (authority === "local") {
+            const source = requireValue(store.listConnectionSources({
+              connectionId: account.id,
+            })[0]);
+            assert.equal(source.lastErrorCode, liveSource.lastErrorCode);
+            assert.equal(source.lifecycleEpoch, liveSource.lifecycleEpoch);
+          }
+        } finally {
+          store.close();
+          await rm(tempDir, { force: true, recursive: true });
+        }
+      }
+    }
+  },
+);
+
+test("an empty terminal segment retries when its post-fetch source reread fails", async () => {
   const requests: TimeseriesRequest[] = [];
   const provider = createProvider({ bloodPressureRecords: [], requests });
-  const original = createScheduledBloodPressureJob(provider);
+  const original = withHistoricalFixtureDays(createScheduledBloodPressureJob(provider), 1);
   const failure = deviceSyncError({
     code: "HOSTED_DEVICE_SYNC_SOURCE_STATE_UNAVAILABLE",
     httpStatus: 503,
@@ -5101,7 +5273,7 @@ test.each(SOURCE_DISCONNECT_FENCE_CODES)(
         id: "bp-disconnected-source",
         provider_connection_id: "provider-omron-1",
         sourceProviderSlug: "omron",
-        timestamp: "2026-05-20T08:30:00.000Z",
+        timestamp: "2026-05-12T08:30:00.000Z",
         systolic: 120,
         diastolic: 78,
       }],


### PR DESCRIPTION
## Why and outcome

Intermediate Junction history segments reread source authority solely to queue another segment. Empty segments now omit the post-fetch read, and successfully imported segments omit the post-import read. The next epoch-bound continuation still passes fresh admission before health-data fetches; nonempty imports and terminal coverage retain their live checks.

The private precise-import function now takes its single resource directly, removing a redundant list, loop, arity checks, and chunk-size helper. The existing finished-pass log derives source-read totals before selecting its slowest-job sample.

## Product UX

- Effort: Not applicable; internal callback overhead and diagnostic accuracy.
- Result: Ready for final review; local source-fencing and continuation proof passed.
- Walkthrough: History depth, canonical records, source consent, and foreground yielding are preserved. An intermediate continuation may be queued after an unseen source change; its next admission rejects the obsolete epoch before health egress.

## Evidence

- Final ReviewGPT: PASS on `b5f0be51ac68b2ed47f3c69a2071ce28490891b0`, with verified model and exact response capture. Final head `7808e63093cfd511fbe211d58093fc1d871c70a6` closes the execution plan, records the unrelated Chromium-bootstrap defect, and pins the existing audio replay fixture clock. Production source matches the reviewed head exactly; the isolated test correction follows the completion workflow proof exemption. All four required final-head checks pass: Release checks (ubuntu), the hosted Stripe billing boundary, and both CLI host platforms. The build/typecheck job passed on retry after an unrelated GitHub Markdown API HTTP 403; all package coverage, Web tests/build, and Cloudflare verification passed.

- Direct: 128 consecutive synthetic empty segments use 128 source reads rather than 256; 128 imported segments use 256 rather than 384. Exactly one lookup is removed per qualifying segment, against the already-merged source-read simplification.
- Coverage: Local and hosted authority tests persist and restore SQLite continuations after disconnect/reconnect during empty fetches or imports. Nonempty revocation fixtures now place records inside the fetched day; terminal checks, unresolved evidence, dedupe identity, original window, and lifecycle epoch remain covered.
- Passed: 159 tests in `junction-blood-pressure-backfill`, `junction-admission-source-reads`, `junction-timeseries-source-reuse`, and `junction-provider-identity`.
- Passed: 16 focused service/store regressions for reconnect, disconnected sources, source fences, epoch changes, historical suffix ordering, and connection generations.
- Passed: the existing maintenance log sampling test extended to prove that source-read totals include omitted timings; both device-syncd and assistant-runtime typechecks; `git diff --check`.
- CI remediation: the unchanged audio replay fixture crossed the 14-day content-retention boundary and reproduced locally. Pinning Date to its synthetic event day preserves real timers and all existing assertions; all 3 audio tests and the assistant-runtime typecheck pass. This is the fixed-date fixture failure pattern already recorded by the training-summary Frog entry.
- Synthetic counts are not deployed request-volume evidence. Matched production measurement remains necessary; faster passes can process additional history and offset a wall-clock bucket reduction. The new diagnostic total does not itself save requests.

## Non-obvious affected surfaces

The maintenance diagnostic adds one derived JSON number to an existing log entry. Existing log parsing and batching accept it without another write. The scalar-resource signature is private and has one caller; source-read transport, Web apply, store completion, and checkpoint contracts are unchanged.

## Architecture and reuse

- Existing systems reused: epoch-bound continuation payloads, fresh source admission, SQLite job persistence, canonical normalization, and existing pass timing diagnostics.
- New logic: skip a read whose only remaining consumer is an intermediate continuation; sum already-collected source-read counters.
- New abstractions: None. Remove the single-resource list wrapper and its chunk helper.
- Complexity intentionally avoided: authorization caching, invalidation coordination, new services/state/configuration, and additional log requests.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base 62a2c36e57e7ed2f91a32ae3b86c5d5c860a49cf`; Junction debt 406 to 405, maintenance debt 105 to 105.
- Hotspots: `importTimeseriesPreciseSnapshots` 42 to 41; `executeResourceJob` remains 143 with only the scalar call-site change. `writeHostedDeviceSyncPassLifecycleLog` remains 46. Other listed changed-file hotspots are unchanged; their unrelated normalization, source projection, and scheduling behavior stays outside this correction.
- Agent judgment: removed actual crossings and unnecessary generality. Further extraction solely to redistribute the metric would add concepts without simplifying these boundaries.

## Hot reply path impact

- Path status: Not applicable; background device-sync execution and an existing diagnostic entry.
- Database calls: None added or moved onto the foreground path.
- Network/provider calls: No new calls; one fewer Web snapshot lookup per qualifying intermediate segment.
- Other awaited latency: None added. Existing yield, provider work, timeout, retry, and checkpoint owners remain.
- Before/after proof: Consecutive segment call counts and source-fenced restart scenarios above.

## Murph initial provider input impact

Not applicable to either individual or group runtimes: no assistant prompt, tool/schema, history assembly, or provider-input surface changes. No provider-input measurement claimed.

ReviewGPT first-reviewed head: b5f0be51ac68b2ed47f3c69a2071ce28490891b0
ReviewGPT context sensitivity: sensitive
Classification reason: source authority, historical continuation ordering, and hosted runtime behavior.

## Deployment concerns

- Deployment: applicable
- Supported skew: existing Web/Worker callbacks and persisted continuation payloads are unchanged; old/new runtimes consume the same jobs.
- Safe order: ordinary runtime release through the existing pipeline; no coordinated schema or Web rollout.
- Rollback floor: existing runtime compatibility floor; this patch introduces no new wire or persisted-state requirement.
- Expected exposure: Junction intermediate precise-history segments; terminal segments retain their current checks. Diagnostic totals describe collected attempts in each finished pass.
- Reversibility: a normal forward runtime release can restore the old reads without data migration; no rollback performed here.
- Convergence proof: SQLite continuation restore preserves payload, dedupe key, original window, and source epoch; disconnect/reconnect prevents further health egress. Existing source admission/reuse and service/store regressions pass.
- Post-deploy checks: confirm the serving runtime revision, compare source reads against job/workload counts and total edge requests, and check retry/fenced continuation outcomes and terminal history progress. Bucket-level savings remain unverified until that observation.

## Change-shape breakdown

Classification rule: package `src` files are source, package `test` files are tests, and Markdown owners/plan are docs. No binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 31 | 34 |
| Tests / fixtures | 189 | 11 |
| Docs | 120 | 4 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **340** | **49** |

## Changelog

- Changelog: not applicable
- Reason: internal callback efficiency and diagnostic accuracy; no new member-facing feature, action, or promised sync freshness change.
