### PR TITLE
Give homepage features stronger hierarchy and remove supporting copy

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-09-homepage-feature-art-direction.md
+++ b/agent-docs/exec-plans/completed/2026-09-09-homepage-feature-art-direction.md
@@ -1,0 +1,56 @@
+# Give homepage feature sections distinct visual hierarchy
+
+Status: completed
+Created: 2026-09-09
+Updated: 2026-09-09
+
+## Goal
+
+Give the group and personal homepage sections a stronger visual hierarchy after removing their supporting paragraphs.
+
+## Success criteria
+
+- All eight headings and existing demos remain, without restoring supporting paragraphs.
+- Larger features, open compositions, and varied scale replace the repeated equal-size panels.
+- Phone reading order, audio controls, and horizontal overflow remain correct.
+- Review real desktop, tablet, and phone screenshots, run focused checks, and refresh PR preview evidence.
+
+## Scope
+
+- In scope: TogetherSection, AsksGridSection, shared feature presentation, focused tests, changelog, and existing PR.
+- Out of scope: Other homepage sections, new product promises, assistant behavior, and production deployment.
+
+## Constraints
+
+- Reuse the existing fonts, demo components, and anchored screenshot study.
+- Keep headings before demos in DOM order, including visually reversed desktop rows.
+- Preserve synthetic demo content and existing playback behavior.
+
+## Risks and mitigations
+
+1. Large typography may wrap poorly on phones. Inspect 390px, 1024px, and 1440px renderings and full-page transitions.
+2. Strong panel colors may reduce contrast. Use light text on deep green and rust, and dark text on yellow.
+
+## Tasks
+
+1. Completed: replaced the repeated grid treatment with distinct compositions.
+2. Completed: inspected desktop, tablet, phone, and full-page renders; corrected narrow tablet wrapping and decorative phone overflow.
+3. Completed: 17 focused tests, prepared web typecheck, ESLint, complexity guard, and three responsive browser journeys passed.
+4. Candidate reviewed for scoped commit. PR owns publication of selected screenshots, hosted preview verification, and exact-head CI evidence.
+
+## Decisions
+
+- Keep all removed subtext absent.
+- Reuse one feature wrapper with compact, wide, and reversed layouts.
+- Use deep green, warm yellow, and rust for selected featured demos; leave smaller demos unframed.
+
+## Verification
+
+- Focused homepage and changelog tests; prepared web typecheck; focused ESLint; complexity diff.
+- Browser proof on homepage and screenshot study, with play/pause and overflow checks.
+- Exact-head CI and a ready hosted preview.
+
+## Outcome
+
+The implementation and local review are complete. The existing PR records hosted preview and final-head CI results as they finish. No assistant or runtime contract changed.
+Completed: 2026-09-09

--- a/apps/web/changelog/entries/2026-09-09/homepage-feature-headings.json
+++ b/apps/web/changelog/entries/2026-09-09/homepage-feature-headings.json
@@ -7,7 +7,7 @@
     "priority": 1,
     "title": "A shorter homepage tour",
     "summary": "The group and personal feature sections now pair their headings directly with examples.",
-    "details": "Removed the supporting paragraphs so the challenges, family newsletter, and personal assistant demos are easier to scan.",
+    "details": "A tighter desktop layout and consistent heading-first order on phones make the demos easier to scan without extra supporting paragraphs.",
     "relevanceTags": ["website"],
     "sourcePullRequests": [3113]
   }

--- a/apps/web/changelog/entries/2026-09-09/homepage-feature-headings.json
+++ b/apps/web/changelog/entries/2026-09-09/homepage-feature-headings.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-09",
+  "order": 100,
+  "item": {
+    "id": "homepage-feature-headings",
+    "kind": "improvement",
+    "priority": 1,
+    "title": "A shorter homepage tour",
+    "summary": "The group and personal feature sections now pair their headings directly with examples.",
+    "details": "Removed the supporting paragraphs so the challenges, family newsletter, and personal assistant demos are easier to scan.",
+    "relevanceTags": ["website"],
+    "sourcePullRequests": []
+  }
+}

--- a/apps/web/changelog/entries/2026-09-09/homepage-feature-headings.json
+++ b/apps/web/changelog/entries/2026-09-09/homepage-feature-headings.json
@@ -7,7 +7,7 @@
     "priority": 1,
     "title": "A shorter homepage tour",
     "summary": "The group and personal feature sections now pair their headings directly with examples.",
-    "details": "A tighter desktop layout and consistent heading-first order on phones make the demos easier to scan without extra supporting paragraphs.",
+    "details": "Larger featured demos, open layouts, and consistent heading-first order on phones give the tour more variety without extra supporting paragraphs.",
     "relevanceTags": ["website"],
     "sourcePullRequests": [3113]
   }

--- a/apps/web/changelog/entries/2026-09-09/homepage-feature-headings.json
+++ b/apps/web/changelog/entries/2026-09-09/homepage-feature-headings.json
@@ -9,6 +9,6 @@
     "summary": "The group and personal feature sections now pair their headings directly with examples.",
     "details": "Removed the supporting paragraphs so the challenges, family newsletter, and personal assistant demos are easier to scan.",
     "relevanceTags": ["website"],
-    "sourcePullRequests": []
+    "sourcePullRequests": [3113]
   }
 }

--- a/apps/web/src/components/homepage/asks-section.tsx
+++ b/apps/web/src/components/homepage/asks-section.tsx
@@ -35,7 +35,6 @@ const TINTS: Record<
 export function WideFeature({
   artifactAlign = "end",
   artifactSide,
-  body,
   bubble,
   headline,
   tint,
@@ -45,7 +44,6 @@ export function WideFeature({
   // anchor to the bottom edge.
   artifactAlign?: "center" | "end";
   artifactSide: "left" | "right";
-  body: string;
   bubble: string;
   headline: string;
   tint: Tint;
@@ -53,13 +51,10 @@ export function WideFeature({
 }) {
   const t = TINTS[tint];
   const copy = (
-    <div className="flex flex-col justify-center gap-4 px-5 pt-8 pb-1 sm:gap-5 sm:px-10 sm:pt-12 sm:pb-2 lg:col-span-5 lg:py-16 lg:px-12">
+    <div className="flex flex-col justify-center px-5 pt-8 pb-1 sm:px-10 sm:pt-12 sm:pb-2 lg:col-span-5 lg:py-16 lg:px-12">
       <h3 className="font-serif text-[1.5rem] font-semibold leading-[1.08] tracking-[-0.03em] text-balance text-[#1f1c18] sm:text-[clamp(1.75rem,2.8vw,2.625rem)] sm:leading-[1.02] sm:tracking-[-0.035em]">
         {headline}
       </h3>
-      <p className="text-[0.875rem] leading-[1.6] text-pretty text-[#635a48] sm:text-[0.9375rem] sm:leading-[1.65] lg:max-w-[34ch]">
-        {body}
-      </p>
     </div>
   );
 
@@ -119,24 +114,17 @@ export function WideFeature({
 }
 
 function CompactCard({
-  body,
   headline,
   artifact,
 }: {
-  body: string;
   headline: string;
   artifact: React.ReactNode;
 }) {
   return (
     <article className="flex min-w-0 flex-col gap-5 rounded-[1.5rem] bg-[#fffcf6] p-5 ring-1 ring-black/[0.04] shadow-[0_1px_2px_rgba(45,52,54,0.04),0_16px_50px_-30px_rgba(45,52,54,0.1)] sm:gap-6 sm:rounded-[1.75rem] sm:p-9">
-      <div className="flex flex-col gap-2.5 sm:gap-3">
-        <h3 className="font-serif text-[1.25rem] font-semibold leading-[1.08] tracking-[-0.025em] text-balance text-[#1f1c18] sm:text-[clamp(1.375rem,2vw,1.75rem)] sm:leading-[1.05] sm:tracking-[-0.03em]">
-          {headline}
-        </h3>
-        <p className="text-[0.875rem] leading-[1.55] text-pretty text-[#635a48] sm:leading-[1.6]">
-          {body}
-        </p>
-      </div>
+      <h3 className="font-serif text-[1.25rem] font-semibold leading-[1.08] tracking-[-0.025em] text-balance text-[#1f1c18] sm:text-[clamp(1.375rem,2vw,1.75rem)] sm:leading-[1.05] sm:tracking-[-0.03em]">
+        {headline}
+      </h3>
       <div className="mt-auto rounded-2xl bg-[#f5f0e8]/60 p-2.5 ring-1 ring-black/[0.03] sm:rounded-[1.25rem] sm:p-3">
         {artifact}
       </div>
@@ -424,18 +412,12 @@ export function AsksGridSection() {
           <h2 className="font-serif text-[1.875rem] font-semibold leading-[1.08] tracking-[-0.03em] text-[#2d3436] sm:text-[clamp(2rem,4vw,3.25rem)]">
             No group? You’re still not doing this alone.
           </h2>
-          <p className="mt-5 max-w-[62ch] text-[1rem] leading-[1.7] text-[#3a322a]">
-            Outside the group chat, Murph is all yours. Experiments, bloodwork,
-            habits, bookings, and daily readouts, in a private one on one
-            thread.
-          </p>
         </div>
         <div className="space-y-5 sm:space-y-6">
           <WideFeature
             tint="gold"
             artifactSide="right"
             headline="I run experiments so you know what actually works for you."
-            body="Pick a protocol. Murph baselines you for two weeks, runs the active phase, then texts the before-and-after. No more guessing whether anything moved."
             bubble="Did the magnesium actually work?"
             artifact={<ExperimentArtifact />}
           />
@@ -443,12 +425,10 @@ export function AsksGridSection() {
           <div className="grid gap-5 sm:gap-6 lg:grid-cols-2">
             <CompactCard
               headline="I find insights in your bloodwork over time."
-              body="Drop in your latest panel. Murph flags what crept up or down and turns it into the questions worth asking your doctor."
               artifact={<BloodworkArtifact />}
             />
             <CompactCard
               headline="I make it easy to build healthy habits."
-              body="A version small enough for bad days, anchored to something you already do. Reminders ease off as it takes hold."
               artifact={<HabitArtifact />}
             />
           </div>
@@ -457,7 +437,6 @@ export function AsksGridSection() {
             tint="bronze"
             artifactSide="left"
             headline="I order the supplements and book the scans."
-            body="Murph finds the DEXA scan nearby, drafts the supplement re-up, and queues the doctor recap on your calendar. You give the final tap. The errands stop slipping."
             bubble="Order me Omega-3, find me a DEXA scan, and confirm my doctor's appointment."
             artifact={<ErrandsArtifact />}
           />
@@ -465,12 +444,10 @@ export function AsksGridSection() {
           <div className="grid gap-5 sm:gap-6 lg:grid-cols-2">
             <CompactCard
               headline="I call the dentist and book the appointment."
-              body="Dentist, dermatologist, vet, mechanic. Murph dials, waits on hold, picks a slot that fits your week."
               artifact={<CallArtifact />}
             />
             <CompactCard
               headline="I read your wearables and tell you what actually matters."
-              body="Murph pulls Oura, WHOOP, Garmin, or Apple Health overnight. Wake up to a one-line readout."
               artifact={<RecoveryArtifact />}
             />
           </div>

--- a/apps/web/src/components/homepage/asks-section.tsx
+++ b/apps/web/src/components/homepage/asks-section.tsx
@@ -4,129 +4,58 @@ import { VoiceMemoPlayer } from "@/src/components/ui/voice-memo-player";
 
 type Tint = "sage" | "gold" | "bronze";
 
-const TINTS: Record<
-  Tint,
-  {
-    panel: string;
-    bubble: string;
-    glow: string;
-  }
-> = {
+const TINTS: Record<Tint, { panel: string; bubble: string }> = {
   sage: {
-    panel:
-      "bg-[linear-gradient(135deg,#e8efde_0%,#d5e2c4_55%,#c8d7b1_100%)]",
+    panel: "bg-[linear-gradient(135deg,#e8efde_0%,#d5e2c4_55%,#c8d7b1_100%)]",
     bubble: "bg-[#2c7a3f]",
-    glow: "shadow-[0_30px_80px_-35px_rgba(58,80,40,0.45)]",
   },
   gold: {
-    panel:
-      "bg-[linear-gradient(135deg,#f3e8d0_0%,#ead7af_55%,#dec390_100%)]",
+    panel: "bg-[linear-gradient(135deg,#f3e8d0_0%,#ead7af_55%,#dec390_100%)]",
     bubble: "bg-[#8a5d17]",
-    glow: "shadow-[0_30px_80px_-35px_rgba(138,100,40,0.45)]",
   },
   bronze: {
-    panel:
-      "bg-[linear-gradient(135deg,#ead0b0_0%,#d6ad7e_55%,#bf8a55_100%)]",
+    panel: "bg-[linear-gradient(135deg,#ead0b0_0%,#d6ad7e_55%,#bf8a55_100%)]",
     bubble: "bg-[#94591f]",
-    glow: "shadow-[0_30px_80px_-35px_rgba(125,74,26,0.45)]",
   },
 };
 
-export function WideFeature({
-  artifactAlign = "end",
-  artifactSide,
+export function FeatureCard({
   bubble,
   headline,
   tint,
   artifact,
 }: {
-  // Short artifacts read better vertically centered in the panel; tall ones
-  // anchor to the bottom edge.
-  artifactAlign?: "center" | "end";
-  artifactSide: "left" | "right";
-  bubble: string;
+  bubble?: string;
   headline: string;
-  tint: Tint;
+  tint?: Tint;
   artifact: React.ReactNode;
 }) {
-  const t = TINTS[tint];
-  const copy = (
-    <div className="flex flex-col justify-center px-5 pt-8 pb-1 sm:px-10 sm:pt-12 sm:pb-2 lg:col-span-5 lg:py-16 lg:px-12">
-      <h3 className="font-serif text-[1.5rem] font-semibold leading-[1.08] tracking-[-0.03em] text-balance text-[#1f1c18] sm:text-[clamp(1.75rem,2.8vw,2.625rem)] sm:leading-[1.02] sm:tracking-[-0.035em]">
+  const colors = tint ? TINTS[tint] : null;
+
+  return (
+    <article className="grid min-w-0 grid-rows-[auto_1fr] gap-5 lg:row-span-2 lg:grid-rows-subgrid">
+      <h3 className="max-w-[30ch] font-serif text-2xl font-semibold leading-[1.12] tracking-[-0.025em] text-balance text-[#2d3436] sm:text-[1.75rem]">
         {headline}
       </h3>
-    </div>
-  );
-
-  const panel = (
-    <div className="p-2.5 sm:p-4 lg:col-span-7 lg:p-5">
       <div
         className={cn(
-          "relative min-h-[330px] overflow-hidden rounded-[1.25rem] sm:min-h-[440px] sm:rounded-[1.5rem] lg:min-h-[480px]",
-          t.panel,
-          t.glow,
+          "flex min-w-0 flex-col gap-6 overflow-hidden rounded-3xl p-5 sm:gap-8 sm:p-8",
+          colors?.panel ?? "bg-[#ece6da]",
         )}
       >
-        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(120%_80%_at_20%_-10%,rgba(255,255,255,0.55)_0%,rgba(255,255,255,0)_55%)]" />
-        {/* Below lg the bubble sits in flow above the artifact: with the
-            fixed-reserve overlay, long bubble copy wraps on narrow screens
-            and collides with the artifact card. */}
-        <div
-          className={cn(
-            "relative z-20 flex px-4 pt-5 sm:px-7 sm:pt-8 lg:absolute lg:top-8 lg:px-0 lg:pt-0",
-            artifactSide === "left"
-              ? "justify-start lg:left-7"
-              : "justify-end lg:right-7",
-          )}
-        >
+        {bubble ? (
           <div
             className={cn(
-              "max-w-[240px] px-3.5 py-2 text-[0.875rem] leading-[1.4] text-white shadow-[0_8px_24px_-6px_rgba(60,40,20,0.3)] sm:max-w-[280px] sm:px-4 sm:py-2.5 sm:text-[0.9375rem]",
-              t.bubble,
-              artifactSide === "left"
-                ? "rounded-2xl rounded-tl-[6px]"
-                : "rounded-2xl rounded-tr-[6px]",
+              "max-w-[280px] self-end rounded-2xl rounded-tr-md px-4 py-2.5 text-[0.875rem] leading-[1.4] text-white sm:text-[0.9375rem]",
+              colors?.bubble ?? "bg-[#5a6e32]",
             )}
           >
             {bubble}
           </div>
+        ) : null}
+        <div className="flex flex-1 items-center justify-center">
+          <div className="w-full min-w-0 max-w-[440px]">{artifact}</div>
         </div>
-        <div
-          className={cn(
-            "relative z-10 flex h-full justify-center px-3 pb-4 pt-4 sm:px-8 sm:pb-8 sm:pt-6 lg:pt-32",
-            artifactAlign === "center"
-              ? "items-center lg:absolute lg:inset-0"
-              : "items-end",
-          )}
-        >
-          <div className="w-full max-w-[440px]">{artifact}</div>
-        </div>
-      </div>
-    </div>
-  );
-
-  return (
-    <article className="overflow-hidden rounded-[1.5rem] bg-[#fffcf6] ring-1 ring-black/[0.04] shadow-[0_1px_2px_rgba(45,52,54,0.04),0_20px_60px_-30px_rgba(45,52,54,0.12)] sm:rounded-[2rem] lg:grid lg:grid-cols-12 lg:items-stretch">
-      {artifactSide === "right" ? copy : panel}
-      {artifactSide === "right" ? panel : copy}
-    </article>
-  );
-}
-
-function CompactCard({
-  headline,
-  artifact,
-}: {
-  headline: string;
-  artifact: React.ReactNode;
-}) {
-  return (
-    <article className="flex min-w-0 flex-col gap-5 rounded-[1.5rem] bg-[#fffcf6] p-5 ring-1 ring-black/[0.04] shadow-[0_1px_2px_rgba(45,52,54,0.04),0_16px_50px_-30px_rgba(45,52,54,0.1)] sm:gap-6 sm:rounded-[1.75rem] sm:p-9">
-      <h3 className="font-serif text-[1.25rem] font-semibold leading-[1.08] tracking-[-0.025em] text-balance text-[#1f1c18] sm:text-[clamp(1.375rem,2vw,1.75rem)] sm:leading-[1.05] sm:tracking-[-0.03em]">
-        {headline}
-      </h3>
-      <div className="mt-auto rounded-2xl bg-[#f5f0e8]/60 p-2.5 ring-1 ring-black/[0.03] sm:rounded-[1.25rem] sm:p-3">
-        {artifact}
       </div>
     </article>
   );
@@ -413,44 +342,38 @@ export function AsksGridSection() {
             No group? You’re still not doing this alone.
           </h2>
         </div>
-        <div className="space-y-5 sm:space-y-6">
-          <WideFeature
+        <div className="grid gap-x-10 gap-y-8 sm:gap-y-10 lg:grid-cols-2">
+          <FeatureCard
             tint="gold"
-            artifactSide="right"
             headline="I run experiments so you know what actually works for you."
             bubble="Did the magnesium actually work?"
             artifact={<ExperimentArtifact />}
           />
 
-          <div className="grid gap-5 sm:gap-6 lg:grid-cols-2">
-            <CompactCard
-              headline="I find insights in your bloodwork over time."
-              artifact={<BloodworkArtifact />}
-            />
-            <CompactCard
-              headline="I make it easy to build healthy habits."
-              artifact={<HabitArtifact />}
-            />
-          </div>
+          <FeatureCard
+            headline="I find insights in your bloodwork over time."
+            artifact={<BloodworkArtifact />}
+          />
+          <FeatureCard
+            headline="I make it easy to build healthy habits."
+            artifact={<HabitArtifact />}
+          />
 
-          <WideFeature
+          <FeatureCard
             tint="bronze"
-            artifactSide="left"
             headline="I order the supplements and book the scans."
             bubble="Order me Omega-3, find me a DEXA scan, and confirm my doctor's appointment."
             artifact={<ErrandsArtifact />}
           />
 
-          <div className="grid gap-5 sm:gap-6 lg:grid-cols-2">
-            <CompactCard
-              headline="I call the dentist and book the appointment."
-              artifact={<CallArtifact />}
-            />
-            <CompactCard
-              headline="I read your wearables and tell you what actually matters."
-              artifact={<RecoveryArtifact />}
-            />
-          </div>
+          <FeatureCard
+            headline="I call the dentist and book the appointment."
+            artifact={<CallArtifact />}
+          />
+          <FeatureCard
+            headline="I read your wearables and tell you what actually matters."
+            artifact={<RecoveryArtifact />}
+          />
         </div>
       </div>
     </section>

--- a/apps/web/src/components/homepage/asks-section.tsx
+++ b/apps/web/src/components/homepage/asks-section.tsx
@@ -4,18 +4,21 @@ import { VoiceMemoPlayer } from "@/src/components/ui/voice-memo-player";
 
 type Tint = "sage" | "gold" | "bronze";
 
-const TINTS: Record<Tint, { panel: string; bubble: string }> = {
+const TINTS: Record<Tint, { panel: string; bubble: string; heading: string }> = {
   sage: {
-    panel: "bg-[linear-gradient(135deg,#e8efde_0%,#d5e2c4_55%,#c8d7b1_100%)]",
-    bubble: "bg-[#2c7a3f]",
+    panel: "bg-[#243f32]",
+    bubble: "bg-[#d7e59b] text-[#243f32]",
+    heading: "text-[#f5f0e8]",
   },
   gold: {
-    panel: "bg-[linear-gradient(135deg,#f3e8d0_0%,#ead7af_55%,#dec390_100%)]",
-    bubble: "bg-[#8a5d17]",
+    panel: "bg-[#eddc91]",
+    bubble: "bg-[#7b4d24] text-[#fffcf6]",
+    heading: "text-[#383321]",
   },
   bronze: {
-    panel: "bg-[linear-gradient(135deg,#ead0b0_0%,#d6ad7e_55%,#bf8a55_100%)]",
-    bubble: "bg-[#94591f]",
+    panel: "bg-[#ad542f]",
+    bubble: "bg-[#f4dbaf] text-[#613517]",
+    heading: "text-[#fffcf6]",
   },
 };
 
@@ -24,37 +27,59 @@ export function FeatureCard({
   headline,
   tint,
   artifact,
+  layout = "compact",
 }: {
   bubble?: string;
   headline: string;
   tint?: Tint;
   artifact: React.ReactNode;
+  layout?: "compact" | "wide" | "reverse";
 }) {
   const colors = tint ? TINTS[tint] : null;
+  const wide = layout !== "compact";
 
   return (
-    <article className="grid min-w-0 grid-rows-[auto_1fr] gap-5 lg:row-span-2 lg:grid-rows-subgrid">
-      <h3 className="max-w-[30ch] font-serif text-2xl font-semibold leading-[1.12] tracking-[-0.025em] text-balance text-[#2d3436] sm:text-[1.75rem]">
+    <article
+      className={cn(
+        "min-w-0",
+        wide
+          ? "grid items-center gap-8 sm:gap-12 lg:col-span-2 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)] lg:gap-12 xl:gap-16"
+          : "flex flex-col gap-8 border-t border-[#2d3436]/20 pt-7 sm:gap-10 sm:pt-8",
+        colors
+          ? cn("rounded-[1.5rem] px-5 py-8 sm:rounded-[2rem] sm:p-10 lg:p-14", colors.panel)
+          : wide && "py-4 sm:py-8",
+      )}
+    >
+      <h3
+        className={cn(
+          "font-serif font-semibold tracking-[-0.035em] text-balance",
+          colors?.heading ?? "text-[#2d3436]",
+          wide
+            ? "max-w-[18ch] text-[2rem] leading-[1.06] sm:text-[2.75rem] lg:text-[2.5rem] xl:text-[3.25rem]"
+            : "max-w-[25ch] text-[1.75rem] leading-[1.12] sm:text-[2.125rem]",
+          layout === "reverse" && "lg:col-start-2 lg:row-start-1",
+        )}
+      >
         {headline}
       </h3>
       <div
         className={cn(
-          "flex min-w-0 flex-col gap-6 overflow-hidden rounded-3xl p-5 sm:gap-8 sm:p-8",
-          colors?.panel ?? "bg-[#ece6da]",
+          "flex min-w-0 flex-col gap-6 sm:gap-8",
+          layout === "reverse" && "lg:col-start-1 lg:row-start-1",
         )}
       >
         {bubble ? (
           <div
             className={cn(
-              "max-w-[280px] self-end rounded-2xl rounded-tr-md px-4 py-2.5 text-[0.875rem] leading-[1.4] text-white sm:text-[0.9375rem]",
-              colors?.bubble ?? "bg-[#5a6e32]",
+              "max-w-[280px] self-end rounded-2xl rounded-tr-md px-4 py-2.5 text-[0.875rem] leading-[1.4] sm:text-[0.9375rem]",
+              colors?.bubble ?? "bg-[#2c7a3f] text-[#fffcf6]",
             )}
           >
             {bubble}
           </div>
         ) : null}
-        <div className="flex flex-1 items-center justify-center">
-          <div className="w-full min-w-0 max-w-[440px]">{artifact}</div>
+        <div className={cn("w-full min-w-0", wide ? "mx-auto max-w-[440px]" : "max-w-[500px]")}>
+          {artifact}
         </div>
       </div>
     </article>
@@ -337,14 +362,15 @@ export function AsksGridSection() {
       <div className="mx-auto max-w-[1200px]">
         {/* Bridges the group-chat story above back to the 1:1 assistant:
             everything below happens in a private thread with Murph. */}
-        <div className="mb-10 max-w-[720px] sm:mb-12">
-          <h2 className="font-serif text-[1.875rem] font-semibold leading-[1.08] tracking-[-0.03em] text-[#2d3436] sm:text-[clamp(2rem,4vw,3.25rem)]">
+        <div className="mb-12 max-w-[960px] sm:mb-16 lg:mb-20">
+          <h2 className="font-serif text-[2.375rem] font-semibold leading-[1.02] tracking-[-0.045em] text-balance text-[#2d3436] sm:text-[clamp(3rem,5.5vw,4.75rem)]">
             No group? You’re still not doing this alone.
           </h2>
         </div>
-        <div className="grid gap-x-10 gap-y-8 sm:gap-y-10 lg:grid-cols-2">
+        <div className="grid gap-x-16 gap-y-12 sm:gap-y-16 lg:grid-cols-2 lg:gap-y-20">
           <FeatureCard
             tint="gold"
+            layout="wide"
             headline="I run experiments so you know what actually works for you."
             bubble="Did the magnesium actually work?"
             artifact={<ExperimentArtifact />}
@@ -361,6 +387,7 @@ export function AsksGridSection() {
 
           <FeatureCard
             tint="bronze"
+            layout="wide"
             headline="I order the supplements and book the scans."
             bubble="Order me Omega-3, find me a DEXA scan, and confirm my doctor's appointment."
             artifact={<ErrandsArtifact />}

--- a/apps/web/src/components/homepage/together-section.tsx
+++ b/apps/web/src/components/homepage/together-section.tsx
@@ -9,19 +9,20 @@ export function TogetherSection() {
   return (
     <section className="bg-[#f5f0e8] px-4 pt-20 pb-10 sm:px-8 sm:pt-20 sm:pb-20 lg:px-16 lg:pt-28 lg:pb-28">
       <div className="mx-auto max-w-[1200px]">
-        <div className="max-w-[720px]">
-          <h2 className="font-serif text-[1.875rem] font-semibold leading-[1.08] tracking-[-0.03em] text-[#2d3436] sm:text-[clamp(2rem,4vw,3.25rem)]">
+        <div className="max-w-[900px]">
+          <h2 className="font-serif text-[2.5rem] font-semibold leading-[1.02] tracking-[-0.045em] text-balance text-[#2d3436] sm:text-[clamp(3rem,6vw,5.25rem)]">
             Do it with your people.
           </h2>
         </div>
 
-        <div className="mt-10 grid gap-x-10 gap-y-8 sm:mt-12 sm:gap-y-10 lg:grid-cols-2">
+        <div className="mt-10 grid gap-12 sm:mt-14 sm:gap-16 lg:grid-cols-2 lg:gap-20">
           <FeatureCard
             tint="sage"
+            layout="wide"
             headline="I referee health challenges with your friends."
             bubble="no shot you guys are keeping up with me this week 😤"
             artifact={
-              <div className="mx-auto w-full max-w-[340px]">
+              <div className="mx-auto w-full max-w-[390px]">
                 <ChallengeCard />
                 <div className="mt-3 flex items-end gap-1.5">
                   <MurphHeadshotAvatar
@@ -29,7 +30,7 @@ export function TogetherSection() {
                     className="mb-0.5 size-[22px] shrink-0"
                   />
                   <div className="min-w-0">
-                    <p className="mb-0.5 pl-1 font-mono text-[9px] tracking-[0.08em] text-[#736a58]">
+                    <p className="mb-0.5 pl-1 font-mono text-[9px] tracking-[0.08em] text-[#d7e59b]">
                       Murph
                     </p>
                     <div className="w-fit rounded-2xl rounded-bl-[6px] bg-white px-4 py-2.5 text-[0.9375rem] leading-[1.4] text-[#2d3436] shadow-[0_8px_24px_-6px_rgba(60,40,20,0.2)]">
@@ -42,11 +43,11 @@ export function TogetherSection() {
           />
 
           <FeatureCard
-            tint="gold"
+            layout="reverse"
             headline="I send the whole family a weekly health newsletter."
             bubble="can you send grandpa our weekly wins?"
             artifact={
-              <div className="mx-auto w-full max-w-[360px]">
+              <div className="mx-auto w-full max-w-[440px] px-5 py-3">
                 <div className="relative">
                   <div
                     aria-hidden="true"

--- a/apps/web/src/components/homepage/together-section.tsx
+++ b/apps/web/src/components/homepage/together-section.tsx
@@ -1,4 +1,4 @@
-import { WideFeature } from "./asks-section";
+import { FeatureCard } from "./asks-section";
 import { ChallengeCard, NewsletterCard } from "./group-chat-cards";
 import {
   DEFAULT_MURPH_HEADSHOT,
@@ -15,10 +15,9 @@ export function TogetherSection() {
           </h2>
         </div>
 
-        <div className="mt-10 space-y-5 sm:mt-12 sm:space-y-6">
-          <WideFeature
+        <div className="mt-10 grid gap-x-10 gap-y-8 sm:mt-12 sm:gap-y-10 lg:grid-cols-2">
+          <FeatureCard
             tint="sage"
-            artifactSide="right"
             headline="I referee health challenges with your friends."
             bubble="no shot you guys are keeping up with me this week 😤"
             artifact={
@@ -42,12 +41,10 @@ export function TogetherSection() {
             }
           />
 
-          <WideFeature
+          <FeatureCard
             tint="gold"
-            artifactSide="left"
             headline="I send the whole family a weekly health newsletter."
             bubble="can you send grandpa our weekly wins?"
-            artifactAlign="center"
             artifact={
               <div className="mx-auto w-full max-w-[360px]">
                 <div className="relative">

--- a/apps/web/src/components/homepage/together-section.tsx
+++ b/apps/web/src/components/homepage/together-section.tsx
@@ -13,11 +13,6 @@ export function TogetherSection() {
           <h2 className="font-serif text-[1.875rem] font-semibold leading-[1.08] tracking-[-0.03em] text-[#2d3436] sm:text-[clamp(2rem,4vw,3.25rem)]">
             Do it with your people.
           </h2>
-          <p className="mt-5 max-w-[62ch] text-[1rem] leading-[1.7] text-[#3a322a]">
-            Habits stick when someone else is watching. Start a challenge with
-            friends, or set up a weekly newsletter so the whole family knows
-            how everyone is doing.
-          </p>
         </div>
 
         <div className="mt-10 space-y-5 sm:mt-12 sm:space-y-6">
@@ -25,7 +20,6 @@ export function TogetherSection() {
             tint="sage"
             artifactSide="right"
             headline="I referee health challenges with your friends."
-            body="Murph is the referee. It sets fair baselines across different devices, keeps score, nudges the slackers, and calls the winner at the end."
             bubble="no shot you guys are keeping up with me this week 😤"
             artifact={
               <div className="mx-auto w-full max-w-[340px]">
@@ -52,7 +46,6 @@ export function TogetherSection() {
             tint="gold"
             artifactSide="left"
             headline="I send the whole family a weekly health newsletter."
-            body="Every Sunday the group gets an email recap of the week. Wins, trends, and gentle callouts. Grandparents included."
             bubble="can you send grandpa our weekly wins?"
             artifactAlign="center"
             artifact={

--- a/apps/web/test/homepage-asks-section.test.tsx
+++ b/apps/web/test/homepage-asks-section.test.tsx
@@ -14,7 +14,6 @@ test("WideFeature keeps the phone treatment compact and restores the desktop sca
     createElement(WideFeature, {
       artifact: createElement("div", null, "Artifact"),
       artifactSide: "right",
-      body: "Body",
       bubble: "Bubble",
       headline: "Headline",
       tint: "sage",

--- a/apps/web/test/homepage-asks-section.test.tsx
+++ b/apps/web/test/homepage-asks-section.test.tsx
@@ -6,28 +6,21 @@ import { test } from "vitest";
 
 import {
   AsksGridSection,
-  WideFeature,
+  FeatureCard,
 } from "@/src/components/homepage/asks-section";
 
-test("WideFeature keeps the phone treatment compact and restores the desktop scale", () => {
+test("FeatureCard keeps the heading before the message and demo", () => {
   const markup = renderToStaticMarkup(
-    createElement(WideFeature, {
+    createElement(FeatureCard, {
       artifact: createElement("div", null, "Artifact"),
-      artifactSide: "right",
       bubble: "Bubble",
       headline: "Headline",
       tint: "sage",
     }),
   );
 
-  assert.match(markup, /rounded-\[1\.5rem\]/);
-  assert.match(markup, /sm:rounded-\[2rem\]/);
-  assert.match(markup, /min-h-\[330px\]/);
-  assert.match(markup, /sm:min-h-\[440px\]/);
-  assert.match(markup, /max-w-\[240px\]/);
-  assert.match(markup, /sm:max-w-\[280px\]/);
-  assert.match(markup, /text-\[1\.5rem\]/);
-  assert.match(markup, /sm:text-\[clamp\(1\.75rem,2\.8vw,2\.625rem\)\]/);
+  assert.ok(markup.indexOf("Headline") < markup.indexOf("Bubble"));
+  assert.ok(markup.indexOf("Bubble") < markup.indexOf("Artifact"));
 });
 
 test("AsksGridSection stacks dense health findings at iPhone Mini widths", () => {

--- a/apps/web/test/homepage-asks-section.test.tsx
+++ b/apps/web/test/homepage-asks-section.test.tsx
@@ -9,18 +9,21 @@ import {
   FeatureCard,
 } from "@/src/components/homepage/asks-section";
 
-test("FeatureCard keeps the heading before the message and demo", () => {
-  const markup = renderToStaticMarkup(
-    createElement(FeatureCard, {
-      artifact: createElement("div", null, "Artifact"),
-      bubble: "Bubble",
-      headline: "Headline",
-      tint: "sage",
-    }),
-  );
+test("FeatureCard keeps the heading before the message and demo in every layout", () => {
+  for (const layout of ["compact", "wide", "reverse"] as const) {
+    const markup = renderToStaticMarkup(
+      createElement(FeatureCard, {
+        artifact: createElement("div", null, "Artifact"),
+        bubble: "Bubble",
+        headline: "Headline",
+        tint: "sage",
+        layout,
+      }),
+    );
 
-  assert.ok(markup.indexOf("Headline") < markup.indexOf("Bubble"));
-  assert.ok(markup.indexOf("Bubble") < markup.indexOf("Artifact"));
+    assert.ok(markup.indexOf("Headline") < markup.indexOf("Bubble"));
+    assert.ok(markup.indexOf("Bubble") < markup.indexOf("Artifact"));
+  }
 });
 
 test("AsksGridSection stacks dense health findings at iPhone Mini widths", () => {

--- a/apps/web/test/homepage-together-section.test.tsx
+++ b/apps/web/test/homepage-together-section.test.tsx
@@ -11,10 +11,6 @@ test("TogetherSection renders the static social feature reframe", () => {
 
   assert.doesNotMatch(markup, /Better together/);
   assert.match(markup, /Do it with your people\./);
-  assert.match(
-    markup,
-    /Habits stick when someone else is watching\. Start a challenge with friends/,
-  );
   assert.doesNotMatch(markup, /Group challenges/);
   assert.match(markup, /I referee health challenges with your friends\./);
   assert.match(markup, /no shot you guys are keeping up with me this week/);
@@ -24,15 +20,7 @@ test("TogetherSection renders the static social feature reframe", () => {
   );
   assert.match(
     markup,
-    /Murph is the referee\. It sets fair baselines across different devices/,
-  );
-  assert.match(
-    markup,
     /I send the whole family a weekly health newsletter\./,
-  );
-  assert.match(
-    markup,
-    /Every Sunday the group gets an email recap of the week\. Wins, trends, and gentle callouts\. Grandparents included\./,
   );
   assert.match(markup, /so proud of you kids/);
   assert.match(markup, /Grandpa/);

--- a/apps/web/test/homepage-together-section.test.tsx
+++ b/apps/web/test/homepage-together-section.test.tsx
@@ -27,6 +27,6 @@ test("TogetherSection renders the static social feature reframe", () => {
   assert.match(markup, /pt-20 pb-10/);
   assert.match(markup, /sm:pb-20/);
   assert.match(markup, /lg:pb-28/);
-  assert.match(markup, /mt-10 space-y-5/);
+  assert.ok(markup.indexOf("I send the whole family") < markup.indexOf("can you send grandpa"));
   assert.doesNotMatch(markup, /leaderboard/i);
 });


### PR DESCRIPTION
## Why and outcome

Remove the supporting paragraphs from the homepage's group and personal feature sections and give the demos a stronger visual hierarchy. Larger type, deep-green challenge and rust errands features, an open newsletter composition, and smaller unframed examples replace the repeated equal-size panels.

All eight demo headings and contents remain. Both section introductions and all eight supporting paragraphs are removed.

## Product UX

- Effort: Patch.
- Result: Ready.
- Walkthrough: Public homepage visitors at 390px, 1024px, and 1440px. Headings precede demos in DOM order and on phones; the newsletter reverses visually on desktop. Voice-memo play/pause remains functional.

## Evidence

- Direct: Prepared web typecheck, focused ESLint, and 17 tests across homepage layout, health-claims copy, and changelog rendering passed.
- Coverage: Three Playwright journeys cover the real homepage and existing component study, heading order, removed paragraphs, horizontal overflow, and voice-memo playback. All six section screenshots and the full desktop page were inspected.
- CI: All required checks passed on head 6aa090f553c8ad87dad90b6183f5edd4b35d7df0. Merged as 63092655393b6498539b262131c4d7d4f6231ab1.
- Review: Parent diff and rendered review complete. Final ReviewGPT is exempt under the frontend-only presentation rule.

## Non-obvious affected surfaces

The existing homepage feature-card study composes the same components; browser checks cover it alongside the homepage. The newsletter's decorative paper stack has an explicit inset to avoid phone overflow.

## Architecture and reuse

- Existing systems reused: Homepage demos, voice-memo player, fonts, and existing component study.
- New logic: Presentation variants only; no product or assistant behavior changes.
- New abstractions: FeatureCard replaces the prior wide and compact wrappers and supports compact, wide, and visually reversed compositions.
- Complexity intentionally avoided: No new dependencies, layout state, animations, or demo reimplementation.

## Complexity impact

- Guard: pass — pnpm complexity:diff.
- Hotspots: No changed functions above 20.
- Agent judgment: Conditional classes express the three current compositions in one shared wrapper; further indirection would obscure a small presentation boundary.

## Hot reply path impact

- Path status: Not applicable; public homepage presentation only.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Diff changes static copy, component layout, and focused tests.

## Murph initial provider input impact

Not applicable to individual or group runtimes; no assistant prompts, tools, or provider request assembly changed.

## Design proof

- Design page: [Homepage feature cards](https://murph-luh8m44xd-cobuildwithus.vercel.app/screenshots/home#homepage-feature-cards). Ready preview; authenticated HTTP 200 verified on the homepage and study, with the updated colors, layout, and copy present. Vercel sign-in is required.
- Evidence: New desktop and phone captures attached below, inspected at native resolution. Sticky navigation and the Next development indicator are hidden only in captures.
- Coverage: Both sections on the real homepage and shared component study at phone, tablet, and desktop widths, including typography, contrast, reading order, decorative overflow, and audio playback.

## Deployment concerns

- Deployment: not applicable
- Reason: Presentation only; no schema, API, runtime protocol, or deployment-order changes.

## Change-shape breakdown

Classification rule: TSX components are source, test files are tests, the execution plan is docs, and changelog JSON is authored content under generated/other. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 82 | 164 |
| Tests / fixtures | 16 | 33 |
| Docs | 56 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 14 | 0 |
| **Total** | **168** | **197** |

## Changelog

- Changelog: updated
- Items: 2026-09-09 · homepage-feature-headings

![Group features desktop](https://github.com/user-attachments/assets/19669183-e40b-4b87-8a94-0220e2aa186f)

![Personal features desktop](https://github.com/user-attachments/assets/66043f03-144c-485d-b482-fbd97dae5290)

![Group features phone](https://github.com/user-attachments/assets/7caabe28-5b49-4fdf-ab28-f0e309e72338)

![Personal features phone](https://github.com/user-attachments/assets/ae942185-660e-4825-aeb0-2cb11ec656f7)
