### PR TITLE
Simplify WHOOP snapshot projections

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-complexity-collapse-whoop.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-complexity-collapse-whoop.md
@@ -1,0 +1,51 @@
+# Simplify WHOOP snapshot normalization
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+Reduce repeated branching and projections in the WHOOP snapshot normalizer while preserving every emitted event, timestamp, identity, and evidence association.
+
+## Success criteria
+
+- Lower function and file cyclomatic complexity through deletion of repeated decisions.
+- Preserve provider/vault day precedence, legacy aliases, body account scope, fallback IDs, event order, and numeric omission semantics.
+- Pass focused provider regressions, importer typecheck, and the complexity guard.
+
+## Scope
+
+- WHOOP normalization source, focused provider tests, and this execution record.
+- No provider API, schema, canonical storage, credential, scheduling, prompt, or product behavior changes.
+
+## Architecture and evidence
+
+The importer owns pure provider snapshot normalization and delegates writes to core. The current body-measurement block repeatedly guards one optional object even though its inner date helpers repeat the same guard. Workout metrics repeat seven finite-number assignment branches. Sleep, cycle, and workout records repeat identical interval timestamp parsing. Consolidate those existing projections within the WHOOP owner and reuse existing omission helpers. No persisted state or public abstraction is added.
+
+## Risks and mitigations
+
+- Body day and legacy identity precedence affects replay: retain the exact candidate order and run canonical replay, user-edit, tombstone, and account-scope regressions.
+- Missing, invalid, and zero-valued data must remain distinct: test absent bodies and metric omission alongside zero values.
+- Sleep/cycle/workout occurrence and day rules differ: share only identical timestamp parsing and keep each record family's policy explicit.
+- The change preserves output schemas and has no deploy sequencing or mixed-version requirement.
+
+## Tasks
+
+1. Consolidate body projection behind one absence guard, use existing metric omission primitives, and deduplicate interval timestamp parsing.
+2. Add focused omission regressions and run existing provider-shaped normalization and replay proof.
+3. Inspect the complete diff, privacy, and complexity results; close the plan with a scoped neutral-authored commit and open a draft PR for parent review.
+
+## Product UX and changelog
+
+Internal behavior-preserving refactor. No member-facing flow or meaning changes; no changelog entry is needed.
+
+## Verification
+
+- Passed: `pnpm --dir packages/importers exec vitest run --config vitest.config.ts --no-coverage test/device-providers.test.ts test/device-provider-snapshot-validation.test.ts test/device-providers/deletion-normalization.test.ts` — 92 tests across three files, including canonical replay, provider-day precedence, body legacy identities, and deletion behavior.
+- Passed: `pnpm --dir packages/importers typecheck`.
+- Passed: `pnpm complexity:diff --base HEAD --json -- packages/importers/src/device-providers/whoop.ts` against the pre-change checkout. Maximum/normalizer complexity 93 to 69, debt 73 to 49, total complexity 235 to 213; body projection 17, workout metric builder 13 to 6.
+- Source changed by +82/-131 lines (net -49). The remaining normalizer hotspot keeps distinct sleep/recovery/cycle/workout rules explicit; further extraction alone would relocate its decisions.
+- Full source/test diff and privacy review passed; `git diff --check` passed. Existing Frog entries were inspected; no new repository friction was encountered.
+- The scoped implementation is complete. Parent owns candidate review, exact-head CI, final ReviewGPT, and Ready admission; these remain pending at draft handoff.
+Completed: 2026-09-10

--- a/packages/importers/src/device-providers/whoop.ts
+++ b/packages/importers/src/device-providers/whoop.ts
@@ -118,6 +118,14 @@ function cycleOrFallbackTimestamp(...candidates: Array<string | undefined>): str
   return candidates.find((candidate) => typeof candidate === "string" && candidate.length > 0);
 }
 
+function whoopRecordTimestamps(record: PlainObject, importedAt: string) {
+  const startAt = toIso(record.start);
+  const endAt = toIso(record.end);
+  const version = toIso(record.updated_at);
+  const recordedAt = cycleOrFallbackTimestamp(version, endAt, startAt, importedAt);
+  return { startAt, endAt, version, recordedAt };
+}
+
 function firstDayKey(...candidates: Array<string | undefined>): string | undefined {
   for (const candidate of candidates) {
     if (typeof candidate !== "string") {
@@ -247,11 +255,7 @@ function millisecondsToMinutes(value: unknown): number | undefined {
   return numeric / 60000;
 }
 
-function firstBodyMeasurementMeasuredAt(bodyMeasurement: PlainObject | undefined): string | undefined {
-  if (!bodyMeasurement) {
-    return undefined;
-  }
-
+function firstBodyMeasurementMeasuredAt(bodyMeasurement: PlainObject): string | undefined {
   return cycleOrFallbackTimestamp(
     toIso(bodyMeasurement.measured_at),
     toIso(bodyMeasurement.measuredAt),
@@ -260,22 +264,14 @@ function firstBodyMeasurementMeasuredAt(bodyMeasurement: PlainObject | undefined
   );
 }
 
-function firstBodyMeasurementUpdatedAt(bodyMeasurement: PlainObject | undefined): string | undefined {
-  if (!bodyMeasurement) {
-    return undefined;
-  }
-
+function firstBodyMeasurementUpdatedAt(bodyMeasurement: PlainObject): string | undefined {
   return cycleOrFallbackTimestamp(
     toIso(bodyMeasurement.updated_at),
     toIso(bodyMeasurement.updatedAt),
   );
 }
 
-function firstBodyMeasurementExplicitDayKey(bodyMeasurement: PlainObject | undefined): string | undefined {
-  if (!bodyMeasurement) {
-    return undefined;
-  }
-
+function firstBodyMeasurementExplicitDayKey(bodyMeasurement: PlainObject): string | undefined {
   return firstDayKey(
     stringId(bodyMeasurement.day),
     stringId(bodyMeasurement.date),
@@ -285,9 +281,9 @@ function firstBodyMeasurementExplicitDayKey(bodyMeasurement: PlainObject | undef
   );
 }
 
-function calculateBodyMassIndex(bodyMeasurement: PlainObject | undefined): number | undefined {
-  const weightKilograms = finiteNumber(bodyMeasurement?.weight_kilogram ?? bodyMeasurement?.weightKilogram);
-  const heightMeters = finiteNumber(bodyMeasurement?.height_meter ?? bodyMeasurement?.heightMeter);
+function calculateBodyMassIndex(bodyMeasurement: PlainObject): number | undefined {
+  const weightKilograms = finiteNumber(bodyMeasurement.weight_kilogram ?? bodyMeasurement.weightKilogram);
+  const heightMeters = finiteNumber(bodyMeasurement.height_meter ?? bodyMeasurement.heightMeter);
 
   if (weightKilograms === undefined || heightMeters === undefined || heightMeters <= 0) {
     return undefined;
@@ -460,46 +456,74 @@ const WHOOP_BODY_OBSERVATION_METRICS: readonly ObservationMetricDescriptor<Whoop
   },
 ];
 
-function nonEmptyWorkoutMetrics(metrics: WorkoutSessionMetrics): WorkoutSessionMetrics | undefined {
-  return Object.keys(metrics).length > 0 ? metrics : undefined;
+function emitWhoopBodyMeasurement(
+  events: DeviceEventPayload[],
+  measurement: PlainObject | undefined,
+  accountId: string | undefined,
+  importedAt: string,
+  defaultTimeZone: string | undefined,
+): string | undefined {
+  if (!measurement) {
+    return undefined;
+  }
+
+  const explicitDayKey = firstBodyMeasurementExplicitDayKey(measurement);
+  const measuredAt = firstBodyMeasurementMeasuredAt(measurement);
+  const updatedAt = firstBodyMeasurementUpdatedAt(measurement);
+  const accountScope = bodyMeasurementAccountScope(accountId);
+  const observedAt = explicitDayKey ? measuredAt : measuredAt ?? updatedAt;
+  const recordedAt = measuredAt ?? updatedAt ?? importedAt;
+  const occurredAt = observedAt ??
+    (explicitDayKey ? `${explicitDayKey}T00:00:00.000Z` : undefined) ?? recordedAt;
+  const dayKey = explicitDayKey ??
+    firstWhoopLocalDayKey(measurement, recordedAt) ??
+    firstVaultLocalDayKey(defaultTimeZone, recordedAt);
+  const fallbackDayKey = firstDayKey(observedAt) ?? firstDayKey(recordedAt);
+  const resourceDayKey = dayKey ?? fallbackDayKey;
+  const resourceId = resourceDayKey
+    ? bodyMeasurementDayResourceId(resourceDayKey, accountScope)
+    : bodyMeasurementCurrentResourceId(accountScope);
+  const legacyDayKey = firstDayKey(measuredAt, updatedAt, importedAt);
+  const legacyResourceIds = [
+    dayKey ? bodyMeasurementDayResourceId(dayKey, undefined) : undefined,
+    fallbackDayKey,
+    fallbackDayKey ? bodyMeasurementDayResourceId(fallbackDayKey, undefined) : undefined,
+    legacyDayKey,
+    legacyDayKey ? bodyMeasurementDayResourceId(legacyDayKey, undefined) : undefined,
+  ].filter((legacyId): legacyId is string => Boolean(legacyId) && legacyId !== resourceId);
+
+  emitObservationMetrics(
+    events,
+    {
+      source: { measurement, bmi: calculateBodyMassIndex(measurement) },
+      occurredAt,
+      recordedAt,
+      dayKey,
+      observationGrain: "summary",
+      evidenceRoles: ["body-measurement"],
+      externalRef: (facet) => makeExternalRef("body-measurement", resourceId, undefined, facet),
+      legacyExternalRefs: (facet) => [...new Set(legacyResourceIds)]
+        .map((legacyId) => makeExternalRef("body-measurement", legacyId, undefined, facet)),
+    },
+    WHOOP_BODY_OBSERVATION_METRICS,
+  );
+
+  return dayKey;
 }
 
 function buildWhoopWorkoutMetrics(
   workout: PlainObject,
   score: PlainObject | undefined,
 ): WorkoutSessionMetrics | undefined {
-  const metrics: WorkoutSessionMetrics = {};
-  const workoutStrain = finiteNumber(score?.strain);
-  const averageHeartRate = finiteNumber(score?.average_heart_rate);
-  const maxHeartRate = finiteNumber(score?.max_heart_rate);
-  const totalCalories = kilojoulesToKilocalories(score?.kilojoule);
-  const percentRecorded = finiteNumber(score?.percent_recorded);
-  const totalElevationGainMeters = finiteNumber(workout.altitude_gain_meter);
-  const altitudeChangeMeters = finiteNumber(workout.altitude_change_meter);
-
-  if (workoutStrain !== undefined) {
-    metrics.workoutStrain = workoutStrain;
-  }
-  if (averageHeartRate !== undefined) {
-    metrics.averageHeartRate = averageHeartRate;
-  }
-  if (maxHeartRate !== undefined) {
-    metrics.maxHeartRate = maxHeartRate;
-  }
-  if (totalCalories !== undefined) {
-    metrics.totalCalories = totalCalories;
-  }
-  if (percentRecorded !== undefined) {
-    metrics.percentRecorded = percentRecorded;
-  }
-  if (totalElevationGainMeters !== undefined) {
-    metrics.totalElevationGainMeters = totalElevationGainMeters;
-  }
-  if (altitudeChangeMeters !== undefined) {
-    metrics.altitudeChangeMeters = altitudeChangeMeters;
-  }
-
-  return nonEmptyWorkoutMetrics(metrics);
+  return stripEmptyObject(stripUndefined({
+    workoutStrain: finiteNumber(score?.strain),
+    averageHeartRate: finiteNumber(score?.average_heart_rate),
+    maxHeartRate: finiteNumber(score?.max_heart_rate),
+    totalCalories: kilojoulesToKilocalories(score?.kilojoule),
+    percentRecorded: finiteNumber(score?.percent_recorded),
+    totalElevationGainMeters: finiteNumber(workout.altitude_gain_meter),
+    altitudeChangeMeters: finiteNumber(workout.altitude_change_meter),
+  }));
 }
 
 function pushDeletionObservation(
@@ -574,82 +598,15 @@ export function normalizeWhoopSnapshot(
     }
   }
 
-  const bodyMeasurementExplicitDayKey = bodyMeasurement
-    ? firstBodyMeasurementExplicitDayKey(bodyMeasurement)
-    : undefined;
-  const bodyMeasurementMeasuredAt = bodyMeasurement
-    ? firstBodyMeasurementMeasuredAt(bodyMeasurement)
-    : undefined;
-  const bodyMeasurementUpdatedAt = bodyMeasurement
-    ? firstBodyMeasurementUpdatedAt(bodyMeasurement)
-    : undefined;
-  const bodyMeasurementScope = bodyMeasurementAccountScope(accountId);
-  const bodyMeasurementObservedAt = bodyMeasurementExplicitDayKey
-    ? bodyMeasurementMeasuredAt
-    : bodyMeasurementMeasuredAt ?? bodyMeasurementUpdatedAt;
-  const bodyMeasurementRecordedAt = bodyMeasurement
-    ? bodyMeasurementMeasuredAt ?? bodyMeasurementUpdatedAt ?? importedAt
-    : undefined;
-  const bodyMeasurementOccurredAt = bodyMeasurement
-    ? bodyMeasurementObservedAt ??
-      (bodyMeasurementExplicitDayKey ? `${bodyMeasurementExplicitDayKey}T00:00:00.000Z` : undefined) ??
-      bodyMeasurementRecordedAt
-    : undefined;
-  const bodyMeasurementDayKey = bodyMeasurement
-    ? bodyMeasurementExplicitDayKey ??
-      firstWhoopLocalDayKey(bodyMeasurement, bodyMeasurementRecordedAt) ??
-      firstVaultLocalDayKey(context.defaultTimeZone, bodyMeasurementRecordedAt)
-    : undefined;
-  const bodyMeasurementFallbackDayKey = firstDayKey(bodyMeasurementObservedAt) ?? firstDayKey(bodyMeasurementRecordedAt);
-  const bodyMeasurementResourceId = bodyMeasurementDayKey
-    ? bodyMeasurementDayResourceId(bodyMeasurementDayKey, bodyMeasurementScope)
-    : bodyMeasurementFallbackDayKey
-      ? bodyMeasurementDayResourceId(bodyMeasurementFallbackDayKey, bodyMeasurementScope)
-      : bodyMeasurementCurrentResourceId(bodyMeasurementScope);
-  const bodyMeasurementLegacyResourceId = firstDayKey(
-    bodyMeasurementMeasuredAt,
-    bodyMeasurementUpdatedAt,
-    importedAt,
-  );
-  const bodyMeasurementLegacyResourceIds = [
-    bodyMeasurementDayKey ? bodyMeasurementDayResourceId(bodyMeasurementDayKey, undefined) : undefined,
-    bodyMeasurementFallbackDayKey,
-    bodyMeasurementFallbackDayKey ? bodyMeasurementDayResourceId(bodyMeasurementFallbackDayKey, undefined) : undefined,
-    bodyMeasurementLegacyResourceId,
-    bodyMeasurementLegacyResourceId ? bodyMeasurementDayResourceId(bodyMeasurementLegacyResourceId, undefined) : undefined,
-  ].filter((resourceId): resourceId is string => Boolean(resourceId) && resourceId !== bodyMeasurementResourceId);
-  const bodyMeasurementBmi = calculateBodyMassIndex(bodyMeasurement);
-
   pushEvidencePart(evidenceParts, createEvidencePart("profile", "profile.json", profile));
   pushEvidencePart(evidenceParts, createEvidencePart("body-measurement", "body-measurement.json", bodyMeasurement));
-
-  if (bodyMeasurement && bodyMeasurementOccurredAt && bodyMeasurementRecordedAt) {
-    emitObservationMetrics(
-      events,
-      {
-        source: {
-          measurement: bodyMeasurement,
-          bmi: bodyMeasurementBmi,
-        },
-        occurredAt: bodyMeasurementOccurredAt,
-        recordedAt: bodyMeasurementRecordedAt,
-        dayKey: bodyMeasurementDayKey,
-        observationGrain: "summary",
-        evidenceRoles: ["body-measurement"],
-        externalRef: (facet) => makeExternalRef("body-measurement", bodyMeasurementResourceId, undefined, facet),
-        legacyExternalRefs: (facet) => [...new Set(bodyMeasurementLegacyResourceIds)]
-          .map((resourceId) => makeExternalRef("body-measurement", resourceId, undefined, facet)),
-      },
-      WHOOP_BODY_OBSERVATION_METRICS,
-    );
-  }
+  const bodyMeasurementDayKey = emitWhoopBodyMeasurement(
+    events, bodyMeasurement, accountId, importedAt, context.defaultTimeZone,
+  );
 
   for (const sleep of sleeps) {
     const sleepId = stringId(sleep.id) ?? `sleep-${events.length + 1}`;
-    const startAt = toIso(sleep.start);
-    const endAt = toIso(sleep.end);
-    const version = toIso(sleep.updated_at);
-    const recordedAt = cycleOrFallbackTimestamp(toIso(sleep.updated_at), endAt, startAt, importedAt);
+    const { startAt, endAt, version, recordedAt } = whoopRecordTimestamps(sleep, importedAt);
     const dayKey = firstWhoopLocalDayKey(sleep, endAt, startAt, recordedAt);
     const occurredAt = dayKey ? startAt ?? recordedAt : endAt ?? startAt ?? recordedAt;
     const durationMinutes = minutesBetween(startAt, endAt);
@@ -769,10 +726,7 @@ export function normalizeWhoopSnapshot(
   for (const cycle of cycles) {
     const cycleId = stringId(cycle.id) ?? `cycle-${events.length + 1}`;
     const cycleRole = `cycle:${cycleId}`;
-    const startAt = toIso(cycle.start);
-    const endAt = toIso(cycle.end);
-    const version = toIso(cycle.updated_at);
-    const recordedAt = cycleOrFallbackTimestamp(toIso(cycle.updated_at), endAt, startAt, importedAt);
+    const { startAt, endAt, version, recordedAt } = whoopRecordTimestamps(cycle, importedAt);
     const occurredAt = endAt ?? startAt ?? recordedAt;
     const dayKey = firstWhoopLocalDayKey(cycle, endAt, startAt, recordedAt);
     const score = asPlainObject(cycle.score);
@@ -800,10 +754,7 @@ export function normalizeWhoopSnapshot(
   for (const workout of workouts) {
     const workoutId = stringId(workout.id) ?? `workout-${events.length + 1}`;
     const workoutRole = `workout:${workoutId}`;
-    const startAt = toIso(workout.start);
-    const endAt = toIso(workout.end);
-    const version = toIso(workout.updated_at);
-    const recordedAt = cycleOrFallbackTimestamp(toIso(workout.updated_at), endAt, startAt, importedAt);
+    const { startAt, endAt, version, recordedAt } = whoopRecordTimestamps(workout, importedAt);
     const occurredAt = startAt ?? recordedAt;
     const dayKey = firstWhoopOffsetDayKey(whoopTimezoneOffsetMinutes(workout), startAt, recordedAt, endAt);
     const durationMinutes = minutesBetween(startAt, endAt);

--- a/packages/importers/test/device-providers.test.ts
+++ b/packages/importers/test/device-providers.test.ts
@@ -66,6 +66,80 @@ test("WHOOP sleep normalization preserves strict nap identity and leaves missing
   assert.equal(byId.get("missing"), undefined);
 });
 
+test("WHOOP normalization omits absent body measurements without changing provenance", () => {
+  for (const bodyMeasurement of [undefined, null, [], false, "invalid"]) {
+    const payload = normalizeWhoopSnapshot({
+      importedAt: "2026-03-16T10:00:00.000Z",
+      bodyMeasurement,
+    }, { defaultTimeZone: "America/New_York" });
+
+    assert.deepEqual(payload.events, []);
+    assert.deepEqual(payload.evidenceParts, []);
+    assert.equal(payload.provenance?.bodyMeasurementDay, undefined);
+    assert.deepEqual(payload.provenance?.importedSections, {
+      profile: false,
+      bodyMeasurement: false,
+      sleeps: 0,
+      recoveries: 0,
+      cycles: 0,
+      workouts: 0,
+      deletions: 0,
+    });
+  }
+});
+
+test("WHOOP workout metrics omit missing and invalid values while preserving zero values", () => {
+  const payload = normalizeWhoopSnapshot({
+    importedAt: "2026-03-16T10:00:00.000Z",
+    workouts: [
+      {},
+      {
+        altitude_gain_meter: "bad",
+        altitude_change_meter: null,
+        score: {
+          strain: null,
+          average_heart_rate: "bad",
+          max_heart_rate: Infinity,
+          kilojoule: "",
+          percent_recorded: false,
+        },
+      },
+      {
+        altitude_gain_meter: "0",
+        altitude_change_meter: 0,
+        score: {
+          strain: 0,
+          average_heart_rate: "0",
+          max_heart_rate: 0,
+          kilojoule: "0",
+          percent_recorded: 0,
+        },
+      },
+    ].map((workout) => ({
+      ...workout,
+      start: "2026-03-15T17:00:00.000Z",
+      end: "2026-03-15T17:45:00.000Z",
+    })),
+  });
+
+  assert.deepEqual(payload.events?.map(workoutMetricsFromEvent), [
+    undefined,
+    undefined,
+    {
+      workoutStrain: 0,
+      averageHeartRate: 0,
+      maxHeartRate: 0,
+      totalCalories: 0,
+      percentRecorded: 0,
+      totalElevationGainMeters: 0,
+      altitudeChangeMeters: 0,
+    },
+  ]);
+  assert.deepEqual(payload.events?.map((event) => event.externalRef?.resourceId), [
+    "workout-1", "workout-2", "workout-3",
+  ]);
+});
+
 type _normalizedDeviceBatchMatchesCorePayload = AssertTrue<
   IsMutuallyAssignable<NormalizedDeviceBatch, Omit<DeviceBatchImportPayload, "vaultRoot">>
 >;


### PR DESCRIPTION
## Why and outcome

WHOOP snapshot normalization repeatedly guarded the same optional body measurement, assigned seven workout metrics through identical conditional blocks, and reparsed interval timestamps in three record families. One guarded body projection, the existing omission helpers, and one shared timestamp projection remove these repetitions while preserving event order, identities, date precedence, and emitted values.

The normalizer's cyclomatic complexity falls from 93 to 69, total file complexity falls from 235 to 213, and source shrinks by 49 lines.

## Product UX

- Effort: Not applicable — internal behavior-preserving refactor.
- Result: Not applicable — no product meaning or interaction changes.
- Walkthrough: Existing canonical import tests preserve provider-local dates, account-scoped body measurements, legacy aliases, repeated imports, user edits, delayed revisions, and tombstones. No journeys or data are excluded.

## Evidence

- Direct: `pnpm --dir packages/importers exec vitest run --config vitest.config.ts --no-coverage test/device-providers.test.ts test/device-provider-snapshot-validation.test.ts test/device-providers/deletion-normalization.test.ts` — 92 tests passed across three files.
- Coverage: Added absent-body provenance assertions and missing/invalid/zero workout metric cases, including fallback event identities and order. Existing tests exercise canonical replay and provider-shaped date, identity, unit, validation, and deletion behavior.
- Typecheck: `pnpm --dir packages/importers typecheck` — passed.
- Diff: `git diff --check` and full authored-diff privacy review — passed.
- CI: Required exact-head CI and final ReviewGPT are pending parent candidate review and Ready admission.

## Non-obvious affected surfaces

Body measurement legacy references participate in canonical reconciliation. Existing replay, account-scoping, user-edit, delayed-revision, and tombstone tests passed with unchanged identity and date precedence.

## Architecture and reuse

- Existing systems reused: WHOOP metric descriptors, `emitObservationMetrics`, `stripUndefined`, `stripEmptyObject`, provider timestamp helpers, and canonical import reconciliation.
- New logic: None; the existing projections and precedence rules are preserved.
- New abstractions: Two private WHOOP helpers consolidate one guarded body projection and duplicated start/end/version/recorded-time parsing. The redundant workout-empty helper is removed.
- Complexity intentionally avoided: No provider framework, new state owner, public API, schema, dependency, or compatibility mechanism.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base b2a559812972d70644cffb2bf43923fc9211047d --json -- packages/importers/src/device-providers/whoop.ts`. File maximum 93 to 69; debt above 20 falls from 73 to 49; aggregate complexity 235 to 213. The body helper is 17 and the workout metric builder falls from 13 to 6.
- Hotspots: `normalizeWhoopSnapshot` remains at 69. Sleep, recovery, cycle, and workout occurrence/day rules remain visibly distinct; event order and fallback IDs remain at the existing owner.
- Agent judgment: This removes repeated decisions and 49 source lines. Further function extraction alone would relocate the remaining provider policy, so no framework or additional splitting is justified in this change.

## Hot reply path impact

- Path status: Not applicable — synchronous snapshot normalization only; no reply scheduling or awaited operation changes.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved.
- Before/after proof: Existing canonical import tests pass; timestamp parsing is deduplicated within each interval record.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no prompt assembly, tools, schemas, generated guidance, or provider request construction changes.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

ReviewGPT first-reviewed head: 65509f51fcc74e0aec0b8894a826f41436096876
ReviewGPT context sensitivity: sensitive
Classification reason: WHOOP health-data normalization and canonical replay identity semantics.

## Deployment concerns

- Deployment: not applicable
- Reason: This internal normalization refactor preserves payload shapes, ordering, external references, and persisted identity semantics. It changes no deployment protocol, schema, or independently deployed consumer contract.

## Change-shape breakdown

Classification rule: Production WHOOP TypeScript is source, provider regression additions are tests, and the completed execution record is docs. No binary files or generated output.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 82 | 131 |
| Tests / fixtures | 74 | 0 |
| Docs | 51 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **207** | **131** |

## Changelog

- Changelog: not applicable
- Reason: Internal maintainability refactor preserves member-visible behavior.

## Final review evidence

- Round 1: PASS on 65509f51fcc74e0aec0b8894a826f41436096876; zero findings received, accepted, or rejected.
- Scope and identity: Full immutable snapshot and diff reviewed; response hashes, captured turn, model, and exact head were verified.
- Model and lane: gpt-6-pro on vonneumann. The successful wrapper enforced at least 270 seconds; exact elapsed time was not persisted.
- Tooling retries: None. Tooling retries did not advance the substantive round.
