### PR TITLE
refactor(importers): collapse Junction feature validation complexity

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-junction-feature-complexity-collapse.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-junction-feature-complexity-collapse.md
@@ -1,0 +1,54 @@
+# Collapse Junction bounded-feature validation complexity
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+Reduce repeated numeric validation in the existing Junction bounded-feature owner while preserving every admitted feature and rejection envelope.
+
+## Success criteria
+
+- Collapse repeated optional ranges and average/maximum comparisons; lower the cyclomatic guard debt without moving the same branches into another giant function.
+- Preserve finite numeric strings, absent optional values, explicit undefined/null rejection, every bound, ECG required fields, and feature/split/identity error precedence.
+- Pass focused regression proof on base and candidate, focused coverage, importer typecheck, and the complexity guard.
+
+## Scope
+
+- Existing bounded-feature validator, its focused tests, and this plan.
+- No public API, schema, canonical output, provider fetch, persistence, or dependency changes.
+
+## Constraints
+
+Keep the importer as the bounded health-data admission owner. Retain compact evidence and raw-array exclusions. Use synthetic proof and neutral Git metadata. The parent owns candidate review, Ready status, exact-head CI, and final ReviewGPT.
+
+## Risks and mitigations
+
+1. Optional and required numeric rules differ: retain the explicit ECG/duration required gate and test missing, null, invalid, and finite string values.
+2. Range checks overlap pair constraints: test every boundary independently and test each pair with absent, equal, ordered, and reversed values.
+3. Validation errors have ordering: assert generic feature rejection precedes split validation, which precedes identity conflicts.
+
+## Tasks
+
+1. Add focused public-boundary regression matrices and prove they pass before implementation.
+2. Replace repeated numeric rules with closed local range/pair data and small predicates; retain resource-specific guards.
+3. Run focused coverage, importer typecheck, complexity guard, and full candidate diff/privacy review.
+4. Close the plan with a scoped commit, push, and open a complete draft PR for parent review.
+
+## Decisions
+
+- The cause is repeated optional metric ranges and ordered numeric pairs inside assertFeature (base complexity 118).
+- No new state or external effect is needed. Failure remains the existing TypeError envelope; retry and deployment compatibility remain unchanged because accepted inputs and outputs are preserved.
+- The existing owner contract does not change, so no architecture or product document update is needed.
+
+## Verification
+
+- Base proof: `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir packages/importers test test/device-providers-junction-bounded-features.test.ts` passed all 37 tests before the validator changed.
+- Candidate proof: `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir packages/importers test:coverage test/device-providers-junction-bounded-features.test.ts --coverage.include=src/device-providers/junction-bounded-features.ts` passed all 37 tests. Focused file coverage: 89.27% statements, 81.23% branches, 100% functions, 91.09% lines.
+- `pnpm --dir packages/importers typecheck` passed.
+- `pnpm complexity:diff --base HEAD -- packages/importers/src/device-providers/junction-bounded-features.ts` passed against the unchanged base: assertFeature 118 to 43, file maximum 118 to 48, and debt above 20 from 134 to 59.
+- Remaining hotspots: the unchanged workout reducer (48), the generic/resource-specific feature gate (43), and unchanged split validator (28). The new helpers remove repeated rules; further separation of the structural gate would mainly relocate distinct necessary checks.
+- Full candidate diff, whitespace, and added-content privacy review passed. No new actionable Frog friction was encountered.
+- Candidate implementation is complete. Push and draft PR handoff follow this scoped commit; parent candidate review, exact-head CI, and final ReviewGPT remain explicit gates.
+Completed: 2026-09-10

--- a/packages/importers/src/device-providers/junction-bounded-features.ts
+++ b/packages/importers/src/device-providers/junction-bounded-features.ts
@@ -31,6 +31,27 @@ const WORKOUT_FIELDS = new Set([
   "sourceProviderSlug", "sourceType", "sourceInstanceId",
 ]);
 
+const WORKOUT_METRIC_BOUNDS = [
+  ["distanceMeters", 0, Number.POSITIVE_INFINITY],
+  ["averageHeartRate", 20, 300],
+  ["maxHeartRate", 20, 300],
+  ["firstHalfAverageHeartRate", 20, 300],
+  ["secondHalfAverageHeartRate", 20, 300],
+  ["averageCadence", 0, 400],
+  ["maxCadence", 0, 400],
+  ["averagePower", 0, 5_000],
+  ["maxPower", 0, 5_000],
+  ["averageSpeed", 0, 150],
+  ["maxSpeed", 0, 150],
+] as const;
+
+const WORKOUT_METRIC_PAIRS = [
+  ["averageHeartRate", "maxHeartRate"],
+  ["averageCadence", "maxCadence"],
+  ["averagePower", "maxPower"],
+  ["averageSpeed", "maxSpeed"],
+] as const;
+
 const WORKOUT_SPLIT_FIELDS = new Set([
   "index", "distanceMeters", "durationSeconds", "endedAt",
   "averageHeartRate", "averageCadence", "cadenceUnit", "averagePower",
@@ -790,19 +811,10 @@ function assertFeature(
   const start = firstTimestamp(feature, ecg ? ["sessionStart"] : ["startAt"]);
   const end = firstTimestamp(feature, ecg ? ["sessionEnd"] : ["endAt"]);
   const count = finiteNumber(feature[ecg ? "voltageSampleCount" : "sampleCount"]);
-  const numericFields = ecg
+  const requiredNumericFields = ecg
     ? ["durationSeconds", "voltageMin", "voltageMax", "voltageMean", "voltageRms", "leadCount"]
-    : [
-        "durationSeconds", "distanceMeters", "averageHeartRate", "maxHeartRate",
-        "firstHalfAverageHeartRate", "secondHalfAverageHeartRate",
-        "averageCadence", "maxCadence", "averagePower", "maxPower",
-        "averageSpeed", "maxSpeed",
-      ];
-  const invalidNumber = numericFields.some((key) => {
-    const value = feature[key];
-    return (ecg || key === "durationSeconds" || value !== undefined)
-      && finiteNumber(value) === undefined;
-  });
+    : ["durationSeconds"];
+  const invalidNumber = requiredNumericFields.some((key) => finiteNumber(feature[key]) === undefined);
   const boundedShape = Object.entries(feature).every(
     ([key, value]) => key === "splits"
       ? !ecg && Array.isArray(value)
@@ -811,21 +823,9 @@ function assertFeature(
   const policy = resolveJunctionTimeseriesResourcePolicy(resource);
   const countLimit = ecg ? policy?.maxSamplesPerWindow : policy?.maxSamplesPerRecord;
   const duration = finiteNumber(feature.durationSeconds);
-  const distance = finiteNumber(feature.distanceMeters);
-  const averageHeartRate = finiteNumber(feature.averageHeartRate);
-  const maxHeartRate = finiteNumber(feature.maxHeartRate);
-  const firstHalfAverageHeartRate = finiteNumber(feature.firstHalfAverageHeartRate);
-  const secondHalfAverageHeartRate = finiteNumber(feature.secondHalfAverageHeartRate);
-  const averageCadence = finiteNumber(feature.averageCadence);
-  const maxCadence = finiteNumber(feature.maxCadence);
-  const averagePower = finiteNumber(feature.averagePower);
-  const maxPower = finiteNumber(feature.maxPower);
-  const averageSpeed = finiteNumber(feature.averageSpeed);
-  const maxSpeed = finiteNumber(feature.maxSpeed);
   const voltageMin = finiteNumber(feature.voltageMin);
   const voltageMax = finiteNumber(feature.voltageMax);
   const voltageMean = finiteNumber(feature.voltageMean);
-  const voltageRms = finiteNumber(feature.voltageRms);
   const leadCount = finiteNumber(feature.leadCount);
   if (
     feature.schema !== schema
@@ -844,35 +844,41 @@ function assertFeature(
     || invalidNumber
     || duration === undefined
     || duration < 0
-    || (!ecg && distance !== undefined && distance < 0)
-    || (!ecg && averageHeartRate !== undefined && (averageHeartRate < 20 || averageHeartRate > 300))
-    || (!ecg && maxHeartRate !== undefined && (maxHeartRate < 20 || maxHeartRate > 300))
-    || (!ecg && averageHeartRate !== undefined && maxHeartRate !== undefined && averageHeartRate > maxHeartRate)
-    || (!ecg && firstHalfAverageHeartRate !== undefined && (firstHalfAverageHeartRate < 20 || firstHalfAverageHeartRate > 300))
-    || (!ecg && secondHalfAverageHeartRate !== undefined && (secondHalfAverageHeartRate < 20 || secondHalfAverageHeartRate > 300))
-    || (!ecg && averageCadence !== undefined && (averageCadence < 0 || averageCadence > 400))
-    || (!ecg && maxCadence !== undefined && (maxCadence < 0 || maxCadence > 400))
-    || (!ecg && averageCadence !== undefined && maxCadence !== undefined && averageCadence > maxCadence)
-    || (!ecg && averagePower !== undefined && (averagePower < 0 || averagePower > 5_000))
-    || (!ecg && maxPower !== undefined && (maxPower < 0 || maxPower > 5_000))
-    || (!ecg && averagePower !== undefined && maxPower !== undefined && averagePower > maxPower)
-    || (!ecg && averageSpeed !== undefined && (averageSpeed < 0 || averageSpeed > 150))
-    || (!ecg && maxSpeed !== undefined && (maxSpeed < 0 || maxSpeed > 150))
-    || (!ecg && averageSpeed !== undefined && maxSpeed !== undefined && averageSpeed > maxSpeed)
-    || (!ecg && feature.workoutDayKey !== undefined && strictDayKey(firstString(feature, ["workoutDayKey"])) !== feature.workoutDayKey)
-    || (!ecg && !firstTimestamp(feature, ["version"]))
-    || (ecg && (voltageMin === undefined || voltageMax === undefined || voltageMean === undefined || voltageRms === undefined))
-    || (ecg && voltageMin !== undefined && voltageMax !== undefined && voltageMin > voltageMax)
-    || (ecg && voltageMean !== undefined && voltageMin !== undefined && voltageMean < voltageMin)
-    || (ecg && voltageMean !== undefined && voltageMax !== undefined && voltageMean > voltageMax)
-    || (ecg && voltageRms !== undefined && voltageRms < 0)
-    || (ecg && (leadCount === undefined || !Number.isSafeInteger(leadCount) || leadCount < 1))
-    || (ecg && !firstString(feature, ["voltageUnit"]))
+    || (!ecg && (
+      WORKOUT_METRIC_BOUNDS.some(([key, minimum, maximum]) =>
+        optionalNumberOutsideRange(feature[key], minimum, maximum)
+      )
+      || WORKOUT_METRIC_PAIRS.some(([average, maximum]) =>
+        numbersOutOfOrder(finiteNumber(feature[average]), finiteNumber(feature[maximum]))
+      )
+      || (feature.workoutDayKey !== undefined && strictDayKey(firstString(feature, ["workoutDayKey"])) !== feature.workoutDayKey)
+      || !firstTimestamp(feature, ["version"])
+    ))
+    || (ecg && (
+      numbersOutOfOrder(voltageMin, voltageMax)
+      || numbersOutOfOrder(voltageMin, voltageMean)
+      || numbersOutOfOrder(voltageMean, voltageMax)
+      || optionalNumberOutsideRange(feature.voltageRms, 0, Number.POSITIVE_INFINITY)
+      || leadCount === undefined
+      || !Number.isSafeInteger(leadCount)
+      || leadCount < 1
+      || !firstString(feature, ["voltageUnit"])
+    ))
   ) invalid(`${resource} feature was invalid`);
   if (!ecg) {
     assertWorkoutSplits(feature.splits);
   }
   consistentId(feature, ecg ? ECG_IDS : WORKOUT_IDS, "feature");
+}
+
+function optionalNumberOutsideRange(value: unknown, minimum: number, maximum: number): boolean {
+  if (value === undefined) return false;
+  const number = finiteNumber(value);
+  return number === undefined || number < minimum || number > maximum;
+}
+
+function numbersOutOfOrder(lower: number | undefined, upper: number | undefined): boolean {
+  return lower !== undefined && upper !== undefined && lower > upper;
 }
 
 function assertWorkoutSplits(value: unknown): void {

--- a/packages/importers/test/device-providers-junction-bounded-features.test.ts
+++ b/packages/importers/test/device-providers-junction-bounded-features.test.ts
@@ -749,3 +749,132 @@ test("bounded feature identity requires workout ids and conflicts fail closed", 
     })),
   ), /feature cardinality/u);
 });
+
+test.each([
+  ["distanceMeters", 0, Number.MAX_VALUE],
+  ["averageHeartRate", 20, 300],
+  ["maxHeartRate", 20, 300],
+  ["firstHalfAverageHeartRate", 20, 300],
+  ["secondHalfAverageHeartRate", 20, 300],
+  ["averageCadence", 0, 400],
+  ["maxCadence", 0, 400],
+  ["averagePower", 0, 5_000],
+  ["maxPower", 0, 5_000],
+  ["averageSpeed", 0, 150],
+  ["maxSpeed", 0, 150],
+] as const)("workout %s preserves optional numeric bounds and input shapes", (field, minimum, maximum) => {
+  const featureWith = (value: unknown) => workoutFeature({
+    averageHeartRate: undefined,
+    maxHeartRate: undefined,
+    [field]: value,
+  });
+  for (const value of [undefined, minimum, maximum, String(minimum), String(maximum)]) {
+    const feature = featureWith(value);
+    assert.deepEqual(resolveJunctionBoundedFeatureRecords("workout_stream", [feature]), [feature]);
+  }
+  for (const value of [null, "", "invalid", true, [], {}, Number.NaN, Infinity, -Infinity, minimum - 1, maximum * 2]) {
+    assert.throws(
+      () => resolveJunctionBoundedFeatureRecords("workout_stream", [featureWith(value)]),
+      { name: "TypeError", message: "Junction workout_stream feature was invalid." },
+    );
+  }
+  const explicitUndefined = featureWith(undefined);
+  explicitUndefined[field] = undefined;
+  assert.throws(
+    () => resolveJunctionBoundedFeatureRecords("workout_stream", [explicitUndefined]),
+    { name: "TypeError", message: "Junction workout_stream feature was invalid." },
+  );
+});
+
+test.each([
+  ["averageHeartRate", "maxHeartRate", 20],
+  ["averageCadence", "maxCadence", 0],
+  ["averagePower", "maxPower", 0],
+  ["averageSpeed", "maxSpeed", 0],
+] as const)("workout %s and %s preserve ordering only when both exist", (average, maximum, minimum) => {
+  for (const [averageValue, maximumValue] of [
+    [undefined, minimum], [minimum, undefined], [undefined, undefined],
+    [minimum, minimum], [minimum, minimum + 1], [String(minimum), String(minimum + 1)],
+  ]) {
+    const feature = workoutFeature({ [average]: averageValue, [maximum]: maximumValue });
+    assert.deepEqual(resolveJunctionBoundedFeatureRecords("workout_stream", [feature]), [feature]);
+  }
+  for (const [averageValue, maximumValue] of [[minimum + 1, minimum], [String(minimum + 1), String(minimum)]]) {
+    assert.throws(
+      () => resolveJunctionBoundedFeatureRecords("workout_stream", [workoutFeature({
+        [average]: averageValue, [maximum]: maximumValue,
+      })]),
+      { name: "TypeError", message: "Junction workout_stream feature was invalid." },
+    );
+  }
+});
+
+test.each([
+  "durationSeconds", "voltageMin", "voltageMax", "voltageMean", "voltageRms", "leadCount",
+] as const)("ECG %s remains required and accepts finite numeric strings", (field) => {
+  const feature = ecgFeature();
+  feature[field] = String(feature[field]);
+  assert.deepEqual(resolveJunctionBoundedFeatureRecords("electrocardiogram_voltage", [feature]), [feature]);
+  for (const value of [undefined, null, "", "invalid", true, Number.NaN, Infinity, -Infinity]) {
+    assert.throws(
+      () => resolveJunctionBoundedFeatureRecords("electrocardiogram_voltage", [ecgFeature({ [field]: value })]),
+      { name: "TypeError", message: "Junction electrocardiogram_voltage feature was invalid." },
+    );
+  }
+});
+
+test("ECG range, ordering, and lead constraints preserve inclusive boundaries", () => {
+  for (const overrides of [
+    { voltageMean: -0.4 }, { voltageMean: 0.5 }, { voltageRms: 0 },
+    { voltageMin: 0, voltageMean: 0, voltageMax: 0 }, { durationSeconds: 0 },
+    { voltageMin: "2", voltageMean: "9", voltageMax: "10" },
+  ]) {
+    const feature = ecgFeature(overrides);
+    assert.deepEqual(resolveJunctionBoundedFeatureRecords("electrocardiogram_voltage", [feature]), [feature]);
+  }
+  for (const overrides of [
+    { voltageMin: 0.6 }, { voltageMean: -0.401 }, { voltageMean: 0.501 },
+    { voltageRms: -0.001 }, { leadCount: 0 }, { leadCount: 1.5 },
+    { leadCount: Number.MAX_SAFE_INTEGER + 1 }, { voltageUnit: "" }, { durationSeconds: -1 },
+  ]) {
+    assert.throws(
+      () => resolveJunctionBoundedFeatureRecords("electrocardiogram_voltage", [ecgFeature(overrides)]),
+      { name: "TypeError", message: "Junction electrocardiogram_voltage feature was invalid." },
+    );
+  }
+});
+
+test("bounded feature errors precede split errors and then stable identity conflicts", () => {
+  const conflicting = workoutFeature({ workoutId: "different-workout", splits: [{}] });
+  assert.throws(
+    () => resolveJunctionBoundedFeatureRecords("workout_stream", [{ ...conflicting, averagePower: -1 }]),
+    { name: "TypeError", message: "Junction workout_stream feature was invalid." },
+  );
+  assert.throws(
+    () => resolveJunctionBoundedFeatureRecords("workout_stream", [conflicting]),
+    { name: "TypeError", message: "Junction workout split 1 was invalid." },
+  );
+  assert.throws(
+    () => resolveJunctionBoundedFeatureRecords("workout_stream", [{ ...conflicting, splits: [] }]),
+    { name: "TypeError", message: "Junction feature contained conflicting stable identifiers." },
+  );
+  assert.throws(
+    () => resolveJunctionBoundedFeatureRecords("electrocardiogram_voltage", [ecgFeature({
+      recordingId: "different-recording", voltageMean: 1,
+    })]),
+    { name: "TypeError", message: "Junction electrocardiogram_voltage feature was invalid." },
+  );
+});
+
+test("workout duration stays required with an inclusive zero lower bound", () => {
+  for (const durationSeconds of [0, "0", "1800"]) {
+    const feature = workoutFeature({ durationSeconds });
+    assert.deepEqual(resolveJunctionBoundedFeatureRecords("workout_stream", [feature]), [feature]);
+  }
+  for (const durationSeconds of [undefined, null, "", Number.NaN, Infinity, -Infinity, -1]) {
+    assert.throws(
+      () => resolveJunctionBoundedFeatureRecords("workout_stream", [workoutFeature({ durationSeconds })]),
+      { name: "TypeError", message: "Junction workout_stream feature was invalid." },
+    );
+  }
+});


### PR DESCRIPTION
## Why and outcome

Junction bounded-feature admission repeated eleven optional numeric ranges and four average/maximum comparisons inside a function with cyclomatic complexity 118. Closed local rule tables now share finite-number/range and ordering predicates, while the existing owner retains required ECG fields and structural admission.

Accepted values, numeric-string handling, bounds, canonical output, and the feature → split → identity error order remain unchanged. The target function falls to complexity 43.

## Product UX

- Effort: Not applicable — behavior-preserving importer maintenance.
- Result: Not applicable.
- Walkthrough: Workout and ECG admission preserve the same public inputs, outputs, and error envelopes; no member interaction changes.

## Evidence

- Direct: All 37 focused tests passed against the unchanged base and the candidate, including 24 new regression cases for optional bounds, average/maximum pairs, required ECG numerics, finite strings, null/nonfinite/explicit undefined values, and error precedence.
- Coverage: `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir packages/importers test:coverage test/device-providers-junction-bounded-features.test.ts --coverage.include=src/device-providers/junction-bounded-features.ts` passed. Target file: 89.27% statements, 81.23% branches, 100% functions, 91.09% lines.
- Typecheck: `pnpm --dir packages/importers typecheck` passed.
- Broad verification: Exact-head CI and parent review remain pending while this PR is draft.

## Non-obvious affected surfaces

ECG voltage ordering reuses the same numeric-order predicate. Required-number admission still rejects missing or invalid ECG scalars before ordering, and explicit ECG regression cases pass on both implementations. Split validation and canonical reduction output remain unchanged.

## Architecture and reuse

- Existing systems reused: The current bounded-feature admission owner, contracts-owned resource limits, and shared `finiteNumber` conversion.
- New logic: No new admission policy; repeated rules are expressed once and redundant ECG absence guards are removed behind the existing required-number gate.
- New abstractions: Two closed readonly rule tables and two local scalar predicates, with no new exports, dependency, or state owner.
- Complexity intentionally avoided: No schema framework, generic validator dispatcher, second normalization layer, or new persistence path.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base b2a559812972d70644cffb2bf43923fc9211047d --head HEAD -- packages/importers/src/device-providers/junction-bounded-features.ts`; debt above 20 falls 134 → 59 and file maximum falls 118 → 48.
- Hotspots: `assertFeature` falls 118 → 43; its remaining structural, count, and resource-specific guards protect distinct admission requirements. Unchanged `reduceJunctionWorkoutStreamPayload` (48) and `assertWorkoutSplits` (28) remain separate owners outside this refactor.
- Agent judgment: This removes repeated validation rules and the duplicated optional-field inventory. Further splitting of the structural gate would mostly relocate necessary checks; no additional abstraction is justified for this seam.

## Hot reply path impact

- Path status: Not applicable — synchronous device feature admission remains outside foreground reply dispatch.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved.
- Before/after proof: Source diff contains local scalar validation only; no call-boundary or async change.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged for both runtimes.
- Tool/schema/generated guidance: Unchanged for both runtimes.
- Other provider-visible input: Unchanged; feature records retain their existing contents.
- Measurement method: Not run — no individual or group provider-input assembly surface changes.

## Deployment concerns

- Deployment: not applicable
- Reason: Pure importer refactoring preserves accepted payloads, canonical output, and wire/persisted schemas; no migration or component deployment order is required.

## Change-shape breakdown

Classification rule: Production TypeScript is source, the focused test file is tests, and the completed execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 54 | 48 |
| Tests/fixtures | 129 | 0 |
| Docs | 54 | 0 |
| Config/tooling | 0 | 0 |
| Generated/other | 0 | 0 |
| Total | 237 | 48 |

## Changelog

- Changelog: not applicable
- Reason: Internal maintainability work preserves member-visible behavior.

ReviewGPT first-reviewed head: 1d76ef760083cd14ad0ec5e15ea41f910bb0083c
ReviewGPT context sensitivity: sensitive
Classification reason: Health-data admission validation is a trust boundary.

## Final review evidence

- Round 1: PASS on 1d76ef760083cd14ad0ec5e15ea41f910bb0083c; zero findings received, accepted, or rejected.
- Scope and identity: Full immutable snapshot and diff reviewed; response hashes, captured turn, model, and exact head were verified.
- Model and lane: gpt-6-pro on vonneumann. The successful wrapper enforced at least 270 seconds; exact elapsed time was not persisted.
- Tooling retries: None. Tooling retries did not advance the substantive round.
