### PR TITLE
refactor(importers): collapse repeated Oura daily normalization

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-complexity-collapse-oura-daily.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-complexity-collapse-oura-daily.md
@@ -1,0 +1,73 @@
+# Collapse repeated Oura daily normalization
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+Remove repeated daily-resource normalization in the Oura importer while preserving
+the complete normalized device payload and existing canonical ownership.
+
+## Success criteria
+
+- Replace four duplicated daily loops with one explicitly ordered resource loop.
+- Preserve event and evidence ordering, fallback identities, timestamps, facets,
+  summary grain, metric omission, collection counts, and SpO2 alias precedence.
+- Reduce source lines and measured complexity without moving branches elsewhere.
+- Pass focused provider tests, importers typecheck, and Cyclomatic Complexity Guard.
+
+## Scope
+
+- Oura normalizer and existing Oura coverage tests.
+- No transport, canonical writer, schema, public API, or other provider changes.
+
+## Constraints
+
+The importer remains the parsing and normalization owner; core remains the sole
+canonical writer. Existing metric descriptors and evidence helpers retain all
+validation and emission behavior. No new state, dependency, or shared framework.
+
+## Risks and mitigations
+
+1. Resource ordering determines fallback IDs from the current event count.
+   Keep activity, sleep summary, readiness, and SpO2 order explicit and test
+   missing identities, skipped metrics, and the subsequent sleep resource.
+2. Empty objects count in provenance but emit no evidence or metrics.
+   Exercise invalid records and compare evidence contents and collection counts.
+3. Date-only identity, timestamp version, and provider-local day have distinct
+   fallback rules. Assert each through the actual normalizer before refactoring.
+
+## Tasks
+
+1. Add and run synthetic compatibility cases against the existing normalizer.
+2. Collapse the repeated daily loops at their existing owner.
+3. Run focused provider proof, typecheck, complexity guard, and inspect the diff.
+4. Close the plan with the scoped commit; push and open a draft PR for parent review.
+
+## Decisions
+
+- Keep prefiltered arrays because they already own provenance counts.
+- Keep sleep, session, workout, and deletion branches in place.
+- Internal behavior-preserving refactor: no product flow or changelog change.
+- Parent owns candidate admission, exact-head CI, and final ReviewGPT.
+
+## Verification
+
+- Focused Vitest: Oura coverage, device-provider normalization, and deletion normalization.
+- Typecheck: `pnpm --dir packages/importers typecheck`.
+- Guard: `pnpm complexity:diff --base origin/main -- packages/importers/src/device-providers/oura.ts`.
+- Baseline compatibility: all 10 Oura coverage cases pass against the original
+  normalizer, including the six new cases.
+- Candidate: all 92 tests pass across the three focused files.
+- Importers typecheck passes.
+- Cyclomatic Complexity Guard passes: target/file maximum 66 -> 55; file debt
+  above threshold 20 falls from 46 -> 35. Source changes are +32 / -99 lines.
+- Remaining complexity is the existing distinct sleep, session, workout, and
+  deletion behavior. Splitting those branches would relocate complexity rather
+  than remove demonstrated duplication.
+- Diff whitespace and privacy inspection pass. No new Frog entry was needed;
+  the frozen install and ordinary repository checks succeeded.
+- Local implementation and proof are complete. Draft PR handoff retains parent
+  ownership of candidate admission, exact-head CI, and final ReviewGPT.
+Completed: 2026-09-10

--- a/packages/importers/src/device-providers/oura.ts
+++ b/packages/importers/src/device-providers/oura.ts
@@ -515,105 +515,38 @@ export function normalizeOuraSnapshot(snapshot: OuraSnapshotInput): NormalizedDe
 
   pushEvidencePart(evidenceParts, createEvidencePart("personal-info", "personal-info.json", personalInfo));
 
-  for (const activity of dailyActivity) {
-    const activityId = stringId(activity.id) ?? stringId(activity.day) ?? `daily-activity-${events.length + 1}`;
-    const recordedAt = firstIso(activity.timestamp, activity.day) ?? importedAt;
-    const occurredAt = recordedAt;
-    const dayKey = firstDayKey(stringId(activity.day), recordedAt);
-    const role = `daily-activity:${activityId}`;
-    const version = firstIso(activity.timestamp);
+  const dailyResources = [
+    { resourceType: "daily-activity", records: dailyActivity, metrics: OURA_DAILY_ACTIVITY_METRICS },
+    { resourceType: "daily-sleep", records: dailySleep, metrics: OURA_DAILY_SLEEP_METRICS },
+    { resourceType: "daily-readiness", records: dailyReadiness, metrics: OURA_DAILY_READINESS_METRICS },
+    { resourceType: "daily-spo2", records: dailySpO2, metrics: OURA_DAILY_SPO2_METRICS },
+  ];
 
-    pushEvidencePart(evidenceParts, createEvidencePart(role, `daily-activity-${activityId}.json`, activity));
+  // Resource order also determines event-count fallback identities.
+  for (const { resourceType, records, metrics } of dailyResources) {
+    for (const record of records) {
+      const resourceId = stringId(record.id) ?? stringId(record.day) ?? `${resourceType}-${events.length + 1}`;
+      const recordedAt = firstIso(record.timestamp, record.day) ?? importedAt;
+      const dayKey = firstDayKey(stringId(record.day), recordedAt);
+      const role = `${resourceType}:${resourceId}`;
+      const version = firstIso(record.timestamp);
 
-    emitObservationMetrics(
-      events,
-      {
-        source: activity,
-        occurredAt,
-        recordedAt,
-        dayKey,
-        observationGrain: "summary",
-        evidenceRoles: [role],
-        externalRef: (facet) => makeExternalRef("daily-activity", activityId, version, facet),
-      },
-      OURA_DAILY_ACTIVITY_METRICS,
-    );
-  }
+      pushEvidencePart(evidenceParts, createEvidencePart(role, `${resourceType}-${resourceId}.json`, record));
 
-  for (const summary of dailySleep) {
-    const summaryId = stringId(summary.id) ?? stringId(summary.day) ?? `daily-sleep-${events.length + 1}`;
-    const recordedAt = firstIso(summary.timestamp, summary.day) ?? importedAt;
-    const occurredAt = recordedAt;
-    const dayKey = firstDayKey(stringId(summary.day), recordedAt);
-    const role = `daily-sleep:${summaryId}`;
-    const version = firstIso(summary.timestamp);
-
-    pushEvidencePart(evidenceParts, createEvidencePart(role, `daily-sleep-${summaryId}.json`, summary));
-
-    emitObservationMetrics(
-      events,
-      {
-        source: summary,
-        occurredAt,
-        recordedAt,
-        dayKey,
-        observationGrain: "summary",
-        evidenceRoles: [role],
-        externalRef: (facet) => makeExternalRef("daily-sleep", summaryId, version, facet),
-      },
-      OURA_DAILY_SLEEP_METRICS,
-    );
-  }
-
-  for (const readiness of dailyReadiness) {
-    const readinessId =
-      stringId(readiness.id) ?? stringId(readiness.day) ?? `daily-readiness-${events.length + 1}`;
-    const recordedAt = firstIso(readiness.timestamp, readiness.day) ?? importedAt;
-    const occurredAt = recordedAt;
-    const dayKey = firstDayKey(stringId(readiness.day), recordedAt);
-    const role = `daily-readiness:${readinessId}`;
-    const version = firstIso(readiness.timestamp);
-
-    pushEvidencePart(evidenceParts, createEvidencePart(role, `daily-readiness-${readinessId}.json`, readiness));
-
-    emitObservationMetrics(
-      events,
-      {
-        source: readiness,
-        occurredAt,
-        recordedAt,
-        dayKey,
-        observationGrain: "summary",
-        evidenceRoles: [role],
-        externalRef: (facet) => makeExternalRef("daily-readiness", readinessId, version, facet),
-      },
-      OURA_DAILY_READINESS_METRICS,
-    );
-  }
-
-  for (const spo2 of dailySpO2) {
-    const spo2Id = stringId(spo2.id) ?? stringId(spo2.day) ?? `daily-spo2-${events.length + 1}`;
-    const recordedAt = firstIso(spo2.timestamp, spo2.day) ?? importedAt;
-    const occurredAt = recordedAt;
-    const dayKey = firstDayKey(stringId(spo2.day), recordedAt);
-    const role = `daily-spo2:${spo2Id}`;
-    const version = firstIso(spo2.timestamp);
-
-    pushEvidencePart(evidenceParts, createEvidencePart(role, `daily-spo2-${spo2Id}.json`, spo2));
-
-    emitObservationMetrics(
-      events,
-      {
-        source: spo2,
-        occurredAt,
-        recordedAt,
-        dayKey,
-        observationGrain: "summary",
-        evidenceRoles: [role],
-        externalRef: (facet) => makeExternalRef("daily-spo2", spo2Id, version, facet),
-      },
-      OURA_DAILY_SPO2_METRICS,
-    );
+      emitObservationMetrics(
+        events,
+        {
+          source: record,
+          occurredAt: recordedAt,
+          recordedAt,
+          dayKey,
+          observationGrain: "summary",
+          evidenceRoles: [role],
+          externalRef: (facet) => makeExternalRef(resourceType, resourceId, version, facet),
+        },
+        metrics,
+      );
+    }
   }
 
   for (const sleep of sleeps) {

--- a/packages/importers/test/oura-coverage.test.ts
+++ b/packages/importers/test/oura-coverage.test.ts
@@ -51,6 +51,115 @@ test("normalizeOuraSnapshot covers dailySpo2 aliasing", () => {
   assert.equal(payload.samples?.length ?? 0, 0);
 });
 
+test("normalizeOuraSnapshot preserves daily resource order, fallback identity, and evidence", () => {
+  const importedAt = "2026-03-16T10:00:00.000Z";
+  const personalInfo = { id: "synthetic-oura-account" };
+  const activity = {
+    id: 42,
+    day: "2026-03-14",
+    timestamp: "2026-03-15T01:30:00+02:00",
+    score: "80",
+    steps: 42,
+  };
+  const dailySleep = { day: "2026-03-15", score: 90 };
+  const invalidReadiness = { score: "invalid", temperature_deviation: Infinity };
+  const readiness = { score: 0, temperature_deviation: "-0.2" };
+  const spo2 = {
+    spo2_percentage: { average: 97 },
+    breathing_disturbance_index: 2,
+  };
+  const sleep = { average_hrv: 42 };
+  const payload = normalizeOuraSnapshot({
+    importedAt,
+    personalInfo,
+    dailyActivity: [null, false, [], {}, activity],
+    dailySleep: [dailySleep],
+    dailyReadiness: [invalidReadiness, readiness],
+    dailySpO2: [spo2],
+    sleeps: [sleep],
+  });
+
+  assert.deepEqual(payload.events?.map((event) => [
+    event.externalRef?.resourceType,
+    event.externalRef?.resourceId,
+    event.externalRef?.facet,
+    event.fields?.value,
+  ]), [
+    ["daily-activity", "42", "activity-score", 80],
+    ["daily-activity", "42", "steps", 42],
+    ["daily-sleep", "2026-03-15", "sleep-score", 90],
+    ["daily-readiness", "daily-readiness-4", "readiness-score", 0],
+    ["daily-readiness", "daily-readiness-4", "temperature-deviation", -0.2],
+    ["daily-spo2", "daily-spo2-6", "spo2-average", 97],
+    ["daily-spo2", "daily-spo2-6", "breathing-disturbance-index", 2],
+    ["sleep", "sleep-8", "average-hrv", 42],
+  ]);
+  assert.deepEqual(payload.events?.slice(0, 7).map((event) => [
+    event.occurredAt, event.recordedAt, event.dayKey, event.externalRef?.version,
+  ]), [
+    ["2026-03-14T23:30:00.000Z", "2026-03-14T23:30:00.000Z", "2026-03-14", "2026-03-14T23:30:00.000Z"],
+    ["2026-03-14T23:30:00.000Z", "2026-03-14T23:30:00.000Z", "2026-03-14", "2026-03-14T23:30:00.000Z"],
+    ["2026-03-15T00:00:00.000Z", "2026-03-15T00:00:00.000Z", "2026-03-15", undefined],
+    [importedAt, importedAt, "2026-03-16", undefined],
+    [importedAt, importedAt, "2026-03-16", undefined],
+    [importedAt, importedAt, "2026-03-16", undefined],
+    [importedAt, importedAt, "2026-03-16", undefined],
+  ]);
+  for (const event of payload.events?.slice(0, 7) ?? []) {
+    assert.equal(event.fields?.observationGrain, "summary");
+    assert.equal(event.externalRef?.system, "oura");
+    assert.deepEqual(event.evidenceRoles, [
+      `${event.externalRef?.resourceType}:${event.externalRef?.resourceId}`,
+    ]);
+  }
+  assert.deepEqual(payload.evidenceParts?.map((part) => [part.role, part.fileName]), [
+    ["personal-info", "personal-info.json"],
+    ["daily-activity:42", "daily-activity-42.json"],
+    ["daily-sleep:2026-03-15", "daily-sleep-2026-03-15.json"],
+    ["daily-readiness:daily-readiness-4", "daily-readiness-daily-readiness-4.json"],
+    ["daily-readiness:daily-readiness-4", "daily-readiness-daily-readiness-4.json"],
+    ["daily-spo2:daily-spo2-6", "daily-spo2-daily-spo2-6.json"],
+    ["sleep:sleep-8", "sleep-sleep-8.json"],
+  ]);
+  assert.deepEqual(payload.evidenceParts?.map((part) => part.content), [
+    personalInfo, activity, dailySleep, invalidReadiness, readiness, spo2, sleep,
+  ]);
+  assert.deepEqual(payload.provenance?.importedSections, {
+    personalInfo: true,
+    dailyActivity: 2,
+    dailySleep: 1,
+    dailyReadiness: 2,
+    dailySpO2: 1,
+    sleeps: 1,
+    sessions: 0,
+    workouts: 0,
+    deletions: 0,
+  });
+});
+
+test("normalizeOuraSnapshot prefers dailySpO2 even when the primary collection is empty", () => {
+  const alias = [{ day: "2026-03-15", spo2_percentage: { average: 97 } }];
+  for (const dailySpO2 of [[], [{ day: "2026-03-14", spo2_percentage: { average: 98 } }]]) {
+    const payload = normalizeOuraSnapshot({
+      importedAt: "2026-03-16T10:00:00.000Z",
+      dailySpO2,
+      dailySpo2: alias,
+    });
+    assert.deepEqual(payload.events?.map((event) => event.fields?.value), dailySpO2.length ? [98] : []);
+    assert.deepEqual(payload.evidenceParts?.map((part) => part.content), dailySpO2);
+  }
+});
+
+test.each(["dailyActivity", "dailySleep", "dailyReadiness", "dailySpO2"])(
+  "normalizeOuraSnapshot rejects an invalid %s timestamp before day fallback",
+  (collection) => {
+    assert.throws(() => normalizeOuraSnapshot({
+      importedAt: "2026-03-16T10:00:00.000Z",
+      [collection]: [{ timestamp: "invalid", day: "2026-03-15" }],
+    }), { name: "TypeError", message: "timestamp must be a valid timestamp" });
+  },
+);
+
 test("normalizeOuraSnapshot preserves explicit main-sleep and nap identity without guessing unknown types", () => {
   const sleeps = [
     { id: "main", type: "sleep" },


### PR DESCRIPTION
## Why and outcome

Oura daily activity, sleep, readiness, and SpO2 normalization repeated the same identity, timestamp, evidence, and metric-emission steps four times. Use one explicitly ordered resource list and loop so those rules have one implementation; remove 67 net source lines while preserving normalized output.

## Product UX

- Effort: Not applicable — internal behavior-preserving importer refactor.
- Result: Not applicable.
- Walkthrough: Existing wearable summaries, evidence, ordering, invalid-input behavior, and canonical writes remain unchanged. No frontend or member workflow changes.

## Evidence

- Direct: The expanded Oura compatibility suite passed against the original normalizer before refactoring (10 tests), then against the candidate.
- Coverage: Synthetic fixtures assert daily resource/event order, event-count fallback identities across omitted metrics and later sleep resources, evidence roles/file names/content, numeric conversion, zero values, timestamps, provider-local day keys, versions, summary grain, invalid record filtering, provenance counts, SpO2 alias precedence, and invalid timestamp rejection before day fallback.
- `pnpm --dir packages/importers exec vitest run --config vitest.config.ts --no-coverage test/oura-coverage.test.ts test/device-providers.test.ts test/device-providers/deletion-normalization.test.ts` — passed, 92 tests in 3 files, including existing provider normalization and real-core contract round trips.
- `pnpm --dir packages/importers typecheck` — passed.
- `pnpm complexity:diff --base origin/main -- packages/importers/src/device-providers/oura.ts` — passed.
- `git diff --check` and candidate privacy inspection — passed.
- Required exact-head CI and parent final review remain pending after parent candidate review.

## Non-obvious affected surfaces

Event-count fallback IDs depend on earlier emitted metrics and resource order. The compatibility fixture proves skipped metrics do not advance those IDs and that the subsequent sleep resource keeps its original identity. Evidence for invalid metric records and provenance counts for empty objects are preserved.

## Architecture and reuse

- Existing systems reused: Oura metric descriptors, `emitObservationMetrics`, existing timestamp/identity helpers, and evidence/batch builders; core remains the canonical writer.
- New logic: None; the ordered resource list selects the same arrays, resource names, and metric descriptors.
- New abstractions: One local resource list replaces four duplicate loop bodies; no exported type, shared helper, or new state owner.
- Complexity intentionally avoided: No provider framework, dynamic provenance assembly, dependency, or relocation of sleep/session/workout/deletion branches.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base origin/main -- packages/importers/src/device-providers/oura.ts`.
- Hotspots: `normalizeOuraSnapshot` drops from 66 to 55; file maximum drops from 66 to 55 and debt above 20 drops from 46 to 35. It is the only remaining hotspot in the changed source file.
- Agent judgment: The four equivalent daily branches are collapsed. Remaining branches express distinct sleep, session, workout, and deletion semantics; moving them to helpers would not remove demonstrated duplication and is outside this focused change.

## Hot reply path impact

- Path status: Not applicable — background wearable snapshot normalization only.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None; this normalizer is synchronous.
- Before/after proof: Compatibility tests verify the same emitted batch; no foreground reply operation changes.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no assistant prompt, tool schema, generated guidance, request assembly, or history builder changes.

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Behavior-preserving code consolidation within one importer; no runtime protocol, persisted shape, configuration, deployment ordering, or rollback boundary changes.

## Change-shape breakdown

Classification rule: Importer implementation is source; existing coverage-file additions are tests; the completed execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 32 | 99 |
| Tests / fixtures | 109 | 0 |
| Docs | 73 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **214** | **99** |

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving normalization refactor with no member-visible change.

ReviewGPT first-reviewed head: 3773a3e29975264cabb4e85060a3873a27e741af
ReviewGPT context sensitivity: sensitive
Classification reason: Wearable provider normalization preserves external identities and canonical health-data output.

## Final review evidence

- Round 1: PASS on 3773a3e29975264cabb4e85060a3873a27e741af; zero findings received, accepted, or rejected.
- Scope and identity: Full immutable snapshot and diff reviewed; response hashes, captured turn, model, and exact head were verified.
- Model and lane: gpt-6-pro on vonneumann. The successful wrapper enforced at least 270 seconds; exact elapsed time was not persisted.
- Tooling retries: A response below the required duration was retained as diagnostic output and retried; one invocation was corrected before send. Tooling retries did not advance the substantive round.
