### PR TITLE
Use canonical schemas for goal targets and assessment writes

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-10-canonical-model-parsers.md
+++ b/agent-docs/exec-plans/active/2026-09-10-canonical-model-parsers.md
@@ -1,0 +1,43 @@
+# Use canonical parsers for goal targets and assessment writes
+
+Status: active
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+Use the existing canonical schemas for metric-goal targets and new assessment records. Remove duplicate interpretation while preserving canonical writes and historical reads.
+
+## Product UX
+
+- Outcome: saved goal rules retain their meaning; new assessment links satisfy the existing contract.
+- Reaches: goal progress in SQLite/browser projections, assessment imports, and historical intake reads.
+- Proof: policy/default/invalid-input cases, canonical import and audit roundtrip, historical assessment reads, and projection refresh tests. Patch effort; result Ready after focused verification.
+
+## Scope and constraints
+
+Contracts remain the shape owner; core remains the canonical writer. Health metrics retains its dependency-free computation interface. No canonical migration, private data, new dependency, or external runtime operation. Query adaptation retains omitted target identity/kind and metric alias handling. New assessment writes validate the entire record; a schema-derived legacy read profile preserves previously accepted string links and ignores unknown historical fields without rewriting evidence.
+
+## Risks and mitigation
+
+- Invalid goal policies must be omitted rather than silently turned into another policy. Preserve schema defaults and valid qualifiers.
+- Existing assessment evidence must remain readable. Test the explicit read compatibility profile separately from strict writes.
+- Existing projections must converge without a canonical edit. Increment the existing SQLite version and browser replica generation and prove rebuild/freshness behavior.
+
+## Tasks
+
+1. Add focused failing regressions and replace duplicate parsing.
+2. Update projection versions and durable owner notes; decide changelog scope.
+3. Run focused source tests, relevant typechecks, complexity and privacy review.
+4. Commit, open draft PR, mark ready after candidate review, and start required ReviewGPT concurrently with CI.
+5. Resolve gates, close this plan, and report the PR.
+
+## Verification
+
+- Query: 84 focused tests passed across goal parsing, nutrition goals, metric/browser projection, replica generation, and provider projection compatibility.
+- Core: 139 tests passed across assessment writes/legacy reads, storage failures, import/projection provenance, and canonical core behavior.
+- Contracts: 2 browser generation tests passed.
+- Core, query, and contracts package typechecks passed.
+- Complexity guard passed: four changed source files, zero functions above 20; goal parser maximum falls from 20 to 11.
+- Exact-head CI and ReviewGPT are pending PR admission. A small changelog item will describe saved goal-rule preservation.
+

--- a/agent-docs/exec-plans/active/2026-09-10-canonical-model-parsers.md
+++ b/agent-docs/exec-plans/active/2026-09-10-canonical-model-parsers.md
@@ -39,5 +39,7 @@ Contracts remain the shape owner; core remains the canonical writer. Health metr
 - Contracts: 2 browser generation tests passed.
 - Core, query, and contracts package typechecks passed.
 - Complexity guard passed: four changed source files, zero functions above 20; goal parser maximum falls from 20 to 11.
-- Exact-head CI and ReviewGPT are pending PR admission. A small changelog item will describe saved goal-rule preservation.
+- Changelog: `2026-09-10 / goal-progress-saved-rules`, linked to PR #3138. All 10 changelog archive tests passed.
+- Continuation confirmed the worktree and pushed PR head match the implementation handoff. Parent candidate review found no additional required source edits.
+- Exact-head CI and ReviewGPT are pending Ready admission. Initial CI failures explicitly rejected draft proof; they did not run the runtime suites.
 

--- a/agent-docs/exec-plans/completed/2026-09-10-canonical-model-parsers.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-canonical-model-parsers.md
@@ -1,6 +1,6 @@
 # Use canonical parsers for goal targets and assessment writes
 
-Status: active
+Status: completed
 Created: 2026-09-10
 Updated: 2026-09-10
 
@@ -30,7 +30,7 @@ Contracts remain the shape owner; core remains the canonical writer. Health metr
 2. Update projection versions and durable owner notes; decide changelog scope.
 3. Run focused source tests, relevant typechecks, complexity and privacy review.
 4. Commit, open draft PR, mark ready after candidate review, and start required ReviewGPT concurrently with CI.
-5. Resolve gates, close this plan, and report the PR.
+5. Complete local remediation and archive the implementation plan; finish exact-head CI on PR #3138 before final handoff.
 
 ## Verification
 
@@ -41,5 +41,11 @@ Contracts remain the shape owner; core remains the canonical writer. Health metr
 - Complexity guard passed: four changed source files, zero functions above 20; goal parser maximum falls from 20 to 11.
 - Changelog: `2026-09-10 / goal-progress-saved-rules`, linked to PR #3138. All 10 changelog archive tests passed.
 - Continuation confirmed the worktree and pushed PR head match the implementation handoff. Parent candidate review found no additional required source edits.
-- Exact-head CI and ReviewGPT are pending Ready admission. Initial CI failures explicitly rejected draft proof; they did not run the runtime suites.
+- Final ReviewGPT round 1 passed at `3d35cbef75c840a3f24883d74f82c0118f4fa3c5`: zero findings. Vonneumann lane; exact committed-turn signature and response hash match the captured `gpt-6-pro` model. Response wait was at least 425 seconds. The reviewer checked the full snapshot and all 11 changed blobs. No review tooling retries; the owned target closed normally. Local tests and CI, not the source-only review, provide automated execution evidence.
+- Web typecheck and all 10 changelog archive tests passed.
+- Initial Ready CI passed 29 checks. Platform coverage exposed five stale version assertions: four pinned browser generation 15 and one pinned SQLite version 26. They now enforce the original compatibility floor while the owning contracts test pins the current browser generation. Production source is unchanged after ReviewGPT.
+- Remediation verification: 33 query browser compatibility tests, 10 hosted-execution tests, and the focused v24 SQLite rebuild test passed. Query and hosted-execution typechecks passed after their final test edits. The other 102 tests in the broad query file were deliberately excluded from that focused command; broader coverage belongs to CI.
+- Parent final review: five test-only corrections retain the existing behavioral assertions and production contracts. No new source, dependencies, persisted state, or generated artifacts. These isolated proof changes and this plan closure are exempt from another substantive ReviewGPT round.
+- Final exact-head CI is pending the remediation push and Ready admission. The completion owner remains responsible for observing it on PR #3138. This archived record does not claim a future CI or deployment result.
 
+Completed: 2026-09-10

--- a/agent-docs/references/data-model-seams.md
+++ b/agent-docs/references/data-model-seams.md
@@ -1,6 +1,6 @@
 # Data Model Seams
 
-Last verified: 2026-04-20
+Last verified: 2026-09-10
 
 ## Implemented in this patch
 
@@ -46,8 +46,7 @@ This patch aliases the core type to the contract type instead of keeping a secon
 
 **Why this is simpler:** the write model no longer has two nominal owners for the same persisted record shape.
 
-**Main refactor risk:** `packages/core/src/assessment/storage.ts` still partially reconstructs the record around `assessmentResponseSchema` instead of letting the contract parser own the full persisted object.
-If that cleanup is attempted later, do it after confirming there is no persisted data depending on the looser `relatedIds` handling there.
+New assessment writes now validate the complete normalized record through `assessmentResponseSchema`, including related IDs. Historical ledger reads use a schema-derived read profile that retains the previously accepted arbitrary string links and ignores unknown fields; that profile never authorizes new writes or rewrites append-only evidence. Both paths retain the same core-owned validation error. Tests cover strict writes, raw/manifest/audit roundtrips, and historical read compatibility.
 
 
 ### 4. Keep assistant CLI contract ownership in operator-config
@@ -514,3 +513,10 @@ Web composes event ids or source-specific reason mapping around those builders, 
 The event model is not being restated independently in web, Cloudflare, and assistant-runtime.
 
 **Main failure mode if changed poorly:** moving event construction or parsing back into web or assistant-runtime would recreate the exact parallel-representation drift that other review findings are trying to remove.
+
+
+### 25. Keep goal target interpretation with the canonical schema
+
+`packages/query/src/metrics/goals.ts` uses the contracts-owned `goalMetricTargetSchema` for complete target, evaluation, and selection-policy parsing. The adapter only supplies omitted legacy identity/kind fields and normalizes metric aliases; invalid targets are omitted without silently replacing their evaluation or policy. SQLite target extraction and browser progress use that same adapter. Health metrics retains its dependency-free computation interface.
+
+The existing SQLite projection version and browser replica generation advance when interpretation changes so unchanged canonical goals can rebuild stale results. No canonical schema migration or new persistence owner is required. Focused proof covers policy/default parity, invalid bounds and policies, legacy adaptation, SQLite/browser target parity, and rebuilding carried SQLite targets without changing the goal document.

--- a/apps/web/changelog/entries/2026-09-10/goal-progress-saved-rules.json
+++ b/apps/web/changelog/entries/2026-09-10/goal-progress-saved-rules.json
@@ -1,0 +1,19 @@
+{
+  "publishedOn": "2026-09-10",
+  "order": 100,
+  "item": {
+    "id": "goal-progress-saved-rules",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Goal progress follows saved measurement rules",
+    "summary": "Goal progress now checks saved measurement rules consistently before calculating a result.",
+    "details": "Valid rules stay intact, and invalid targets are left out instead of being evaluated with a different rule. Refreshing progress leaves your saved goals and health records unchanged.",
+    "relevanceTags": [
+      "goals",
+      "reliability"
+    ],
+    "sourcePullRequests": [
+      3138
+    ]
+  }
+}

--- a/packages/contracts/src/browser-vault.ts
+++ b/packages/contracts/src/browser-vault.ts
@@ -7,7 +7,7 @@ export const BROWSER_VAULT_TRAINING_SESSION_SCHEMA =
  * Increment when a projection-shape or projection-interpretation change makes
  * an otherwise source-current browser replica incomplete for current readers.
  */
-export const BROWSER_VAULT_REPLICA_CURRENT_GENERATION = 15 as const;
+export const BROWSER_VAULT_REPLICA_CURRENT_GENERATION = 16 as const;
 
 export const BROWSER_VAULT_METRIC_BUCKET_IDS = [
   "00",

--- a/packages/contracts/test/browser-vault.test.ts
+++ b/packages/contracts/test/browser-vault.test.ts
@@ -9,8 +9,8 @@ import {
   isBrowserVaultMetricBucketId,
 } from "../src/browser-vault.ts";
 
-test("browser vault generation rebuilds replicas for the bucketed metrics layout", () => {
-  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 15);
+test("browser vault generation rebuilds replicas for canonical goal target interpretation", () => {
+  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 16);
 });
 
 test("browser vault owns one fixed 32-bucket lowercase hexadecimal namespace", () => {

--- a/packages/core/src/assessment/storage.ts
+++ b/packages/core/src/assessment/storage.ts
@@ -7,6 +7,8 @@ import {
   safeParseContract,
 } from "@murphai/contracts";
 
+import * as z from "@murphai/contracts/zod-runtime";
+
 import { buildAuditRecord, resolveAuditShardPath } from "../audit.ts";
 import { generateRecordId } from "../ids.ts";
 import { readJsonlRecords, toMonthlyShardRelativePath } from "../jsonl.ts";
@@ -16,7 +18,6 @@ import { WriteBatch } from "../operations/write-batch.ts";
 import { prepareRawArtifact } from "../raw.ts";
 import { compareIsoTimestampsAscending, toIsoTimestamp } from "../time.ts";
 import { VaultError } from "../errors.ts";
-import { isPlainRecord } from "../types.ts";
 
 import type { UnknownRecord } from "../types.ts";
 import type {
@@ -55,58 +56,23 @@ function parseAssessmentResponse(content: string): UnknownRecord {
   return result.data;
 }
 
-function toAssessmentResponseRecord(value: unknown): AssessmentResponseRecord {
-  if (!isPlainRecord(value)) {
-    throw new VaultError("ASSESSMENT_RESPONSE_INVALID", "Assessment response record must be an object.");
-  }
+// Old ledger readers accepted arbitrary string links and discarded unknown
+// fields. Keep that read compatibility without weakening new canonical writes.
+const storedAssessmentResponseSchema = assessmentResponseSchema
+  .extend({ relatedIds: z.array(z.string()).optional() })
+  .strip();
 
-  const rawPath = normalizeRawPath(value.rawPath);
-  const relatedIds = normalizeRelatedIds(value.relatedIds);
-  const result = safeParseContract(assessmentResponseSchema, {
-    schemaVersion: value.schemaVersion,
-    id: value.id,
-    assessmentType: value.assessmentType,
-    recordedAt: value.recordedAt,
-    source: value.source,
-    rawPath,
-    title: value.title,
-    questionnaireSlug: value.questionnaireSlug,
-    responses: value.responses,
-  });
-
+function toAssessmentResponseRecord(
+  value: unknown,
+  schema: z.ZodType<AssessmentResponseRecord> = assessmentResponseSchema,
+): AssessmentResponseRecord {
+  const result = safeParseContract(schema, value);
   if (!result.success) {
     throw new VaultError("ASSESSMENT_RESPONSE_INVALID", "Assessment response record failed contract validation.", {
       errors: result.errors,
     });
   }
-
-  return {
-    ...result.data,
-    rawPath,
-    ...(relatedIds ? { relatedIds } : {}),
-  };
-}
-
-function normalizeRelatedIds(value: unknown): string[] | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
-    throw new VaultError("ASSESSMENT_RESPONSE_INVALID", "Assessment response relatedIds must be a string array.");
-  }
-
-  return value;
-}
-
-function normalizeRawPath(value: unknown): string {
-  if (typeof value !== "string") {
-    throw new VaultError("ASSESSMENT_RESPONSE_INVALID", "Assessment response rawPath is invalid.", {
-      rawPath: value instanceof Error ? value.message : String(value),
-    });
-  }
-
-  return value;
+  return result.data;
 }
 
 function sortAssessmentResponses(records: readonly AssessmentResponseRecord[]): AssessmentResponseRecord[] {
@@ -255,7 +221,7 @@ export async function listAssessmentResponses({
       relativePath: shardPath,
     });
 
-    records.push(...shardRecords.map((record) => toAssessmentResponseRecord(record)));
+    records.push(...shardRecords.map((record) => toAssessmentResponseRecord(record, storedAssessmentResponseSchema)));
   }
 
   return sortAssessmentResponses(records);

--- a/packages/core/test/assessment-contract-writes.test.ts
+++ b/packages/core/test/assessment-contract-writes.test.ts
@@ -1,0 +1,59 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { assessmentResponseSchema } from "@murphai/contracts";
+import { expect, it } from "vitest";
+import { importAssessmentResponse, initializeVault, listAssessmentResponses, readAssessmentResponse } from "../src/index.ts";
+
+it("validates normalized assessment links before committing and preserves import evidence", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "murph-assessment-contract-"));
+  const vaultRoot = path.join(root, "vault");
+  const sourcePath = path.join(root, "intake.json");
+  const goalId = "goal_01JNW7YJ7MNE7M9Q2QWQK4Z3F8";
+  try {
+    await initializeVault({ vaultRoot });
+    await writeFile(sourcePath, JSON.stringify({ energy: 4 }));
+    await expect(importAssessmentResponse({ vaultRoot, sourcePath, relatedIds: ["not-a-contract-id"] }))
+      .rejects.toMatchObject({ code: "ASSESSMENT_RESPONSE_INVALID" });
+    expect(await listAssessmentResponses({ vaultRoot })).toEqual([]);
+    const result = await importAssessmentResponse({
+      vaultRoot, sourcePath, relatedIds: [goalId, ` ${goalId} `, " "],
+    });
+    expect(assessmentResponseSchema.parse(result.assessment)).toEqual(result.assessment);
+    expect(result.assessment.relatedIds).toEqual([goalId]);
+    expect(await readAssessmentResponse({ vaultRoot, assessmentId: result.assessment.id })).toEqual(result.assessment);
+    expect(await readFile(path.join(vaultRoot, result.assessment.rawPath), "utf8"))
+      .toBe(await readFile(sourcePath, "utf8"));
+    const manifest = JSON.parse(await readFile(path.join(vaultRoot, result.manifestPath), "utf8"));
+    expect(manifest.owner.id).toBe(result.assessment.id);
+    expect(manifest.provenance.relatedIds).toEqual([goalId]);
+    const audit = (await readFile(path.join(vaultRoot, result.auditPath), "utf8"))
+      .trim().split("\n").map((line) => JSON.parse(line));
+    expect(audit.filter((row) => row.action === "intake_import")).toHaveLength(1);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+it("keeps previously accepted assessment links readable without rewriting the ledger", async () => {
+  const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-assessment-legacy-"));
+  try {
+    await initializeVault({ vaultRoot });
+    const record = {
+      schemaVersion: "murph.assessment-response.v1", id: "asmt_01JNW7YJ7MNE7M9Q2QWQK4Z3F8",
+      assessmentType: "intake", recordedAt: "2026-04-08T00:00:00.000Z", source: "import",
+      rawPath: "raw/assessments/asmt_01JNW7YJ7MNE7M9Q2QWQK4Z3F8/source.json", responses: {},
+      relatedIds: ["legacy-goal", "legacy-goal"], oldMetadata: true,
+    };
+    const ledgerPath = path.join(vaultRoot, "ledger/assessments/2026/2026-04.jsonl");
+    await mkdir(path.dirname(ledgerPath), { recursive: true });
+    const bytes = `${JSON.stringify(record)}\n`;
+    await writeFile(ledgerPath, bytes);
+    const read = await readAssessmentResponse({ vaultRoot, assessmentId: record.id });
+    expect(read.relatedIds).toEqual(record.relatedIds);
+    expect(read).not.toHaveProperty("oldMetadata");
+    expect(await readFile(ledgerPath, "utf8")).toBe(bytes);
+  } finally {
+    await rm(vaultRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/hosted-execution/test/hosted-execution.test.ts
+++ b/packages/hosted-execution/test/hosted-execution.test.ts
@@ -470,7 +470,7 @@ describe("hosted execution coverage gaps", () => {
   });
 
   it("centralizes browser-vault replica source hash and refresh decisions", () => {
-    expect(BROWSER_VAULT_REPLICA_CURRENT_GENERATION).toBe(15);
+    expect(BROWSER_VAULT_REPLICA_CURRENT_GENERATION).toBeGreaterThanOrEqual(15);
     const base = {
       hash: "a".repeat(64),
       key: "cloudflare-workspace-snapshots/base.bundle",

--- a/packages/query/src/metrics/goals.ts
+++ b/packages/query/src/metrics/goals.ts
@@ -1,126 +1,26 @@
-import {
-  normalizeMetricKey,
-  type GoalMetricTarget,
-  type MetricComparator,
-  type MetricSelectionPolicy,
-} from "@murphai/health-metrics";
+import { goalMetricTargetSchema } from "@murphai/contracts";
+import { normalizeMetricKey, type GoalMetricTarget } from "@murphai/health-metrics";
 
 import type { CanonicalEntity } from "../canonical-entities.ts";
 
 export function parseGoalMetricTargets(entity: CanonicalEntity): GoalMetricTarget[] {
   const source = entity.frontmatter ?? entity.attributes;
   const rawTargets = Array.isArray(source.metricTargets) ? source.metricTargets : [];
-  return rawTargets.flatMap((target, index) => parseGoalMetricTarget(entity.entityId, target, index));
-}
+  return rawTargets.flatMap((value, index) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+    const record = value as Record<string, unknown>;
+    if (typeof record.metricKey !== "string" || !record.metricKey.trim()) return [];
 
-function parseGoalMetricTarget(goalId: string, value: unknown, index: number): GoalMetricTarget[] {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return [];
-  const record = value as Record<string, unknown>;
-  const metricKey = readString(record.metricKey);
-  const comparator = readComparator(record.comparator);
-  const targetValue = readNumber(record.value);
-  const unit = readString(record.unit);
-  if (!metricKey || !comparator || targetValue === null || !unit) return [];
-
-  const targetId = readString(record.targetId) ?? `metric-target-${index + 1}`;
-  return [{
-    biomarkerKey: readString(record.biomarkerKey) ?? undefined,
-    comparator,
-    evaluation: readEvaluation(record.evaluation),
-    highValue: readNumber(record.highValue) ?? undefined,
-    kind: "metric",
-    metricKey: normalizeMetricKey(metricKey),
-    note: readString(record.note) ?? undefined,
-    selectionPolicyOverride: readSelectionPolicyOverride(record.selectionPolicyOverride) ?? undefined,
-    startAt: readString(record.startAt) ?? undefined,
-    targetAt: readString(record.targetAt) ?? undefined,
-    targetId,
-    unit,
-    value: targetValue,
-  } satisfies GoalMetricTarget];
-}
-
-function readEvaluation(value: unknown): GoalMetricTarget["evaluation"] {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return { kind: "selected-value" };
-  const record = value as Record<string, unknown>;
-  const kind = readString(record.kind);
-  if (kind === "latest-lab") return { kind };
-  if (kind === "rolling-window") {
-    const statistic = readString(record.statistic);
-    const windowDays = readNumber(record.windowDays);
-    if ((statistic === "mean" || statistic === "median") && windowDays !== null) {
-      return { kind, statistic, windowDays };
-    }
-  }
-  return { kind: "selected-value" };
-}
-
-function readSelectionPolicyOverride(value: unknown): MetricSelectionPolicy | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-  const kind = readString(record.kind);
-  const staleAfterDays = readNumber(record.staleAfterDays) ?? undefined;
-  if (kind === "latest-valid") return { kind, staleAfterDays };
-  if (kind === "latest-device-estimate") return { kind, staleAfterDays };
-  if (kind === "latest-lab") {
-    return {
-      kind,
-      preferCollectedAt: true,
-      preferFasting: readBoolean(record.preferFasting) ?? undefined,
-      staleAfterDays,
-    };
-  }
-  if (kind === "daily-aggregate") {
-    const statistic = readString(record.statistic);
-    if (
-      statistic === "mean" ||
-      statistic === "median" ||
-      statistic === "min" ||
-      statistic === "max" ||
-      statistic === "sum" ||
-      statistic === "count"
-    ) {
-      return {
-        kind,
-        latestWindowDays: readNumber(record.latestWindowDays) ?? undefined,
-        minimumPoints: readNumber(record.minimumPoints) ?? undefined,
-        staleAfterDays,
-        statistic,
-      };
-    }
-  }
-  if (kind === "qualified-latest") {
-    const requiredQualifiers = readQualifierMap(record.requiredQualifiers);
-    if (requiredQualifiers) return { kind, requiredQualifiers, staleAfterDays };
-  }
-  return null;
-}
-
-function readQualifierMap(value: unknown): Record<string, string | number | boolean> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const output: Record<string, string | number | boolean> = {};
-  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof entry === "string" || typeof entry === "number" || typeof entry === "boolean") {
-      output[key] = entry;
-    }
-  }
-  return Object.keys(output).length > 0 ? output : null;
-}
-
-function readString(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
-}
-
-function readNumber(value: unknown): number | null {
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
-function readBoolean(value: unknown): boolean | null {
-  return typeof value === "boolean" ? value : null;
-}
-
-function readComparator(value: unknown): GoalMetricTarget["comparator"] | null {
-  return value === "<" || value === "<=" || value === ">" || value === ">=" || value === "between"
-    ? value as MetricComparator | "between"
-    : null;
+    // Older query inputs omitted these fields; keep that adaptation outside the
+    // canonical schema instead of reconstructing evaluation and policy variants.
+    const result = goalMetricTargetSchema.safeParse({
+      ...record,
+      kind: record.kind ?? "metric",
+      targetId: typeof record.targetId === "string"
+        ? record.targetId.trim() || `metric-target-${index + 1}`
+        : record.targetId ?? `metric-target-${index + 1}`,
+      metricKey: normalizeMetricKey(record.metricKey),
+    });
+    return result.success ? [result.data] : [];
+  });
 }

--- a/packages/query/src/projection/schema.ts
+++ b/packages/query/src/projection/schema.ts
@@ -24,7 +24,8 @@ export const QUERY_PROJECTION_SCHEMA_ID = "murph.query-projection";
 // 24: Store bounded per-workout stream features in wearable activity summaries.
 // 25: Omit audit rows and unused indexes from rebuilt query stores.
 // 26: Rebuild wearable provider rows after public query slug canonicalization.
-export const QUERY_PROJECTION_SQLITE_VERSION = 26;
+// 27: Rebuild goal targets through the canonical target schema.
+export const QUERY_PROJECTION_SQLITE_VERSION = 27;
 
 export interface QueryProjectionLocation {
   absolutePath: string;

--- a/packages/query/test/browser-vault-lab-results.test.ts
+++ b/packages/query/test/browser-vault-lab-results.test.ts
@@ -140,7 +140,7 @@ test("browser vault projects all live lab history without widening the wearable 
     sourceBundleHash: "f".repeat(64),
     vault,
   });
-  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 15);
+  assert.ok(BROWSER_VAULT_REPLICA_CURRENT_GENERATION >= 15);
   assert.equal(replica.generation, BROWSER_VAULT_REPLICA_CURRENT_GENERATION);
   const client = createBrowserVaultQueryClient(
     parseBrowserVaultReplica(replica),

--- a/packages/query/test/browser-vault-replica-shards.test.ts
+++ b/packages/query/test/browser-vault-replica-shards.test.ts
@@ -353,7 +353,7 @@ test("browser vault shard parsers validate schemas, bucket placement, and genera
 test("browser vault metric bucket assignment has stable SHA-256 test vectors", async () => {
   // Changing any vector requires a generation bump so old refs are never read
   // with a new canonical-key placement rule.
-  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 15);
+  assert.ok(BROWSER_VAULT_REPLICA_CURRENT_GENERATION >= 15);
   assert.equal(await getBrowserVaultMetricBucketId("spo2"), "02");
   assert.equal(await getBrowserVaultMetricBucketId("lowest-spo2"), "19");
   assert.equal(await getBrowserVaultMetricBucketId("estimated-vo2-max"), "0d");

--- a/packages/query/test/browser-vault-training-projection.test.ts
+++ b/packages/query/test/browser-vault-training-projection.test.ts
@@ -311,7 +311,7 @@ test("browser vault replicas expose a bounded sanitized training projection with
   assert.equal(liveTraining.state, "in_progress");
   assert.equal("sourceApp" in liveTraining, false);
   assert.deepEqual(liveTraining.exercises, []);
-  assert.equal(BROWSER_VAULT_REPLICA_CURRENT_GENERATION, 15);
+  assert.ok(BROWSER_VAULT_REPLICA_CURRENT_GENERATION >= 15);
 });
 
 test("browser training projection preserves completed next-local-day sessions before UTC midnight", async () => {

--- a/packages/query/test/metric-goal-contracts.test.ts
+++ b/packages/query/test/metric-goal-contracts.test.ts
@@ -1,0 +1,105 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { goalMetricTargetSchema } from "@murphai/contracts";
+import { initializeVault, upsertGoal } from "@murphai/core";
+import { openSqliteRuntimeDatabase, QUERY_DB_RELATIVE_PATH } from "@murphai/runtime-state/node";
+import { describe, expect, it } from "vitest";
+import type { CanonicalEntity } from "../src/canonical-entities.ts";
+import { parseGoalMetricTargets } from "../src/metrics/goals.ts";
+import { listMetricTargets, rebuildQueryProjection } from "../src/index.ts";
+import { extractMetricTargetsFromCanonicalEntities } from "../src/projection/metric-store.ts";
+import { createBrowserVaultReplica, createVaultReadModel } from "../src/browser.ts";
+
+const target = {
+  targetId: "weight-range", kind: "metric", metricKey: "body-weight",
+  comparator: "between", value: 70, highValue: 80, unit: "kg",
+};
+function goal(targets: unknown[]): CanonicalEntity {
+  return {
+    entityId: "synthetic-goal", primaryLookupId: "synthetic-goal", lookupIds: ["synthetic-goal"],
+    family: "goal", recordClass: "bank", kind: "goal", status: "active", occurredAt: null,
+    date: null, path: "bank/goals/synthetic-goal.md", title: "Synthetic goal", body: null,
+    attributes: { metricTargets: targets }, frontmatter: null, links: [], relatedIds: [],
+    stream: null, experimentSlug: null, tags: [],
+  };
+}
+
+describe("canonical goal target interpretation", () => {
+  it.each([
+    { kind: "latest-valid", staleAfterDays: 7 },
+    { kind: "latest-lab", preferFasting: true },
+    { kind: "daily-aggregate", statistic: "mean", latestWindowDays: 7, minimumPoints: 2 },
+    { kind: "latest-device-estimate" },
+    { kind: "qualified-latest", requiredQualifiers: {} },
+    { kind: "qualified-latest", requiredQualifiers: { position: "standing", repeated: true } },
+  ])("preserves canonical policy and defaults: %j", (selectionPolicyOverride) => {
+    const raw = { ...target, selectionPolicyOverride };
+    expect(parseGoalMetricTargets(goal([raw]))).toEqual([goalMetricTargetSchema.parse(raw)]);
+  });
+
+  it.each([
+    { highValue: undefined },
+    { evaluation: { kind: "rolling-window", statistic: "mean", windowDays: 0 } },
+    { evaluation: { kind: "unknown" } },
+    { selectionPolicyOverride: { kind: "unknown" } },
+    { selectionPolicyOverride: { kind: "daily-aggregate", statistic: "mean", minimumPoints: -1 } },
+    { selectionPolicyOverride: { kind: "qualified-latest", requiredQualifiers: { position: {} } } },
+    { targetAt: "not-a-date" },
+    { kind: "other" },
+  ])("omits invalid targets without replacing their meaning: %j", (overrides) => {
+    const raw = { ...target, ...overrides };
+    expect(goalMetricTargetSchema.safeParse(raw).success).toBe(false);
+    expect(parseGoalMetricTargets(goal([raw, target]))).toEqual([goalMetricTargetSchema.parse(target)]);
+  });
+
+  it("retains omitted legacy identity and metric aliases without mutating input", () => {
+    const raw = { ...target, targetId: undefined, kind: undefined, metricKey: "body_weight" };
+    const entity = goal([null, raw]);
+    const before = structuredClone(entity);
+    expect(parseGoalMetricTargets(entity)).toEqual([
+      goalMetricTargetSchema.parse({ ...target, targetId: "metric-target-2" }),
+    ]);
+    expect(entity).toEqual(before);
+  });
+
+  it("uses the same accepted targets for SQLite and browser progress", async () => {
+    const entity = goal([{ ...target, highValue: undefined }, target]);
+    const rows = extractMetricTargetsFromCanonicalEntities([entity]);
+    expect(rows.map((row) => row.target.targetId)).toEqual([target.targetId]);
+    const replica = await createBrowserVaultReplica({
+      vault: createVaultReadModel({ entities: [entity], metadata: null, vaultRoot: "browser://vault" }),
+      metricPoints: [], generatedAt: "2026-09-10T12:00:00.000Z", sourceBundleHash: "f".repeat(64),
+    });
+    expect(replica.metricGoalProgressRows.map((row) => row.targetId)).toEqual([target.targetId]);
+  });
+
+  it("rebuilds carried v26 targets without modifying the canonical goal", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-goal-contracts-"));
+    try {
+      await initializeVault({ vaultRoot });
+      const accepted = goalMetricTargetSchema.parse({
+        ...target, selectionPolicyOverride: { kind: "qualified-latest", requiredQualifiers: {} },
+      });
+      const saved = await upsertGoal({
+        vaultRoot, title: "Synthetic weight goal", status: "active", horizon: "ongoing",
+        window: { startAt: "2026-09-01" }, metricTargets: [accepted],
+      });
+      const canonicalPath = path.join(vaultRoot, saved.record.document.relativePath);
+      const before = await readFile(canonicalPath, "utf8");
+      await rebuildQueryProjection(vaultRoot);
+      const database = openSqliteRuntimeDatabase(path.join(vaultRoot, QUERY_DB_RELATIVE_PATH), { create: false });
+      try {
+        database.prepare("UPDATE query_metric_targets SET target_json = ?").run(JSON.stringify(target));
+        database.exec("PRAGMA user_version = 26;");
+      } finally {
+        database.close();
+      }
+      const rows = await listMetricTargets(vaultRoot);
+      expect(rows.map((row) => row.target)).toEqual([accepted]);
+      expect(await readFile(canonicalPath, "utf8")).toBe(before);
+    } finally {
+      await rm(vaultRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/query/test/query-projection-provider-scope.test.ts
+++ b/packages/query/test/query-projection-provider-scope.test.ts
@@ -157,7 +157,7 @@ test("first provider-filtered read rebuilds carried v25 underscore provider rows
       readOnly: true,
     });
     try {
-      assert.equal(QUERY_PROJECTION_SQLITE_VERSION, 26);
+      assert.ok(QUERY_PROJECTION_SQLITE_VERSION >= 26);
       assert.equal(
         readSqliteRuntimeUserVersion(rebuiltDatabase),
         QUERY_PROJECTION_SQLITE_VERSION,

--- a/packages/query/test/query.test.ts
+++ b/packages/query/test/query.test.ts
@@ -4868,9 +4868,9 @@ test("rebuildQueryProjection recreates v24 stores without unused indexes", async
     });
 
     try {
-      // Pin the literal version: visibility and schema changes must invalidate
-      // carried stores before ordinary reads can serve stale projection rows.
-      assert.equal(QUERY_PROJECTION_SQLITE_VERSION, 26);
+      // The index-removal migration must invalidate v24 stores while allowing
+      // later projection versions to retain the same compatibility guarantee.
+      assert.ok(QUERY_PROJECTION_SQLITE_VERSION > 24);
       assert.equal(readSqliteRuntimeUserVersion(database), QUERY_PROJECTION_SQLITE_VERSION);
 
       const columnRows = database


### PR DESCRIPTION
## Why and outcome

Goal projections reconstructed saved target policies independently of their canonical schema, accepting invalid ranges and dropping valid empty qualifier rules. Query now uses the existing goal-target schema, preserving established legacy identity defaults and metric aliases. SQLite and browser projection versions advance so cached interpretations rebuild without editing saved goals.

New assessment imports validate the complete normalized record, including related IDs. A schema-derived read profile preserves previously accepted historical string links and unknown-field tolerance; append-only evidence remains unchanged.

## Product UX

- Effort: Patch.
- Result: Ready.
- Walkthrough: Valid saved goal policies keep their defaults and qualifiers; invalid bounds or policies are omitted rather than interpreted differently. SQLite and browser target extraction agree. Existing projections refresh without a canonical edit. New assessment imports normalize and validate links, preserve raw/manifest/audit provenance, and read back successfully; historical assessments remain readable. No presentation or permission changes, and no differences from the scoped plan.

## Evidence

- Direct: 84 focused query tests passed across `metric-goal-contracts`, `meal-nutrition-goals`, `browser-vault-metric-points-labs-measurements`, `query-projection-provider-scope`, and `browser-vault-replica`. Command: `pnpm --dir packages/query exec vitest run --config vitest.config.ts test/metric-goal-contracts.test.ts test/meal-nutrition-goals.test.ts test/browser-vault-metric-points-labs-measurements.test.ts test/query-projection-provider-scope.test.ts test/browser-vault-replica.test.ts --no-coverage`. The final edited goal-contract test was rerun separately: 17 passed.
- Direct: 139 core tests passed: `pnpm --dir packages/core exec vitest run --config vitest.config.ts test/assessment-contract-writes.test.ts test/assessment-automation-thresholds.test.ts test/core.test.ts --no-coverage`.
- Direct: 2 contracts tests passed: `pnpm --dir packages/contracts exec vitest run --config vitest.config.ts test/browser-vault.test.ts --no-coverage`.
- Direct: Core, query, and contracts package typechecks passed. Web typecheck: passed (`pnpm --dir apps/web typecheck`).
- Direct: `pnpm --dir apps/web test:prepared -- changelog-page.test.tsx`: all 10 tests passed, including fragment validation and production archive rendering.
- Coverage: Source regressions exercise canonical writer/readback, raw/manifest/audit preservation, schema-policy parity, retained legacy reads, shared SQLite/browser target extraction, and rebuilding a carried v26 projection without changing the canonical goal file.
- Final ReviewGPT round 1: PASS at `3d35cbef75c840a3f24883d74f82c0118f4fa3c5`; zero findings received or accepted. Vonneumann lane; captured `gpt-6-pro` model slug and response hash match the exact submitted turn. Response wait was at least 425 seconds. Full snapshot and all 11 changed blobs were checked; no tooling retries. This is independent source review; automated evidence comes from the local checks and CI.
- Initial Ready CI completed with 29 passing checks; the two failed platform coverage jobs contained five stale generation/version assertions. Those isolated test expectations now preserve their original compatibility floors while accepting later versions. Production source remains byte-identical to the reviewed commit.
- Remediation proof: `pnpm --dir packages/query exec vitest run --config vitest.config.ts test/browser-vault-replica-shards.test.ts test/browser-vault-lab-results.test.ts test/browser-vault-training-projection.test.ts --no-coverage`: 33 passed. `pnpm --dir packages/hosted-execution exec vitest run --config vitest.config.ts test/hosted-execution.test.ts --no-coverage`: 10 passed. Focused `test/query.test.ts -t 'rebuildQueryProjection recreates v24 stores without unused indexes'`: 1 passed, 102 unrelated cases excluded. Final query and hosted-execution typechecks passed.
- Final-head test, build, typecheck, and coverage jobs all passed at `20ad525eb76334606a7c6bd71e6afa920555ce6b`, including both corrected platform coverage jobs. Temporal reader proof passed. The PR check summary records the final aggregate release and compatibility-publication receipts. This head contains only isolated proof/document changes beyond the reviewed source, so it does not require another substantive ReviewGPT round.

## Non-obvious affected surfaces

SQLite projection version 27 and browser replica generation 16 force existing rebuild/freshness owners to refresh goal interpretation. Provider-scope and v24 index-removal migration coverage still verify their original compatibility floors while accepting later projection versions. Existing lab-history, training, metric-bucket, and hosted freshness tests retain their behavior assertions without duplicating the exact browser-generation pin owned by contracts. Historical assessment reads retain the old accepted string-link behavior separately from strict new writes.

## Architecture and reuse

- Existing systems reused: `goalMetricTargetSchema`, `assessmentResponseSchema`, core `WriteBatch`, query target extraction, and the existing SQLite/browser projection versions.
- New logic: A small legacy-input adapter precedes canonical goal parsing; a schema-derived assessment read profile isolates proven historical tolerance from canonical writes.
- New abstractions: None; existing contracts remain the shape owners, core remains the writer, and health-metrics retains its dependency-free computation interface.
- Complexity intentionally avoided: Removed manual evaluation/policy/link reconstruction. No new package, dependency, persistence owner, migration, dual write, or canonical-record rewrite.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`, four changed source files.
- Hotspots: None above 20. Goal parser maximum complexity drops from 20 to 11.
- Agent judgment: The existing schemas remove duplicate interpretation with substantially less source. The small legacy read profile preserves demonstrated compatibility; further consolidation would erase that boundary.

## Hot reply path impact

- Path status: Not applicable to foreground orchestration; the patch changes synchronous validation and existing projection interpretation.
- Database calls: None added or moved onto the foreground path.
- Network/provider calls: None added or moved.
- Other awaited latency: No new awaited operation. The existing projection invalidation mechanism performs its normal rebuild when it encounters an older version.
- Before/after proof: Diff inspection preserves I/O placement; focused projection tests prove a stale cache rebuilds through the existing owner.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no assembled instructions, messages, tools, schemas advertised to the provider, deferred guidance, or provider-input builders change. No provider-input measurement was run.

## Design proof

- Design page: [Production changelog archive](https://www.withmurph.ai/screenshots/ops#changelog-archive).
- Evidence: Content-only entry under the changelog README exemption; authored JSON was reviewed and all 10 archive tests passed through the production component.
- Coverage: Unchanged archive presentation and interaction. No new visual, layout, viewport behavior, or branch preview is required for this content-only fragment.

ReviewGPT first-reviewed head: 3d35cbef75c840a3f24883d74f82c0118f4fa3c5
ReviewGPT context sensitivity: sensitive
Classification reason: Cross-package canonical validation and persisted projection interpretation change.

## Deployment concerns

- Deployment: applicable
- Supported skew: Assessment record shape is unchanged; new strict writes remain readable by old and new readers, and the new read profile accepts old string links. Browser generation changes freshness, not payload compatibility. SQLite v26 data is rebuildable from unchanged canonical records.
- Safe order: Normal coordinated release of the shared packages and their Web/runtime consumers. Updated readers may arrive first; no canonical migration or writer cutover is required.
- Rollback floor: The previous release can still read canonical records produced by this patch. Returning to it also returns the prior goal interpretation; deployment rollback requires its separate authorization.
- Expected exposure: During a mixed rollout, existing cached goal progress can retain the prior interpretation until the normal refresh completes. No new remote work or canonical rewrite occurs. Production member/event volume was not queried for this patch.
- Reversibility: Rebuildable projections can be regenerated from canonical records. Assessment evidence remains append-only and is never rewritten by this change.
- Convergence proof: Focused tests rebuild a carried v26 SQLite projection without touching the goal and prove browser freshness through the existing generation owner. Static inspection confirms old/new assessment shape compatibility. Live rollout convergence is a post-deploy check.
- Post-deploy checks: Confirm projection version 27 and replica generation 16 after normal refresh; check representative goal-policy results and assessment import/readback. Observe bounded assessment validation errors without collecting private contents.

## Change-shape breakdown

Classification rule: Production TS is source, test paths are tests, Markdown and authored release copy are docs; no binary files or committed generated output.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 37 | 170 |
| Tests / fixtures | 174 | 10 |
| Docs | 79 | 3 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **290** | **183** |

## Changelog

- Changelog: updated
- Items: 2026-09-10 · goal-progress-saved-rules
