### PR TITLE
Recognize connected health sources during onboarding

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-09-onboarding-source-awareness.md
+++ b/agent-docs/exec-plans/completed/2026-09-09-onboarding-source-awareness.md
@@ -1,0 +1,79 @@
+# Acknowledge connected health sources during onboarding
+
+Status: completed
+Created: 2026-09-09
+Updated: 2026-09-09
+
+## Goal and scope
+
+Update the existing onboarding skill to acknowledge connected sources before
+asking for missing wearable context. Apple Health alone is not evidence of
+wearable ownership. Keep the existing hosted device tool and canonical memory
+owners; no runtime, provider, persistence, or authorization changes.
+
+## Product UX and success criteria
+
+Patch effort. Replay synthetic private onboarding journeys: Apple Health with
+unknown wearable use asks once about a watch or ring; an already answered
+negative moves on; an identified wearable moves on; no accounts permits the
+ordinary discovery question; lookup failure stays unknown. Current evidence
+avoids a lookup, otherwise at most one unfiltered read precedes the reply.
+Never reconnect an established source, infer fresh data, or require a wearable.
+
+## Tasks
+
+1. Remove the unconditional wearable question from the park example and update
+   the data-source checkpoint and Apple Health setup exclusion.
+2. Add deterministic policy proof and production-derived real-Codex journeys.
+3. Run focused tests, relevant typecheck, changelog validation, and complexity
+   review; inspect every synthetic reply and the complete diff.
+4. Add a public outcome changelog, close this plan, and make a scoped commit.
+
+## Verification
+
+- Passed: `pnpm --dir packages/assistant-engine test test/assistant-skill-assets.test.ts -t onboarding` (4 tests).
+- Passed: `pnpm --dir packages/assistant-engine typecheck`.
+- Passed: `pnpm --dir apps/web test changelog-page.test.tsx` (10 tests).
+- Passed: `pnpm --dir apps/web typecheck`.
+- Passed: `pnpm complexity:diff`; runtime implementation is Markdown, with no
+  authored JavaScript/TypeScript source changes. Test branches cover distinct
+  product outcomes and need no production abstraction.
+- Passed: five individually selected `pnpm test:assistant:live -- --test
+  "onboarding source awareness: .*<case>"` journeys, using `gpt-5.6-terra`
+  with local subscription auth. Cases: `unknown wearable use`,
+  `wearable use already answered`, `an identified wearable`,
+  `no connected sources`, and `an unavailable account lookup`.
+- A working authenticated local profile was selected under the documented
+  retry contract after pre-action authentication/startup failures. No auth
+  material was copied or persisted by this task.
+- Exact effects: one unfiltered account read in each unknown-state case;
+  zero reads with current Apple Health evidence and an earlier negative
+  answer. Zero connection mutations or hosted device CLI fallbacks.
+- Reply review: Ready for all five journeys. Apple Health is acknowledged
+  before a watch/ring question only when wearable use remains unknown;
+  identified wearables and earlier answers advance to the foundation memo;
+  no accounts permits discovery; unavailable lookup remains explicitly
+  unknown with no retry or reconnect suggestion.
+- The failure journey initially exposed a second read following the generic
+  tool error hint. The onboarding owner now explicitly keeps its optional
+  one-read limit after any result, and the same journey passed on rerun.
+- The identified-wearable journey accepts a truthful connection acknowledgement
+  without requiring the incidental adjective “connected.” Its exact action
+  and forbidden-claim assertions remain in place; the rerun passed.
+- Passed: final diff whitespace and personal-identifier scans. All fixtures and
+  release notes are synthetic and contain no private feedback or account rows.
+
+## Review and delivery
+
+The runtime implementation is one onboarding reference. Existing account reads,
+conversation evidence, and optional connection paths remain the owners. There
+is at most one on-demand hosted account read at the data-source checkpoint;
+no background snapshot or per-message read is added. Initial provider input
+and group behavior are unchanged because this reference is read on demand in
+private onboarding. A failed read preserves uncertainty and continues without
+retry or a connection mutation.
+
+Prompt-primary work qualifies for the ReviewGPT exemption. No PR, push,
+deployment, or production mutation is part of this task. The changelog fragment
+has no source PR number because this task produces a local scoped commit.
+Completed: 2026-09-09

--- a/apps/web/changelog/entries/2026-09-09/onboarding-connected-sources.json
+++ b/apps/web/changelog/entries/2026-09-09/onboarding-connected-sources.json
@@ -9,6 +9,6 @@
     "summary": "Murph checks existing connections before asking about your wearable or health app during onboarding.",
     "details": "When Apple Health is connected, Murph acknowledges it and asks about a watch or ring only if you have not already answered. You can continue without a wearable or another connection.",
     "relevanceTags": ["onboarding", "wearables"],
-    "sourcePullRequests": []
+    "sourcePullRequests": [3125]
   }
 }

--- a/apps/web/changelog/entries/2026-09-09/onboarding-connected-sources.json
+++ b/apps/web/changelog/entries/2026-09-09/onboarding-connected-sources.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-09",
+  "order": 100,
+  "item": {
+    "id": "onboarding-connected-sources",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Onboarding recognizes connected health sources",
+    "summary": "Murph checks existing connections before asking about your wearable or health app during onboarding.",
+    "details": "When Apple Health is connected, Murph acknowledges it and asks about a watch or ring only if you have not already answered. You can continue without a wearable or another connection.",
+    "relevanceTags": ["onboarding", "wearables"],
+    "sourcePullRequests": []
+  }
+}

--- a/packages/assistant-engine/skills/murph-onboarding/references/aspiration-foundation-delegation.md
+++ b/packages/assistant-engine/skills/murph-onboarding/references/aspiration-foundation-delegation.md
@@ -158,25 +158,25 @@ internal storage or call it the user's permanent “main direction.”
 
 Then explicitly explain the ordering without foregrounding a refusal to help.
 For a casual user who named strength and sleep as the threads, confidence and
-energy as the reason, and has not resolved the data-source checkpoint, a
-complete reply can be:
+energy as the reason, the reflection can be:
 
 ```text
-got it — stronger and sleeping better, mainly for more confidence and energy. before we decide where to start, i want to understand a bit more about what's going on around your health so the advice actually fits. do you use a wearable or health app?
+got it — stronger and sleeping better, mainly for more confidence and energy. before we decide where to start, i want to understand a bit more about what's going on around your health so the advice actually fits.
 ```
 
 Treat this as a worked example, not fixed copy. Substitute the user's actual
-threads and reason, match their register, and ask the first unresolved
-foundation question rather than repeating the wearable question when that
-checkpoint is already known. Before sending the data-source question, make it
+threads and reason, match their register, then apply the data-source evidence
+check below before appending the first unresolved foundation question rather
+than repeating the wearable question when that checkpoint is already known. Before sending the data-source question, make it
 concrete from live capability guidance. The current prompt's “Hosted wearable
 connection links are available for …” line is the sole source of provider
 examples. Append a short “like …” clause using only labels from that line: one
 when only one is available and a few when more are available. If the line is
 absent, omit provider examples rather than inventing or recalling names. Keep
 Apple Health out of this provider-example clause; it is offered only through
-the separate native-app relay after a clear “none,” never as a `murph.device`
-provider.
+the separate native-app relay after a clear “none” when it is not already
+connected, never as a `murph.device` connect provider. This does not restrict
+acknowledging an existing Apple Health connection.
 
 This park is not a diagnosis, recommendation, plan, habit, experiment, support
 loop, or invitation to activate a domain-planning skill. Do not provide any of
@@ -263,17 +263,46 @@ Do not wait for schema inspection, label research, or canonical readback. If
 spawning is unavailable, the parent falls back to one compact bounded save for
 the supplied facts before replying and leaves optional label details unknown.
 
-1. **Data sources and wearables.** Check visible context and the resume
-   snapshot first. When connection state is unclear, use `murph.device` with
-   `action: list_accounts` when available. Only in a non-hosted local-operator
-   route, use `vault-cli device account list --format json` when the prompt
-   explicitly grants that command for the current turn. A hosted runtime must
-   not use the device CLI as fallback. Otherwise continue from visible and
-   saved evidence without pretending a device action is available. Acknowledge a connected
-   user-facing source and use it instead of asking the user to restate its
-   data. If none is visible, ask whether they use a wearable or health app and
-   explain that connecting one can reduce manual reporting and improve later
-   interpretation. Build its example clause only from labels on the current
+1. **Data sources and wearables.** Before asking, check visible conversation,
+   saved context, and current connection evidence. Never repeat a wearable
+   question already answered, including an explicit none, skip, or deferral.
+   If current connection state is missing, empty only in the resume snapshot,
+   or errored, call `murph.device` with unfiltered `action: list_accounts`
+   once this turn when available, before the user-facing question. A hosted
+   resume snapshot's device-account error does not mean no connections. Only
+   in a non-hosted local-operator route, use
+   `vault-cli device account list --format json` when the prompt explicitly
+   grants it. Never use the device CLI as a hosted fallback. If the lookup
+   fails or is unavailable, keep the state unknown, briefly say you could not
+   check it, and continue from known facts without claiming disconnection,
+   offering reconnection, or retrying in this turn. For this optional
+   onboarding lookup, a tool error's generic retry hint does not override the
+   one-read limit: after any result, use that result and reply without another
+   `list_accounts` call.
+
+   Acknowledge any established user-facing source, including Apple Health,
+   before asking for missing context. An active connection does not prove
+   that data has arrived or is current. A known wearable resolves device
+   discovery; advance to the next unresolved foundation area without asking
+   which wearable they use or offering to connect it again.
+
+   Apple Health alone does not establish whether the user wears a device.
+   When it is connected and wearable use is still unknown, ask once in this
+   shape, matching the user's register:
+
+   ```text
+   I can see Apple Health is connected. Do you also use a watch or ring?
+   ```
+
+   If visible or saved context already answers that question, including no
+   wearable, acknowledge the connection and advance. Their answer or skip
+   ends this follow-up; never make wearable ownership or another connection
+   a requirement. Do not repeat the generic wearable-or-health-app question
+   or offer Apple Health setup when Apple Health is already connected.
+
+   When no source is known after the available check, ask whether they use
+   a wearable or health app and explain that connecting one can reduce manual
+   reporting and improve later interpretation. Build its example clause only from labels on the current
    prompt's hosted wearable connection line: one label when only one exists and
    a few when several do. If that line is absent, omit provider examples; never
    supply remembered names. Keep Apple Health separate for the post-“none”
@@ -290,8 +319,9 @@ the supplied facts before replying and leaves optional label details unknown.
    checkpoint until the user returns or the connection is visible. A clear
    “none,” “not relevant,” or skip resolves
    the checkpoint. After a clear “none,” when the current prompt includes the
-   Apple Health relay, make one optional conditional offer unless context
-   already rules out an iPhone or the user declined connection help:
+   Apple Health relay, make one optional conditional offer unless Apple Health
+   is already connected, context already rules out an iPhone, or the user
+   declined connection help:
 
    ```text
    no wearable is totally fine. if you use an iPhone, you can connect Apple Health in the Murph app so i can start using the daily steps your phone sends. want the app link?

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -381,6 +381,9 @@ const REAL_CODEX_ONBOARDING_ALLOWED_POLICY_PATHS = {
   ],
   minimal_identity_answer: [],
   minimal_identity_prompt: [],
+  wearable_source_awareness: [
+    ...ONBOARDING_POLICY_PATHS.map((entry) => entry[1]),
+  ],
   wearable_connection_offer: [
     ONBOARDING_POLICY_PATHS[0][1],
     ONBOARDING_POLICY_PATHS[1][1],
@@ -1676,6 +1679,158 @@ describeRealCodex('real Codex onboarding progressive disclosure e2e', () => {
         expect(reply).not.toMatch(/bank\/|memory\.md|memory_document_invalid|\b(?:canonical|field|line \d+|invalid id)\b/iu)
         expect(reply).not.toMatch(/(?:you(?:['’]ll| will| need to| should)?|please) (?:fix|repair|edit)|\b(?:i|we)(?:['’]ll| will| have|['’]ve) (?:fix|repair|retry|escalate|contact|report|flag)|\b(?:support|team) (?:has been|was) (?:notified|contacted)/iu)
         expect(reply).not.toMatch(/what should i call you|how old|gender/iu)
+      } finally {
+        await removeRealCodexTemporaryPaths(temporaryPaths)
+      }
+    },
+    360_000,
+  )
+
+  it.each([
+    { name: 'Apple Health with unknown wearable use', source: 'apple', knownNone: false, failure: false },
+    { name: 'Apple Health with wearable use already answered', source: 'apple', knownNone: true, failure: false },
+    { name: 'an identified wearable', source: 'oura', knownNone: false, failure: false },
+    { name: 'no connected sources', source: 'none', knownNone: false, failure: false },
+    { name: 'an unavailable account lookup', source: 'none', knownNone: false, failure: true },
+  ] as const)(
+    'onboarding source awareness: $name',
+    async (scenario) => {
+      const config = await resolveRealCodexE2eConfig()
+      const temporaryPaths = [...config.temporaryPaths]
+      const deviceRequests: AssistantHostedDeviceToolRequest[] = []
+      try {
+        const workingDirectory = await prepareRealCodexOnboardingDirectory()
+        temporaryPaths.unshift(workingDirectory)
+        const resume = buildRealCodexOnboardingResumeContext('ordinary_records')
+        if (resume.memory.status !== 'ok') {
+          throw new Error('Expected available synthetic onboarding memory.')
+        }
+        const records = resume.memory.records.filter((record) =>
+          typeof record !== 'object' || record === null || !('id' in record)
+          || record.id !== 'ordinary_health_context'
+        )
+        const empty = { count: 0, items: [], status: 'ok', truncated: false } as const
+        await writeFile(
+          path.join(workingDirectory, 'onboarding-resume-context.json'),
+          `${JSON.stringify({
+            ...resume,
+            allergies: empty,
+            conditions: empty,
+            deviceAccounts: {
+              status: 'error',
+              code: 'invalid_option',
+              message: 'This onboarding context surface could not be read.',
+              retryable: false,
+            },
+            experiments: empty,
+            regimens: empty,
+            supplements: empty,
+            memory: { ...resume.memory, recordCount: records.length, records },
+          })}\n`,
+          { encoding: 'utf8', mode: 0o600 },
+        )
+        const deviceTool: NonNullable<AssistantHostedToolContext['deviceTool']> = {
+          async request(request) {
+            deviceRequests.push(request)
+            if (request.action !== 'list_accounts') {
+              throw new Error('Onboarding discovery must not change a connection.')
+            }
+            if (scenario.failure) {
+              throw new Error('Synthetic account lookup unavailable.')
+            }
+            return {
+              action: 'list_accounts',
+              provider: null,
+              sourceProvider: null,
+              accounts: scenario.source === 'none' ? [] : [{
+                accountId: 'synthetic-connected-source',
+                displayName: scenario.source === 'apple' ? 'Apple Health' : 'Oura',
+                provider: scenario.source === 'apple' ? 'junction' : 'oura',
+                status: 'active',
+                lastErrorCode: null,
+                lastSyncCompletedAt: null,
+              }],
+            }
+          },
+        }
+        const result = await executeRealCodexOnboardingProbe({
+          ...buildRealCodexOnboardingTurnInput({ config, workingDirectory }),
+          developerInstructions: buildDirectConversationDeveloperInstructions(
+            true,
+            [
+              'Assistant context snapshot (engine-supplied evidence): private onboarding is open. The welcome, minimal identity, aspiration readiness, save, reflection, and park are complete. The visible conversation is at the data-source checkpoint. Movement, protocols, supplements, medical context, and recent labs are unresolved.',
+              'The last Murph message parked the saved sleep aspiration and explained that learning the health context comes next.',
+              ...(scenario.knownNone ? [
+                'Current operational evidence: Apple Health has an active connection. No completed sync is reported.',
+                'Earlier in this conversation, the member explicitly said they do not use a wearable.',
+              ] : []),
+            ].join('\n'),
+            [{ label: 'Oura', provider: 'oura' }],
+          ),
+          dynamicTools: [MURPH_DEVICE_TOOL],
+          excludeResumeTurns: true,
+          hostedToolContext: {
+            computerToolsAvailable: false,
+            currentHostedDeliveryContext: () => null,
+            currentHostedMailboxItemIds: () => [],
+            currentInvocationScope: () => ({
+              conversationScope: 'direct',
+              origin: {
+                assistantInputId: 'ain_00000000000000000000000000000028',
+                kind: 'accepted_input',
+                sessionId: 'session-onboarding-source-awareness',
+              },
+              originSessionId: 'session-onboarding-source-awareness',
+            }),
+            deviceTool,
+            sendVaultFile: async () => {
+              throw new Error('File delivery is unavailable in this discovery journey.')
+            },
+            vaultFileSendAvailable: false,
+          },
+          prompt: 'Yes, let’s keep going.',
+          scenario: 'wearable_source_awareness',
+        })
+        const reply = result.finalMessage.trim()
+        process.stdout.write(`[onboarding-source-awareness-e2e] ${JSON.stringify({
+          scenario: scenario.name, deviceRequests, reply,
+        })}\n`)
+        expect(deviceRequests).toEqual(scenario.knownNone ? [] : [{ action: 'list_accounts' }])
+        expect(reply.match(/\?/gu) ?? []).toHaveLength(1)
+        expect(reply).not.toMatch(/https?:\/\/|\bjunction\b|list_accounts|vault-cli/iu)
+        expect(reply).not.toMatch(/(?:your|the) (?:steps|sleep|workouts|data) (?:are|is) (?:syncing|coming in|up to date)/iu)
+        expect(result.actions.filter((action) => action.kind === 'dynamic')).toHaveLength(
+          scenario.knownNone ? 0 : 1,
+        )
+        expect(result.actions.filter((action) =>
+          action.kind === 'command' && /vault-cli\s+device\b/iu.test(action.command)
+        )).toEqual([])
+        if (scenario.source === 'apple') {
+          expect(reply).toMatch(/apple health/iu)
+          expect(reply).toMatch(/connected|linked/iu)
+          expect(reply).not.toMatch(/do you use (?:a |any )?wearable or health app/iu)
+          expect(reply).not.toMatch(/(?:want|need|like|help)[^.!?\n]{0,40}(?:connect|app link)|reconnect/iu)
+          if (!scenario.knownNone) {
+            expect(reply).toMatch(/\bwatch\b/iu)
+            expect(reply).toMatch(/\bring\b/iu)
+            expect(reply).not.toMatch(/your (?:watch|ring)|voice memo|supplements|medical basics/iu)
+          }
+        }
+        if (scenario.knownNone || scenario.source === 'oura') {
+          expect(reply).toMatch(/voice memo|how you move|movement/iu)
+          expect(reply).not.toMatch(/do you (?:also )?(?:use|wear|have)|which (?:watch|ring|wearable)/iu)
+        }
+        if (scenario.source === 'oura') {
+          expect(reply).toMatch(/oura/iu)
+          expect(reply).toMatch(/connected|linked|I can see your Oura connection/iu)
+        }
+        if (scenario.source === 'none') {
+          expect(reply).toMatch(/wearable|watch|ring|health app/iu)
+          if (scenario.failure) {
+            expect(reply).toMatch(/couldn[’']t|can[’']t|unable|unavailable|trouble|could not/iu)
+            expect(reply).not.toMatch(/no (?:device|wearable|account|source|connection)|nothing connected|reconnect/iu)
+          }
+        }
       } finally {
         await removeRealCodexTemporaryPaths(temporaryPaths)
       }

--- a/packages/assistant-engine/test/assistant-skill-assets.test.ts
+++ b/packages/assistant-engine/test/assistant-skill-assets.test.ts
@@ -2208,7 +2208,7 @@ describe('assistant skill assets', () => {
     )
     expect(raw).toContain('### 4. Reflect, save, and park the threads')
     expect(compact).toContain(
-      "got it — stronger and sleeping better, mainly for more confidence and energy. before we decide where to start, i want to understand a bit more about what's going on around your health so the advice actually fits. do you use a wearable or health app?",
+      "got it — stronger and sleeping better, mainly for more confidence and energy. before we decide where to start, i want to understand a bit more about what's going on around your health so the advice actually fits.",
     )
     expect(compact).toContain(
       'The current prompt\'s “Hosted wearable connection links are available for …” line is the sole source of provider examples.',
@@ -2217,7 +2217,7 @@ describe('assistant skill assets', () => {
       'If the line is absent, omit provider examples rather than inventing or recalling names.',
     )
     expect(compact).toContain(
-      'Keep Apple Health out of this provider-example clause; it is offered only through the separate native-app relay after a clear “none,” never as a `murph.device` provider.',
+      'Keep Apple Health out of this provider-example clause; it is offered only through the separate native-app relay after a clear “none” when it is not already connected, never as a `murph.device` connect provider.',
     )
     expect(compact).toContain(
       'Before the visible reply, also save the confirmed definition of progress and reason it matters through the Context-memory rule in `persistence-recovery-follow-up.md`',
@@ -2240,6 +2240,31 @@ describe('assistant skill assets', () => {
     )
     expect(raw).toContain('### 5. Resolve the foundation checkpoints')
     expect(raw).toContain('1. **Data sources and wearables.**')
+    expect(compact).toContain(
+      'call `murph.device` with unfiltered `action: list_accounts` once this turn when available, before the user-facing question.',
+    )
+    expect(compact).toContain(
+      "A hosted resume snapshot's device-account error does not mean no connections.",
+    )
+    expect(compact).toContain(
+      'If the lookup fails or is unavailable, keep the state unknown',
+    )
+    expect(compact).toContain(
+      "a tool error's generic retry hint does not override the one-read limit",
+    )
+    expect(compact).toContain(
+      'Apple Health alone does not establish whether the user wears a device.',
+    )
+    expect(compact).toContain(
+      'I can see Apple Health is connected. Do you also use a watch or ring?',
+    )
+    expect(compact).toContain(
+      'If visible or saved context already answers that question, including no wearable, acknowledge the connection and advance.',
+    )
+    expect(compact).not.toContain('If none is visible, ask whether')
+    expect(compact).not.toContain(
+      'so the advice actually fits. do you use a wearable or health app?',
+    )
     expect(compact).toContain(
       'Build its example clause only from labels on the current prompt\'s hosted wearable connection line: one label when only one exists and a few when several do.',
     )
@@ -2509,7 +2534,7 @@ describe('assistant skill assets', () => {
       parkIndex,
     )
     const workedReplyStart = aspirationReference.indexOf(
-      'a\ncomplete reply can be:',
+      'the reflection can be:',
     )
     expect(workedReplyStart).toBeGreaterThan(parkIndex)
     const workedReplySection = aspirationReference.slice(


### PR DESCRIPTION
## Why and outcome

Onboarding can ask which wearable or health app a member uses before checking existing connections. Murph now checks available connection evidence first, acknowledges Apple Health, and asks about a watch or ring only when wearable use is still unknown. Earlier answers and identified wearables advance to the next foundation area.

## Product UX

- Effort: Patch.
- Result: Ready.
- Walkthrough: Five synthetic private onboarding journeys cover Apple Health with unknown wearable use, an earlier negative answer, an identified wearable, no connections, and unavailable lookup. A connection does not prove wearable ownership or fresh data. Wearables and additional connections remain optional. Failed optional discovery does not retry or suggest reconnection.

## Evidence

- Direct: Five individually selected real-Codex journeys passed with `gpt-5.6-terra` using local subscription auth and production onboarding assets, prompt builders, and device-tool schema. Each run used `pnpm test:assistant:live -- --test "onboarding source awareness: .*<case>"`; cases were `unknown wearable use`, `wearable use already answered`, `an identified wearable`, `no connected sources`, and `an unavailable account lookup`.
- Coverage: Unknown-state cases make exactly one unfiltered account read; current Apple Health evidence with an earlier answer makes none. All cases forbid connection mutations and hosted device CLI fallback. Replies were reviewed for acknowledgement, non-repetition, optional setup, and honest failure. UX verdict: Ready.
- Passed: `pnpm --dir packages/assistant-engine test test/assistant-skill-assets.test.ts -t onboarding` (4 tests), `pnpm --dir packages/assistant-engine typecheck`, `pnpm --dir apps/web test changelog-page.test.tsx` (10 tests), and `pnpm --dir apps/web typecheck`.
- Passed: `pnpm complexity:diff`, diff whitespace check, and privacy review. Required exact-head CI passed on `e9187c9c72c7a483d9e1c5ef8462805ca417cc60`: both CLI host platforms, release checks, and the hosted Stripe billing boundary. All other reported checks passed or were intentionally skipped. Current-base mergeability passed.
- ReviewGPT: Exempt under the completion workflow's prompt-primary rule; there are no runtime implementation, persistence, schema, authorization, or deployment-protocol changes.

## Non-obvious affected surfaces

The existing no-wearable Apple Health setup offer is suppressed when Apple Health is already connected. The failed-lookup journey proves that a generic tool-error retry hint does not cause a second optional onboarding read.

## Architecture and reuse

- Existing systems reused: Onboarding skill reference, visible/saved context, hosted `murph.device` account reads, and the public changelog fragment loader.
- New logic: Evidence-first discovery, a conditional Apple Health follow-up, and an explicit one-read limit for this optional checkpoint.
- New abstractions: None; the existing prompt and tool owners suffice.
- Complexity intentionally avoided: No new state, device-status injection, connection API, background task, or per-message lookup.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`; no authored JavaScript or TypeScript runtime source changed.
- Hotspots: None in changed production code. The parameterized test branches represent distinct product outcomes.
- Agent judgment: One existing reference owns the policy; further production abstraction is not justified.

## Hot reply path impact

- Path status: Touched at the onboarding tool-selection policy only.
- Database calls: No database implementation changes; existing account-read internals remain unchanged.
- Network/provider calls: At most one logical, unfiltered `murph.device list_accounts` request when current connection state is unknown, before the reply. Known current state needs none. Existing pagination, cancellation, and timeout behavior is unchanged; onboarding performs no retry after a result or error.
- Other awaited latency: No new operation beyond the existing account tool. The reference is already loaded for this checkpoint.
- Before/after proof: The previous prompt allowed the example question without an explicit evidence check. Five synthetic live journeys now assert exact tool counts and replies. Mocked device ports prove ordering and effects, not production network latency; no production latency estimate is claimed.

## Murph initial provider input impact

Not applicable to initial input: this change edits an on-demand stage reference, not the top-level skill metadata, initial system prompt, tool/schema definitions, or conversation wrappers. Individual onboarding reads the changed reference after provider start. Group onboarding and group initial input are unchanged. Initial-input measurement was not run because no initial provider-input surface changed.

- Assembled instructions: Initial instructions unchanged; the existing private stage reference changes on demand.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: No production history or wrapper changes.
- Measurement method: Not run for unchanged initial individual and group input.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: Content-only changelog fragment reviewed directly; the existing archive rendering test passed.
- Coverage: Existing presentation is unchanged. Chat behavior is covered by the five live journeys above.

## Deployment concerns

- Deployment: not applicable
- Reason: No coordinated deployment, schema migration, protocol skew, or new rollback boundary. The updated skill ships through the normal runtime asset rollout; the changelog uses the existing web publication path.

## Change-shape breakdown

Classification rule: Runtime-consumed Markdown and public changelog JSON are source; test files are tests/fixtures; the completed execution plan is docs. No generated or binary changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 65 | 21 |
| Tests / fixtures | 183 | 3 |
| Docs | 79 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **327** | **24** |

## Changelog

- Changelog: updated
- Items: 2026-09-09 · onboarding-connected-sources
