### PR TITLE
Unify timeline projection across entity families

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-complexity-timeline.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-complexity-timeline.md
@@ -1,0 +1,56 @@
+# Collapse repeated timeline entry projection
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+- Remove repeated journal, event, and assessment timeline projection while preserving the complete read-only query result.
+
+## Success criteria
+
+- Preserve family inclusion, date and experiment scope, event stream filtering, timestamp and title fallbacks, ordering, and limits.
+- Reduce the measured complexity of `buildTimeline` and delete duplicate production code.
+
+## Scope
+
+- In scope: `packages/query/src/timeline.ts` and focused timeline regression tests.
+- Out of scope: public API, persistence, product behavior, sample aggregation, and dependencies.
+
+## Constraints
+
+- The existing query read model remains the owner; no canonical state is mutated.
+- Assessments remain independent of experiment scope. Journal empty timestamps and event/assessment rejection retain their existing distinct behavior.
+- Keep the PR draft for parent candidate review and CI admission.
+
+## Risks and mitigations
+
+1. Shared projection could erase family differences or change ordering.
+   Mitigation: prove synthetic family-specific filtering, metadata, invalid/empty occurrence, and bounded output cases against the original implementation before refactoring.
+
+## Tasks
+
+1. Completed: read the timeline, query owner, and existing regression coverage.
+2. Completed: added family scope/metadata, invalid/empty occurrence, and limit assertions; all nine focused cases passed against the original source.
+3. Completed: consolidated the three family pipelines and removed repeated summary stream filtering and per-summary kind checks.
+4. Completed: final focused tests, query typecheck, complexity guard, and source/privacy review passed.
+5. Delivery: close the implementation plan and publish the scoped draft candidate for parent review and CI admission.
+
+## Decisions
+
+- Keep family traversal in journal/event/assessment order so complete sort ties retain their stable behavior.
+- Use one shared entry projector and an explicit title fallback helper; do not add a registry, dependency, or persisted owner.
+- Daily sample summaries already enforce stream filtering, so the timeline's duplicate stream recheck can be deleted.
+- No deployment compatibility or rollback contract changes: this is an in-memory behavior-preserving refactor.
+
+## Verification
+
+- Baseline: nine focused cases passed before source edits, including the three new regression cases.
+- Final: `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage test/query.test.ts test/health-internals-coverage.test.ts test/browser-vault-replica.test.ts -t 'buildTimeline|buildExportPack renders experiment|export pack, overview, and timeline|browser vault replicas round-trip'` passed all 10 selected tests.
+- `pnpm --dir packages/query typecheck` passed after the final TypeScript edits.
+- `pnpm complexity:diff --base origin/main -- packages/query/src/timeline.ts` passed: target and file maximum 43 to 19; debt above 20 from 23 to zero; total function complexity 61 to 57.
+- Production source: 78 lines added, 115 removed (net deletion of 37 lines). Two duplicate entity projections and filter/occurrence pipelines are gone; no new shared or persisted owner exists.
+- `git diff --check` passed. Only the timeline source, its existing test file, and this plan belong to the candidate; no private data or direct personal identifiers were added.
+- Broad exact-head CI and parent candidate/final reviews remain owned by the parent session after draft delivery.
+Completed: 2026-09-10

--- a/packages/query/src/timeline.ts
+++ b/packages/query/src/timeline.ts
@@ -1,5 +1,7 @@
 import { extractIsoDatePrefix } from "@murphai/contracts";
 
+import type { CanonicalEntity } from "./canonical-entities.ts";
+
 import {
   entityRelationTargetIds,
   listEntities,
@@ -46,145 +48,50 @@ export interface TimelineEntry {
   data: Record<string, unknown>;
 }
 
+type EntityTimelineEntryType = Exclude<TimelineEntry["entryType"], "sample_summary">;
+
 export function buildTimeline(
   vault: VaultReadModel,
   filters: TimelineFilters = {},
 ): TimelineEntry[] {
   const kindSet = filters.kinds?.length ? new Set(filters.kinds) : null;
   const streamSet = filters.streams?.length ? new Set(filters.streams) : null;
-  const includeJournal = filters.includeJournal ?? true;
-  const includeEvents = filters.includeEvents ?? true;
-  const includeAssessments = filters.includeAssessments ?? true;
-  const includeDailySampleSummaries =
-    filters.includeDailySampleSummaries ?? true;
-
+  const families = [
+    ["journal", filters.includeJournal ?? true],
+    ["event", filters.includeEvents ?? true],
+    ["assessment", filters.includeAssessments ?? true],
+  ] as const;
   const entries: TimelineEntry[] = [];
 
-  if (includeJournal) {
-    for (const journal of listEntities(vault, {
-      families: ["journal"],
-      experimentSlug: filters.experimentSlug,
+  for (const [entryType, included] of families) {
+    if (!included) {
+      continue;
+    }
+
+    for (const entity of listEntities(vault, {
+      families: [entryType],
+      experimentSlug: entryType === "assessment" ? undefined : filters.experimentSlug,
       from: filters.from,
       to: filters.to,
     })) {
-      const journalKind = journal.kind || "journal_day";
-      if (kindSet && !kindSet.has(journalKind)) {
-        continue;
+      const entry = entityToTimelineEntry(entity, entryType, kindSet, streamSet);
+      if (entry) {
+        entries.push(entry);
       }
-
-      const occurrence = resolveTimelineOccurrence(journal, "12:00:00Z");
-      if (!occurrence) {
-        continue;
-      }
-
-      entries.push({
-        id: journal.entityId,
-        entryType: "journal",
-        occurredAt: occurrence.occurredAt,
-        date: occurrence.date,
-        title: journal.title ?? journal.entityId,
-        kind: journalKind,
-        stream: null,
-        experimentSlug: journal.experimentSlug,
-        path: journal.path,
-        relatedIds: entityRelationTargetIds(journal),
-        tags: journal.tags,
-        data: journal.attributes,
-      });
     }
   }
 
-  if (includeEvents) {
-    for (const event of listEntities(vault, {
-      families: ["event"],
-      experimentSlug: filters.experimentSlug,
-      from: filters.from,
-      to: filters.to,
-    })) {
-      if (streamSet && (!event.stream || !streamSet.has(event.stream))) {
-        continue;
-      }
-
-      const eventKind = event.kind || "event";
-      if (kindSet && !kindSet.has(eventKind)) {
-        continue;
-      }
-
-      const occurrence = resolveTimelineOccurrence(event, "00:00:00Z");
-      if (!occurrence || !occurrence.occurredAt) {
-        continue;
-      }
-
-      entries.push({
-        id: event.entityId,
-        entryType: "event",
-        occurredAt: occurrence.occurredAt,
-        date: occurrence.date,
-        title: event.title ?? eventKind,
-        kind: eventKind,
-        stream: event.stream,
-        experimentSlug: event.experimentSlug,
-        path: event.path,
-        relatedIds: entityRelationTargetIds(event),
-        tags: event.tags,
-        data: event.attributes,
-      });
-    }
-  }
-
-  if (includeAssessments) {
-    for (const assessment of listEntities(vault, {
-      families: ["assessment"],
-      from: filters.from,
-      to: filters.to,
-    })) {
-      const assessmentKind = assessment.kind || "assessment";
-      if (kindSet && !kindSet.has(assessmentKind)) {
-        continue;
-      }
-
-      const occurrence = resolveTimelineOccurrence(assessment, "12:00:00Z");
-      if (!occurrence || !occurrence.occurredAt) {
-        continue;
-      }
-
-      entries.push({
-        id: assessment.entityId,
-        entryType: "assessment",
-        occurredAt: occurrence.occurredAt,
-        date: occurrence.date,
-        title:
-          assessment.title ??
-          stringData(assessment.attributes.assessmentType) ??
-          assessment.entityId,
-        kind: assessmentKind,
-        stream: null,
-        experimentSlug: null,
-        path: assessment.path,
-        relatedIds: entityRelationTargetIds(assessment),
-        tags: assessment.tags,
-        data: assessment.attributes,
-      });
-    }
-  }
-
-  if (includeDailySampleSummaries) {
+  if (
+    (filters.includeDailySampleSummaries ?? true) &&
+    (!kindSet || kindSet.has("sample_summary"))
+  ) {
     const summaries = summarizeDailySamples(vault, {
       from: filters.from,
       to: filters.to,
       streams: filters.streams,
       experimentSlug: filters.experimentSlug,
     });
-
     for (const summary of summaries) {
-      if (streamSet && !streamSet.has(summary.stream)) {
-        continue;
-      }
-
-      if (kindSet && !kindSet.has("sample_summary")) {
-        continue;
-      }
-
       entries.push(summaryToTimelineEntry(summary));
     }
   }
@@ -192,6 +99,62 @@ export function buildTimeline(
   return entries
     .sort(compareTimelineEntries)
     .slice(0, normalizeLimit(filters.limit));
+}
+
+function entityToTimelineEntry(
+  entity: CanonicalEntity,
+  entryType: EntityTimelineEntryType,
+  kindSet: ReadonlySet<string> | null,
+  streamSet: ReadonlySet<string> | null,
+): TimelineEntry | null {
+  if (
+    entryType === "event" && streamSet &&
+    (!entity.stream || !streamSet.has(entity.stream))
+  ) {
+    return null;
+  }
+
+  const kind = entity.kind || (entryType === "journal" ? "journal_day" : entryType);
+  if (kindSet && !kindSet.has(kind)) {
+    return null;
+  }
+
+  const occurrence = resolveTimelineOccurrence(
+    entity,
+    entryType === "event" ? "00:00:00Z" : "12:00:00Z",
+  );
+  if (!occurrence || (entryType !== "journal" && !occurrence.occurredAt)) {
+    return null;
+  }
+
+  return {
+    id: entity.entityId,
+    entryType,
+    occurredAt: occurrence.occurredAt,
+    date: occurrence.date,
+    title: entity.title ?? timelineFallbackTitle(entity, entryType, kind),
+    kind,
+    stream: entryType === "event" ? entity.stream : null,
+    experimentSlug: entryType === "assessment" ? null : entity.experimentSlug,
+    path: entity.path,
+    relatedIds: entityRelationTargetIds(entity),
+    tags: entity.tags,
+    data: entity.attributes,
+  };
+}
+
+function timelineFallbackTitle(
+  entity: CanonicalEntity,
+  entryType: EntityTimelineEntryType,
+  kind: string,
+): string {
+  if (entryType === "event") {
+    return kind;
+  }
+  if (entryType === "assessment") {
+    return stringData(entity.attributes.assessmentType) ?? entity.entityId;
+  }
+  return entity.entityId;
 }
 
 interface TimelineOccurrence {

--- a/packages/query/test/query.test.ts
+++ b/packages/query/test/query.test.ts
@@ -2925,6 +2925,10 @@ test("buildTimeline merges journals, events, and daily sample summaries into a d
   assert.equal(timeline[0]?.kind, "sample_summary");
   assert.equal(timeline[0]?.stream, "heart_rate");
   assert.equal(timeline[0]?.data.averageValue, 69);
+  assert.deepEqual(
+    buildTimeline(vault, { streams: [] }).map((entry) => entry.entryType),
+    ["event", "journal"],
+  );
 });
 
 test("searchVault supports blank queries, structured-only matches, and filter normalization", () => {
@@ -3301,6 +3305,130 @@ test("buildTimeline applies toggles, fallback timestamps, and filter caps", () =
 
   assert.equal(summariesOnly.length, 1);
   assert.equal(summariesOnly[0]?.entryType, "sample_summary");
+});
+
+test("buildTimeline preserves family-specific scope, metadata, and fallback titles", () => {
+  const entities = (["journal", "event", "assessment"] as const).map((family) =>
+    createRecord({
+      id: `timeline_${family}`,
+      recordType: family,
+      sourcePath: `ledger/${family}/fixture.jsonl`,
+      date: "2026-03-13",
+      kind: "",
+      status: "archived",
+      stream: family === "event" ? "glucose" : "ignored",
+      experimentSlug: family === "assessment" ? "other" : "focus",
+      relatedIds: ["evt_related"],
+      tags: ["fixture"],
+      data: { assessmentType: "  Intake  ", value: 3 },
+    }),
+  );
+  const event = entities.find((entity) => entity.family === "event")!;
+  const vault = createReadModelFromEntities([
+    ...entities,
+    { ...event, entityId: "wrong_stream", stream: "heart_rate" },
+    { ...event, entityId: "missing_stream", stream: null },
+    { ...event, entityId: "empty_stream", stream: "" },
+    { ...event, entityId: "other_experiment", experimentSlug: "other" },
+    { ...entities[0]!, entityId: "other_journal", experimentSlug: "other" },
+    { ...entities[2]!, entityId: "old_assessment", date: "2026-03-12" },
+  ]);
+  const before = structuredClone(vault.entities);
+  const filters = {
+    from: "2026-03-13",
+    to: "2026-03-13",
+    experimentSlug: "focus",
+    streams: ["glucose", ""],
+    kinds: ["journal_day", "event", "assessment"],
+    includeDailySampleSummaries: false,
+  };
+
+  const entries = buildTimeline(vault, filters);
+  assert.deepEqual(
+    entries.map(({ entryType, kind, title, stream, experimentSlug, occurredAt }) =>
+      [entryType, kind, title, stream, experimentSlug, occurredAt]),
+    [
+      ["assessment", "assessment", "  Intake  ", null, null, "2026-03-13T12:00:00Z"],
+      ["journal", "journal_day", "timeline_journal", null, "focus", "2026-03-13T12:00:00Z"],
+      ["event", "event", "event", "glucose", "focus", "2026-03-13T00:00:00Z"],
+    ],
+  );
+  for (const entry of entries) {
+    const source = entities.find((entity) => entity.entityId === entry.id)!;
+    assert.equal(entry.date, source.date);
+    assert.equal(entry.path, source.path);
+    assert.deepEqual(entry.relatedIds, ["evt_related"]);
+    assert.strictEqual(entry.tags, source.tags);
+    assert.strictEqual(entry.data, source.attributes);
+  }
+  assert.deepEqual(vault.entities, before);
+  assert.deepEqual(
+    buildTimeline(vault, { ...filters, includeAssessments: false }).map((entry) => entry.entryType),
+    ["journal", "event"],
+  );
+  assert.deepEqual(
+    buildTimeline(vault, { ...filters, kinds: ["assessment"] }).map((entry) => entry.entryType),
+    ["assessment"],
+  );
+});
+
+test("buildTimeline preserves family-specific empty and invalid occurrence handling", () => {
+  const cases = [
+    { id: "missing", date: null, occurredAt: null, admitted: false },
+    { id: "invalid", date: null, occurredAt: "invalid", admitted: false },
+    { id: "empty_date", date: "", occurredAt: "2026-03-13T09:00:00Z", admitted: false },
+    { id: "derived_date", date: null, occurredAt: "2026-03-13T09:00:00Z", admitted: true },
+    { id: "explicit_date", date: "2026-03-13", occurredAt: "invalid", admitted: true },
+    { id: "empty_occurrence", date: "2026-03-13", occurredAt: "", admitted: true },
+  ];
+  for (const family of ["journal", "event", "assessment"] as const) {
+    for (const scenario of cases) {
+      const source = createRecord({
+        id: `${family}_${scenario.id}`,
+        recordType: family,
+        sourcePath: "ledger/fixture.jsonl",
+        date: scenario.date,
+        occurredAt: scenario.occurredAt,
+        title: "",
+      });
+      const entries = buildTimeline(createReadModelFromEntities([source]), {
+        includeDailySampleSummaries: false,
+      });
+      const admitted = scenario.admitted &&
+        (scenario.id !== "empty_occurrence" || family === "journal");
+      assert.equal(entries.length, Number(admitted), `${family}: ${scenario.id}`);
+      if (admitted) {
+        assert.equal(entries[0]?.occurredAt, scenario.occurredAt);
+        assert.equal(entries[0]?.date, "2026-03-13");
+        assert.equal(entries[0]?.title, "");
+      }
+    }
+  }
+});
+
+test("buildTimeline applies default, finite, and maximum limits after global ordering", () => {
+  const vault = createReadModelFromEntities(Array.from({ length: 501 }, (_, index) =>
+    createRecord({
+      id: `evt_${String(500 - index).padStart(3, "0")}`,
+      recordType: "event",
+      sourcePath: "ledger/events/fixture.jsonl",
+      date: "2026-03-13",
+    }),
+  ));
+  for (const [limit, expectedCount] of [
+    [undefined, 200],
+    [Number.NaN, 200],
+    [Number.POSITIVE_INFINITY, 200],
+    [-1, 1],
+    [0, 1],
+    [2.9, 2],
+    [999, 500],
+  ] as const) {
+    const entries = buildTimeline(vault, { limit, includeDailySampleSummaries: false });
+    assert.equal(entries.length, expectedCount);
+    assert.equal(entries[0]?.id, "evt_000");
+    assert.equal(entries.at(-1)?.id, `evt_${String(expectedCount - 1).padStart(3, "0")}`);
+  }
 });
 
 test("buildTimeline breaks sort ties by date then id when timestamps match", () => {


### PR DESCRIPTION
## Why and outcome

Timeline reads repeated nearly the same journal, event, and assessment filtering and field projection in three branches. One ordered family traversal now feeds a shared entry projector with explicit family-specific title, timestamp, stream, and experiment behavior. This removes 37 production lines and lowers the maximum cyclomatic complexity from 43 to 19 without changing timeline output.

## Product UX

- Effort: Not applicable — internal behavior-preserving query refactor.
- Result: Not applicable — no intended product or presentation change.
- Walkthrough: Synthetic proof preserves each family’s inclusion, metadata, missing/invalid occurrence handling, global ordering, and output limits; browser-vault history remains available through the existing selector.

## Evidence

- Direct: Three new timeline regressions passed against the original implementation before refactoring. Final focused Vitest command passed 10 tests: `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage test/query.test.ts test/health-internals-coverage.test.ts test/browser-vault-replica.test.ts -t 'buildTimeline|buildExportPack renders experiment|export pack, overview, and timeline|browser vault replicas round-trip'`.
- Coverage: Tests cover family-specific experiment and stream filters, archived records, empty title preservation, assessment fallback text, relations/tags/data, no source mutation, missing/invalid/empty occurrences, empty stream filters, sorting, default 200/max 500 limits, and browser replica/history round-trip.
- Typecheck: `pnpm --dir packages/query typecheck` passed after the final TypeScript changes.
- Diff hygiene: `git diff --check` and candidate privacy inspection passed.
- CI: Pending exact-head CI after parent candidate review.

## Non-obvious affected surfaces

CLI timeline reads and browser-vault history consume the same query boundary. The focused query assertions preserve CLI result semantics, and the browser replica round-trip test proves the history selector still exposes timeline entries.

## Architecture and reuse

- Existing systems reused: The canonical read model, `listEntities`, daily sample aggregation, occurrence resolution, relation projection, comparator, and limit normalization retain ownership.
- New logic: No new product policy; equivalent family rules now share filtering and projection, and summaries skip repeated stream filtering and per-row kind checks.
- New abstractions: Two private helpers share entity projection and make title fallback policy explicit; a private entry-family type derives from the existing public entry type.
- Complexity intentionally avoided: No registry framework, additional state owner, dependency, persisted format, or duplicate family projection is introduced.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base origin/main -- packages/query/src/timeline.ts`; file maximum 43 → 19 and debt above 20 from 23 → 0.
- Hotspots: None remain above 20. `buildTimeline` is 19, the shared entity projector is 16, and the title fallback helper is 4; total function complexity falls from 61 to 57.
- Agent judgment: Two duplicate filter/occurrence/projection pipelines are removed. The remaining family differences encode existing behavior, so further merging would obscure their purpose.

## Hot reply path impact

- Path status: Not applicable — synchronous query projection does not change durable acceptance, provider start, or reply handoff.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None; the changed projection is synchronous.
- Before/after proof: Baseline and final focused query tests preserve output; the diff adds no I/O or await.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged; no instruction builder or prompt edits.
- Tool/schema/generated guidance: Unchanged; no tool contract or schema edits.
- Other provider-visible input: Unchanged; timeline result behavior is preserved.
- Measurement method: Not run — no initial provider-input surface changes for either runtime.

## Deployment concerns

- Deployment: not applicable
- Reason: In-memory query refactoring preserves the existing API, serialized entries, and persistence contracts; no independently deployed protocol or migration changes.

## Change-shape breakdown

Classification rule: Timeline implementation is Source; the existing query test file is Tests / fixtures; the completed execution plan is Docs. No binary files or generated output.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 78 | 115 |
| Tests / fixtures | 128 | 0 |
| Docs | 56 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **262** | **115** |

## Changelog

- Changelog: not applicable
- Reason: Internal maintainability improvement preserves member-visible timeline behavior.

ReviewGPT first-reviewed head: f6764e26cfa485b62fe25443075a70600b41b94f
ReviewGPT context sensitivity: routine
Classification reason: Behavior-preserving synchronous timeline projection refactor across three entity families.

## Final review evidence

- Round 1: PASS on f6764e26cfa485b62fe25443075a70600b41b94f; zero findings received, accepted, or rejected.
- Scope and identity: Full immutable snapshot and diff reviewed; response hashes, captured turn, model, and exact head were verified.
- Model and lane: gpt-6-pro on apollo. The successful wrapper enforced at least 270 seconds; exact elapsed time was not persisted.
- Tooling retries: None. Tooling retries did not advance the substantive round.
