### PR TITLE
refactor(importers): collapse workout CSV planning complexity

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-complexity-collapse-workout-csv.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-complexity-collapse-workout-csv.md
@@ -1,0 +1,65 @@
+# Simplify workout CSV load metadata and set assembly
+
+## Outcome and protected contract
+
+Reduce duplicated decisions in `buildSessions` while preserving the complete
+Strong/Hevy planning result. The existing non-writing importer remains the owner;
+canonical persistence, source identity, grouping, output order, numeric handling,
+unit authority, skip reasons and warning timing must stay unchanged.
+
+## Evidence and design
+
+The complexity guard reports `buildSessions` and the file maximum at 111, file
+debt 104, and total complexity 417. Primary and three auxiliary loads repeat unit
+resolution/conflict logic; optional set values repeat presence decisions during
+assembly and again during set admission.
+
+Reuse one local weight metadata resolver for the four load fields, preserving
+primary validation before auxiliary validation and metadata conflicts before
+explicit-option conflicts. Keep each unitless warning update in its original
+phase: later rejection can preserve a warning. Build the typed optional set
+values once, omit undefined values in one pass, and derive set admission from
+the resulting object. No new state owner, dependency, public API, or persistence
+behavior is needed; failure, retry, and deployment contracts remain unchanged.
+
+## Product UX and proof
+
+Internal maintainability refactor; replay existing planner cases plus synthetic
+sparse/zero/invalid set values and competing metadata conflicts. Verify exact
+set shape, grouping, IDs, skip-reason precedence, and unit-warning timing. Run
+the focused workout CSV suite, importer typecheck, and complexity guard. Use a
+bounded base/head differential matrix if it adds coverage of field combinations.
+Broad exact-head CI and final review remain with the parent completion owner.
+
+## Progress
+
+- [x] Trace source, contract, and existing tests; inspect Frog entries.
+- [x] Add focused boundary evidence and simplify the existing owner.
+- [x] Run focused proof, typecheck, complexity guard, and privacy/diff review.
+- [x] Prepare the scoped final commit and complete draft PR; parent owns readiness and final gates.
+
+## Completion evidence
+
+- Focused planner suite: 50 tests passed, including sparse output, zero/invalid
+  values, metadata authority, and warning/skip precedence.
+- Temporary differential suite: 2,886 complete base/head plans matched, covering
+  all 512 optional-field combinations with zero, positive, and fractional values
+  plus 1,350 combinations of primary/auxiliary units, headers, and overrides.
+  The temporary baseline copy and harness were removed after passing.
+- `pnpm --dir packages/importers typecheck`: passed.
+- `pnpm complexity:diff --base HEAD -- packages/importers/src/workout-csv-planner.ts`:
+  passed; `buildSessions`/file maximum 111 → 74, file debt 104 → 67.
+- Source shape: +63/-69 lines. Tests add 125 lines. Numeric presence validation
+  and weight-header inference also use one repeated-rule pass.
+- Remaining changed-file hotspots: `buildSessions` 74 retains existing identity,
+  session, and dialect sequencing. Unchanged parsers remain 22 and 25; the
+  public planner remains 26. Further extraction would relocate policy without
+  removing a demonstrated duplicate in this scoped change.
+- Full diff and `git diff --check` reviewed; only synthetic test values and
+  neutral Git metadata are used. No new reproducible repository friction.
+- Product UX: Ready at the planner boundary; no product behavior, schema,
+  persistence, provider input, or foreground reply path changed. Broad CI and
+  any routed final review are pending with the parent completion owner.
+Status: completed
+Updated: 2026-09-10
+Completed: 2026-09-10

--- a/packages/importers/src/workout-csv-planner.ts
+++ b/packages/importers/src/workout-csv-planner.ts
@@ -462,6 +462,26 @@ function toKilograms(value: number, unit: WorkoutCsvWeightUnit): number {
   return unit === "lb" ? value * 0.45359237 : value;
 }
 
+function resolveWeightMetadata(
+  parsed: ReturnType<typeof parseWeightValue>,
+  metadataUnits: (WorkoutCsvWeightUnit | undefined)[],
+  explicitUnit: WorkoutCsvWeightUnit | undefined,
+) {
+  const declaredUnits = [parsed.unit, ...metadataUnits]
+    .filter((unit): unit is WorkoutCsvWeightUnit => unit !== undefined);
+  const declaredUnit = declaredUnits[0];
+  const unit = declaredUnit ?? explicitUnit;
+  return {
+    unit,
+    metadataConflict: new Set(declaredUnits).size > 1,
+    explicitConflict: explicitUnit && declaredUnit && explicitUnit !== declaredUnit,
+    requiresUnit: (parsed.weight ?? 0) > 0 && !unit,
+    kilograms: parsed.weight === 0
+      ? 0
+      : parsed.weight !== undefined && unit ? toKilograms(parsed.weight, unit) : undefined,
+  };
+}
+
 function normalizeSetType(value: string | undefined, detectedSource: WorkoutCsvSource | null): WorkoutSetType {
   const normalized = normalizeOptionalText(value)?.toLowerCase();
   if (detectedSource === "strong") {
@@ -650,18 +670,9 @@ function buildSessions(input: {
   const warmupIndex = findHeaderIndex(headers, ["warmup", "warm up"]);
   const dropsetIndex = findHeaderIndex(headers, ["dropset", "drop set"]);
   const failureIndex = findHeaderIndex(headers, ["failure"]);
-  const bodyweightHeaderUnit = bodyweightIndex === undefined
-    ? undefined
-    : inferWeightUnitFromHeader(headers[bodyweightIndex]);
-  const assistanceHeaderUnit = assistanceIndex === undefined
-    ? undefined
-    : inferWeightUnitFromHeader(headers[assistanceIndex]);
-  const addedWeightHeaderUnit = addedWeightIndex === undefined
-    ? undefined
-    : inferWeightUnitFromHeader(headers[addedWeightIndex]);
-  const weightHeaderUnit = weightIndex === undefined
-    ? undefined
-    : inferWeightUnitFromHeader(headers[weightIndex]);
+  const [bodyweightHeaderUnit, assistanceHeaderUnit, addedWeightHeaderUnit, weightHeaderUnit] = [
+    bodyweightIndex, assistanceIndex, addedWeightIndex, weightIndex,
+  ].map((index) => inferWeightUnitFromHeader(index === undefined ? undefined : headers[index]));
 
   const sessions = new Map<string, MutableWorkoutCsvSession>();
   const titleByOccurredAt = new Map<string, string>();
@@ -717,66 +728,57 @@ function buildSessions(input: {
     const parsedAssistance = parseWeightValue(assistanceText);
     const parsedAddedWeight = parseWeightValue(addedWeightText);
     if (
-      (repsText !== undefined && reps === undefined)
-      || (weightText !== undefined && weight === undefined)
-      || (distanceText !== undefined && distance === undefined)
+      [
+        [repsText, reps],
+        [weightText, weight],
+        [distanceText, distance],
+        [bodyweightText, parsedBodyweight.weight],
+        [assistanceText, parsedAssistance.weight],
+        [addedWeightText, parsedAddedWeight.weight],
+      ].some(([text, value]) => text !== undefined && value === undefined)
       || (secondsText !== undefined && parseNonnegativeNumber(secondsText) !== 0 && durationSeconds === undefined)
       || (rpeText !== undefined && (rpe === undefined || rpe > 10))
-      || (bodyweightText !== undefined && parsedBodyweight.weight === undefined)
-      || (assistanceText !== undefined && parsedAssistance.weight === undefined)
-      || (addedWeightText !== undefined && parsedAddedWeight.weight === undefined)
     ) {
       skippedRowCount += 1;
       incrementReason(input.skipReasons, "invalid numeric set value");
       continue;
     }
 
-    const weightUnitCell = normalizeWeightUnit(valueAt(row, weightUnitIndex));
-    const declaredWeightUnits = [parsedWeight.unit, weightUnitCell, weightHeaderUnit]
-      .filter((unit): unit is WorkoutCsvWeightUnit => unit !== undefined);
-    if (new Set(declaredWeightUnits).size > 1) {
+    const weightMetadata = resolveWeightMetadata(parsedWeight, [
+      normalizeWeightUnit(valueAt(row, weightUnitIndex)), weightHeaderUnit,
+    ], input.weightUnit);
+    if (weightMetadata.metadataConflict) {
       skippedRowCount += 1;
       incrementReason(input.skipReasons, "weight units conflict within CSV metadata");
       continue;
     }
-    const declaredWeightUnit = parsedWeight.unit ?? weightUnitCell ?? weightHeaderUnit;
-    if (input.weightUnit && declaredWeightUnit && input.weightUnit !== declaredWeightUnit) {
+    if (weightMetadata.explicitConflict) {
       skippedRowCount += 1;
       incrementReason(input.skipReasons, "explicit weight unit conflicts with CSV metadata");
       continue;
     }
-    const resolvedWeightUnit = declaredWeightUnit ?? input.weightUnit;
-    if (typeof weight === "number" && weight > 0 && !resolvedWeightUnit) {
+    if (weightMetadata.requiresUnit) {
       hasUnitlessPositiveWeight = true;
     }
     const auxiliaryLoads = [
-      { parsed: parsedBodyweight, headerUnit: bodyweightHeaderUnit },
-      { parsed: parsedAssistance, headerUnit: assistanceHeaderUnit },
-      { parsed: parsedAddedWeight, headerUnit: addedWeightHeaderUnit },
+      resolveWeightMetadata(parsedBodyweight, [bodyweightHeaderUnit], input.weightUnit),
+      resolveWeightMetadata(parsedAssistance, [assistanceHeaderUnit], input.weightUnit),
+      resolveWeightMetadata(parsedAddedWeight, [addedWeightHeaderUnit], input.weightUnit),
     ];
-    if (auxiliaryLoads.some(({ parsed, headerUnit }) =>
-      parsed.unit && headerUnit && parsed.unit !== headerUnit)) {
+    if (auxiliaryLoads.some((load) => load.metadataConflict)) {
       skippedRowCount += 1;
       incrementReason(input.skipReasons, "weight units conflict within CSV metadata");
       continue;
     }
-    if (auxiliaryLoads.some(({ parsed, headerUnit }) =>
-      input.weightUnit && (parsed.unit ?? headerUnit) && input.weightUnit !== (parsed.unit ?? headerUnit))) {
+    if (auxiliaryLoads.some((load) => load.explicitConflict)) {
       skippedRowCount += 1;
       incrementReason(input.skipReasons, "explicit weight unit conflicts with CSV metadata");
       continue;
     }
-    if (auxiliaryLoads.some(({ parsed, headerUnit }) =>
-      typeof parsed.weight === "number"
-      && parsed.weight > 0
-      && !(parsed.unit ?? headerUnit ?? input.weightUnit))) {
+    if (auxiliaryLoads.some((load) => load.requiresUnit)) {
       hasUnitlessPositiveWeight = true;
     }
-    const [bodyweightKg, assistanceKg, addedWeightKg] = auxiliaryLoads.map(({ parsed, headerUnit }) => {
-      if (parsed.weight === undefined) return undefined;
-      const unit = parsed.unit ?? headerUnit ?? input.weightUnit;
-      return parsed.weight === 0 ? 0 : unit ? toKilograms(parsed.weight, unit) : undefined;
-    });
+    const [bodyweightKg, assistanceKg, addedWeightKg] = auxiliaryLoads.map((load) => load.kilograms);
     const declaredDistanceUnit = parsedDistance.unit ?? headerDistanceUnit;
     if (input.distanceUnit && declaredDistanceUnit && input.distanceUnit !== declaredDistanceUnit) {
       skippedRowCount += 1;
@@ -873,34 +875,26 @@ function buildSessions(input: {
     const requestedOrder = input.detectedSource === "strong"
       ? undefined
       : parseNonnegativeInteger(rawSetOrder);
-    const set: WorkoutSet = {
-      order: requestedOrder && requestedOrder > 0 ? requestedOrder : exercise.sets.length + 1,
-      type,
-      ...(reps !== undefined ? { reps } : {}),
-      ...(weight !== undefined && weight > 0 ? { weight } : {}),
-      ...(resolvedWeightUnit && weight !== undefined && weight > 0
-        ? { weightUnit: resolvedWeightUnit }
-        : {}),
-      ...(durationSeconds !== undefined ? { durationSeconds: Math.round(durationSeconds) } : {}),
-      ...(distanceMeters !== undefined
-        ? { distanceMeters }
-        : {}),
-      ...(rpe !== undefined ? { rpe } : {}),
-      ...(bodyweightKg !== undefined ? { bodyweightKg } : {}),
-      ...(assistanceKg !== undefined ? { assistanceKg } : {}),
-      ...(addedWeightKg !== undefined ? { addedWeightKg } : {}),
+    const setValues: Omit<WorkoutSet, "order" | "type"> = {
+      reps,
+      weight: weight === 0 ? undefined : weight,
+      weightUnit: weight ? weightMetadata.unit : undefined,
+      durationSeconds,
+      distanceMeters,
+      rpe,
+      bodyweightKg,
+      assistanceKg,
+      addedWeightKg,
     };
-    if (
-      set.reps !== undefined
-      || set.weight !== undefined
-      || set.durationSeconds !== undefined
-      || set.distanceMeters !== undefined
-      || set.rpe !== undefined
-      || set.bodyweightKg !== undefined
-      || set.assistanceKg !== undefined
-      || set.addedWeightKg !== undefined
-    ) {
-      exercise.sets.push(set);
+    for (const key of Object.keys(setValues) as (keyof typeof setValues)[]) {
+      if (setValues[key] === undefined) delete setValues[key];
+    }
+    if (Object.keys(setValues).length > 0) {
+      exercise.sets.push({
+        order: requestedOrder && requestedOrder > 0 ? requestedOrder : exercise.sets.length + 1,
+        type,
+        ...setValues,
+      });
     }
   }
 

--- a/packages/importers/test/workout-csv-planner.test.ts
+++ b/packages/importers/test/workout-csv-planner.test.ts
@@ -19,6 +19,131 @@ const STRONG_HEADER = [
 ].join(",");
 
 describe("planWorkoutCsvImport", () => {
+  test.each([
+    { column: "Reps", value: "0", expected: { reps: 0 } },
+    { column: "Weight", value: "0", expected: undefined },
+    { column: "Weight Unit", value: "kg", expected: undefined },
+    { column: "Seconds", value: "0", expected: undefined },
+    { column: "Seconds", value: "0.1", expected: { durationSeconds: 0 } },
+    { column: "Distance", value: "0", expected: undefined },
+    { column: "RPE", value: "0", expected: { rpe: 0 } },
+    { column: "Bodyweight", value: "0", expected: { bodyweightKg: 0 } },
+    { column: "Assistance", value: "0", expected: { assistanceKg: 0 } },
+    { column: "Added Weight", value: "0", expected: { addedWeightKg: 0 } },
+    { column: "Reps", value: "", expected: undefined },
+    { column: "Weight", value: "10 kg", expected: { weight: 10, weightUnit: "kg" } },
+    { column: "Distance", value: "1 km", expected: { distanceMeters: 1000 } },
+    { column: "Bodyweight", value: "10 kg", expected: { bodyweightKg: 10 } },
+    { column: "Assistance", value: "10 kg", expected: { assistanceKg: 10 } },
+    { column: "Added Weight", value: "10 kg", expected: { addedWeightKg: 10 } },
+  ])("preserves sparse set shape for $column=$value", ({ column, value, expected }) => {
+    const plan = planWorkoutCsvImport({
+      text: [
+        `Workout Name,Date,Exercise Name,${column}`,
+        `Morning,2026-03-12 07:00:00,Press,${value}`,
+      ].join("\n"),
+      timeZone: "UTC",
+      source: "hevy",
+    });
+
+    assert.equal(plan.importable, true);
+    assert.equal(plan.requiresWeightUnit, false);
+    assert.equal(plan.requiresDistanceUnit, false);
+    assert.deepEqual(
+      plan.sessions[0]?.workout.exercises.flatMap((exercise) => exercise.sets),
+      expected === undefined ? [] : [{ order: 1, type: "normal", ...expected }],
+    );
+  });
+
+  test.each(["Reps", "Weight", "Distance", "Bodyweight", "Assistance", "Added Weight"])(
+    "rejects malformed or negative %s before checking units",
+    (column) => {
+      for (const value of ["invalid", "-1"]) {
+        const plan = planWorkoutCsvImport({
+          text: [
+            `Workout Name,Date,Exercise Name,Weight Unit,${column}`,
+            `Morning,2026-03-12 07:00:00,Press,kg,${value}`,
+          ].join("\n"),
+          timeZone: "UTC",
+          source: "hevy",
+          weightUnit: "lb",
+        });
+        assert.equal(plan.importable, false);
+        assert.deepEqual(plan.sessions, []);
+        assert.deepEqual(plan.skipReasons, [{ reason: "invalid numeric set value", count: 1 }]);
+      }
+    },
+  );
+
+  test("preserves conflict precedence and the phase that records unitless warnings", () => {
+    const fixtures = [
+      {
+        columns: "Weight Kg,Weight Unit,Bodyweight Kg",
+        values: "10 lb,kg,20 lb",
+        reason: "weight units conflict within CSV metadata",
+        requiresWeightUnit: false,
+      },
+      {
+        columns: "Weight,Bodyweight Kg",
+        values: "10 kg,20 lb",
+        weightUnit: "lb" as const,
+        reason: "explicit weight unit conflicts with CSV metadata",
+        requiresWeightUnit: false,
+      },
+      {
+        columns: "Weight,Bodyweight Kg",
+        values: "10,20 lb",
+        reason: "weight units conflict within CSV metadata",
+        requiresWeightUnit: true,
+      },
+      {
+        columns: "Bodyweight Kg,Assistance Kg",
+        values: "20,10 lb",
+        weightUnit: "lb" as const,
+        reason: "weight units conflict within CSV metadata",
+        requiresWeightUnit: false,
+      },
+      {
+        columns: "Bodyweight,Assistance Kg",
+        values: "20,10 lb",
+        reason: "weight units conflict within CSV metadata",
+        requiresWeightUnit: false,
+      },
+      {
+        columns: "Bodyweight,Distance",
+        values: "20,1 km",
+        distanceUnit: "mi" as const,
+        reason: "explicit distance unit conflicts with CSV metadata",
+        requiresWeightUnit: true,
+      },
+      {
+        columns: "Weight,Bodyweight Kg,RPE",
+        values: "10,20 lb,11",
+        reason: "invalid numeric set value",
+        requiresWeightUnit: false,
+      },
+    ];
+    for (const fixture of fixtures) {
+      const plan = planWorkoutCsvImport({
+        text: [
+          `Workout Name,Date,Exercise Name,${fixture.columns}`,
+          `Morning,2026-03-12 07:00:00,Press,${fixture.values}`,
+        ].join("\n"),
+        timeZone: "UTC",
+        source: "hevy",
+        weightUnit: fixture.weightUnit,
+        distanceUnit: fixture.distanceUnit,
+      });
+
+      assert.equal(plan.importable, false, fixture.columns);
+      assert.equal(plan.skippedRowCount, 1, fixture.columns);
+      assert.deepEqual(plan.sessions, [], fixture.columns);
+      assert.deepEqual(plan.skipReasons, [{ reason: fixture.reason, count: 1 }], fixture.columns);
+      assert.equal(plan.requiresWeightUnit, fixture.requiresWeightUnit, fixture.columns);
+      assert.equal(plan.requiresDistanceUnit, false, fixture.columns);
+    }
+  });
+
   test("maps Strong rows in the vault timezone and preserves set tags and notes", () => {
     const plan = planWorkoutCsvImport({
       text: [


### PR DESCRIPTION
## Why and outcome

Workout CSV planning repeated the same load-unit decisions for the primary weight and three auxiliary loads, then checked optional set values once during assembly and again during admission. Reuse one metadata resolver and derive admission from the normalized set values. Consolidate the repeated numeric-presence and header-unit checks at the same owner.

`buildSessions` falls from complexity 111 to 74; total file complexity falls from 417 to 378. Source shrinks by six lines. Strong/Hevy plan contents, grouping, source identities, zero handling, unit authority, and validation/warning order stay the same.

## Product UX

- Effort: Not applicable — internal maintainability refactor with unchanged planner behavior.
- Result: Ready.
- Walkthrough: Existing Strong/Hevy import cases and synthetic sparse, zero, invalid, and conflicting-unit cases pass through the public planner. No changed user journey, permission, persistence, or UI. Product proof is limited to the existing non-writing planner boundary.

## Evidence

- Direct: `pnpm --dir packages/importers exec vitest run --config vitest.config.ts --no-coverage test/workout-csv-planner.test.ts` — 50 focused tests pass; the final run included the temporary differential test alongside this file, for 51 passing tests total.
- Coverage: A temporary baseline/head harness compared 2,886 complete plans: 512 optional-field combinations each with zero, positive, and fractional values, plus 1,350 combinations of unit values, headers, cells, and explicit overrides. All plans matched by deep equality. Temporary baseline/harness files were removed after verification. Committed regressions cover sparse set shape, malformed/negative numbers, metadata conflict precedence, and flags retained before later row rejection.
- Typecheck: `pnpm --dir packages/importers typecheck` — passed.
- Hygiene: `git diff --check` and task-file privacy review — passed; commit author and committer use neutral task-local metadata.
- Broad exact-head CI and parent candidate/final review remain pending after parent candidate review.

## Non-obvious affected surfaces

Unit confirmation can remain required even when a later auxiliary or distance check rejects a row. Regression cases preserve that existing warning timing and the primary/auxiliary conflict precedence. No other owner changes.

## Architecture and reuse

- Existing systems reused: Existing non-writing workout CSV planner, numeric/unit parsers, and canonical `WorkoutSet` type.
- New logic: No new product rule; repeated numeric-presence checks and optional output inclusion use one local pass each.
- New abstractions: One private `resolveWeightMetadata` helper (complexity 9), shared by the four existing load fields, replaces duplicate conflict, resolution, warning, and conversion predicates.
- Complexity intentionally avoided: No new package, dependency, schema, state owner, parser framework, public API, or behavior-relocating module split.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base HEAD^ --head HEAD -- packages/importers/src/workout-csv-planner.ts`. File debt 104 → 67; maximum 111 → 74; total complexity 417 → 378.
- Hotspots: `buildSessions` 111 → 74 preserves existing identity, session, and dialect sequencing. Unchanged `parseSetDurationSeconds` 22, `parseDurationMinutes` 25, and `planWorkoutCsvImport` 26 remain in the changed file and are outside this load/set seam.
- Agent judgment: This removes duplicate decisions and reduces aggregate complexity. Further decomposition of the retained identity/session flow would relocate distinct policy rather than collapse a demonstrated duplicate in this scope.

## Hot reply path impact

- Path status: Not applicable — this changes synchronous workout CSV planning, not durable message acceptance, provider start, or reply handoff.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Complete plan equivalence and focused planner tests; no hot-path timing measurement is claimed.

## Murph initial provider input impact

Not applicable for individual and group runtimes: this changes importer internals and tests, not prompts, provider payload assembly, tool schemas, deferred metadata, or generated guidance.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal, behavior-preserving planner refactor with no storage, schema, API, migration, or independently deployed protocol change.

## Change-shape breakdown

Classification rule: Importer implementation is source; planner tests are tests; the completed execution plan is docs. No binary, generated, configuration, or tooling changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 63 | 69 |
| Tests / fixtures | 125 | 0 |
| Docs | 65 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **253** | **69** |

## Changelog

- Changelog: not applicable
- Reason: Internal maintainability refactor with identical workout CSV planning behavior and no member-visible change.

ReviewGPT first-reviewed head: 8075b4bdc6d1f79c9f3f50c33582f27da7ba91e0
ReviewGPT context sensitivity: sensitive
Classification reason: Workout import planning preserves weight-unit authority, warning timing, and health record output.

## Final review evidence

- Round 1: PASS on 8075b4bdc6d1f79c9f3f50c33582f27da7ba91e0; zero findings received, accepted, or rejected.
- Scope and identity: Full immutable snapshot and diff reviewed; response hashes, captured turn, model, and exact head were verified.
- Model and lane: gpt-6-pro on apollo. The successful wrapper enforced at least 270 seconds; exact elapsed time was not persisted.
- Tooling retries: None. Tooling retries did not advance the substantive round.
