### PR TITLE
refactor(query): collapse experiment progress count selection

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-complexity-collapse-experiment-progress.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-complexity-collapse-experiment-progress.md
@@ -1,0 +1,55 @@
+# Collapse browser experiment progress count selection
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal and protected invariant
+
+Make browser experiment progress easier to read by selecting the adherence count
+source once. Preserve every result field, unknown-target behavior, confidence
+omission, rollup selection, and calendar/occurrence timing boundary.
+
+## Owner and evidence
+
+`packages/query/src/browser-replica/experiments.ts` owns this read-only projection
+over canonical experiment plans and evidence. `buildProgressResult` has cyclomatic
+complexity 102 and repeats the identical count-source ladder for completed,
+partial, missed, and skipped sessions. It also repeats the same target eligibility
+decision. Existing adherence counters remain the source of all counts.
+
+## Scope and decisions
+
+- Collapse duplicate selection in `buildProgressResult`; add no abstraction,
+  dependency, persisted state, API, or health policy.
+- Preserve separate calendar confidence and rollup cell filtering, including the
+  currently unreachable calendar fallback.
+- Internal behavior-preserving refactor; no Product UX or changelog change.
+- Failure, retry, rollback, and deploy skew are unchanged: pure read-side local
+  selection retains the same existing count owners and output schema.
+
+## Tasks
+
+1. Add focused public-selector assertions for count and occurrence sources,
+   unsupported targets, and ambiguous targets; prove them against the base.
+2. Consolidate target eligibility and select one session-count object.
+3. Run the browser experiment suite, query typecheck, and complexity guard.
+4. Inspect privacy and full diff, close this plan through the scoped wrapper,
+   push, and open a draft PR for parent-owned review and CI admission.
+
+## Verification
+
+- Passed: `pnpm --dir packages/query test browser-vault-experiment-results.test.ts`
+  on both the original source and the refactor: 100 tests in each run.
+- Passed: `pnpm --dir packages/query typecheck`.
+- Passed: `pnpm complexity:diff --base b2a559812972d70644cffb2bf43923fc9211047d -- packages/query/src/browser-replica/experiments.ts`.
+  `buildProgressResult` and file maximum complexity fall from 102 to 73; file debt
+  falls from 115 to 86. Source change is 19 added and 42 deleted lines.
+- Reviewed remaining hotspots: progress assembly 73, run context 48, coverage
+  classification 24, and unrelated anonymous parser 21. The latter three are
+  unchanged; further splitting would add scope without deleting this duplication.
+- Passed: `git diff --check`; source, tests, and plan reviewed for privacy.
+- Final exact-head CI and any routed external review remain parent-owned.
+- Existing suite covers repeated daily occurrences, confidence/grace, rollups,
+  time zones, unsupported targets, stopped runs, and saved outcomes.
+Completed: 2026-09-10

--- a/packages/query/src/browser-replica/experiments.ts
+++ b/packages/query/src/browser-replica/experiments.ts
@@ -2029,17 +2029,15 @@ function buildProgressResult(
   occurrenceCounts: CalendarAdherenceSessionCounts | null,
 ): BrowserVaultExperimentProgressResult {
   const rollupTarget = resolveExperimentAdherenceRollupTarget(context.adherenceTargets);
-  const hasAmbiguousTargets = context.adherenceTargets.length > 1 && !rollupTarget;
-  const hasUnsupportedExplicitTargets = context.unsupportedExplicitAdherenceTargets;
-  const targetSessions =
-    hasUnsupportedExplicitTargets ? null :
-    rollupTarget?.rollup?.targetCompletions ??
-    (hasAmbiguousTargets ? null : context.run.runPlan.targetSessions);
-  const minimumUsefulSessions =
-    hasUnsupportedExplicitTargets ? null :
-    rollupTarget?.rollup?.minimumUsefulCompletions ??
-    (hasAmbiguousTargets ? null : context.run.runPlan.minimumUsefulSessions);
-  const progressTarget = hasUnsupportedExplicitTargets || hasAmbiguousTargets
+  const hasUnknownAdherence = context.unsupportedExplicitAdherenceTargets ||
+    (context.adherenceTargets.length > 1 && !rollupTarget);
+  const targetSessions = hasUnknownAdherence
+    ? null
+    : rollupTarget?.rollup?.targetCompletions ?? context.run.runPlan.targetSessions;
+  const minimumUsefulSessions = hasUnknownAdherence
+    ? null
+    : rollupTarget?.rollup?.minimumUsefulCompletions ?? context.run.runPlan.minimumUsefulSessions;
+  const progressTarget = hasUnknownAdherence
     ? null
     : rollupTarget ?? context.adherenceTargets[0] ?? null;
   const progressObservations = progressTarget
@@ -2059,34 +2057,13 @@ function buildProgressResult(
           windows: context.run.windows,
         })
       : null);
-  const completedSessions = hasUnsupportedExplicitTargets || hasAmbiguousTargets
-    ? 0
-    : occurrenceCounts
-      ? occurrenceCounts.completedSessions
-      : progressTarget?.calendar
-        ? schedule?.completedSessions ?? 0
-        : progressCounts?.completedSessions ?? 0;
-  const partialSessions = hasUnsupportedExplicitTargets || hasAmbiguousTargets
-    ? 0
-    : occurrenceCounts
-      ? occurrenceCounts.partialSessions
-      : progressTarget?.calendar
-        ? schedule?.partialSessions ?? 0
-        : progressCounts?.partialSessions ?? 0;
-  const missedSessions = hasUnsupportedExplicitTargets || hasAmbiguousTargets
-    ? 0
-    : occurrenceCounts
-      ? occurrenceCounts.missedSessions
-      : progressTarget?.calendar
-        ? schedule?.missedSessions ?? 0
-        : progressCounts?.missedSessions ?? 0;
-  const skippedSessions = hasUnsupportedExplicitTargets || hasAmbiguousTargets
-    ? 0
-    : occurrenceCounts
-      ? occurrenceCounts.skippedSessions
-      : progressTarget?.calendar
-        ? schedule?.skippedSessions ?? 0
-        : progressCounts?.skippedSessions ?? 0;
+  const sessionCounts = hasUnknownAdherence
+    ? null
+    : occurrenceCounts ?? (progressTarget?.calendar ? schedule : progressCounts);
+  const completedSessions = sessionCounts?.completedSessions ?? 0;
+  const partialSessions = sessionCounts?.partialSessions ?? 0;
+  const missedSessions = sessionCounts?.missedSessions ?? 0;
+  const skippedSessions = sessionCounts?.skippedSessions ?? 0;
   const loggedSessions = completedSessions + partialSessions;
   const progressSchedule = progressTarget?.calendar && rollupTarget && schedule
     ? {
@@ -2094,7 +2071,7 @@ function buildProgressResult(
         cells: schedule.cells.filter((cell) => cell.targetId === rollupTarget.targetId),
       }
     : progressTarget?.calendar ? schedule : null;
-  const confidenceCounts = hasUnsupportedExplicitTargets || hasAmbiguousTargets
+  const confidenceCounts = hasUnknownAdherence
     ? { sensedSessions: 0, confirmedSessions: 0, assumedSessions: 0 }
     : occurrenceCounts ??
       (progressTarget?.calendar
@@ -2108,7 +2085,7 @@ function buildProgressResult(
             assumedSessions: 0,
           });
   const scheduledExpectedSessionsByNow =
-    hasUnsupportedExplicitTargets || hasAmbiguousTargets
+    hasUnknownAdherence
       ? null
       : computeExpectedSessionsByNow(
           context.run,
@@ -2159,7 +2136,7 @@ function buildProgressResult(
       partialSessions,
       ...(confidenceCounts.sensedSessions > 0 ? { sensedSessions: confidenceCounts.sensedSessions } : {}),
       skippedSessions,
-      status: hasUnsupportedExplicitTargets || hasAmbiguousTargets
+      status: hasUnknownAdherence
         ? "unknown"
         : classifyAdherenceStatus({
             expectedSessionsByNow,

--- a/packages/query/test/browser-vault-experiment-results.test.ts
+++ b/packages/query/test/browser-vault-experiment-results.test.ts
@@ -1027,6 +1027,57 @@ test("browser count path treats partial intervention sessions as logged", () => 
   assert.notEqual(result?.progress?.adherence.status, "not_started");
 });
 
+test.each([
+  { calendar: false, missedSessions: 1, skippedSessions: 1 },
+  { calendar: true, missedSessions: 2, skippedSessions: 0 },
+])("preserves all progress counts for calendar=$calendar", ({ calendar, missedSessions, skippedSessions }) => {
+  const client = createBrowserVaultQueryClient(createReplica({
+    generatedAt: "2026-04-12T12:00:00.000Z",
+    entities: [
+      experimentEntity({
+        runPlan: {
+          interventionStart: "2026-04-08",
+          interventionEnd: "2026-04-11",
+          targetSessions: 4,
+          minimumUsefulSessions: 2,
+          adherenceTargets: [{
+            targetId: "sauna",
+            label: "Sauna",
+            phase: "intervention",
+            ...(calendar ? { calendar: { kind: "daily", timeZone: "UTC" } } : {}),
+            evidence: {
+              kind: "linkedEventCount",
+              eventKind: "intervention_session",
+              missing: "missed_after_grace",
+            },
+            grace: { hours: 0 },
+          }],
+        },
+      }),
+      sessionEvent("2026-04-08", "completed", { attributes: { source: "manual" } }),
+      sessionEvent("2026-04-09", "partial", { attributes: { source: "manual" } }),
+      sessionEvent("2026-04-10", "missed"),
+      sessionEvent("2026-04-11", "skipped"),
+    ],
+  }));
+
+  const result = selectBrowserVaultExperimentResults(client, "exp_sauna");
+
+  assert.deepEqual(result?.progress?.adherence, {
+    completedSessions: 1,
+    confirmedSessions: 2,
+    expectedSessionsByNow: 4,
+    loggedSessions: 2,
+    minimumUsefulSessions: 2,
+    missedSessions,
+    partialSessions: 1,
+    skippedSessions,
+    status: "met_minimum",
+    targetSessions: 4,
+  });
+  assert.equal(result?.schedule === null, !calendar);
+});
+
 test("renders the exact saved outcome after raw metric rows age out", () => {
   const outcome = savedOutcome();
   const client = createBrowserVaultQueryClient(
@@ -3850,8 +3901,62 @@ test("does not synthesize legacy schedules for unsupported explicit metric adher
   assert.ok(result);
   assert.equal(result.schedule, null);
   assert.ok(result.diagnostics.some((diagnostic) => diagnostic.code === "invalid_schedule"));
-  assert.equal(result.progress?.adherence.status, "unknown");
-  assert.equal(result.progress?.adherence.loggedSessions, 0);
+  assert.deepEqual(result.progress?.adherence, {
+    completedSessions: 0,
+    expectedSessionsByNow: null,
+    loggedSessions: 0,
+    minimumUsefulSessions: null,
+    missedSessions: 0,
+    partialSessions: 0,
+    skippedSessions: 0,
+    status: "unknown",
+    targetSessions: null,
+  });
+});
+
+test("keeps ambiguous target progress unknown despite scheduled session evidence", () => {
+  const client = createBrowserVaultQueryClient(createReplica({
+    generatedAt: "2026-04-10T12:00:00.000Z",
+    entities: [
+      experimentEntity({
+        runPlan: {
+          interventionStart: "2026-04-08",
+          interventionEnd: "2026-04-09",
+          targetSessions: 2,
+          minimumUsefulSessions: 1,
+          adherenceTargets: ["first", "second"].map((targetId) => ({
+            targetId,
+            label: targetId,
+            phase: "intervention",
+            calendar: { kind: "daily", timeZone: "UTC" },
+            evidence: {
+              kind: "linkedEventCount",
+              eventKind: "intervention_session",
+              missing: "missed_after_grace",
+            },
+            grace: { hours: 0 },
+          })),
+        },
+      }),
+      sessionEvent("2026-04-08", "completed"),
+      sessionEvent("2026-04-09", "partial"),
+    ],
+  }));
+
+  const result = selectBrowserVaultExperimentResults(client, "exp_sauna");
+
+  assert.equal(result?.schedule?.cells.length, 4);
+  assert.deepEqual(result?.progress?.adherence, {
+    completedSessions: 0,
+    expectedSessionsByNow: null,
+    loggedSessions: 0,
+    minimumUsefulSessions: null,
+    missedSessions: 0,
+    partialSessions: 0,
+    skippedSessions: 0,
+    status: "unknown",
+    targetSessions: null,
+  });
 });
 
 test("keeps comparator-bounded metric thresholds unknown", () => {


### PR DESCRIPTION
## Why and outcome

Browser experiment progress repeated the same source-precedence decision separately for completed, partial, missed, and skipped sessions. Select that count object once and reuse one eligibility decision for unsupported or ambiguous targets.

The output remains unchanged, including confidence fields, skipped-session semantics, rollup selection, expected counts, and calendar boundaries. `buildProgressResult` falls from cyclomatic complexity 102 to 73 while deleting 23 net source lines.

## Product UX

- Effort: Not applicable — internal behavior-preserving read-side refactor.
- Result: Not applicable.
- Walkthrough: Public browser-selector tests preserve count-backed and calendar-backed progress, unsupported targets, ambiguous targets, and existing result journeys. No presentation or product-policy change.

## Evidence

- Direct: `pnpm --dir packages/query test browser-vault-experiment-results.test.ts` passed all 100 tests against both the original source and the refactor. New complete-output assertions cover count versus occurrence sources, skipped counts, confidence omission, unsupported targets, and ambiguous targets with schedule evidence.
- Coverage: Existing tests also exercise repeated daily occurrences, grace boundaries, confirmed/sensed/assumed confidence, rollups, time zones, stopped runs, and saved outcomes through the public browser selector.
- `pnpm --dir packages/query typecheck` passed.
- `git diff --check` passed.
- Required exact-head CI and final review remain pending after parent candidate review.

## Non-obvious affected surfaces

None. The existing browser progress projection is the only production owner changed.

## Architecture and reuse

- Existing systems reused: Existing adherence session and occurrence counters, schedule projection, confidence calculation, and rollup resolver.
- New logic: None; shared local variables express existing source precedence and eligibility.
- New abstractions: None; the selection stays in its current read-side owner.
- Complexity intentionally avoided: No helper framework, state owner, cache, dependency, or policy change. Calendar confidence and rollup filtering retain their distinct responsibilities.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base b2a559812972d70644cffb2bf43923fc9211047d -- packages/query/src/browser-replica/experiments.ts`.
- Hotspots: `buildProgressResult` 102 → 73; file maximum 102 → 73 and debt 115 → 86. The other reported hotspots are unchanged: `buildRunContext` 48, `classifyCoverageStatus` 24, and the anonymous parser callback at line 821 with 21.
- Agent judgment: Consolidating duplicate source selection removes real branching without relocating it. Further splitting of distinct progress, confidence, coverage, and readiness responsibilities is outside this bounded refactor; no new helper exists solely to change the metric.

## Hot reply path impact

- Path status: Not applicable — browser replica progress projection, outside durable message acceptance and provider reply handoff.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Public-selector parity tests; no asynchronous work added or moved.

## Murph initial provider input impact

Not applicable for individual and group runtimes: this changes browser result aggregation only, with no prompt, tool, schema, or provider-input builder changes.

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.


## Deployment concerns

- Deployment: not applicable
- Reason: Pure read-side selection retains the existing output schema and all count owners; no migration, rollout ordering, or cross-version contract changes.

## Change-shape breakdown

Classification rule: Production TypeScript is source; browser selector test changes are tests; the completed execution plan is docs. No binary files or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 19 | 42 |
| Tests / fixtures | 107 | 2 |
| Docs | 55 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **181** | **44** |

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving maintainability improvement; no member-visible behavior change.

ReviewGPT first-reviewed head: 1f311e0869a32230b742ad922939efa62f4b2787
ReviewGPT context sensitivity: sensitive
Classification reason: Experiment adherence and health result counts are refactored while preserving their public output contract.

## Final review evidence

- Round 1: PASS on 1f311e0869a32230b742ad922939efa62f4b2787; zero findings received, accepted, or rejected.
- Scope and identity: Full immutable snapshot and diff reviewed; response hashes, captured turn, model, and exact head were verified.
- Model and lane: gpt-6-pro on mountain. The successful wrapper enforced at least 270 seconds; exact elapsed time was not persisted.
- Tooling retries: None. Tooling retries did not advance the substantive round.
