### PR TITLE
fix(web): open goal prompts in your Murph chat

### DIFF
--- a/.agents/friction-log/20260909145950-shared-client-renderer/friction.md
+++ b/.agents/friction-log/20260909145950-shared-client-renderer/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Shared client renderer cannot dispatch focused input keyboard events'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+A component mounted with renderClientComponent can focus an input and dispatch Enter to exercise its keyboard action.
+
+## Current Behavior
+
+React selects its legacy input-event fallback in LinkeDOM. Keyboard dispatch without focus fails reading a missing instance; focusin fails because attachEvent is absent. The hero-clocks-in tests already carry their own compatibility hooks.
+
+## Minimal Reproducible Example
+
+Render a controlled input with an onKeyDown handler using the shared client renderer. Dispatch focusin followed by a bubbling keydown event with key Enter.
+
+## Possible Solution
+
+Centralize faithful legacy input-event hooks in the shared renderer or run these interactions in the browser harness.
+
+## Context
+
+Goal handoff keyboard regression proof needs the same compatibility hooks already duplicated in another component suite.

--- a/agent-docs/exec-plans/completed/2026-09-09-goal-message-handoff.md
+++ b/agent-docs/exec-plans/completed/2026-09-09-goal-message-handoff.md
@@ -1,0 +1,32 @@
+# Goal messaging handoff
+
+## Outcome
+
+Signed-in visitors can open their assigned Murph conversation from homepage goal cards and the shared composer, with the selected or typed goal prefilled.
+
+## Reaches
+
+Homepage cards, homepage and goal-library composer, and the reused guide contact button. Preserve anonymous native links and desktop signup behavior. Keep private contact resolution authenticated and uncached, with no fallback to a public line on failure. Typed prompts remain in the browser until native handoff.
+
+## Implementation
+
+Reuse the guide contact button for member handoffs. Extend the existing contact route to accept an empty object for contact-only resolution; continue rejecting arbitrary fields and prompts. Preserve canonical guide resolution for existing callers. No database schema or runtime changes.
+
+## Proof
+
+Focused route, rendered component, and interaction tests for member clicks, Enter, anonymous links, Telegram, unavailable routing, repeat clicks, and cancellation. Web typecheck and complexity review. Browser proof with synthetic contacts; actual Messages launch remains an operating-system boundary.
+
+## Progress
+
+- Root cause confirmed in local source and deployed bundle: authenticated goal actions return guide navigation.
+- Implementation complete. Existing contact action owns request timeout, repeat-click suppression, navigation cancellation, and retry. No new route-state owner.
+- Focused proof: 58 tests across seven files passed; two additional Telegram/timeout cases passed in the nine-case interaction suite afterward (60 total cases). Web typecheck and changed-file ESLint passed.
+- Browser proof: the real signed-in production composition rendered at 1440px and 390px on `/design?tab=components#goal-composer`; both captures inspected locally. Temporary capture spec removed. Unrelated catalog controls emitted existing hydration warnings; the changed section rendered correctly.
+- Product UX: Ready for the local patch. Click and Enter preserve the draft and open the assigned URI; stale/unavailable routing stays on-page, repeat clicks do not duplicate lookups, and cancelled/timed-out responses cannot launch later. Anonymous links and authenticated Telegram routing retain regression coverage.
+- Parent review: authenticated lookup remains private/no-store, accepts only an empty object or one canonical goal identifier, rejects caller-supplied contact/member fields, and performs the existing bounded member/contact reads. No assistant input or message delivery path changes; native app launch is delegated to the operating system.
+- Complexity guard passed: six changed source files, no function above 20. Further abstraction is unnecessary.
+- Added the member-visible changelog fragment and a public-safe Frog entry for the shared DOM renderer’s missing keyboard compatibility hooks.
+- Delivery boundary: local scoped commit only. No PR, production deployment, or external native-app launch was performed; release review and CI remain part of a future shipping step.
+Status: completed
+Updated: 2026-09-09
+Completed: 2026-09-09

--- a/agent-docs/product-specs/public-goal-guides.md
+++ b/agent-docs/product-specs/public-goal-guides.md
@@ -1,6 +1,6 @@
 # Public Goal Guides
 
-Last verified: 2026-08-31
+Last verified: 2026-09-09
 
 ## Current State
 
@@ -88,6 +88,12 @@ The primary action shows the Murph mark followed by `Ask Murph to help`.
   resolves that private route at click time and opens native Messages directly
   with the guide-owned start prompt prefilled. The static article never caches
   member routing.
+- Homepage goal cards and the shared homepage/library composer use the same
+  assigned-contact lookup for signed-in or temporarily unverifiable sessions,
+  rather than navigating to a guide or `/home`. A contact-only request contains
+  an empty object; selected and typed prompts are attached in the browser and
+  never sent to that endpoint. Canonical guide requests still accept only their
+  bounded goal identifier.
 - Before that signed-in route resolves, the action is an inert button rather
   than an anonymous link; an early click waits for the same private resolution.
 - Anonymous visitors open Messages directly with the same prefilled prompt,

--- a/apps/web/app/api/goals/contact/route.ts
+++ b/apps/web/app/api/goals/contact/route.ts
@@ -23,13 +23,14 @@ export async function POST(request: Request): Promise<Response> {
     return goalContactError(400, "INVALID_GOAL_CONTACT_REQUEST");
   }
 
+  const contactOnly = Object.keys(body).length === 0;
   const routeId = readGoalRouteId(body.goalRouteId);
-  if (!routeId || Object.keys(body).length !== 1) {
+  if (!contactOnly && (!routeId || Object.keys(body).length !== 1)) {
     return goalContactError(400, "INVALID_GOAL_CONTACT_REQUEST");
   }
 
-  const goal = resolveHealthCommonsCanonicalGoalEntry(routeId);
-  if (!goal) {
+  const goal = routeId ? resolveHealthCommonsCanonicalGoalEntry(routeId) : null;
+  if (!contactOnly && !goal) {
     return goalContactError(404, "GOAL_NOT_FOUND");
   }
 
@@ -50,7 +51,7 @@ export async function POST(request: Request): Promise<Response> {
   }
   const option = resolveGoalContactOption({
     murphPhoneNumber: contactContext.murphPhoneNumber,
-    startPrompt: goal.startPrompt,
+    startPrompt: goal?.startPrompt ?? "",
     textAvailable: contactContext.initialContactChannels.text,
   });
 

--- a/apps/web/app/design/goal-guide-study.tsx
+++ b/apps/web/app/design/goal-guide-study.tsx
@@ -1,5 +1,6 @@
 import { GoalCategoryBrowse } from "@/src/components/goals/goal-category-browse";
 import { GoalGuide } from "@/src/components/goals/goal-guide";
+import { AuthProvider } from "@/src/components/hosted-onboarding/auth-dialog-provider";
 import { GoalsSection } from "@/src/components/homepage/goals-section";
 import type { GoalIndexEntryModel } from "@/src/lib/goals/goal-models";
 import type { HomepageGoalPersona } from "@/src/lib/goals/homepage-goal-personas";
@@ -198,15 +199,17 @@ export function GoalGuideStudy() {
             Hey Murph, help me… composer
           </h1>
           <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
-            Production composition with synthetic personas: the shared goal composer, persona pills opening on Live long, and goal cards that hand off to Messages. Inert here, so nothing fetches or sends.
+            Signed-in production composition with synthetic personas: the shared goal composer, persona pills opening on Live long, and goal cards that hand off to Messages. Inert here, so nothing fetches or sends.
           </p>
 
           <div className="mt-10 overflow-hidden rounded-2xl border border-border bg-background" inert>
-            <GoalsSection
-              personas={DESIGN_GOAL_PERSONAS}
-              startOption={DESIGN_CONTACT_OPTION}
-              totalGoalCount={252}
-            />
+            <AuthProvider authenticated>
+              <GoalsSection
+                personas={DESIGN_GOAL_PERSONAS}
+                startOption={DESIGN_CONTACT_OPTION}
+                totalGoalCount={252}
+              />
+            </AuthProvider>
           </div>
         </div>
       </section>

--- a/apps/web/changelog/entries/2026-09-09/goals-open-your-murph-chat.json
+++ b/apps/web/changelog/entries/2026-09-09/goals-open-your-murph-chat.json
@@ -1,0 +1,15 @@
+{
+  "publishedOn": "2026-09-09",
+  "order": 100,
+  "item": {
+    "id": "goals-open-your-murph-chat",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Open your Murph chat from a goal",
+    "summary": "When you’re signed in, homepage goal cards and the goal input open your Murph conversation with the goal prefilled.",
+    "details": "If your conversation cannot be opened, you can retry from the same page without losing your draft. Nothing is sent until you send it in your messaging app.",
+    "relevanceTags": ["goals", "messaging"],
+    "sourcePullRequests": [],
+    "tryIt": { "label": "Start with a goal", "href": "/goals" }
+  }
+}

--- a/apps/web/changelog/entries/2026-09-09/goals-open-your-murph-chat.json
+++ b/apps/web/changelog/entries/2026-09-09/goals-open-your-murph-chat.json
@@ -9,7 +9,7 @@
     "summary": "When you’re signed in, homepage goal cards and the goal input open your Murph conversation with the goal prefilled.",
     "details": "If your conversation cannot be opened, you can retry from the same page without losing your draft. Nothing is sent until you send it in your messaging app.",
     "relevanceTags": ["goals", "messaging"],
-    "sourcePullRequests": [],
+    "sourcePullRequests": [3117],
     "tryIt": { "label": "Start with a goal", "href": "/goals" }
   }
 }

--- a/apps/web/src/components/goals/goal-composer.tsx
+++ b/apps/web/src/components/goals/goal-composer.tsx
@@ -15,7 +15,6 @@ import {
   useGoalHandoff,
 } from "@/src/components/goals/goal-handoff";
 import { Input } from "@/src/components/ui/input";
-import { HOSTED_APP_HOME_PATH } from "@/src/lib/hosted-onboarding/app-routes";
 import type { MurphContactOption } from "@/src/lib/murph-contact-routing";
 import { cn } from "@/src/lib/utils";
 
@@ -97,7 +96,6 @@ export function GoalComposer({
   autoFocusOnView = false,
   className,
   inputRef,
-  memberHref = HOSTED_APP_HOME_PATH,
   onEngage,
   onQueryChange,
   placeholders,
@@ -107,7 +105,6 @@ export function GoalComposer({
   autoFocusOnView?: boolean;
   className?: string;
   inputRef?: React.RefObject<HTMLInputElement | null>;
-  memberHref?: string;
   /** Fires when the visitor focuses or hovers the field: a good time to prepare search data. */
   onEngage?: () => void;
   onQueryChange: (query: string) => void;
@@ -296,10 +293,9 @@ export function GoalComposer({
           )}
           data-goal-composer-ready={sendReady ? true : undefined}
           data-goal-composer-send
-          guideHref={memberHref}
+          errorClassName="absolute left-0 top-full text-xs"
           handoff={handoff}
           labels={{
-            guide: "Open Murph",
             message: prompt ? `Text Murph: ${prompt}` : "Text Murph about a goal",
             signup: prompt
               ? `Get started with Murph: ${prompt}`

--- a/apps/web/src/components/goals/goal-contact-action.tsx
+++ b/apps/web/src/components/goals/goal-contact-action.tsx
@@ -6,6 +6,7 @@ import {
   useEffect,
   useRef,
   useState,
+  type ComponentProps,
 } from "react";
 
 import { useAuth } from "@/src/components/hosted-onboarding/auth-dialog-provider";
@@ -16,7 +17,10 @@ import {
   GOAL_CONTACT_RESOLUTION_PATH,
   type GoalContactResolution,
 } from "@/src/lib/goals/goal-contact-contract";
-import type { MurphContactOption } from "@/src/lib/murph-contact-routing";
+import {
+  type MurphContactOption,
+  withMurphContactOptionBody,
+} from "@/src/lib/murph-contact-routing";
 import { cn } from "@/src/lib/utils";
 
 const GOAL_CONTACT_RESOLUTION_TIMEOUT_MS = 10_000;
@@ -36,6 +40,8 @@ export function GoalContactAction({
     <div>
       {requiresLiveResolution ? (
         <AuthenticatedGoalContactAction
+          aria-label="Ask Murph to help with this goal"
+          className={cn(buttonVariants({ size: "xl" }), "w-full sm:w-auto")}
           key={goalRouteId}
           goalRouteId={goalRouteId}
           initiallyUnavailable={authenticationStatus === "unavailable"}
@@ -59,12 +65,18 @@ interface GoalContactAttempt {
   timeout: ReturnType<typeof setTimeout>;
 }
 
-function AuthenticatedGoalContactAction({
+export function AuthenticatedGoalContactAction({
+  children = <GoalContactActionContents />,
+  errorClassName,
   goalRouteId,
-  initiallyUnavailable,
-}: {
-  goalRouteId: string;
-  initiallyUnavailable: boolean;
+  initiallyUnavailable = false,
+  prompt,
+  ...buttonProps
+}: Omit<ComponentProps<"button">, "onClick" | "disabled" | "type"> & {
+  errorClassName?: string;
+  goalRouteId?: string;
+  initiallyUnavailable?: boolean;
+  prompt?: string | null;
 }) {
   const activeAttempt = useRef<GoalContactAttempt | null>(null);
   const [status, setStatus] = useState<"failed" | "idle" | "opening">(
@@ -133,7 +145,10 @@ function AuthenticatedGoalContactAction({
 
         finishGoalContactAttempt(activeAttempt, attempt);
         try {
-          window.location.assign(resolvedOption.href);
+          const option = prompt
+            ? withMurphContactOptionBody(resolvedOption, prompt)
+            : resolvedOption;
+          window.location.assign(option.href);
           setStatus("idle");
         } catch {
           setStatus("failed");
@@ -150,17 +165,16 @@ function AuthenticatedGoalContactAction({
   return (
     <>
       <button
-        aria-label="Ask Murph to help with this goal"
+        {...buttonProps}
         aria-busy={status === "opening"}
-        className={cn(buttonVariants({ size: "xl" }), "w-full sm:w-auto")}
         disabled={status === "opening"}
         onClick={handlePersonalizedClick}
         type="button"
       >
-        <GoalContactActionContents />
+        {children}
       </button>
       {status === "failed" ? (
-        <p className="mt-2 text-sm text-muted-foreground" role="status">
+        <p className={cn("mt-2 text-sm text-muted-foreground", errorClassName)} role="status">
           Couldn’t open your Murph chat. Try again.
         </p>
       ) : null}
@@ -169,12 +183,13 @@ function AuthenticatedGoalContactAction({
 }
 
 async function resolvePersonalizedGoalContact(input: {
-  goalRouteId: string;
+  goalRouteId?: string;
   signal: AbortSignal;
 }): Promise<MurphContactOption> {
   const resolution = await requestHostedOnboardingJson<GoalContactResolution>({
     method: "POST",
-    payload: { goalRouteId: input.goalRouteId },
+    // Composer drafts stay in the browser; this request resolves only the route.
+    payload: input.goalRouteId ? { goalRouteId: input.goalRouteId } : {},
     signal: input.signal,
     url: GOAL_CONTACT_RESOLUTION_PATH,
   });

--- a/apps/web/src/components/goals/goal-handoff.tsx
+++ b/apps/web/src/components/goals/goal-handoff.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import Link from "next/link";
 import {
   useSyncExternalStore,
   type ReactNode,
 } from "react";
 
+import { AuthenticatedGoalContactAction } from "@/src/components/goals/goal-contact-action";
 import { useAuth } from "@/src/components/hosted-onboarding/auth-dialog-provider";
 import {
   type MurphContactOption,
@@ -30,15 +30,15 @@ function readNativeMessagingPlatformOnServer(): boolean | null {
   return null;
 }
 
-export type GoalHandoffKind = "guide" | "message" | "signup";
+export type GoalHandoffKind = "personal" | "message" | "signup";
 
 /**
- * Where a goal click goes. Members and uncertain sessions open the guide,
- * whose CTA resolves their own Murph line. Anonymous visitors message Murph
+ * Where a goal click goes. Members and uncertain sessions resolve their own
+ * Murph line at click time. Anonymous visitors message Murph
  * directly when the platform can, and otherwise open the signup dialog.
  */
 export type GoalHandoff =
-  | { kind: "guide" }
+  | { kind: "personal" }
   | {
       external: boolean;
       hrefFor: (prompt: string | null) => string;
@@ -57,7 +57,7 @@ export function useGoalHandoff(option: MurphContactOption): GoalHandoff {
   );
 
   if (auth.authenticated || auth.authenticationStatus === "unavailable") {
-    return { kind: "guide" };
+    return { kind: "personal" };
   }
   if (option.kind !== "text" || nativeMessaging !== false) {
     return {
@@ -71,14 +71,14 @@ export function useGoalHandoff(option: MurphContactOption): GoalHandoff {
 }
 
 /**
- * One clickable goal rendered as whatever the handoff needs: a guide link, a
+ * One clickable goal rendered as whatever the handoff needs: a private lookup, a
  * message link, or a button that opens signup. Icon-only children should pass
  * `labels`; children with visible text name themselves.
  */
 export function GoalHandoffAction({
   children,
   className,
-  guideHref,
+  errorClassName,
   handoff,
   labels,
   prompt,
@@ -87,7 +87,7 @@ export function GoalHandoffAction({
 }: {
   children: ReactNode;
   className: string;
-  guideHref: string;
+  errorClassName?: string;
   handoff: GoalHandoff;
   labels?: GoalHandoffLabels;
   prompt: string | null;
@@ -95,18 +95,18 @@ export function GoalHandoffAction({
   "data-goal-composer-send"?: boolean;
   "data-goal-composer-ready"?: boolean;
 }) {
-  if (handoff.kind === "guide") {
+  if (handoff.kind === "personal") {
     return (
-      <Link
+      <AuthenticatedGoalContactAction
         {...dataProps}
-        aria-label={labels?.guide}
+        aria-label={labels?.message}
         className={className}
-        href={guideHref}
-        prefetch={false}
+        errorClassName={errorClassName}
+        prompt={prompt}
         ref={ref}
       >
         {children}
-      </Link>
+      </AuthenticatedGoalContactAction>
     );
   }
   if (handoff.kind === "message") {

--- a/apps/web/src/components/homepage/goals-section.tsx
+++ b/apps/web/src/components/homepage/goals-section.tsx
@@ -234,7 +234,6 @@ export function GoalsSection({
               <li className="min-w-0" key={goal.guideHref}>
                 <GoalHandoffAction
                   className={cn(GOAL_BROWSE_CARD_CLASS_NAME, "h-full w-full text-left")}
-                  guideHref={goal.guideHref}
                   handoff={handoff}
                   prompt={`Hey Murph, help me ${goal.phrase}`}
                 >

--- a/apps/web/test/goal-contact-route.test.ts
+++ b/apps/web/test/goal-contact-route.test.ts
@@ -63,6 +63,28 @@ describe("goal contact resolver route", () => {
     expect(mocks.getHostedMurphContactContext).toHaveBeenCalledTimes(1);
   });
 
+  it("resolves contact-only requests without accepting or looking up a draft", async () => {
+    const response = await POST(goalContactRequest({}));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    await expect(response.json()).resolves.toMatchObject({
+      option: { kind: "text", href: expect.stringMatching(/^sms:\+15550100001\?/) },
+    });
+    expect(mocks.resolveHealthCommonsCanonicalGoalEntry).not.toHaveBeenCalled();
+    expect(mocks.getHostedMurphContactContext).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { prompt: "synthetic draft" },
+    { goalRouteId: null },
+    { goalRouteId: "" },
+    { memberId: "another-member" },
+    { murphPhoneNumber: "+15550100002" },
+  ])("rejects extra fields or invalid identifiers: %j", async (payload) => {
+    expect((await POST(goalContactRequest(payload))).status).toBe(400);
+    expect(mocks.getHostedMurphContactContext).not.toHaveBeenCalled();
+  });
+
   it("accepts only one bounded canonical goal ID and never accepts free-text prompts", async () => {
     const extraTextResponse = await POST(goalContactRequest({
       goalRouteId: "lower-resting-heart-rate",
@@ -78,14 +100,12 @@ describe("goal contact resolver route", () => {
     expect(mocks.getHostedMurphContactContext).not.toHaveBeenCalled();
   });
 
-  it("rejects stale authentication instead of returning the anonymous fallback", async () => {
+  it.each([{}, { goalRouteId: "lower-resting-heart-rate" }])("rejects stale authentication for %j", async (payload) => {
     mocks.getHostedPageAuthSnapshot.mockResolvedValue({
       authenticatedMember: null,
     });
 
-    const response = await POST(goalContactRequest({
-      goalRouteId: "lower-resting-heart-rate",
-    }));
+    const response = await POST(goalContactRequest(payload));
 
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toMatchObject({
@@ -94,7 +114,7 @@ describe("goal contact resolver route", () => {
     expect(mocks.getHostedMurphContactContext).not.toHaveBeenCalled();
   });
 
-  it("fails closed when an assigned text route cannot be resolved", async () => {
+  it.each([{}, { goalRouteId: "lower-resting-heart-rate" }])("fails closed for an unresolved text route: %j", async (payload) => {
     mocks.getHostedMurphContactContext.mockResolvedValue({
       initialContactChannels: {
         email: true,
@@ -105,9 +125,7 @@ describe("goal contact resolver route", () => {
       murphPhoneNumber: null,
     });
 
-    const response = await POST(goalContactRequest({
-      goalRouteId: "lower-resting-heart-rate",
-    }));
+    const response = await POST(goalContactRequest(payload));
 
     expect(response.status).toBe(503);
     await expect(response.json()).resolves.toMatchObject({
@@ -115,7 +133,7 @@ describe("goal contact resolver route", () => {
     });
   });
 
-  it("uses Telegram only when it is the authenticated member's available channel", async () => {
+  it.each([{}, { goalRouteId: "lower-resting-heart-rate" }])("uses the authenticated Telegram channel for %j", async (payload) => {
     mocks.getHostedMurphContactContext.mockResolvedValue({
       initialContactChannels: {
         email: false,
@@ -126,9 +144,7 @@ describe("goal contact resolver route", () => {
       murphPhoneNumber: null,
     });
 
-    const response = await POST(goalContactRequest({
-      goalRouteId: "lower-resting-heart-rate",
-    }));
+    const response = await POST(goalContactRequest(payload));
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({

--- a/apps/web/test/goal-handoff-interaction.test.tsx
+++ b/apps/web/test/goal-handoff-interaction.test.tsx
@@ -1,0 +1,162 @@
+import { act, createElement, useState, type ReactElement } from "react";
+import { afterEach, expect, test, vi } from "vitest";
+
+import { AuthContext } from "@/src/components/hosted-onboarding/auth-dialog-provider";
+import { renderClientComponent } from "./render-client-component";
+
+const publicOption = { href: "sms:+15550100001", kind: "text" as const, label: "Messages" };
+const privateOption = { href: "sms:+15550100002", kind: "text" as const, label: "Messages" };
+
+function signedIn(children: ReactElement, unavailable = false) {
+  return createElement(AuthContext.Provider, {
+    value: {
+      authenticated: !unavailable,
+      authenticationStatus: unavailable ? "unavailable" : "ready",
+      openAuthDialog: vi.fn(), prepareAuth: vi.fn(), shared: false,
+    },
+  }, children);
+}
+
+function contactResponse(option = privateOption) {
+  return new Response(JSON.stringify({ option }), {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+test.each(["click", "Enter"])("member composer %s opens the assigned line and keeps the draft off the network", async (action) => {
+  const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(contactResponse());
+  vi.stubGlobal("fetch", fetchMock);
+  const rendered = await renderClientComponent(<div />, { requireButton: false });
+  const { GoalComposer } = await import("@/src/components/goals/goal-composer");
+  function Composer() {
+    const [query, setQuery] = useState("build a walking habit");
+    return <GoalComposer onQueryChange={setQuery} placeholders={[]} query={query} startOption={publicOption} />;
+  }
+  try {
+    await rendered.rerender(signedIn(<Composer />));
+    expect(fetchMock).not.toHaveBeenCalled();
+    const input = rendered.container.querySelector("input")!;
+    const send = rendered.container.querySelector<HTMLButtonElement>("[data-goal-composer-send]")!;
+    await act(async () => {
+      if (action === "click") send.click();
+      else {
+        // LinkeDOM selects React’s legacy input-event fallback, as in hero-clocks-in.
+        Object.defineProperties(input, {
+          attachEvent: { value: (name: string, listener: EventListener) => input.addEventListener(name.slice(2), listener) },
+          detachEvent: { value: (name: string, listener: EventListener) => input.removeEventListener(name.slice(2), listener) },
+        });
+        input.focus();
+        input.dispatchEvent(new rendered.window.Event("focusin", { bubbles: true }));
+        const event = new rendered.window.Event("keydown", { bubbles: true });
+        Object.defineProperty(event, "key", { value: "Enter" });
+        input.dispatchEvent(event);
+      }
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]).toEqual([
+      "/api/goals/contact", expect.objectContaining({ method: "POST", body: "{}", cache: "no-store", credentials: "same-origin" }),
+    ]);
+    expect(rendered.assign).toHaveBeenCalledWith(`sms:+15550100002?body=${encodeURIComponent("Hey Murph, help me build a walking habit")}`);
+    expect(input.value).toBe("build a walking habit");
+  } finally { await rendered.cleanup(); }
+});
+
+test("member homepage card resolves the private chat with its selected prompt", async () => {
+  const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(contactResponse());
+  vi.stubGlobal("fetch", fetchMock);
+  const rendered = await renderClientComponent(<div />, { requireButton: false });
+  const { GoalsSection } = await import("@/src/components/homepage/goals-section");
+  try {
+    await rendered.rerender(signedIn(<GoalsSection personas={[{
+      id: "feel-better", label: "Just feel better", goals: [{
+        href: "/goals/walk-every-day", phrase: "walk every day", illustrationSrc: null,
+      }],
+    }]} startOption={publicOption} totalGoalCount={1} />));
+    const card = rendered.container.querySelector<HTMLButtonElement>("li button")!;
+    await act(async () => card.click());
+    expect(rendered.assign).toHaveBeenCalledWith(`sms:+15550100002?body=${encodeURIComponent("Hey Murph, help me walk every day")}`);
+    expect(fetchMock.mock.calls[0]?.[1]?.body).toBe("{}");
+  } finally { await rendered.cleanup(); }
+});
+
+test("private resolution failure permits retry without falling back to the public number", async () => {
+  const fetchMock = vi.fn<typeof fetch>()
+    .mockResolvedValueOnce(new Response("{}", { status: 503 }))
+    .mockResolvedValueOnce(contactResponse());
+  vi.stubGlobal("fetch", fetchMock);
+  const { GoalComposer } = await import("@/src/components/goals/goal-composer");
+  const rendered = await renderClientComponent(signedIn(
+    <GoalComposer onQueryChange={() => {}} placeholders={[]} query="walk every day" startOption={publicOption} />,
+    true,
+  ));
+  try {
+    await act(async () => rendered.button.click());
+    expect(rendered.assign).not.toHaveBeenCalled();
+    expect(rendered.container.textContent).toContain("Couldn’t open your Murph chat. Try again.");
+    expect(rendered.container.querySelector('a[href^="sms:"]')).toBeNull();
+    await act(async () => rendered.button.click());
+    expect(rendered.assign).toHaveBeenCalledTimes(1);
+    expect(rendered.container.querySelector("input")?.value).toBe("walk every day");
+  } finally { await rendered.cleanup(); }
+});
+
+test.each(["pagehide", "popstate", "unmount"])("pending contact lookup ignores repeat clicks and cancels on %s", async (exit) => {
+  let resolve!: (response: Response) => void;
+  const fetchMock = vi.fn<typeof fetch>().mockImplementation(() => new Promise((done) => { resolve = done; }));
+  vi.stubGlobal("fetch", fetchMock);
+  const { GoalComposer } = await import("@/src/components/goals/goal-composer");
+  const rendered = await renderClientComponent(signedIn(
+    <GoalComposer onQueryChange={() => {}} placeholders={[]} query="walk every day" startOption={publicOption} />,
+  ));
+  try {
+    await act(async () => { rendered.button.click(); rendered.button.click(); });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(rendered.button.getAttribute("aria-busy")).toBe("true");
+    if (exit === "unmount") await rendered.rerender(<div />);
+    else await act(async () => rendered.window.dispatchEvent(new rendered.window.Event(exit)));
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+    await act(async () => resolve(contactResponse()));
+    expect(rendered.assign).not.toHaveBeenCalled();
+  } finally { await rendered.cleanup(); }
+});
+
+test("member Telegram handoff attaches the draft to the resolved channel", async () => {
+  vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({
+    option: { kind: "telegram", label: "Telegram", href: "https://t.me/withmurph_bot?text=default" },
+  }), { headers: { "content-type": "application/json" } })));
+  const { GoalComposer } = await import("@/src/components/goals/goal-composer");
+  const rendered = await renderClientComponent(signedIn(
+    <GoalComposer onQueryChange={() => {}} placeholders={[]} query="walk every day" startOption={publicOption} />,
+  ));
+  try {
+    await act(async () => rendered.button.click());
+    const url = new URL(rendered.assign.mock.calls[0]![0]);
+    expect(url.origin).toBe("https://t.me");
+    expect(url.searchParams.get("text")).toBe("Hey Murph, help me walk every day");
+  } finally { await rendered.cleanup(); }
+});
+
+test("a timed-out member lookup offers retry and cannot launch a late response", async () => {
+  vi.useFakeTimers();
+  let resolve!: (response: Response) => void;
+  const fetchMock = vi.fn<typeof fetch>().mockImplementation(() => new Promise((done) => { resolve = done; }));
+  vi.stubGlobal("fetch", fetchMock);
+  const { GoalComposer } = await import("@/src/components/goals/goal-composer");
+  const rendered = await renderClientComponent(signedIn(
+    <GoalComposer onQueryChange={() => {}} placeholders={[]} query="walk every day" startOption={publicOption} />,
+  ), { location: { href: "https://example.test/goals" } });
+  try {
+    await act(async () => rendered.button.click());
+    await act(async () => vi.advanceTimersByTimeAsync(10_000));
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+    expect(rendered.container.textContent).toContain("Couldn’t open your Murph chat. Try again.");
+    expect(rendered.button.disabled).toBe(false);
+    await act(async () => resolve(contactResponse()));
+    expect(rendered.assign).not.toHaveBeenCalled();
+  } finally {
+    await rendered.cleanup();
+    vi.useRealTimers();
+  }
+});

--- a/apps/web/test/homepage-goals-section.test.tsx
+++ b/apps/web/test/homepage-goals-section.test.tsx
@@ -110,15 +110,16 @@ test("GoalsSection routes anonymous visitors to Telegram where that is the defau
   assert.match(markup, /href="https:\/\/t\.me\/withmurph_bot\?text=Hey(?:\+|%20)Murph(?:\+|%20)*[^"]*stay/);
 });
 
-test("GoalsSection sends members to the guide, whose CTA resolves their own line", () => {
+test("GoalsSection resolves the member conversation without linking to home or a guide", () => {
   const { markup } = renderSection({
     messengerChannel: "imessage",
     wrap: (section) =>
       withAuth(section, { authenticated: true, authenticationStatus: "ready" }),
   });
 
-  assert.match(markup, /aria-label="Open Murph"[^>]*href="\/home"/);
-  assert.match(markup, /href="\/goals\/stay-independent-as-i-age"/);
+  assert.match(markup, /<button[^>]*data-goal-composer-send/);
+  assert.doesNotMatch(markup, /href="\/home"/);
+  assert.doesNotMatch(markup, /href="\/goals\/stay-independent-as-i-age"/);
   assert.doesNotMatch(markup, /href="sms:/);
 });
 
@@ -132,8 +133,9 @@ test("GoalsSection never hands the public line to an unverifiable session, even 
       ),
   });
 
-  assert.match(markup, /href="\/goals\/stay-independent-as-i-age"/);
-  assert.match(markup, /aria-label="Open Murph"[^>]*href="\/home"/);
+  assert.doesNotMatch(markup, /href="\/goals\/stay-independent-as-i-age"/);
+  assert.match(markup, /<button[^>]*data-goal-composer-send/);
+  assert.doesNotMatch(markup, /href="\/home"/);
   assert.doesNotMatch(markup, /href="sms:/);
   assert.doesNotMatch(markup, /t\.me\//);
 });


### PR DESCRIPTION
## Why and outcome

Signed-in visitors clicking the goal composer arrow went to `/home`, while homepage goal cards opened guide pages. Both controls now resolve the member’s assigned Murph conversation and open it with the typed or selected goal prefilled.

The shared guide contact action retains its timeout, cancellation, repeat-click suppression, and inline retry behavior. The existing contact endpoint accepts an empty object for contact-only resolution; freeform drafts stay in the browser and caller-selected member or contact fields remain rejected.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Signed-in composer click/Enter and homepage card selection open the resolved messaging URI. Unavailable authentication or routing remains on-page with retry and preserves the draft. Anonymous native links and desktop signup behavior remain covered; Telegram-only member routing remains supported. Nothing is sent automatically.

## Evidence

- Direct: 60 focused cases passed across goal contact route/action, homepage cards, composer interactions, contact routing, and changelog rendering. Member interactions prove the assigned URI and exact prefilled draft, with an empty contact request body, including cancellation and late-response suppression.
- Coverage: `pnpm --dir apps/web test:prepared goal-handoff-interaction.test.tsx goal-contact-route.test.ts goal-contact-action.test.tsx homepage-goals-section.test.tsx goal-contact.test.ts murph-contact-routing.test.ts changelog-page.test.tsx`; the two additional Telegram/timeout cases passed in the subsequent nine-case interaction run. Web typecheck, changed-file ESLint, privacy scan, and diff checks passed.
- Browser: Real signed-in production composition rendered and inspected at 1440px and 390px through the repository Playwright smoke configuration. Captures stayed local and synthetic. Native Messages launch is an operating-system boundary; tests prove the URI handed to it.
- Final ReviewGPT: PASS on `1d5edd4bcdd284c8b40079eed841464f592b79c0`; no qualifying Critical/High bugs or material Complexity Collapse findings. The full snapshot and all 13 changed files were inspected. Mountain lane showed 6 Pro selected; the response reported `MODEL_CONFIRMATION: UNKNOWN`. The user explicitly accepted the 246-second review despite the repository’s 270-second timing threshold; this is a user-approved timing exception, not a tool attestation. Review scope and artifact quality were inspected locally and accepted.
- CI: Web build, all four Web test shards, all package coverage jobs, and Release build/typecheck passed on the final head. The first build/typecheck attempt hit an HTTP 403 from GitHub’s Markdown API in an unchanged Frog test; rerunning that job passed without code changes. The candidate merges cleanly with current `main`.

## Non-obvious affected surfaces

The shared composer also appears on `/goals`. Existing article contact requests still accept a canonical goal identifier and use the same authenticated contact owner; focused route and article CTA tests preserve that contract.

## Architecture and reuse

- Existing systems reused: `AuthenticatedGoalContactAction`, hosted contact context, existing goal contact endpoint, and channel-specific draft encoding.
- New logic: Empty-object contact resolution and browser-side draft attachment for member goal controls.
- New abstractions: None; the existing contact button accepts the required button presentation and optional draft.
- Complexity intentionally avoided: No new endpoint, routing store, line assignment, message send, queue, or persistence.

## Complexity impact

- Guard: Pass, `pnpm complexity:diff`.
- Hotspots: None above 20 in the six changed source files.
- Agent judgment: Reusing the contact button removes guide navigation without duplicating request lifecycle logic; further abstraction is unnecessary.

## Hot reply path impact

- Path status: Not applicable; this changes browser-to-messaging handoff before a member sends anything.
- Database calls: None added to the reply path. A click uses the existing bounded current-member/contact lookup with no collection fanout or new transaction.
- Network/provider calls: None added to the reply path. One browser contact request per active button attempt; 10-second timeout, no automatic retries.
- Other awaited latency: None on the reply path.
- Before/after proof: Interaction tests prove duplicate suppression and one contact request per attempt.

## Murph initial provider input impact

Not applicable to individual or group runtimes: no assembled assistant instructions, tools, schemas, history, or provider-input builders changed. No provider-input measurement was needed.

## Design proof

- Design page: [Goal composer presentation reference](https://www.withmurph.ai/design?tab=components#goal-composer). The existing production page represents the unchanged layout; the updated signed-in study was verified locally. A current-branch hosted preview is unavailable.
- Evidence: Local desktop and phone captures inspected; the study renders the real signed-in components with synthetic props and inert controls.
- Coverage: Initial layout, member action semantics, desktop and phone widths; functional interaction tests cover pending, retry, cancellation, and native-URI handoff.

## Deployment concerns

- Deployment: applicable
- Supported skew: The new endpoint accepts existing canonical-guide requests plus empty contact-only requests. Old clients work with the new server; new member composer clients receiving an old server response show retry rather than using a public number.
- Safe order: Deploy the Web endpoint and client in the normal Web release; no Worker or runner change.
- Rollback floor: No state migration or persistence; reverting the Web change restores prior behavior.
- Expected exposure: During Web version skew, new member composer attempts reaching an old endpoint can fail visibly and be retried after refresh.
- Reversibility: Ordinary Web forward correction or revert; no data cleanup.
- Convergence proof: Existing canonical-guide request tests and new empty-object request tests pass; production convergence remains a release check.
- Post-deploy checks: While signed in, select a homepage goal or submit the composer and confirm Messages opens the assigned conversation with the draft. Check retry behavior and an anonymous visit.

## Change-shape breakdown

Classification rule: Application TS/TSX and changelog content are source; test files are tests; plans, product contracts, and the Frog entry are docs. No binaries or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 73 | 44 |
| Tests / fixtures | 197 | 17 |
| Docs | 63 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **333** | **62** |

## Changelog

- Changelog: updated
- Items: 2026-09-09 · goals-open-your-murph-chat

ReviewGPT context sensitivity: sensitive
Classification reason: Authenticated contact resolution API and external messaging handoff.

ReviewGPT first-reviewed head: 1d5edd4bcdd284c8b40079eed841464f592b79c0
