### PR TITLE
fix: restore assistant ownership of reminder provenance reads

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-10-reminder-outbox-owner.md
+++ b/agent-docs/exec-plans/active/2026-09-10-reminder-outbox-owner.md
@@ -1,0 +1,61 @@
+# Restore assistant ownership of reminder provenance reads
+
+Status: active
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+- Restore assistant-engine ownership of outbox reads used to prove delivered
+  experiment reminders, while preserving canonical occurrence and replay rules.
+
+## Success criteria
+
+- Vault usecases never open assistant-owned outbox files or import assistant-engine.
+- Default and scoped CLI service composition use the public assistant outbox reader.
+- Existing reminder acceptance, owner binding, planned occurrence, and replay tests pass.
+- Focused tests, affected typechecks, boundary guards, required PR CI, and ReviewGPT pass.
+
+## Scope
+
+- In scope: typed service dependency, CLI composition, provenance and boundary proof.
+- Out of scope: prompts, command schemas, delivery behavior, persisted formats, deployment.
+
+## Constraints
+
+- Keep dependencies acyclic and the trusted reader outside command JSON.
+- Preserve ordinary experiment logging without an assistant dependency.
+- Open a separate PR; do not merge or deploy.
+
+## Risks and mitigations
+
+1. A composition path omits the reader.
+   Mitigation: wire default and scoped CLI factories and test composed provenance reads.
+2. Untrusted input substitutes delivery proof.
+   Mitigation: retain intent and occurrence validation; test forged JSON and missing readers.
+
+## Tasks
+
+1. Confirm current consumer and outbox owner paths.
+2. Pass the typed trusted reader through existing lazy service factories.
+3. Migrate provenance proof to composed CLI tests and add lower-level denial tests.
+4. Run focused verification, inspect the candidate, and open a draft PR.
+5. Mark Ready and run ReviewGPT concurrently with required CI; resolve eligible failures.
+
+## Decisions
+
+- Reuse `readAssistantOutboxIntent` through a lazy CLI-owned callback.
+- Keep experiment-specific validation in vault usecases; do not add a reverse dependency.
+- No member-visible behavior or provider input change is intended.
+
+## Verification
+
+- Passed: CLI provenance and wiring (8 tests), lower usecase provenance (5 tests),
+  and architecture guards (3 tests).
+- Passed: vault-usecases and CLI typechecks; workspace boundary and cycle guards;
+  docs drift; diff whitespace and privacy review; `pnpm complexity:diff`.
+- Confirmed: unchanged canonical effects, one lookup per reminder attempt, no lookup
+  for ordinary logging, and fail-closed missing or mismatched owner evidence.
+- Existing complexity hotspots are unchanged; the new owner forwarding adds no
+  product branches to the canonical experiment writer.
+- Pending: pushed candidate, required PR CI, and final ReviewGPT.

--- a/agent-docs/exec-plans/completed/2026-09-10-reminder-outbox-owner.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-reminder-outbox-owner.md
@@ -1,6 +1,6 @@
 # Restore assistant ownership of reminder provenance reads
 
-Status: active
+Status: completed
 Created: 2026-09-10
 Updated: 2026-09-10
 
@@ -45,6 +45,8 @@ Updated: 2026-09-10
 ## Decisions
 
 - Reuse `readAssistantOutboxIntent` through a lazy CLI-owned callback.
+- Only the scoped experiment route loads that CLI composition helper; other
+  scoped commands retain the direct neutral service factory and import budget.
 - Keep experiment-specific validation in vault usecases; do not add a reverse dependency.
 - No member-visible behavior or provider input change is intended.
 
@@ -58,4 +60,19 @@ Updated: 2026-09-10
   for ordinary logging, and fail-closed missing or mismatched owner evidence.
 - Existing complexity hotspots are unchanged; the new owner forwarding adds no
   product branches to the canonical experiment writer.
-- Pending: pushed candidate, required PR CI, and final ReviewGPT.
+- Full CI found that loading the helper for every scoped command added one
+  module beyond the condition-list ceiling. Narrowing composition to the
+  experiment route restores the existing budget without weakening its guard.
+- Passed after that correction: explicit runtime artifact rebuild, CLI
+  typecheck, and all 11 import-surface, provenance, and wiring tests across
+  three suites. Complexity and workspace boundary guards passed again.
+
+## Completion
+
+- Implementation and parent candidate review are complete in PR #3145.
+- ReviewGPT round 1 passed at `89459fdc790c2df4a2a3ba011f9d875bf8a55792`
+  with zero qualifying findings; the captured model identity is verified.
+- The final scoped-loading correction requires the next ReviewGPT round and
+  required CI on the final pushed head. Those remain PR merge-readiness gates;
+  this plan records implementation completion, not permission to merge or deploy.
+Completed: 2026-09-10

--- a/packages/cli/src/vault-cli-bootstrap.ts
+++ b/packages/cli/src/vault-cli-bootstrap.ts
@@ -1,6 +1,4 @@
-import {
-  createIntegratedVaultServices,
-} from '@murphai/vault-usecases'
+import { createCliVaultUsecaseServices } from './vault-cli-services.js'
 import type { CliVaultServices } from './device-services.js'
 import { ensureCliVaultServices } from './device-services.js'
 
@@ -13,6 +11,6 @@ export { createVaultCliShell } from './vault-cli-shell.js'
 
 export function createDefaultVaultServices(): CliVaultServices {
   return ensureCliVaultServices(
-    createIntegratedVaultServices(),
+    createCliVaultUsecaseServices(),
   )
 }

--- a/packages/cli/src/vault-cli-command-routing.ts
+++ b/packages/cli/src/vault-cli-command-routing.ts
@@ -137,12 +137,12 @@ export async function registerScopedVaultCliCommand(input: {
     case 'experiment': {
       const [
         { registerExperimentCommands },
-        services,
+        { createCliVaultUsecaseServices },
       ] = await Promise.all([
         import('./commands/experiment.js'),
-        createScopedVaultServices(),
+        import('./vault-cli-services.js'),
       ])
-      registerExperimentCommands(input.cli, services)
+      registerExperimentCommands(input.cli, createCliVaultUsecaseServices())
       return
     }
     case 'exercise': {
@@ -342,8 +342,8 @@ export async function registerScopedVaultCliCommand(input: {
 }
 
 async function createScopedVaultServices() {
-  const { createCliVaultUsecaseServices } = await import(
-    './vault-cli-services.js'
+  const { createIntegratedVaultServices } = await import(
+    '@murphai/vault-usecases/vault-services'
   )
-  return createCliVaultUsecaseServices()
+  return createIntegratedVaultServices()
 }

--- a/packages/cli/src/vault-cli-command-routing.ts
+++ b/packages/cli/src/vault-cli-command-routing.ts
@@ -342,8 +342,8 @@ export async function registerScopedVaultCliCommand(input: {
 }
 
 async function createScopedVaultServices() {
-  const { createIntegratedVaultServices } = await import(
-    '@murphai/vault-usecases/vault-services'
+  const { createCliVaultUsecaseServices } = await import(
+    './vault-cli-services.js'
   )
-  return createIntegratedVaultServices()
+  return createCliVaultUsecaseServices()
 }

--- a/packages/cli/src/vault-cli-services.ts
+++ b/packages/cli/src/vault-cli-services.ts
@@ -1,0 +1,12 @@
+import { createIntegratedVaultServices } from '@murphai/vault-usecases/vault-services'
+
+export function createCliVaultUsecaseServices() {
+  return createIntegratedVaultServices({
+    async readAssistantOutboxIntent(vault, intentId) {
+      const { readAssistantOutboxIntent } = await import(
+        '@murphai/assistant-engine/assistant-outbox'
+      )
+      return readAssistantOutboxIntent(vault, intentId)
+    },
+  })
+}

--- a/packages/cli/test/experiment-session-reminder-provenance.test.ts
+++ b/packages/cli/test/experiment-session-reminder-provenance.test.ts
@@ -1,0 +1,477 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { createExperiment, initializeVault, readJsonlRecords } from '@murphai/core'
+import { assistantOutboxIntentSchema } from '@murphai/operator-config/assistant-cli-contracts'
+import { saveAssistantOutboxIntent } from '@murphai/assistant-engine/assistant-outbox'
+import { test } from 'vitest'
+import { Cli } from 'incur'
+
+import { createCliVaultUsecaseServices } from '../src/vault-cli-services.js'
+
+const logExperimentSessionRecord = (
+  input: Omit<Parameters<ReturnType<typeof createCliVaultUsecaseServices>['core']['logExperimentSession']>[0], 'requestId'>,
+) => createCliVaultUsecaseServices().core.logExperimentSession({
+  ...input,
+  requestId: null,
+})
+
+const occurrenceDate = new Date()
+occurrenceDate.setUTCDate(occurrenceDate.getUTCDate() - 1)
+occurrenceDate.setUTCHours(15, 0, 0, 0)
+const occurrenceAt = occurrenceDate.toISOString()
+const crossingReminderDate = new Date(occurrenceDate)
+crossingReminderDate.setUTCHours(23, 55, 0, 0)
+const crossingReminderAt = crossingReminderDate.toISOString()
+const plannedOccurrenceAt = new Date(
+  crossingReminderDate.getTime() + 15 * 60 * 1000,
+).toISOString()
+const experimentStartedOn = formatLocalDate(addUtcDays(occurrenceDate, -7))
+const experimentInterventionEnd = formatLocalDate(addUtcDays(occurrenceDate, 60))
+const firstIntentId = 'outbox_experiment_reminder_01'
+const retryIntentId = 'outbox_experiment_reminder_02'
+const automationId = 'automation_experiment_reminder_01'
+
+function addUtcDays(date: Date, days: number): Date {
+  const copy = new Date(date)
+  copy.setUTCDate(copy.getUTCDate() + days)
+  return copy
+}
+
+function formatLocalDate(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+async function countEventIdInLedger(input: {
+  eventId: string
+  ledgerFile: string
+  vaultRoot: string
+}): Promise<number> {
+  const records = await readJsonlRecords({
+    vaultRoot: input.vaultRoot,
+    relativePath: input.ledgerFile,
+  })
+  return records.filter((record) => record.id === input.eventId).length
+}
+
+async function withExperiment(
+  run: (input: { experimentId: string; vaultRoot: string }) => Promise<void>,
+): Promise<void> {
+  const vaultRoot = await mkdtemp(path.join(os.tmpdir(), 'murph-reminder-session-'))
+  try {
+    await initializeVault({ vaultRoot })
+    const created = await createExperiment({
+      vaultRoot,
+      slug: 'reminder-backed-sauna',
+      title: 'Reminder-backed sauna',
+      startedOn: experimentStartedOn,
+      status: 'active',
+      runPlan: {
+        interventionStart: experimentStartedOn,
+        interventionEnd: experimentInterventionEnd,
+        modality: 'sauna',
+        targetSessions: 8,
+        minimumUsefulSessions: 4,
+      },
+    })
+    await run({
+      experimentId: created.experiment.id,
+      vaultRoot,
+    })
+  } finally {
+    await rm(vaultRoot, { recursive: true, force: true })
+  }
+}
+
+async function writeReminderIntent(input: {
+  automationId?: string
+  experimentId: string
+  intentId: string
+  plannedOccurrenceAt?: string | null
+  scheduledOccurrenceAt?: string
+  status?: 'pending' | 'sent'
+  supportSeriesId?: string
+  threadIsDirect?: boolean
+  vaultRoot: string
+}): Promise<void> {
+  const message = 'Sauna session time. Reply when you finish.'
+  const status = input.status ?? 'sent'
+  const scheduledOccurrenceAt = input.scheduledOccurrenceAt ?? occurrenceAt
+  const intent = assistantOutboxIntentSchema.parse({
+    schema: 'murph.assistant-outbox-intent.v1',
+    intentId: input.intentId,
+    sessionId: `session_${input.intentId}`,
+    turnId: `turn_${input.intentId}`,
+    createdAt: scheduledOccurrenceAt,
+    updatedAt: scheduledOccurrenceAt,
+    lastAttemptAt: scheduledOccurrenceAt,
+    nextAttemptAt: null,
+    sentAt: status === 'sent' ? scheduledOccurrenceAt : null,
+    attemptCount: status === 'sent' ? 1 : 0,
+    status,
+    message,
+    subject: null,
+    operation: null,
+    dedupeKey: `experiment-reminder-dedupe:${input.intentId}`,
+    targetFingerprint: 'experiment-reminder-target',
+    channel: 'linq',
+    identityId: null,
+    actorId: 'member-1',
+    threadId: 'thread-1',
+    threadIsDirect: input.threadIsDirect ?? true,
+    replyToMessageId: null,
+    bindingDelivery: null,
+    deliverySource: null,
+    automationAuthority: {
+      automationId: input.automationId ?? automationId,
+      supportSeriesId:
+        input.supportSeriesId ?? `experiment:${input.experimentId}`,
+      expectedUpdatedAt: scheduledOccurrenceAt,
+    },
+    scheduledOccurrenceAt,
+    plannedOccurrenceAt:
+      input.plannedOccurrenceAt === undefined
+        ? scheduledOccurrenceAt
+        : input.plannedOccurrenceAt,
+    explicitTarget: null,
+    delivery:
+      status === 'sent'
+        ? {
+            kind: 'message',
+            channel: 'linq',
+            idempotencyKey: null,
+            target: 'thread-1',
+            targetKind: 'thread',
+            sentAt: scheduledOccurrenceAt,
+            messageLength: message.length,
+            providerMessageId: `linq-message:${input.intentId}`,
+            providerThreadId: 'thread-1',
+          }
+        : null,
+    deliveryConfirmationPending: false,
+    deliveryIdempotencyKey: null,
+    deliveryTransportIdempotent: false,
+    lastError: null,
+  })
+  await saveAssistantOutboxIntent(input.vaultRoot, intent)
+}
+
+test('delivered reminder provenance owns one deterministic experiment occurrence without a current automation read', async () => {
+  await withExperiment(async ({ experimentId, vaultRoot }) => {
+    await writeReminderIntent({
+      automationId: 'automation_first_session_prep',
+      experimentId,
+      intentId: firstIntentId,
+      plannedOccurrenceAt,
+      scheduledOccurrenceAt: crossingReminderAt,
+      vaultRoot,
+    })
+    await writeReminderIntent({
+      automationId: 'automation_planned_session_support',
+      experimentId,
+      intentId: retryIntentId,
+      plannedOccurrenceAt,
+      scheduledOccurrenceAt: plannedOccurrenceAt,
+      vaultRoot,
+    })
+
+    const [first, replay] = await Promise.all([
+      logExperimentSessionRecord({
+        vault: vaultRoot,
+        lookup: experimentId,
+        reminderIntentId: firstIntentId,
+      }),
+      logExperimentSessionRecord({
+        vault: vaultRoot,
+        lookup: experimentId,
+        reminderIntentId: retryIntentId,
+      }),
+    ])
+    const sequentialReplay = await logExperimentSessionRecord({
+      vault: vaultRoot,
+      lookup: experimentId,
+      reminderIntentId: retryIntentId,
+    })
+
+    assert.equal([first, replay].filter((result) => result.created).length, 1)
+    assert.equal(replay.eventId, first.eventId)
+    assert.equal(sequentialReplay.created, false)
+    assert.equal(sequentialReplay.eventId, first.eventId)
+    if (
+      !('progress' in first)
+      || !('progress' in replay)
+      || !('progress' in sequentialReplay)
+    ) {
+      assert.fail('reminder-backed writes must return canonical progress readback')
+    }
+    assert.equal(first.progress?.adherence.completedSessions, 1)
+    assert.deepEqual(first.progress?.adherence.sessionEventIds, [first.eventId])
+    assert.equal(replay.progress?.adherence.completedSessions, 1)
+    assert.deepEqual(replay.progress?.adherence.sessionEventIds, [first.eventId])
+    assert.equal(sequentialReplay.progress?.adherence.completedSessions, 1)
+    assert.deepEqual(
+      sequentialReplay.progress?.adherence.sessionEventIds,
+      [first.eventId],
+    )
+    assert.equal(
+      await countEventIdInLedger({
+        eventId: first.eventId,
+        ledgerFile: first.ledgerFile,
+        vaultRoot,
+      }),
+      1,
+    )
+  })
+})
+
+test('distinct planned occurrences retain distinct canonical session effects', async () => {
+  await withExperiment(async ({ experimentId, vaultRoot }) => {
+    const laterOccurrenceAt = new Date(
+      Date.parse(occurrenceAt) + 60 * 60 * 1000,
+    ).toISOString()
+    await writeReminderIntent({
+      automationId: 'automation_session_one',
+      experimentId,
+      intentId: firstIntentId,
+      plannedOccurrenceAt: occurrenceAt,
+      scheduledOccurrenceAt: occurrenceAt,
+      vaultRoot,
+    })
+    await writeReminderIntent({
+      automationId: 'automation_session_two',
+      experimentId,
+      intentId: retryIntentId,
+      plannedOccurrenceAt: laterOccurrenceAt,
+      scheduledOccurrenceAt: laterOccurrenceAt,
+      vaultRoot,
+    })
+
+    const first = await logExperimentSessionRecord({
+      vault: vaultRoot,
+      lookup: experimentId,
+      reminderIntentId: firstIntentId,
+    })
+    const second = await logExperimentSessionRecord({
+      vault: vaultRoot,
+      lookup: experimentId,
+      reminderIntentId: retryIntentId,
+    })
+
+    assert.notEqual(second.eventId, first.eventId)
+    assert.equal(first.created, true)
+    assert.equal(second.created, true)
+    if (!('progress' in second)) {
+      assert.fail('reminder-backed writes must return canonical progress readback')
+    }
+    assert.equal(second.progress?.adherence.completedSessions, 2)
+    assert.deepEqual(
+      second.progress?.adherence.sessionEventIds,
+      [first.eventId, second.eventId],
+    )
+  })
+})
+
+test('reminder-backed logging records a planned session after midnight instead of the earlier reminder date', async () => {
+  await withExperiment(async ({ experimentId, vaultRoot }) => {
+    await writeReminderIntent({
+      experimentId,
+      intentId: firstIntentId,
+      plannedOccurrenceAt,
+      scheduledOccurrenceAt: crossingReminderAt,
+      vaultRoot,
+    })
+
+    const result = await logExperimentSessionRecord({
+      vault: vaultRoot,
+      lookup: experimentId,
+      reminderIntentId: firstIntentId,
+    })
+    const records = await readJsonlRecords({
+      vaultRoot,
+      relativePath: result.ledgerFile,
+    })
+    const event = records.find((record) => record.id === result.eventId)
+
+    assert.equal(event?.occurredAt, plannedOccurrenceAt)
+  })
+})
+
+test('reminder-backed session logging rejects transport, owner, and occurrence substitutions', async () => {
+  await withExperiment(async ({ experimentId, vaultRoot }) => {
+    await writeReminderIntent({
+      experimentId,
+      intentId: firstIntentId,
+      supportSeriesId: 'experiment:exp_other_owner',
+      vaultRoot,
+    })
+    await assert.rejects(
+      () =>
+        logExperimentSessionRecord({
+          vault: vaultRoot,
+          lookup: experimentId,
+          reminderIntentId: firstIntentId,
+        }),
+      /does not own experiment/u,
+    )
+
+    await writeReminderIntent({
+      experimentId,
+      intentId: firstIntentId,
+      status: 'pending',
+      vaultRoot,
+    })
+    await assert.rejects(
+      () =>
+        logExperimentSessionRecord({
+          vault: vaultRoot,
+          lookup: experimentId,
+          reminderIntentId: firstIntentId,
+        }),
+      /not a provider-accepted private reminder message/u,
+    )
+
+    await writeReminderIntent({
+      experimentId,
+      intentId: firstIntentId,
+      threadIsDirect: false,
+      vaultRoot,
+    })
+    await assert.rejects(
+      () =>
+        logExperimentSessionRecord({
+          vault: vaultRoot,
+          lookup: experimentId,
+          reminderIntentId: firstIntentId,
+        }),
+      /not a provider-accepted private reminder message/u,
+    )
+
+    await writeReminderIntent({
+      experimentId,
+      intentId: firstIntentId,
+      plannedOccurrenceAt: null,
+      vaultRoot,
+    })
+    await assert.rejects(
+      () =>
+        logExperimentSessionRecord({
+          vault: vaultRoot,
+          lookup: experimentId,
+          reminderIntentId: firstIntentId,
+        }),
+      /has no planned occurrence provenance/u,
+    )
+
+    await writeReminderIntent({
+      experimentId,
+      intentId: firstIntentId,
+      vaultRoot,
+    })
+    await assert.rejects(
+      () =>
+        logExperimentSessionRecord({
+          vault: vaultRoot,
+          lookup: experimentId,
+          reminderIntentId: firstIntentId,
+          occurredAt: '2026-08-10T16:00:00.000Z',
+        }),
+      /Do not pass date, occurredAt, or source/u,
+    )
+    await assert.rejects(
+      () =>
+        logExperimentSessionRecord({
+          vault: vaultRoot,
+          lookup: experimentId,
+          reminderIntentId: firstIntentId,
+          date: '2026-08-10',
+        }),
+      /Do not pass date, occurredAt, or source/u,
+    )
+    await assert.rejects(
+      () =>
+        logExperimentSessionRecord({
+          vault: vaultRoot,
+          lookup: experimentId,
+          reminderIntentId: firstIntentId,
+          source: 'device',
+        }),
+      /Do not pass date, occurredAt, or source/u,
+    )
+  })
+})
+
+test('reminder occurrence replays reject semantic changes instead of silently rewriting or duplicating the event', async () => {
+  await withExperiment(async ({ experimentId, vaultRoot }) => {
+    await writeReminderIntent({
+      experimentId,
+      intentId: firstIntentId,
+      vaultRoot,
+    })
+    const created = await logExperimentSessionRecord({
+      vault: vaultRoot,
+      lookup: experimentId,
+      reminderIntentId: firstIntentId,
+      sessionStatus: 'completed',
+    })
+
+    await assert.rejects(
+      () =>
+        logExperimentSessionRecord({
+          vault: vaultRoot,
+          lookup: experimentId,
+          reminderIntentId: firstIntentId,
+          sessionStatus: 'missed',
+        }),
+      /already logged with different sessionStatus/u,
+    )
+    assert.equal(
+      await countEventIdInLedger({
+        eventId: created.eventId,
+        ledgerFile: created.ledgerFile,
+        vaultRoot,
+      }),
+      1,
+    )
+  })
+})
+
+test('default and scoped CLI composition both resolve delivered reminder provenance through the owner', async () => {
+  await withExperiment(async ({ experimentId, vaultRoot }) => {
+    await writeReminderIntent({ experimentId, intentId: firstIntentId, vaultRoot })
+    const { createDefaultVaultServices } = await import('../src/vault-cli-bootstrap.js')
+    const first = await createDefaultVaultServices().core.logExperimentSession({
+      vault: vaultRoot,
+      lookup: experimentId,
+      reminderIntentId: firstIntentId,
+      requestId: null,
+    })
+    assert.equal(first.created, true)
+
+    const { registerScopedVaultCliCommand } = await import('../src/vault-cli-command-routing.js')
+    const cli = Cli.create('vault-cli', { description: 'reminder provenance test' })
+    await registerScopedVaultCliCommand({ cli, root: 'experiment' })
+    const output: string[] = []
+    await cli.serve([
+      'experiment', 'session', 'log', experimentId,
+      '--vault', vaultRoot,
+      '--reminder-intent-id', firstIntentId,
+      '--full-output', '--format', 'json',
+    ], {
+      env: process.env,
+      exit() {},
+      stdout(chunk) { output.push(chunk) },
+    })
+    const replay = JSON.parse(output.join('')) as {
+      data: { eventId: string; created: boolean }
+    }
+    assert.equal(replay.data.eventId, first.eventId)
+    assert.equal(replay.data.created, false)
+    assert.equal(await countEventIdInLedger({
+      eventId: first.eventId,
+      ledgerFile: first.ledgerFile,
+      vaultRoot,
+    }), 1)
+  })
+})

--- a/packages/vault-usecases/README.md
+++ b/packages/vault-usecases/README.md
@@ -12,6 +12,14 @@ This package exists to give CLI shells, assistant runtimes, daemons, setup flows
 
 It does not own canonical record schemas, canonical write behavior, query entity-family contracts, query projection storage, device-sync runtime state, inbox daemon behavior, assistant/session state, hosted product facts, or CLI-only device/control-plane composition. Those stay with their owning packages.
 
+Reminder-backed experiment logging receives a trusted `readAssistantOutboxIntent`
+dependency through the service factory. CLI composition supplies the assistant
+engine's public reader; vault usecases never open assistant outbox files. The
+usecase still validates the exact intent, private accepted delivery, experiment
+owner, and planned occurrence before the canonical write. The reader is not a
+command or JSON input, and reminder-backed writes fail closed when it is absent.
+Ordinary experiment logging does not require the assistant reader.
+
 Keep this package thin. Add a surface here only when multiple CLI/headless callers need the same vault usecase orchestration and importing the lower-level owner internals would create the wrong dependency direction.
 
 Exact command paths compose core-owned canonical readers or query-owned bounded

--- a/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
+++ b/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
@@ -57,7 +57,7 @@ import {
   summarizeExperimentOutcomeEvidencePlan,
   validateExperimentSessionMetricValue,
 } from '@murphai/query'
-import { resolveAssistantStatePaths } from '@murphai/runtime-state/node'
+import type { IntegratedVaultServiceDependencies } from './types.js'
 import {
   loadQueryRuntime,
   type QueryCanonicalEntity,
@@ -1605,7 +1605,7 @@ export async function logExperimentSessionRecordFromInput(input: {
   vault: string
   lookup: string
   inputFile: string
-}) {
+}, dependencies: IntegratedVaultServiceDependencies = {}) {
   const payload = experimentSessionPayloadSchema.parse(
     await readJsonPayload(input.inputFile, 'experiment session payload'),
   )
@@ -1614,7 +1614,7 @@ export async function logExperimentSessionRecordFromInput(input: {
     vault: input.vault,
     lookup: input.lookup,
     ...payload,
-  })
+  }, dependencies)
 }
 
 type ExperimentSessionRecordInput = {
@@ -1660,7 +1660,10 @@ const EXPERIMENT_REMINDER_REPLAY_EFFECT_FIELDS = [
   'fields',
 ] as const
 
-export async function logExperimentSessionRecord(input: ExperimentSessionRecordInput) {
+export async function logExperimentSessionRecord(
+  input: ExperimentSessionRecordInput,
+  dependencies?: IntegratedVaultServiceDependencies,
+) {
   const experiment = await requireEntityFamily(input.vault, input.lookup, 'experiment')
   const frontmatter = requireExperimentFrontmatter(experiment)
   const reminderProof = input.reminderIntentId === undefined
@@ -1669,7 +1672,7 @@ export async function logExperimentSessionRecord(input: ExperimentSessionRecordI
         experimentId: frontmatter.experimentId,
         reminderIntentId: input.reminderIntentId,
         vault: input.vault,
-      })
+      }, dependencies)
   if (reminderProof !== null) {
     assertExperimentReminderSessionInput(input)
   }
@@ -1821,7 +1824,7 @@ async function resolveExperimentReminderOccurrenceProof(input: {
   experimentId: string
   reminderIntentId: string
   vault: string
-}): Promise<ExperimentReminderOccurrenceProof> {
+}, dependencies: IntegratedVaultServiceDependencies | undefined): Promise<ExperimentReminderOccurrenceProof> {
   const parsedIntentId = assistantOutboxIntentIdSchema.safeParse(
     input.reminderIntentId,
   )
@@ -1832,12 +1835,14 @@ async function resolveExperimentReminderOccurrenceProof(input: {
     )
   }
   const intentId = parsedIntentId.data
-  const intentPath = path.join(
-    resolveAssistantStatePaths(input.vault).outboxDirectory,
-    `${intentId}.json`,
-  )
+  if (!dependencies?.readAssistantOutboxIntent) {
+    throw new VaultCliError(
+      'runtime_unavailable',
+      'Delivered reminder provenance requires the assistant outbox reader.',
+    )
+  }
   const parsedIntent = assistantOutboxIntentSchema.safeParse(
-    await readJsonPayload(intentPath, 'delivered reminder provenance'),
+    await dependencies.readAssistantOutboxIntent(input.vault, intentId),
   )
   if (!parsedIntent.success || parsedIntent.data.intentId !== intentId) {
     throw new VaultCliError(

--- a/packages/vault-usecases/src/usecases/integrated-services.ts
+++ b/packages/vault-usecases/src/usecases/integrated-services.ts
@@ -19,6 +19,7 @@ import type { QueryEntityFamily } from "../query-runtime.js"
 import type {
   CoreWriteServices,
   ImporterServices,
+  IntegratedVaultServiceDependencies,
   ProjectAssessmentInput,
   QueryEntity,
   QueryServices,
@@ -456,7 +457,9 @@ function isJsonObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
-function createIntegratedCoreServices(): CoreWriteServices {
+function createIntegratedCoreServices(
+  dependencies: IntegratedVaultServiceDependencies,
+): CoreWriteServices {
   return {
     async init(input: CommandContext & {
       timezone?: string
@@ -743,13 +746,13 @@ function createIntegratedCoreServices(): CoreWriteServices {
       return stopExperimentRecord(input)
     },
     async logExperimentSession(input) {
-      return logExperimentSessionRecord(input)
+      return logExperimentSessionRecord(input, dependencies)
     },
     async logExperimentSessionJson(input: CommandContext & {
       lookup: string
       inputFile: string
     }) {
-      return logExperimentSessionRecordFromInput(input)
+      return logExperimentSessionRecordFromInput(input, dependencies)
     },
     async attachExperimentSession(input) {
       return attachExperimentSessionRecord(input)
@@ -1860,9 +1863,11 @@ function normalizeOptionalString(value: string | undefined): string | undefined 
   return typeof value === 'string' && value.trim() ? value.trim() : undefined
 }
 
-function createIntegratedVaultServiceGroups(): VaultServices {
+function createIntegratedVaultServiceGroups(
+  dependencies: IntegratedVaultServiceDependencies = {},
+): VaultServices {
   return {
-    core: createIntegratedCoreServices(),
+    core: createIntegratedCoreServices(dependencies),
     importers: createIntegratedImporterServices(),
     query: createIntegratedQueryServices(),
   }
@@ -1888,9 +1893,9 @@ function createUnwiredServiceGroup<
 }
 
 export function createIntegratedVaultServices(
-  _dependencies: Record<string, unknown> = {},
+  dependencies: IntegratedVaultServiceDependencies = {},
 ): VaultServices {
-  return createIntegratedVaultServiceGroups()
+  return createIntegratedVaultServiceGroups(dependencies)
 }
 
 export function createUnwiredVaultServices(

--- a/packages/vault-usecases/src/usecases/types.ts
+++ b/packages/vault-usecases/src/usecases/types.ts
@@ -27,6 +27,7 @@ import type {
   VaultInitResult,
   VaultValidateResult,
 } from "@murphai/operator-config/vault-cli-contracts"
+import type { AssistantOutboxIntent } from "@murphai/operator-config/assistant-cli-contracts"
 import type {
   AddCaptureRecordInput,
   CaptureAddResult,
@@ -62,6 +63,13 @@ import type {
 } from "../query-runtime.js"
 
 export type { CommandContext } from "../health-cli-method-types.js"
+
+export interface IntegratedVaultServiceDependencies {
+  readAssistantOutboxIntent?: (
+    vault: string,
+    intentId: string,
+  ) => Promise<AssistantOutboxIntent | null>
+}
 
 export interface ProjectAssessmentInput extends CommandContext {
   assessmentId: string

--- a/packages/vault-usecases/src/vault-services.ts
+++ b/packages/vault-usecases/src/vault-services.ts
@@ -10,6 +10,7 @@ import { createUnwiredMethod } from "./usecases/runtime.js"
 import type {
   CoreWriteServices,
   ImporterServices,
+  IntegratedVaultServiceDependencies,
   QueryServices,
   VaultServices,
 } from "./usecases/types.js"
@@ -18,6 +19,7 @@ export type { CommandContext } from "./usecases/types.js"
 export type {
   CoreWriteServices,
   ImporterServices,
+  IntegratedVaultServiceDependencies,
   QueryServices,
   VaultServices,
 } from "./usecases/types.js"
@@ -27,7 +29,6 @@ type AsyncMethodKeys<TServiceGroup> = {
   [TKey in keyof TServiceGroup]-?:
     TServiceGroup[TKey] extends AsyncServiceMethod ? TKey : never
 }[keyof TServiceGroup] & string
-type IntegratedVaultServiceDependencies = Record<string, unknown>
 
 const coreServiceMethodNames = [
   "init",
@@ -196,12 +197,14 @@ function createUnwiredServiceGroup<
   return services
 }
 
-function createIntegratedServicesLoader(): () => Promise<VaultServices> {
+function createIntegratedServicesLoader(
+  dependencies: IntegratedVaultServiceDependencies,
+): () => Promise<VaultServices> {
   let servicesPromise: Promise<VaultServices> | null = null
 
   return async () => {
     servicesPromise ??= import("./usecases/integrated-services.js")
-      .then(({ createIntegratedVaultServices }) => createIntegratedVaultServices())
+      .then(({ createIntegratedVaultServices }) => createIntegratedVaultServices(dependencies))
       .catch((error) => {
         servicesPromise = null
         throw error
@@ -212,9 +215,9 @@ function createIntegratedServicesLoader(): () => Promise<VaultServices> {
 }
 
 export function createIntegratedVaultServices(
-  _dependencies: IntegratedVaultServiceDependencies = {},
+  dependencies: IntegratedVaultServiceDependencies = {},
 ): VaultServices {
-  const loadServices = createIntegratedServicesLoader()
+  const loadServices = createIntegratedServicesLoader(dependencies)
 
   return {
     core: createLoaderBackedServiceGroup<CoreWriteServices, keyof CoreWriteServices & string>(

--- a/packages/vault-usecases/test/experiment-session-reminder-provenance.test.ts
+++ b/packages/vault-usecases/test/experiment-session-reminder-provenance.test.ts
@@ -1,436 +1,190 @@
 import assert from 'node:assert/strict'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
 import { createExperiment, initializeVault, readJsonlRecords } from '@murphai/core'
 import { assistantOutboxIntentSchema } from '@murphai/operator-config/assistant-cli-contracts'
-import { resolveAssistantStatePaths } from '@murphai/runtime-state/node'
-import { test } from 'vitest'
+import { test, vi } from 'vitest'
 
-import { logExperimentSessionRecord } from '../src/usecases/experiment-journal-vault.js'
+import {
+  logExperimentSessionRecord,
+  logExperimentSessionRecordFromInput,
+} from '../src/usecases/experiment-journal-vault.js'
+import { createIntegratedVaultServices } from '../src/vault-services.js'
 
-const occurrenceDate = new Date()
-occurrenceDate.setUTCDate(occurrenceDate.getUTCDate() - 1)
-occurrenceDate.setUTCHours(15, 0, 0, 0)
-const occurrenceAt = occurrenceDate.toISOString()
-const crossingReminderDate = new Date(occurrenceDate)
-crossingReminderDate.setUTCHours(23, 55, 0, 0)
-const crossingReminderAt = crossingReminderDate.toISOString()
-const plannedOccurrenceAt = new Date(
-  crossingReminderDate.getTime() + 15 * 60 * 1000,
-).toISOString()
-const experimentStartedOn = formatLocalDate(addUtcDays(occurrenceDate, -7))
-const experimentInterventionEnd = formatLocalDate(addUtcDays(occurrenceDate, 60))
-const firstIntentId = 'outbox_experiment_reminder_01'
-const retryIntentId = 'outbox_experiment_reminder_02'
-const automationId = 'automation_experiment_reminder_01'
-
-function addUtcDays(date: Date, days: number): Date {
-  const copy = new Date(date)
-  copy.setUTCDate(copy.getUTCDate() + days)
-  return copy
-}
-
-function formatLocalDate(date: Date): string {
-  return date.toISOString().slice(0, 10)
-}
-
-async function countEventIdInLedger(input: {
-  eventId: string
-  ledgerFile: string
-  vaultRoot: string
-}): Promise<number> {
-  const records = await readJsonlRecords({
-    vaultRoot: input.vaultRoot,
-    relativePath: input.ledgerFile,
-  })
-  return records.filter((record) => record.id === input.eventId).length
-}
+const occurrenceAt = '2026-08-10T15:00:00.000Z'
+const intentId = 'outbox_experiment_reminder_01'
 
 async function withExperiment(
-  run: (input: { experimentId: string; vaultRoot: string }) => Promise<void>,
+  run: (input: { experimentId: string; vault: string }) => Promise<void>,
 ): Promise<void> {
-  const vaultRoot = await mkdtemp(path.join(os.tmpdir(), 'murph-reminder-session-'))
+  const vault = await mkdtemp(path.join(os.tmpdir(), 'murph-reminder-reader-'))
   try {
-    await initializeVault({ vaultRoot })
+    await initializeVault({ vaultRoot: vault })
     const created = await createExperiment({
-      vaultRoot,
-      slug: 'reminder-backed-sauna',
-      title: 'Reminder-backed sauna',
-      startedOn: experimentStartedOn,
+      vaultRoot: vault,
+      slug: 'reminder-reader-sauna',
+      title: 'Sauna',
+      startedOn: '2026-08-01',
       status: 'active',
       runPlan: {
-        interventionStart: experimentStartedOn,
-        interventionEnd: experimentInterventionEnd,
+        interventionStart: '2026-08-01',
+        interventionEnd: '2026-08-31',
         modality: 'sauna',
         targetSessions: 8,
         minimumUsefulSessions: 4,
       },
     })
-    await run({
-      experimentId: created.experiment.id,
-      vaultRoot,
-    })
+    await run({ experimentId: created.experiment.id, vault })
   } finally {
-    await rm(vaultRoot, { recursive: true, force: true })
+    await rm(vault, { recursive: true, force: true })
   }
 }
 
-async function writeReminderIntent(input: {
-  automationId?: string
-  experimentId: string
-  intentId: string
-  plannedOccurrenceAt?: string | null
-  scheduledOccurrenceAt?: string
-  status?: 'pending' | 'sent'
-  supportSeriesId?: string
-  threadIsDirect?: boolean
-  vaultRoot: string
-}): Promise<void> {
-  const message = 'Sauna session time. Reply when you finish.'
-  const status = input.status ?? 'sent'
-  const scheduledOccurrenceAt = input.scheduledOccurrenceAt ?? occurrenceAt
-  const intent = assistantOutboxIntentSchema.parse({
+function reminderIntent(experimentId: string) {
+  return assistantOutboxIntentSchema.parse({
     schema: 'murph.assistant-outbox-intent.v1',
-    intentId: input.intentId,
-    sessionId: `session_${input.intentId}`,
-    turnId: `turn_${input.intentId}`,
-    createdAt: scheduledOccurrenceAt,
-    updatedAt: scheduledOccurrenceAt,
-    lastAttemptAt: scheduledOccurrenceAt,
+    intentId,
+    sessionId: 'session_reminder',
+    turnId: 'turn_reminder',
+    createdAt: occurrenceAt,
+    updatedAt: occurrenceAt,
+    lastAttemptAt: occurrenceAt,
     nextAttemptAt: null,
-    sentAt: status === 'sent' ? scheduledOccurrenceAt : null,
-    attemptCount: status === 'sent' ? 1 : 0,
-    status,
-    message,
-    subject: null,
-    operation: null,
-    dedupeKey: `experiment-reminder-dedupe:${input.intentId}`,
-    targetFingerprint: 'experiment-reminder-target',
+    sentAt: occurrenceAt,
+    attemptCount: 1,
+    status: 'sent',
+    message: 'Session time.',
+    dedupeKey: 'experiment-reminder',
+    targetFingerprint: 'private-reminder',
     channel: 'linq',
     identityId: null,
-    actorId: 'member-1',
-    threadId: 'thread-1',
-    threadIsDirect: input.threadIsDirect ?? true,
-    replyToMessageId: null,
+    actorId: 'member-demo',
+    threadId: 'thread-demo',
+    threadIsDirect: true,
     bindingDelivery: null,
-    deliverySource: null,
-    automationAuthority: {
-      automationId: input.automationId ?? automationId,
-      supportSeriesId:
-        input.supportSeriesId ?? `experiment:${input.experimentId}`,
-      expectedUpdatedAt: scheduledOccurrenceAt,
-    },
-    scheduledOccurrenceAt,
-    plannedOccurrenceAt:
-      input.plannedOccurrenceAt === undefined
-        ? scheduledOccurrenceAt
-        : input.plannedOccurrenceAt,
     explicitTarget: null,
-    delivery:
-      status === 'sent'
-        ? {
-            kind: 'message',
-            channel: 'linq',
-            idempotencyKey: null,
-            target: 'thread-1',
-            targetKind: 'thread',
-            sentAt: scheduledOccurrenceAt,
-            messageLength: message.length,
-            providerMessageId: `linq-message:${input.intentId}`,
-            providerThreadId: 'thread-1',
-          }
-        : null,
-    deliveryConfirmationPending: false,
-    deliveryIdempotencyKey: null,
-    deliveryTransportIdempotent: false,
+    automationAuthority: {
+      automationId: 'automation_reminder',
+      supportSeriesId: `experiment:${experimentId}`,
+      expectedUpdatedAt: occurrenceAt,
+    },
+    scheduledOccurrenceAt: occurrenceAt,
+    plannedOccurrenceAt: occurrenceAt,
+    delivery: {
+      kind: 'message',
+      channel: 'linq',
+      idempotencyKey: null,
+      target: 'thread-demo',
+      targetKind: 'thread',
+      sentAt: occurrenceAt,
+      messageLength: 13,
+      providerMessageId: 'message-demo',
+      providerThreadId: 'thread-demo',
+    },
     lastError: null,
   })
-  const outboxDirectory = resolveAssistantStatePaths(input.vaultRoot).outboxDirectory
-  await mkdir(outboxDirectory, { recursive: true })
-  await writeFile(
-    path.join(outboxDirectory, `${input.intentId}.json`),
-    `${JSON.stringify(intent)}\n`,
-    'utf8',
-  )
 }
 
-test('delivered reminder provenance owns one deterministic experiment occurrence without a current automation read', async () => {
-  await withExperiment(async ({ experimentId, vaultRoot }) => {
-    await writeReminderIntent({
-      automationId: 'automation_first_session_prep',
-      experimentId,
-      intentId: firstIntentId,
-      plannedOccurrenceAt,
-      scheduledOccurrenceAt: crossingReminderAt,
-      vaultRoot,
-    })
-    await writeReminderIntent({
-      automationId: 'automation_planned_session_support',
-      experimentId,
-      intentId: retryIntentId,
-      plannedOccurrenceAt,
-      scheduledOccurrenceAt: plannedOccurrenceAt,
-      vaultRoot,
-    })
-
-    const [first, replay] = await Promise.all([
-      logExperimentSessionRecord({
-        vault: vaultRoot,
-        lookup: experimentId,
-        reminderIntentId: firstIntentId,
-      }),
-      logExperimentSessionRecord({
-        vault: vaultRoot,
-        lookup: experimentId,
-        reminderIntentId: retryIntentId,
-      }),
-    ])
-    const sequentialReplay = await logExperimentSessionRecord({
-      vault: vaultRoot,
-      lookup: experimentId,
-      reminderIntentId: retryIntentId,
-    })
-
-    assert.equal([first, replay].filter((result) => result.created).length, 1)
-    assert.equal(replay.eventId, first.eventId)
-    assert.equal(sequentialReplay.created, false)
-    assert.equal(sequentialReplay.eventId, first.eventId)
-    if (
-      !('progress' in first)
-      || !('progress' in replay)
-      || !('progress' in sequentialReplay)
-    ) {
-      assert.fail('reminder-backed writes must return canonical progress readback')
-    }
-    assert.equal(first.progress?.adherence.completedSessions, 1)
-    assert.deepEqual(first.progress?.adherence.sessionEventIds, [first.eventId])
-    assert.equal(replay.progress?.adherence.completedSessions, 1)
-    assert.deepEqual(replay.progress?.adherence.sessionEventIds, [first.eventId])
-    assert.equal(sequentialReplay.progress?.adherence.completedSessions, 1)
-    assert.deepEqual(
-      sequentialReplay.progress?.adherence.sessionEventIds,
-      [first.eventId],
-    )
-    assert.equal(
-      await countEventIdInLedger({
-        eventId: first.eventId,
-        ledgerFile: first.ledgerFile,
-        vaultRoot,
-      }),
-      1,
-    )
-  })
-})
-
-test('distinct planned occurrences retain distinct canonical session effects', async () => {
-  await withExperiment(async ({ experimentId, vaultRoot }) => {
-    const laterOccurrenceAt = new Date(
-      Date.parse(occurrenceAt) + 60 * 60 * 1000,
-    ).toISOString()
-    await writeReminderIntent({
-      automationId: 'automation_session_one',
-      experimentId,
-      intentId: firstIntentId,
-      plannedOccurrenceAt: occurrenceAt,
-      scheduledOccurrenceAt: occurrenceAt,
-      vaultRoot,
-    })
-    await writeReminderIntent({
-      automationId: 'automation_session_two',
-      experimentId,
-      intentId: retryIntentId,
-      plannedOccurrenceAt: laterOccurrenceAt,
-      scheduledOccurrenceAt: laterOccurrenceAt,
-      vaultRoot,
-    })
-
-    const first = await logExperimentSessionRecord({
-      vault: vaultRoot,
-      lookup: experimentId,
-      reminderIntentId: firstIntentId,
-    })
-    const second = await logExperimentSessionRecord({
-      vault: vaultRoot,
-      lookup: experimentId,
-      reminderIntentId: retryIntentId,
-    })
-
-    assert.notEqual(second.eventId, first.eventId)
-    assert.equal(first.created, true)
-    assert.equal(second.created, true)
-    if (!('progress' in second)) {
-      assert.fail('reminder-backed writes must return canonical progress readback')
-    }
-    assert.equal(second.progress?.adherence.completedSessions, 2)
-    assert.deepEqual(
-      second.progress?.adherence.sessionEventIds,
-      [first.eventId, second.eventId],
-    )
-  })
-})
-
-test('reminder-backed logging records a planned session after midnight instead of the earlier reminder date', async () => {
-  await withExperiment(async ({ experimentId, vaultRoot }) => {
-    await writeReminderIntent({
-      experimentId,
-      intentId: firstIntentId,
-      plannedOccurrenceAt,
-      scheduledOccurrenceAt: crossingReminderAt,
-      vaultRoot,
-    })
-
+test('reminder logging passes the exact vault and intent id to the injected owner reader', async () => {
+  await withExperiment(async ({ experimentId, vault }) => {
+    const readAssistantOutboxIntent = vi.fn(async () => reminderIntent(experimentId))
     const result = await logExperimentSessionRecord({
-      vault: vaultRoot,
+      vault,
       lookup: experimentId,
-      reminderIntentId: firstIntentId,
-    })
-    const records = await readJsonlRecords({
-      vaultRoot,
-      relativePath: result.ledgerFile,
-    })
-    const event = records.find((record) => record.id === result.eventId)
+      reminderIntentId: intentId,
+    }, { readAssistantOutboxIntent })
 
-    assert.equal(event?.occurredAt, plannedOccurrenceAt)
+    assert.deepEqual(readAssistantOutboxIntent.mock.calls, [[vault, intentId]])
+    assert.equal(result.created, true)
+    const records = await readJsonlRecords({ vaultRoot: vault, relativePath: result.ledgerFile })
+    assert.equal(records.find((record) => record.id === result.eventId)?.occurredAt, occurrenceAt)
   })
 })
 
-test('reminder-backed session logging rejects transport, owner, and occurrence substitutions', async () => {
-  await withExperiment(async ({ experimentId, vaultRoot }) => {
-    await writeReminderIntent({
-      experimentId,
-      intentId: firstIntentId,
-      supportSeriesId: 'experiment:exp_other_owner',
-      vaultRoot,
+test('manual session logging needs no outbox reader and never calls an injected reader', async () => {
+  await withExperiment(async ({ experimentId, vault }) => {
+    const input = { vault, lookup: experimentId, occurredAt: occurrenceAt }
+    assert.equal((await logExperimentSessionRecord(input)).created, true)
+    const readAssistantOutboxIntent = vi.fn(async () => {
+      throw new Error('Manual sessions must not read assistant runtime state.')
     })
-    await assert.rejects(
-      () =>
-        logExperimentSessionRecord({
-          vault: vaultRoot,
-          lookup: experimentId,
-          reminderIntentId: firstIntentId,
-        }),
-      /does not own experiment/u,
-    )
-
-    await writeReminderIntent({
-      experimentId,
-      intentId: firstIntentId,
-      status: 'pending',
-      vaultRoot,
-    })
-    await assert.rejects(
-      () =>
-        logExperimentSessionRecord({
-          vault: vaultRoot,
-          lookup: experimentId,
-          reminderIntentId: firstIntentId,
-        }),
-      /not a provider-accepted private reminder message/u,
-    )
-
-    await writeReminderIntent({
-      experimentId,
-      intentId: firstIntentId,
-      threadIsDirect: false,
-      vaultRoot,
-    })
-    await assert.rejects(
-      () =>
-        logExperimentSessionRecord({
-          vault: vaultRoot,
-          lookup: experimentId,
-          reminderIntentId: firstIntentId,
-        }),
-      /not a provider-accepted private reminder message/u,
-    )
-
-    await writeReminderIntent({
-      experimentId,
-      intentId: firstIntentId,
-      plannedOccurrenceAt: null,
-      vaultRoot,
-    })
-    await assert.rejects(
-      () =>
-        logExperimentSessionRecord({
-          vault: vaultRoot,
-          lookup: experimentId,
-          reminderIntentId: firstIntentId,
-        }),
-      /has no planned occurrence provenance/u,
-    )
-
-    await writeReminderIntent({
-      experimentId,
-      intentId: firstIntentId,
-      vaultRoot,
-    })
-    await assert.rejects(
-      () =>
-        logExperimentSessionRecord({
-          vault: vaultRoot,
-          lookup: experimentId,
-          reminderIntentId: firstIntentId,
-          occurredAt: '2026-08-10T16:00:00.000Z',
-        }),
-      /Do not pass date, occurredAt, or source/u,
-    )
-    await assert.rejects(
-      () =>
-        logExperimentSessionRecord({
-          vault: vaultRoot,
-          lookup: experimentId,
-          reminderIntentId: firstIntentId,
-          date: '2026-08-10',
-        }),
-      /Do not pass date, occurredAt, or source/u,
-    )
-    await assert.rejects(
-      () =>
-        logExperimentSessionRecord({
-          vault: vaultRoot,
-          lookup: experimentId,
-          reminderIntentId: firstIntentId,
-          source: 'device',
-        }),
-      /Do not pass date, occurredAt, or source/u,
-    )
+    assert.equal((await logExperimentSessionRecord(input, { readAssistantOutboxIntent })).created, true)
+    assert.equal(readAssistantOutboxIntent.mock.calls.length, 0)
   })
 })
 
-test('reminder occurrence replays reject semantic changes instead of silently rewriting or duplicating the event', async () => {
-  await withExperiment(async ({ experimentId, vaultRoot }) => {
-    await writeReminderIntent({
-      experimentId,
-      intentId: firstIntentId,
-      vaultRoot,
-    })
-    const created = await logExperimentSessionRecord({
-      vault: vaultRoot,
-      lookup: experimentId,
-      reminderIntentId: firstIntentId,
-      sessionStatus: 'completed',
-    })
-
-    await assert.rejects(
-      () =>
-        logExperimentSessionRecord({
-          vault: vaultRoot,
-          lookup: experimentId,
-          reminderIntentId: firstIntentId,
-          sessionStatus: 'missed',
-        }),
-      /already logged with different sessionStatus/u,
-    )
-    assert.equal(
-      await countEventIdInLedger({
-        eventId: created.eventId,
-        ledgerFile: created.ledgerFile,
-        vaultRoot,
+test('reminder logging fails closed without its reader, for a missing intent, and for an id substitution', async () => {
+  await withExperiment(async ({ experimentId, vault }) => {
+    const input = { vault, lookup: experimentId, reminderIntentId: intentId }
+    await assert.rejects(() => logExperimentSessionRecord(input), { code: 'runtime_unavailable' })
+    await assert.rejects(() => logExperimentSessionRecord(input, {
+      readAssistantOutboxIntent: async () => null,
+    }), { code: 'contract_invalid' })
+    await assert.rejects(() => logExperimentSessionRecord(input, {
+      readAssistantOutboxIntent: async () => ({
+        ...reminderIntent(experimentId),
+        intentId: 'outbox_different_intent',
       }),
-      1,
-    )
+    }), { code: 'contract_invalid' })
+
+    const progress = await createIntegratedVaultServices().query.showExperimentProgress({
+      vault,
+      lookup: experimentId,
+      requestId: null,
+    })
+    assert.deepEqual(progress.progress.adherence.sessionEventIds, [])
+  })
+})
+
+test('invalid reminder ids are rejected before invoking the owner reader', async () => {
+  await withExperiment(async ({ experimentId, vault }) => {
+    const readAssistantOutboxIntent = vi.fn(async () => reminderIntent(experimentId))
+    await assert.rejects(() => logExperimentSessionRecord({
+      vault,
+      lookup: experimentId,
+      reminderIntentId: '../outbox_other',
+    }, { readAssistantOutboxIntent }), { code: 'invalid_option' })
+    assert.equal(readAssistantOutboxIntent.mock.calls.length, 0)
+  })
+})
+
+test('JSON payloads cannot supply reminder proof through direct or lazy integrated services', async () => {
+  await withExperiment(async ({ experimentId, vault }) => {
+    const inputFile = path.join(vault, 'session.json')
+    await writeFile(inputFile, JSON.stringify({
+      reminderIntentId: intentId,
+      plannedOccurrenceAt: '2026-08-11T15:00:00.000Z',
+      reminderProof: { plannedOccurrenceAt: '2026-08-11T15:00:00.000Z' },
+      intent: reminderIntent(experimentId),
+      dependencies: { readAssistantOutboxIntent: reminderIntent(experimentId) },
+    }))
+    const input = { vault, lookup: experimentId, inputFile, requestId: null }
+    await assert.rejects(() => logExperimentSessionRecordFromInput(input), {
+      code: 'runtime_unavailable',
+    })
+    const readAssistantOutboxIntent = vi.fn(async () => null)
+    const dependencies = { readAssistantOutboxIntent }
+    await assert.rejects(() => logExperimentSessionRecordFromInput(input, dependencies), {
+      code: 'contract_invalid',
+    })
+    const services = createIntegratedVaultServices(dependencies)
+    await assert.rejects(() => services.core.logExperimentSessionJson(input), {
+      code: 'contract_invalid',
+    })
+    assert.deepEqual(readAssistantOutboxIntent.mock.calls, [[vault, intentId], [vault, intentId]])
+
+    const trustedServices = createIntegratedVaultServices({
+      readAssistantOutboxIntent: async () => reminderIntent(experimentId),
+    })
+    const result = await trustedServices.core.logExperimentSessionJson(input)
+    const records = await readJsonlRecords({ vaultRoot: vault, relativePath: result.ledgerFile })
+    assert.equal(records.find((record) => record.id === result.eventId)?.occurredAt, occurrenceAt)
+    const replay = await logExperimentSessionRecordFromInput(input, {
+      readAssistantOutboxIntent: async () => reminderIntent(experimentId),
+    })
+    assert.equal(replay.eventId, result.eventId)
+    assert.equal(replay.created, false)
   })
 })

--- a/packages/vault-usecases/test/query-read-architecture.test.ts
+++ b/packages/vault-usecases/test/query-read-architecture.test.ts
@@ -61,6 +61,20 @@ const forbiddenExactReaderCalls = [
   "searchVaultRuntime(",
 ] as const;
 
+test("vault usecases read reminder provenance through the injected outbox owner", async () => {
+  const sourceFiles = await walkTypeScriptFiles(
+    path.join(repositoryRoot, "packages", "vault-usecases", "src"),
+  );
+  for (const sourcePath of sourceFiles) {
+    const source = await readFile(sourcePath, "utf8");
+    assert.doesNotMatch(
+      source,
+      /\b(?:resolveAssistantStatePaths|outboxDirectory)\b|@murphai\/assistant-engine/u,
+      `${path.relative(repositoryRoot, sourcePath)} must not reach into assistant-owned outbox storage or reverse the package dependency.`,
+    );
+  }
+});
+
 test("full-vault query hydration remains confined to aggregate and derived owners", async () => {
   const sourceFiles = await Promise.all([
     walkTypeScriptFiles(path.join(repositoryRoot, "packages", "cli", "src")),


### PR DESCRIPTION
## Why and outcome

Experiment-session provenance opened assistant-owned outbox files inside vault-usecases. Route that lookup through the existing assistant outbox reader, injected by CLI composition, so vault-usecases no longer knows the assistant storage layout or needs a reverse package dependency.

Default and scoped CLI paths preserve delivered/private intent validation, experiment ownership, the planned occurrence, and replay behavior. Command JSON cannot supply trusted provenance.

## Product UX

- Effort: Not applicable; internal ownership correction with unchanged command inputs and successful outputs.
- Result: Ready; composed reminder and ordinary logging paths pass focused proof.
- Walkthrough: Valid delivered reminders still log once; missing or mismatched delivery evidence fails closed before canonical writes.

## Evidence

- Direct: Built CLI import-surface, provenance, and wiring suites pass after an explicit runtime artifact rebuild, 11 tests across 3 files; the provenance suite uses real assistant outbox storage and covers default/scoped CLI replay.
- Coverage: Lower usecase provenance suite passes 5 tests covering trusted injection, absent/forged evidence, JSON input, and ordinary logging. Query-read architecture suite passes 3 tests and prohibits assistant storage/layout imports throughout vault-usecases source.
- `pnpm --dir packages/vault-usecases typecheck` and `pnpm --dir packages/cli typecheck` pass.
- Workspace cycle and boundary guards, `pnpm docs:drift`, `pnpm complexity:diff`, and `git diff --check` pass.
- ReviewGPT round 2 passed at `6e55701be140` with no qualifying findings. The built import-surface guard passes with the existing 303-module condition-list ceiling. Required CI runs on this same final head.

## Non-obvious affected surfaces

The existing lazy service loader must retain the trusted dependency. Both object and JSON experiment-session methods receive it separately from command payloads. Only the scoped experiment route shares the default composition helper; unrelated scoped commands retain the direct neutral factory and their existing module ceilings. Headless callers do not use these reminder-session methods.

## Architecture and reuse

- Existing systems reused: Assistant-engine owns `readAssistantOutboxIntent`; operator-config supplies its existing contract; vault-usecases retains experiment-specific acceptance and canonical mutation.
- New logic: Fail closed when reminder provenance is requested without a trusted owner reader; ordinary logging performs no lookup.
- New abstractions: A typed optional service dependency and one CLI composition helper connect the existing owners without a new package or storage owner.
- Complexity intentionally avoided: Removed direct outbox path construction; no reverse dependency, compatibility reader, alternate proof store, or command-schema extension.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; no increased complexity debt.
- Hotspots: Existing functions remain unchanged at 49 (scoped command registration), 38 and 26 (anonymous experiment handlers), 37 (primary outcome builder), 35 (session writer), 23 (analysis plan builder), and 22 (protocol safety check).
- Agent judgment: Further splitting those unrelated decision trees would broaden this correction. Dependency forwarding and owner lookup selection preserve the existing writer branches.

## Hot reply path impact

- Path status: No change to durable message acceptance, provider start, or reply handoff; this changes experiment tool execution composition.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: One lazy assistant-engine module import and one assistant-owned local outbox read per reminder attempt replace one direct local file read; the module is cached. No new retry or timeout. Ordinary logging performs neither lookup nor import.
- Before/after proof: Injected-reader call assertions and real outbox CLI tests preserve single-attempt lookup and canonical replay behavior.

## Murph initial provider input impact

Not applicable for individual and group runtimes: prompts, assembled instructions, tools, schemas, generated guidance, and provider-visible wrappers are unchanged. No token measurement was run because no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: CLI and its workspace libraries are composed in the same build. No persisted format, network protocol, independently deployed consumer contract, or deployment configuration changes.

## Change-shape breakdown

Classification: runtime source by source directory; tests by test directory; Markdown as docs; all other build/config files as tooling. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 61 | 30 |
| Tests / fixtures | 626 | 381 |
| Docs | 86 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **773** | **411** |

## Changelog

- Changelog: not applicable
- Reason: Internal package ownership refactor preserves member-visible experiment logging and reminder behavior.

ReviewGPT first-reviewed head: 89459fdc790c2df4a2a3ba011f9d875bf8a55792
ReviewGPT context sensitivity: sensitive
Classification reason: Cross-package composition and trusted reminder provenance ownership.
