### PR TITLE
refactor: simplify health metric normalization routing

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-complexity-collapse-metric-normalization.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-complexity-collapse-metric-normalization.md
@@ -1,0 +1,63 @@
+# Collapse metric normalization dispatch complexity
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+- Make health metric conversion routing readable by deleting redundant exact-unit cases and expressing conversion exceptions as typed data.
+
+## Success criteria
+
+- Preserve aliases, ordinary versus lab-result catalog scope, conversion factors and rounding, missing/nonfinite values, source units, and warning text.
+- Reduce the target function's cyclomatic complexity and source size; pass focused tests, package typecheck, and the complexity guard.
+
+## Scope
+
+- In scope: `packages/health-metrics/src/normalize.ts`, focused normalization proof, and this plan.
+- Out of scope: catalog changes, new units or formulas, public APIs, persistence, assistant prompts, and UI.
+
+## Constraints
+
+- Technical constraints: retain the health-metrics read-side owner and existing unit converters. Introduce no dependencies, state, external effects, or generic conversion framework.
+- Product/process constraints: internal behavior-preserving refactor; parent owns candidate acceptance and final review/CI after draft PR creation.
+
+## Risks and mitigations
+
+1. Replacing exact-unit cases with declared-unit fallback can change missing-unit output where display and canonical units differ, or when the lab-only catalog treats a body key as custom. Keep explicit percent routing for those exceptions and prove both scopes against the baseline.
+2. Dispatch data can omit aliases or select prototype properties. Keep conversion-only keys explicit, use `Map` lookup, and cover arbitrary custom metric names.
+
+## Tasks
+
+1. Inspect current conversion helpers, catalogs, and behavior tests.
+2. Replace repeated routing with private typed conversion maps and remove proven redundant cases.
+3. Add focused boundary proof and compare synthetic baseline/head normalization results.
+4. Run focused tests, package typecheck, complexity guard, and full diff/privacy review.
+5. Close the plan, commit, push, open a draft PR, and hand off exact-head evidence to the parent.
+
+## Decisions
+
+- The catalog already owns canonical units for exact-unit conversions. Reuse its declared-unit fallback where missing-unit display semantics agree.
+- Keep body-percentage converters for custom lab-result keys and percent converters for the two lab metrics whose display unit is `%`.
+- Preserve separate ordinary and lab-result definition resolution before conversion dispatch.
+- No changelog: the change is internal and preserves member-visible behavior.
+- No deploy skew: no persisted format, protocol, or package API changes.
+
+## Verification
+
+- `pnpm --dir packages/health-metrics test test/index.test.ts test/normalize.test.ts`
+- `pnpm --dir packages/health-metrics typecheck`
+- `pnpm complexity:diff --base b2a559812972d70644cffb2bf43923fc9211047d -- packages/health-metrics/src/normalize.ts`
+- Expected outcomes: focused behavior and type proof pass; file maximum and debt decrease with no new hotspot above 20.
+
+## Results
+
+- Focused suite: 62 tests passed across the existing package index and five new boundary tests.
+- Synthetic baseline/head differential: 957,564 results were identical across 794 metric keys and aliases, 67 source units, nine missing/finite/nonfinite values, and both normalization scopes. Baseline: `b2a559812972d70644cffb2bf43923fc9211047d`. The matrix included null/empty/unknown/incompatible units, custom property-like keys, signed zero, both infinities, and large finite values.
+- Package typecheck: passed; no public entrypoint, dependency, or import-boundary change.
+- Complexity guard: passed. Target `normalizeMetricValueForScope` decreased from 55 to 8; file maximum decreased from 55 to 21 and debt above 20 decreased from 36 to 1.
+- The remaining `resolveComparableMetricPointValue` hotspot is unchanged at 21. Its source-evidence validity rules are separate from conversion routing; simplifying it would widen this refactor without helping the demonstrated repetition.
+- Source change: 56 added / 81 deleted lines, a net reduction of 25. No new external effects, asynchronous work, persisted state, or provider-input changes.
+- Frog: installed ordinary frozen dependencies, then inspected existing entries; no task-owned friction entry was needed.
+Completed: 2026-09-10

--- a/packages/health-metrics/src/normalize.ts
+++ b/packages/health-metrics/src/normalize.ts
@@ -20,6 +20,52 @@ const HOUR_INTENT_DURATION_ALIASES = new Set([
   "total_sleep_hours",
 ].map(normalizeMetricKey));
 
+const MMOL_TO_MG_DL_BY_METRIC = new Map<string, number>([
+  ["glucose", 18.0182],
+  ["ldl-c", 38.67],
+  ["hdl-c", 38.67],
+  ["triglycerides", 88.57],
+  ["calcium", 4],
+  ["serum-calcium", 4],
+  ["total-calcium", 4],
+  ["cholesterol", 38.67],
+  ["cholesterol-total", 38.67],
+  ["total-cholesterol", 38.67],
+  ["serum-uric-acid", 16.812],
+  ["urate", 16.812],
+  ["uric-acid", 16.812],
+]);
+
+type MetricValueNormalizer = (value: number, unit: string | null, label: string) => MetricValueNormalization;
+
+// Exact units come from the catalog; only conversion and source-unit exceptions need routing here.
+const METRIC_VALUE_NORMALIZERS = new Map<string, MetricValueNormalizer>([
+  ["albumin", normalizeAlbumin],
+  ["body-weight", normalizeWeight],
+  ["lean-body-mass", normalizeWeight],
+  ["waist-circumference", normalizeLengthCentimeters],
+  ["bone-mass-percentage", normalizePercent],
+  ["body-fat-percentage", normalizePercent],
+  ["body-water-percentage", normalizePercent],
+  ["muscle-mass-percentage", normalizePercent],
+  ["lymphocyte-percentage", normalizePercent],
+  ["red-cell-distribution-width", normalizePercent],
+  ["creatinine", normalizeCreatinine],
+  ["blood-urea-nitrogen", normalizeBloodUreaNitrogen],
+  ["bilirubin", normalizeBilirubin],
+  ["bilirubin-total", normalizeBilirubin],
+  ["total-bilirubin", normalizeBilirubin],
+  ["apob", normalizeApoB],
+  ["white-blood-cell-count", normalizeCellCount],
+  ["deep-sleep-minutes", normalizeDurationMinutes],
+  ["rem-sleep-minutes", normalizeDurationMinutes],
+  ["sleep-duration-variability-minutes", normalizeDurationMinutes],
+  ["sleep-midpoint-variability-minutes", normalizeDurationMinutes],
+  ["total-sleep-minutes", normalizeDurationMinutes],
+  ["sleep-score", normalizeHundredPointScore],
+  ["readiness-score", normalizeHundredPointScore],
+]);
+
 interface MetricValueNormalizationInput {
   metricKey: string;
   unit: string | null;
@@ -49,84 +95,14 @@ function normalizeMetricValueForScope(
     return { canonicalUnit: null, canonicalValue: null, unit, warnings: [] };
   }
 
-  switch (definition.key) {
-    case "albumin":
-      return normalizeAlbumin(input.value, unit);
-    case "body-weight":
-    case "lean-body-mass":
-      return normalizeWeight(input.value, unit);
-    case "waist-circumference":
-      return normalizeLengthCentimeters(input.value, unit, definition.displayName);
-    case "bone-mass-percentage":
-    case "body-fat-percentage":
-    case "body-water-percentage":
-    case "hba1c":
-    case "lymphocyte-percentage":
-    case "muscle-mass-percentage":
-    case "red-cell-distribution-width":
-      return normalizePercent(input.value, unit, definition.displayName);
-    case "creatinine":
-      return normalizeCreatinine(input.value, unit);
-    case "blood-urea-nitrogen":
-      return normalizeBloodUreaNitrogen(input.value, unit);
-    case "egfr":
-      return normalizeExactUnit(input.value, unit, "mL/min/1.73m^2", definition.displayName);
-    case "glucose":
-      return normalizeMassConcentration(input.value, unit, "mg/dL", 18.0182, definition.displayName);
-    case "ldl-c":
-    case "hdl-c":
-      return normalizeMassConcentration(input.value, unit, "mg/dL", 38.67, definition.displayName);
-    case "triglycerides":
-      return normalizeMassConcentration(input.value, unit, "mg/dL", 88.57, definition.displayName);
-    case "calcium":
-    case "serum-calcium":
-    case "total-calcium":
-      return normalizeMassConcentration(input.value, unit, "mg/dL", 4, definition.displayName);
-    case "cholesterol":
-    case "cholesterol-total":
-    case "total-cholesterol":
-      return normalizeMassConcentration(input.value, unit, "mg/dL", 38.67, definition.displayName);
-    case "serum-uric-acid":
-    case "urate":
-    case "uric-acid":
-      return normalizeMassConcentration(input.value, unit, "mg/dL", 16.812, definition.displayName);
-    case "bilirubin":
-    case "bilirubin-total":
-    case "total-bilirubin":
-      return normalizeMicromolarMassConcentration(input.value, unit, 17.1, definition.displayName);
-    case "apob":
-      return normalizeApoB(input.value, unit);
-    case "hs-crp":
-      return normalizeExactUnit(input.value, unit, "mg/L", definition.displayName);
-    case "ferritin":
-      return normalizeExactUnit(input.value, unit, "ng/mL", definition.displayName);
-    case "mean-corpuscular-hemoglobin":
-      return normalizeExactUnit(input.value, unit, "pg", definition.displayName);
-    case "mean-corpuscular-hemoglobin-concentration":
-      return normalizeExactUnit(input.value, unit, "g/dL", definition.displayName);
-    case "mean-corpuscular-volume":
-      return normalizeExactUnit(input.value, unit, "fL", definition.displayName);
-    case "thyroid-stimulating-hormone":
-      return normalizeExactUnit(input.value, unit, "mIU/L", definition.displayName);
-    case "white-blood-cell-count":
-      return normalizeCellCount(input.value, unit, definition.displayName);
-    case "alkaline-phosphatase":
-    case "alt":
-    case "ast":
-    case "ggt":
-      return normalizeExactUnit(input.value, unit, "U/L", definition.displayName);
-    case "deep-sleep-minutes":
-    case "rem-sleep-minutes":
-    case "sleep-duration-variability-minutes":
-    case "sleep-midpoint-variability-minutes":
-    case "total-sleep-minutes":
-      return normalizeDurationMinutes(input.value, unit, definition.displayName);
-    case "sleep-score":
-    case "readiness-score":
-      return normalizeHundredPointScore(input.value, unit, definition.displayName);
-    default:
-      return normalizeDeclaredMetricUnit(input.value, unit, definition);
+  const mmolToMgDl = MMOL_TO_MG_DL_BY_METRIC.get(definition.key);
+  if (mmolToMgDl !== undefined) {
+    return normalizeMassConcentration(input.value, unit, "mg/dL", mmolToMgDl, definition.displayName);
   }
+  const normalize = METRIC_VALUE_NORMALIZERS.get(definition.key);
+  return normalize
+    ? normalize(input.value, unit, definition.displayName)
+    : normalizeDeclaredMetricUnit(input.value, unit, definition);
 }
 
 function normalizeDeclaredMetricUnit(
@@ -473,10 +449,9 @@ function normalizeMassConcentration(
   return { canonicalUnit: null, canonicalValue: null, unit, warnings: [unitWarning(label, unit, canonicalUnit)] };
 }
 
-function normalizeMicromolarMassConcentration(
+function normalizeBilirubin(
   value: number,
   unit: string | null,
-  micromolesPerMgDl: number,
   label: string,
 ): MetricValueNormalization {
   if (!unit || unitsEquivalent(unit, "mg/dL")) {
@@ -485,7 +460,7 @@ function normalizeMicromolarMassConcentration(
   if (unitsEquivalent(unit, "umol/L")) {
     return {
       canonicalUnit: "mg/dL",
-      canonicalValue: Number((value / micromolesPerMgDl).toFixed(4)),
+      canonicalValue: Number((value / 17.1).toFixed(4)),
       unit,
       warnings: [],
     };

--- a/packages/health-metrics/test/normalize.test.ts
+++ b/packages/health-metrics/test/normalize.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { normalizeLabResultMetricValue, normalizeMetricValue } from "../src/normalize.ts";
+
+test("preserves declared exact units, missing-unit defaults, and mismatch warnings", () => {
+  const metrics = [
+    ["hba1c", "percent", "HbA1c"],
+    ["egfr", "mL/min/1.73m^2", "eGFR"],
+    ["hs-crp", "mg/L", "hs-CRP"],
+    ["ferritin", "ng/mL", "Ferritin"],
+    ["mean-corpuscular-hemoglobin", "pg", "Mean corpuscular hemoglobin"],
+    ["mean-corpuscular-hemoglobin-concentration", "g/dL", "Mean corpuscular hemoglobin concentration"],
+    ["mean-corpuscular-volume", "fL", "Mean corpuscular volume"],
+    ["thyroid-stimulating-hormone", "mIU/L", "Thyroid-stimulating hormone"],
+    ["alkaline-phosphatase", "U/L", "Alkaline phosphatase"],
+    ["alt", "U/L", "ALT"],
+    ["ast", "U/L", "AST"],
+    ["ggt", "U/L", "GGT"],
+  ] as const;
+
+  for (const normalize of [normalizeMetricValue, normalizeLabResultMetricValue]) {
+    for (const [metricKey, canonicalUnit, label] of metrics) {
+      for (const unit of [null, canonicalUnit]) {
+        assert.deepEqual(normalize({ metricKey, unit, value: 12.5 }), {
+          canonicalUnit,
+          canonicalValue: 12.5,
+          unit: canonicalUnit,
+          warnings: [],
+        }, metricKey);
+      }
+      assert.deepEqual(normalize({ metricKey, unit: "unsupported", value: 12.5 }), {
+        canonicalUnit: null,
+        canonicalValue: null,
+        unit: "unsupported",
+        warnings: [{
+          code: "UNIT_NOT_NORMALIZED",
+          message: `${label} uses unsupported; expected ${canonicalUnit}.`,
+        }],
+      }, metricKey);
+    }
+  }
+});
+
+test("keeps canonical percentage defaults when the lab display unit is a percent symbol", () => {
+  for (const normalize of [normalizeMetricValue, normalizeLabResultMetricValue]) {
+    for (const metricKey of ["lymphocyte-percentage", "red-cell-distribution-width"]) {
+      assert.deepEqual(normalize({ metricKey, unit: null, value: 12.5 }), {
+        canonicalUnit: "percent",
+        canonicalValue: 12.5,
+        unit: "percent",
+        warnings: [],
+      });
+    }
+  }
+});
+
+test("normalizes body percentage keys even when they are custom lab-result metrics", () => {
+  for (const metricKey of ["bone-mass-percentage", "body-fat-percentage", "body-water-percentage", "muscle-mass-percentage"]) {
+    assert.deepEqual(normalizeLabResultMetricValue({ metricKey, unit: null, value: 12.5 }), {
+      canonicalUnit: "percent",
+      canonicalValue: 12.5,
+      unit: "percent",
+      warnings: [],
+    });
+  }
+  assert.deepEqual(normalizeLabResultMetricValue({ metricKey: "body-fat-percentage", unit: "unsupported", value: 12.5 }), {
+    canonicalUnit: null,
+    canonicalValue: null,
+    unit: "unsupported",
+    warnings: [{ code: "UNIT_NOT_NORMALIZED", message: "Body Fat Percentage uses unsupported; expected percent." }],
+  });
+});
+
+test("ignores missing and nonfinite values before conversion routing while retaining source units", () => {
+  for (const normalize of [normalizeMetricValue, normalizeLabResultMetricValue]) {
+    for (const metricKey of ["body-weight", "glucose", "bilirubin", "hba1c", "custom-metric"]) {
+      for (const value of [null, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+        assert.deepEqual(normalize({ metricKey, unit: "mmol_l", value }), {
+          canonicalUnit: null,
+          canonicalValue: null,
+          unit: "mmol/L",
+          warnings: [],
+        });
+      }
+    }
+    assert.deepEqual(normalize({ metricKey: "sleep_duration_hours", unit: null, value: null }), {
+      canonicalUnit: null,
+      canonicalValue: null,
+      unit: "hours",
+      warnings: [],
+    });
+  }
+});
+
+test("retains custom metric fallback for names that resemble object properties", () => {
+  for (const normalize of [normalizeMetricValue, normalizeLabResultMetricValue]) {
+    for (const metricKey of ["constructor", "__proto__", "hasOwnProperty"]) {
+      assert.deepEqual(normalize({ metricKey, unit: "points", value: 4 }), {
+        canonicalUnit: null,
+        canonicalValue: null,
+        unit: "points",
+        warnings: [],
+      });
+      assert.deepEqual(normalize({ metricKey, unit: "g/L", value: 40 }), {
+        canonicalUnit: "g/dL",
+        canonicalValue: 4,
+        unit: "g/L",
+        warnings: [],
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Why and outcome

Health metric normalization repeated the same routing and exact-unit rules in a 55-complexity switch. The normalizer now uses the catalog's existing exact-unit fallback, an explicit map of molar conversion factors, and typed dispatch to the existing conversion helpers. The target function's complexity falls from 55 to 8 with 25 fewer source lines.

Aliases, lab-result-only catalog scope, conversion factors and rounding, source units, missing/nonfinite values, and warning text remain unchanged. Body-percentage keys retain their conversion behavior even when the lab catalog treats them as custom metrics.

## Product UX

- Effort: Not applicable — internal behavior-preserving normalization refactor.
- Result: Not applicable.
- Walkthrough: Existing query, export, and lab-result consumers retain the same normalization results; no interaction or product policy changes.

## Evidence

- Direct: `pnpm --dir packages/health-metrics test test/index.test.ts test/normalize.test.ts` — 62 tests passed. `pnpm --dir packages/health-metrics typecheck` — passed.
- Coverage: Five focused boundary tests protect exact-unit defaults and warnings, percent display-unit exceptions, custom lab-result body metrics, nonfinite inputs, and property-like custom names. Existing tests cover conversions, aliases, sleep-unit inference, score semantics, and expanded lab catalog isolation.
- Differential: 957,564 baseline/head normalization outputs were identical across 794 metric keys and aliases, 67 units, nine missing/finite/nonfinite values, and both ordinary/lab-result scopes. The synthetic matrix includes null/empty/unknown/incompatible units, custom property-like names, signed zero, both infinities, and large finite values. Baseline: `b2a559812972d70644cffb2bf43923fc9211047d`.
- Parent candidate review passed. Required exact-head CI and final external review remain pending.

## Non-obvious affected surfaces

Read-side metric normalization is shared by query projections and browser-vault exports. The existing package tests and complete synthetic baseline/head comparison protect those unchanged results. There are no additional edited surfaces.

## Architecture and reuse

- Existing systems reused: The health-metrics catalog, declared-unit fallback, and current conversion/warning helpers remain the owners.
- New logic: None; conversion formulas, accepted units, source scope, and warnings are preserved.
- New abstractions: One private function type and two private maps express existing conversion exceptions and factors. `Map` lookup also preserves arbitrary custom-key fallback without prototype lookup.
- Complexity intentionally avoided: Redundant exact-unit cases are deleted. No conversion framework, dependency, new state owner, or package API is introduced.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base b2a559812972d70644cffb2bf43923fc9211047d -- packages/health-metrics/src/normalize.ts`. Target complexity 55 → 8; changed-file maximum 55 → 21; debt above 20 falls 36 → 1.
- Hotspots: `resolveComparableMetricPointValue` remains unchanged at 21. Its source-evidence validity rules are separate from the repeated conversion routing addressed here.
- Agent judgment: Further simplification of the comparator would widen this refactor without removing the demonstrated routing repetition. The final source diff removes 25 lines and preserves explicit conversion exceptions.

## Hot reply path impact

- Path status: Not applicable — pure synchronous metric normalization changes no accepted-message processing or reply handoff ordering.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: No asynchronous work is introduced; baseline/head normalization outputs match across the synthetic matrix.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no prompt, tool schema, provider-input builder, or generated guidance changes.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: This pure internal refactor changes no persisted shape, protocol, package API, or independently deployed producer/consumer contract.

## Change-shape breakdown

Classification rule: Production TypeScript is source; package tests are tests; the completed execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 56 | 81 |
| Tests / fixtures | 112 | 0 |
| Docs | 63 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **231** | **81** |

## Changelog

- Changelog: not applicable
- Reason: Internal maintainability refactor with identical member-visible behavior.

ReviewGPT first-reviewed head: 9584dddac16e48335831a184ff259d6561c9ebe2
ReviewGPT context sensitivity: sensitive
Classification reason: Behavior-preserving health-data normalization refactor shared by query and browser-vault consumers.

## Final review evidence

- Round 1: PASS on 9584dddac16e48335831a184ff259d6561c9ebe2; zero findings received, accepted, or rejected.
- Scope and identity: Full immutable snapshot and diff reviewed; response hashes, captured turn, model, and exact head were verified.
- Model and lane: gpt-6-pro on mountain. The successful wrapper enforced at least 270 seconds; exact elapsed time was not persisted.
- Tooling retries: A terminal generation failure required a fresh round-one review; one invocation was corrected before send. Tooling retries did not advance the substantive round.
