### PR TITLE
refactor(importers): isolate Junction canonical coverage

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-junction-canonical-coverage.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-junction-canonical-coverage.md
@@ -1,0 +1,67 @@
+# Extract Junction canonical coverage policy
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+Separate accepted-event coverage and cutover admission from raw Junction normalization so each policy has one navigable owner without changing imported facts.
+
+## Success criteria
+
+- Coverage derives only from accepted canonical writer results.
+- Fence filtering preserves event-array identity and order and runs before authoritative-set finalization.
+- Public importer exports, timestamp acceptance, and cancellation propagation remain unchanged.
+- Focused importer, package-boundary, device-sync migration/history tests and both package typechecks pass.
+
+## Scope
+
+- In scope: internal Junction coverage module, existing normalization timestamp primitives, direct internal caller imports, focused proof, and ownership documentation.
+- Out of scope: provider diagnostics, resource-by-resource normalization splits, canonical writer changes, schema changes, and hosted behavior.
+
+## Constraints
+
+- Reuse Junction resource and origin policy owners. No new dependencies or public subpaths.
+- Keep canonical writes, cancellation, source lifecycle fences, and migration persistence at their current owners.
+- Root owns candidate review, Ready, ReviewGPT, exact-head CI, and merge decisions.
+
+## Risks and mitigations
+
+1. Timestamp parsing changes while sharing leaves.
+   Mitigation: move the existing permissive parser unchanged; do not substitute strict toIso.
+2. Fence extraction disconnects the returned array or changes authoritative sets.
+   Mitigation: pass the original events array and retain in-place splice at the same normalization stage.
+3. Accepted coverage is accidentally derived from proposed facts.
+   Mitigation: keep the caller after the writer result and retain canonical-import integration proof.
+
+## Tasks
+
+1. Confirm current callers and owners against the assigned base.
+2. Move coverage types and algorithms into junction-canonical-coverage.ts and share unchanged timestamp leaves through shared-normalization.ts.
+3. Preserve public exports and update direct internal callers plus focused ownership documentation.
+4. Run focused tests, typechecks, complexity diff, privacy checks, and self-review.
+5. Close this plan with a scoped commit, push, and open a draft PR for parent completion.
+
+## Decisions
+
+- Baseline: b2a559812972d70644cffb2bf43923fc9211047d.
+- Internal extraction only; no product or persisted-contract change and no changelog item.
+- Existing coverage tests exercise provider-local day closure, accepted timestamps, migration fences, and canonical-import composition.
+
+## Verification
+
+- Passed: importer Junction and package-boundary suites, 263 tests, with maxWorkers=2.
+- Passed: importer cancellation selection, 2 tests, with maxWorkers=1.
+- Passed: device-sync migration/history/cancellation selection, 10 tests, with maxWorkers=1.
+- Passed: `pnpm --filter @murphai/importers typecheck` and `pnpm --filter @murphai/device-syncd typecheck`.
+- Passed: `pnpm --filter @murphai/importers build`, including emitted public coverage reexports.
+- Passed: `pnpm complexity:diff --base b2a559812972d70644cffb2bf43923fc9211047d`; new coverage maximum 16 and no added debt. Eleven existing normalizer hotspots remain unchanged and outside this extraction.
+- Passed: moved coverage body and timestamp leaves match the base text except for the narrower fence event-array argument; cancellation bridge changes only its import.
+- Passed: parent initial review, `git diff --check`, scoped-path review, and privacy review.
+- Exact-head CI and final ReviewGPT remain with the parent completion owner after the draft handoff.
+
+## Outcome
+
+Coverage types, derivation, provider-day closure, and fence admission now live in one internal module. Public exports remain compatible; source/resource primitives remain with their existing owners. The original event array is filtered in place before authoritative-set finalization, and only accepted canonical writer results produce coverage. No product, persisted-schema, cancellation, or provider-request behavior changed.
+Completed: 2026-09-10

--- a/packages/importers/README.md
+++ b/packages/importers/README.md
@@ -26,6 +26,12 @@ If a provider adapter returns a non-empty snapshot without any provider-owned ra
 
 Built-in providers now share one descriptor surface in `device-providers/provider-descriptors.ts`. That descriptor is the single source for provider key, transport modes, OAuth paths/scopes, webhook support, default sync windows, metric families, and source-priority hints, so importers and `device-syncd` no longer drift on provider metadata.
 
+Junction's `device-providers/junction-canonical-coverage.ts` owns accepted-event
+coverage, provider-day finalization, and migration fence admission. The snapshot
+import bridge derives coverage from the canonical writer's returned events.
+Normalization applies the fence to its original event array before finalizing
+authoritative sets; device-sync continues to own persisted migration progress.
+
 The iOS companion's direct WHOOP overnight-HRV path is a deliberately narrower
 Junction-account ingress rather than a fourth transport provider. It accepts
 only the strict `murph.companion.overnight-prv-rmssd.v1` derived observation

--- a/packages/importers/src/device-providers/import-device-provider-snapshot.ts
+++ b/packages/importers/src/device-providers/import-device-provider-snapshot.ts
@@ -17,7 +17,7 @@ import {
 } from "../shared.ts";
 
 import { defaultDeviceProviderAdapters } from "./defaults.ts";
-import { deriveJunctionCanonicalCoverageEvidence } from "./junction.ts";
+import { deriveJunctionCanonicalCoverageEvidence } from "./junction-canonical-coverage.ts";
 import { buildWearableRawIngestReceipt } from "./raw-ingest-receipt.ts";
 import { createDeviceProviderRegistry } from "./registry.ts";
 

--- a/packages/importers/src/device-providers/junction-canonical-coverage.ts
+++ b/packages/importers/src/device-providers/junction-canonical-coverage.ts
@@ -1,0 +1,287 @@
+import { addDaysToIsoDate, toLocalDayKey } from "@murphai/contracts";
+
+import { normalizeJunctionSourceProviderSlug } from "./junction-origin.ts";
+import {
+  JUNCTION_ALLOWED_SUMMARY_RESOURCES,
+  JUNCTION_ALLOWED_TIMESERIES_RESOURCES,
+  isJunctionDailyCanonicalCoverageResource,
+  maxJunctionCanonicalCoverageBoundary,
+  normalizeJunctionCanonicalCoverageBoundary,
+} from "./junction-resources.ts";
+import {
+  asPlainObject,
+  laterOptionalIsoTimestamp,
+  normalizeProviderTimestamp as normalizeTimestamp,
+  slugify,
+} from "./shared-normalization.ts";
+
+export interface JunctionCanonicalCoverageFence {
+  readonly coverageBoundaryByResource: Readonly<Record<string, string | null>>;
+  readonly sourceProviderSlug: string;
+}
+
+export interface JunctionCanonicalCoverageEvidence {
+  readonly coverageBoundary: string;
+  readonly coverageFinalizedAt?: string;
+  readonly resource: string;
+  readonly sourceProviderSlug: string;
+}
+
+export interface JunctionCanonicalCoverageDerivationOptions {
+  readonly providerPulledAt?: string;
+}
+
+export interface JunctionCanonicalCoverageEvent {
+  readonly dataOrigin?: {
+    readonly sourceProviderSlug?: string;
+    readonly timeZoneOffsetMinutes?: number | null;
+  };
+  readonly dayKey?: string;
+  readonly endAt?: string;
+  readonly externalRef?: { readonly resourceType: string };
+  readonly fields?: Readonly<Record<string, unknown>>;
+  readonly kind: string;
+  readonly occurredAt: string;
+  readonly sample?: { readonly endAt?: string };
+  readonly timeZone?: string;
+  readonly workout?: { readonly endedAt?: string };
+}
+
+const JUNCTION_CANONICAL_COVERAGE_RESOURCES: readonly string[] = [
+  ...JUNCTION_ALLOWED_SUMMARY_RESOURCES.filter((resource) => resource !== "profile"),
+  ...JUNCTION_ALLOWED_TIMESERIES_RESOURCES,
+];
+
+export function deriveJunctionCanonicalCoverageEvidence(
+  events: readonly JunctionCanonicalCoverageEvent[],
+  options?: JunctionCanonicalCoverageDerivationOptions,
+): readonly JunctionCanonicalCoverageEvidence[] {
+  const coverageBySourceAndResource = new Map<string, {
+    evidence: JunctionCanonicalCoverageEvidence;
+    providerDayClosedAt?: string;
+  }>();
+  for (const event of events) {
+    const evidence = resolveJunctionCanonicalCoverageEvidence(event);
+    if (!evidence) {
+      continue;
+    }
+    const providerDayClosedAt = isJunctionDailyCanonicalCoverageResource(evidence.resource)
+      ? resolveJunctionProviderDayClosedAt(evidence.coverageBoundary, event)
+      : undefined;
+
+    const key = `${evidence.sourceProviderSlug}\u0000${evidence.resource}`;
+    const existing = coverageBySourceAndResource.get(key);
+    if (
+      !existing
+      || maxJunctionCanonicalCoverageBoundary(
+          evidence.resource,
+          existing.evidence.coverageBoundary,
+          evidence.coverageBoundary,
+        ) === evidence.coverageBoundary
+    ) {
+      coverageBySourceAndResource.set(
+        key,
+        existing?.evidence.coverageBoundary === evidence.coverageBoundary
+          ? {
+              evidence,
+              providerDayClosedAt: laterOptionalIsoTimestamp(
+                existing.providerDayClosedAt,
+                providerDayClosedAt,
+              ),
+            }
+          : { evidence, providerDayClosedAt },
+      );
+    }
+  }
+
+  const providerPulledAt = normalizeJunctionCoverageProviderPulledAt(
+    options?.providerPulledAt,
+  );
+  return [...coverageBySourceAndResource.values()]
+    .map(({ evidence, providerDayClosedAt }) =>
+      providerPulledAt
+        && providerDayClosedAt
+        && providerPulledAt >= providerDayClosedAt
+        ? { ...evidence, coverageFinalizedAt: providerPulledAt }
+        : evidence
+    )
+    .sort((left, right) =>
+      left.sourceProviderSlug.localeCompare(right.sourceProviderSlug)
+      || left.resource.localeCompare(right.resource)
+    );
+}
+
+const JUNCTION_PROVIDER_DAY_LATEST_UNPROVEN_CLOSE_OFFSET_MINUTES = -12 * 60;
+
+function resolveJunctionProviderDayClosedAt(
+  dayKey: string,
+  event: JunctionCanonicalCoverageEvent,
+): string {
+  const timeZone = event.timeZone?.trim();
+  if (timeZone) {
+    const timeZoneClose = resolveJunctionProviderDayClosedAtInTimeZone(
+      dayKey,
+      timeZone,
+    );
+    if (timeZoneClose) {
+      return timeZoneClose;
+    }
+  }
+
+  const offsetMinutes = event.dataOrigin?.timeZoneOffsetMinutes;
+  if (
+    Number.isInteger(offsetMinutes)
+    && offsetMinutes !== null
+    && offsetMinutes !== undefined
+    && Math.abs(offsetMinutes) <= 24 * 60
+  ) {
+    return resolveJunctionProviderDayClosedAtOffset(dayKey, offsetMinutes);
+  }
+
+  // Junction's closed-calendar importer waits until a date has closed at
+  // UTC-12. Date-only accepted records therefore converge safely without
+  // borrowing the member's mutable vault timezone.
+  return resolveJunctionProviderDayClosedAtOffset(
+    dayKey,
+    JUNCTION_PROVIDER_DAY_LATEST_UNPROVEN_CLOSE_OFFSET_MINUTES,
+  );
+}
+
+function resolveJunctionProviderDayClosedAtInTimeZone(
+  dayKey: string,
+  timeZone: string,
+): string | undefined {
+  try {
+    const nextDayKey = addDaysToIsoDate(dayKey, 1);
+    const nominalNextDayMs = Date.parse(`${nextDayKey}T00:00:00.000Z`);
+    let lowerBoundMs = nominalNextDayMs - 36 * 60 * 60_000;
+    let upperBoundMs = nominalNextDayMs + 36 * 60 * 60_000;
+    if (
+      toLocalDayKey(lowerBoundMs, timeZone) > dayKey
+      || toLocalDayKey(upperBoundMs, timeZone) <= dayKey
+    ) {
+      return undefined;
+    }
+
+    while (upperBoundMs - lowerBoundMs > 1) {
+      const midpointMs = Math.floor((lowerBoundMs + upperBoundMs) / 2);
+      if (toLocalDayKey(midpointMs, timeZone) > dayKey) {
+        upperBoundMs = midpointMs;
+      } else {
+        lowerBoundMs = midpointMs;
+      }
+    }
+    return new Date(upperBoundMs).toISOString();
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveJunctionProviderDayClosedAtOffset(
+  dayKey: string,
+  offsetMinutes: number,
+): string {
+  const nextDayKey = addDaysToIsoDate(dayKey, 1);
+  const nominalNextDayMs = Date.parse(`${nextDayKey}T00:00:00.000Z`);
+  return new Date(nominalNextDayMs - offsetMinutes * 60_000).toISOString();
+}
+
+function normalizeJunctionCoverageProviderPulledAt(
+  providerPulledAt: string | undefined,
+): string | undefined {
+  if (!providerPulledAt) {
+    return undefined;
+  }
+  const providerPulledAtMs = Date.parse(providerPulledAt);
+  if (!Number.isFinite(providerPulledAtMs)) {
+    return undefined;
+  }
+  const normalizedProviderPulledAt = new Date(providerPulledAtMs).toISOString();
+  return normalizedProviderPulledAt === providerPulledAt
+    ? normalizedProviderPulledAt
+    : undefined;
+}
+
+export function applyJunctionCanonicalCoverageFence<Event extends JunctionCanonicalCoverageEvent>(
+  events: Event[],
+  fence: JunctionCanonicalCoverageFence | undefined,
+): void {
+  const sourceProviderSlug = normalizeJunctionSourceProviderSlug(
+    fence?.sourceProviderSlug,
+  );
+  if (!fence || !sourceProviderSlug) {
+    return;
+  }
+
+  const admittedEvents = events.filter((event) => {
+    if (
+      normalizeJunctionSourceProviderSlug(event.dataOrigin?.sourceProviderSlug)
+        !== sourceProviderSlug
+    ) {
+      return true;
+    }
+    const evidence = resolveJunctionCanonicalCoverageEvidence(event);
+    if (!evidence) {
+      return event.externalRef?.resourceType
+        === `junction-${slugify(sourceProviderSlug, "source")}-profile`;
+    }
+    if (!(evidence.resource in fence.coverageBoundaryByResource)) {
+      return true;
+    }
+    const legacyCoverageBoundary = normalizeJunctionCanonicalCoverageBoundary(
+      evidence.resource,
+      fence.coverageBoundaryByResource[evidence.resource],
+    );
+    return legacyCoverageBoundary !== null
+      && evidence.coverageBoundary > legacyCoverageBoundary;
+  });
+  events.splice(0, events.length, ...admittedEvents);
+}
+
+function resolveJunctionCanonicalCoverageEvidence(
+  event: JunctionCanonicalCoverageEvent,
+): JunctionCanonicalCoverageEvidence | null {
+  const sourceProviderSlug = normalizeJunctionSourceProviderSlug(
+    event.dataOrigin?.sourceProviderSlug,
+  );
+  const externalRefResourceType = event.externalRef?.resourceType;
+  if (!sourceProviderSlug || !externalRefResourceType) {
+    return null;
+  }
+
+  const resource = JUNCTION_CANONICAL_COVERAGE_RESOURCES.find((candidate) =>
+    externalRefResourceType
+      === `junction-${slugify(sourceProviderSlug, "source")}-${slugify(candidate, "resource")}`
+  );
+  if (!resource) {
+    return null;
+  }
+
+  const coverageBoundary = normalizeJunctionCanonicalCoverageBoundary(
+    resource,
+    isJunctionDailyCanonicalCoverageResource(resource)
+    ? event.dayKey
+    : resolveCanonicalEventIntervalEnd(event),
+  );
+  return coverageBoundary
+    ? { coverageBoundary, resource, sourceProviderSlug }
+    : null;
+}
+
+function resolveCanonicalEventIntervalEnd(
+  event: JunctionCanonicalCoverageEvent,
+): string | null {
+  if (event.kind === "sleep_session") {
+    return normalizeTimestamp(event.endAt ?? event.fields?.endAt) ?? null;
+  }
+  if (event.kind === "activity_session") {
+    const fieldsWorkout = asPlainObject(event.fields?.workout);
+    return normalizeTimestamp(event.workout?.endedAt ?? fieldsWorkout?.endedAt)
+      ?? normalizeTimestamp(event.occurredAt)
+      ?? null;
+  }
+  if (event.sample?.endAt) {
+    return normalizeTimestamp(event.sample.endAt) ?? null;
+  }
+  return normalizeTimestamp(event.occurredAt) ?? null;
+}

--- a/packages/importers/src/device-providers/junction.ts
+++ b/packages/importers/src/device-providers/junction.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
 
 import {
-  addDaysToIsoDate,
   extractIsoDatePrefix,
   formatTimeZoneDateTimeParts,
   ID_PREFIXES,
@@ -32,6 +31,9 @@ import {
   createEvidencePart,
   finiteNumber,
   kilojoulesToKilocalories,
+  laterIsoTimestamp,
+  laterOptionalIsoTimestamp,
+  normalizeProviderTimestamp as normalizeTimestamp,
   makeNormalizedDeviceBatch,
   makeProviderExternalRef,
   minutesBetween,
@@ -79,9 +81,6 @@ import {
   JUNCTION_SLEEP_TIME_IN_BED_SECOND_PATHS,
   JUNCTION_SLEEP_TOTAL_MINUTE_PATHS,
   JUNCTION_SLEEP_TOTAL_SECOND_PATHS,
-  isJunctionDailyCanonicalCoverageResource,
-  maxJunctionCanonicalCoverageBoundary,
-  normalizeJunctionCanonicalCoverageBoundary,
   JUNCTION_TIMESERIES_RESOURCE_POLICIES,
   isJunctionRawDirectIdentityContainerKey,
   isJunctionRawDirectIdentityKey,
@@ -148,7 +147,19 @@ import type {
   DeviceProviderNormalizationContext,
   NormalizedDeviceBatch,
 } from "./types.ts";
+import {
+  applyJunctionCanonicalCoverageFence,
+  type JunctionCanonicalCoverageFence,
+} from "./junction-canonical-coverage.ts";
 import { JUNCTION_DEVICE_PROVIDER_DESCRIPTOR } from "./provider-descriptors.ts";
+
+export {
+  deriveJunctionCanonicalCoverageEvidence,
+  type JunctionCanonicalCoverageDerivationOptions,
+  type JunctionCanonicalCoverageEvent,
+  type JunctionCanonicalCoverageEvidence,
+  type JunctionCanonicalCoverageFence,
+} from "./junction-canonical-coverage.ts";
 
 export {
   JUNCTION_DENSE_FIDELITY_RESOURCES,
@@ -198,11 +209,6 @@ export interface JunctionSnapshotInput {
   canonicalCoverageProviderPulledAt?: string;
 }
 
-export interface JunctionCanonicalCoverageFence {
-  readonly coverageBoundaryByResource: Readonly<Record<string, string | null>>;
-  readonly sourceProviderSlug: string;
-}
-
 export type JunctionTimeseriesWindowKind = "calendar_day" | "precise";
 
 export interface JunctionSparseCalendarRepairExpectation {
@@ -229,33 +235,6 @@ export interface JunctionSummaryNormalizationEvidenceWindow {
 export interface JunctionBloodPressureProviderRecordIdentityEvidence {
   readonly providerRecordCount: number;
   readonly repairStableExternalRefResourceIds: readonly (string | null)[];
-}
-
-export interface JunctionCanonicalCoverageEvidence {
-  readonly coverageBoundary: string;
-  readonly coverageFinalizedAt?: string;
-  readonly resource: string;
-  readonly sourceProviderSlug: string;
-}
-
-export interface JunctionCanonicalCoverageDerivationOptions {
-  readonly providerPulledAt?: string;
-}
-
-export interface JunctionCanonicalCoverageEvent {
-  readonly dataOrigin?: {
-    readonly sourceProviderSlug?: string;
-    readonly timeZoneOffsetMinutes?: number | null;
-  };
-  readonly dayKey?: string;
-  readonly endAt?: string;
-  readonly externalRef?: { readonly resourceType: string };
-  readonly fields?: Readonly<Record<string, unknown>>;
-  readonly kind: string;
-  readonly occurredAt: string;
-  readonly sample?: { readonly endAt?: string };
-  readonly timeZone?: string;
-  readonly workout?: { readonly endedAt?: string };
 }
 
 export interface JunctionDailyTimeseriesAggregateIdentity {
@@ -374,10 +353,6 @@ const RAW_SOURCE_NAME_KEYS = new Set([
   "name",
 ]);
 
-const JUNCTION_CANONICAL_COVERAGE_RESOURCES: readonly string[] = [
-  ...JUNCTION_ALLOWED_SUMMARY_RESOURCES.filter((resource) => resource !== "profile"),
-  ...JUNCTION_ALLOWED_TIMESERIES_RESOURCES,
-];
 const RAW_SOURCE_LINKAGE_KEY_PARTS = [
   "connectionid",
   "providerconnectionid",
@@ -1274,7 +1249,7 @@ export function normalizeJunctionSnapshot(
   normalizeTimeseries(snapshot.timeseries, context);
   normalizeCompanionHrvRmssd(companionHrvRmssd, context);
   applyJunctionCanonicalCoverageFence(
-    context,
+    events,
     snapshot.canonicalCoverageFence,
   );
   finalizeJunctionTemporalAuthoritativeSets(context);
@@ -1315,241 +1290,6 @@ export function normalizeJunctionSnapshot(
  * local day closed accepts that day. Inline payloads can advance the fence but
  * cannot finalize it. Interval coverage remains anchored to its accepted end.
  */
-export function deriveJunctionCanonicalCoverageEvidence(
-  events: readonly JunctionCanonicalCoverageEvent[],
-  options?: JunctionCanonicalCoverageDerivationOptions,
-): readonly JunctionCanonicalCoverageEvidence[] {
-  const coverageBySourceAndResource = new Map<string, {
-    evidence: JunctionCanonicalCoverageEvidence;
-    providerDayClosedAt?: string;
-  }>();
-  for (const event of events) {
-    const evidence = resolveJunctionCanonicalCoverageEvidence(event);
-    if (!evidence) {
-      continue;
-    }
-    const providerDayClosedAt = isJunctionDailyCanonicalCoverageResource(evidence.resource)
-      ? resolveJunctionProviderDayClosedAt(evidence.coverageBoundary, event)
-      : undefined;
-
-    const key = `${evidence.sourceProviderSlug}\u0000${evidence.resource}`;
-    const existing = coverageBySourceAndResource.get(key);
-    if (
-      !existing
-      || maxJunctionCanonicalCoverageBoundary(
-          evidence.resource,
-          existing.evidence.coverageBoundary,
-          evidence.coverageBoundary,
-        ) === evidence.coverageBoundary
-    ) {
-      coverageBySourceAndResource.set(
-        key,
-        existing?.evidence.coverageBoundary === evidence.coverageBoundary
-          ? {
-              evidence,
-              providerDayClosedAt: laterOptionalIsoTimestamp(
-                existing.providerDayClosedAt,
-                providerDayClosedAt,
-              ),
-            }
-          : { evidence, providerDayClosedAt },
-      );
-    }
-  }
-
-  const providerPulledAt = normalizeJunctionCoverageProviderPulledAt(
-    options?.providerPulledAt,
-  );
-  return [...coverageBySourceAndResource.values()]
-    .map(({ evidence, providerDayClosedAt }) =>
-      providerPulledAt
-        && providerDayClosedAt
-        && providerPulledAt >= providerDayClosedAt
-        ? { ...evidence, coverageFinalizedAt: providerPulledAt }
-        : evidence
-    )
-    .sort((left, right) =>
-      left.sourceProviderSlug.localeCompare(right.sourceProviderSlug)
-      || left.resource.localeCompare(right.resource)
-    );
-}
-
-const JUNCTION_PROVIDER_DAY_LATEST_UNPROVEN_CLOSE_OFFSET_MINUTES = -12 * 60;
-
-function resolveJunctionProviderDayClosedAt(
-  dayKey: string,
-  event: JunctionCanonicalCoverageEvent,
-): string {
-  const timeZone = event.timeZone?.trim();
-  if (timeZone) {
-    const timeZoneClose = resolveJunctionProviderDayClosedAtInTimeZone(
-      dayKey,
-      timeZone,
-    );
-    if (timeZoneClose) {
-      return timeZoneClose;
-    }
-  }
-
-  const offsetMinutes = event.dataOrigin?.timeZoneOffsetMinutes;
-  if (
-    Number.isInteger(offsetMinutes)
-    && offsetMinutes !== null
-    && offsetMinutes !== undefined
-    && Math.abs(offsetMinutes) <= 24 * 60
-  ) {
-    return resolveJunctionProviderDayClosedAtOffset(dayKey, offsetMinutes);
-  }
-
-  // Junction's closed-calendar importer waits until a date has closed at
-  // UTC-12. Date-only accepted records therefore converge safely without
-  // borrowing the member's mutable vault timezone.
-  return resolveJunctionProviderDayClosedAtOffset(
-    dayKey,
-    JUNCTION_PROVIDER_DAY_LATEST_UNPROVEN_CLOSE_OFFSET_MINUTES,
-  );
-}
-
-function resolveJunctionProviderDayClosedAtInTimeZone(
-  dayKey: string,
-  timeZone: string,
-): string | undefined {
-  try {
-    const nextDayKey = addDaysToIsoDate(dayKey, 1);
-    const nominalNextDayMs = Date.parse(`${nextDayKey}T00:00:00.000Z`);
-    let lowerBoundMs = nominalNextDayMs - 36 * 60 * 60_000;
-    let upperBoundMs = nominalNextDayMs + 36 * 60 * 60_000;
-    if (
-      toLocalDayKey(lowerBoundMs, timeZone) > dayKey
-      || toLocalDayKey(upperBoundMs, timeZone) <= dayKey
-    ) {
-      return undefined;
-    }
-
-    while (upperBoundMs - lowerBoundMs > 1) {
-      const midpointMs = Math.floor((lowerBoundMs + upperBoundMs) / 2);
-      if (toLocalDayKey(midpointMs, timeZone) > dayKey) {
-        upperBoundMs = midpointMs;
-      } else {
-        lowerBoundMs = midpointMs;
-      }
-    }
-    return new Date(upperBoundMs).toISOString();
-  } catch {
-    return undefined;
-  }
-}
-
-function resolveJunctionProviderDayClosedAtOffset(
-  dayKey: string,
-  offsetMinutes: number,
-): string {
-  const nextDayKey = addDaysToIsoDate(dayKey, 1);
-  const nominalNextDayMs = Date.parse(`${nextDayKey}T00:00:00.000Z`);
-  return new Date(nominalNextDayMs - offsetMinutes * 60_000).toISOString();
-}
-
-function normalizeJunctionCoverageProviderPulledAt(
-  providerPulledAt: string | undefined,
-): string | undefined {
-  if (!providerPulledAt) {
-    return undefined;
-  }
-  const providerPulledAtMs = Date.parse(providerPulledAt);
-  if (!Number.isFinite(providerPulledAtMs)) {
-    return undefined;
-  }
-  const normalizedProviderPulledAt = new Date(providerPulledAtMs).toISOString();
-  return normalizedProviderPulledAt === providerPulledAt
-    ? normalizedProviderPulledAt
-    : undefined;
-}
-
-function applyJunctionCanonicalCoverageFence(
-  context: NormalizationContext,
-  fence: JunctionCanonicalCoverageFence | undefined,
-): void {
-  const sourceProviderSlug = normalizeJunctionSourceProviderSlug(
-    fence?.sourceProviderSlug,
-  );
-  if (!fence || !sourceProviderSlug) {
-    return;
-  }
-
-  const admittedEvents = context.events.filter((event) => {
-    if (
-      normalizeJunctionSourceProviderSlug(event.dataOrigin?.sourceProviderSlug)
-        !== sourceProviderSlug
-    ) {
-      return true;
-    }
-    const evidence = resolveJunctionCanonicalCoverageEvidence(event);
-    if (!evidence) {
-      return event.externalRef?.resourceType
-        === `junction-${slugify(sourceProviderSlug, "source")}-profile`;
-    }
-    if (!(evidence.resource in fence.coverageBoundaryByResource)) {
-      return true;
-    }
-    const legacyCoverageBoundary = normalizeJunctionCanonicalCoverageBoundary(
-      evidence.resource,
-      fence.coverageBoundaryByResource[evidence.resource],
-    );
-    return legacyCoverageBoundary !== null
-      && evidence.coverageBoundary > legacyCoverageBoundary;
-  });
-  context.events.splice(0, context.events.length, ...admittedEvents);
-}
-
-function resolveJunctionCanonicalCoverageEvidence(
-  event: JunctionCanonicalCoverageEvent,
-): JunctionCanonicalCoverageEvidence | null {
-  const sourceProviderSlug = normalizeJunctionSourceProviderSlug(
-    event.dataOrigin?.sourceProviderSlug,
-  );
-  const externalRefResourceType = event.externalRef?.resourceType;
-  if (!sourceProviderSlug || !externalRefResourceType) {
-    return null;
-  }
-
-  const resource = JUNCTION_CANONICAL_COVERAGE_RESOURCES.find((candidate) =>
-    externalRefResourceType
-      === `junction-${slugify(sourceProviderSlug, "source")}-${slugify(candidate, "resource")}`
-  );
-  if (!resource) {
-    return null;
-  }
-
-  const coverageBoundary = normalizeJunctionCanonicalCoverageBoundary(
-    resource,
-    isJunctionDailyCanonicalCoverageResource(resource)
-    ? event.dayKey
-    : resolveCanonicalEventIntervalEnd(event),
-  );
-  return coverageBoundary
-    ? { coverageBoundary, resource, sourceProviderSlug }
-    : null;
-}
-
-function resolveCanonicalEventIntervalEnd(
-  event: JunctionCanonicalCoverageEvent,
-): string | null {
-  if (event.kind === "sleep_session") {
-    return normalizeTimestamp(event.endAt ?? event.fields?.endAt) ?? null;
-  }
-  if (event.kind === "activity_session") {
-    const fieldsWorkout = asPlainObject(event.fields?.workout);
-    return normalizeTimestamp(event.workout?.endedAt ?? fieldsWorkout?.endedAt)
-      ?? normalizeTimestamp(event.occurredAt)
-      ?? null;
-  }
-  if (event.sample?.endAt) {
-    return normalizeTimestamp(event.sample.endAt) ?? null;
-  }
-  return normalizeTimestamp(event.occurredAt) ?? null;
-}
-
-
 export function classifyJunctionSummaryNormalizationEvidence(
   snapshot: Pick<
     JunctionSnapshotInput,
@@ -7488,22 +7228,6 @@ function earlierIsoTimestamp(left: string, right: string): string {
   return Date.parse(right) < Date.parse(left) ? right : left;
 }
 
-function laterIsoTimestamp(left: string, right: string): string {
-  return Date.parse(right) > Date.parse(left) ? right : left;
-}
-
-function laterOptionalIsoTimestamp(left: string | undefined, right: string | undefined): string | undefined {
-  if (!left) {
-    return right;
-  }
-
-  if (!right) {
-    return left;
-  }
-
-  return laterIsoTimestamp(left, right);
-}
-
 function resolveSleepStageAnchorDayKey(
   coverageEndAt: string,
   timeZone: string | undefined,
@@ -10213,23 +9937,6 @@ function isAppleHealthKitSourceProvider(sourceProviderSlug: string | undefined):
 
 function isJunctionAppleGenericAsleepStageValue(value: unknown): boolean {
   return value === -1 || (typeof value === "string" && value.trim() === "-1");
-}
-
-function normalizeTimestamp(value: unknown): string | undefined {
-  if (value instanceof Date && Number.isFinite(value.getTime())) {
-    return value.toISOString();
-  }
-
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return new Date(value).toISOString();
-  }
-
-  if (typeof value !== "string" || !value.trim()) {
-    return undefined;
-  }
-
-  const time = Date.parse(value);
-  return Number.isFinite(time) ? new Date(time).toISOString() : undefined;
 }
 
 function resolveJunctionFloatingTimestampTimeZone(

--- a/packages/importers/src/device-providers/shared-normalization.ts
+++ b/packages/importers/src/device-providers/shared-normalization.ts
@@ -185,6 +185,40 @@ export function toIso(value: unknown): string | undefined {
   return normalizeTimestamp(value, "timestamp");
 }
 
+/** Preserve provider date-string acceptance without applying the strict event timestamp schema. */
+export function normalizeProviderTimestamp(value: unknown): string | undefined {
+  if (value instanceof Date && Number.isFinite(value.getTime())) {
+    return value.toISOString();
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+
+  const time = Date.parse(value);
+  return Number.isFinite(time) ? new Date(time).toISOString() : undefined;
+}
+
+export function laterIsoTimestamp(left: string, right: string): string {
+  return Date.parse(right) > Date.parse(left) ? right : left;
+}
+
+export function laterOptionalIsoTimestamp(left: string | undefined, right: string | undefined): string | undefined {
+  if (!left) {
+    return right;
+  }
+
+  if (!right) {
+    return left;
+  }
+
+  return laterIsoTimestamp(left, right);
+}
+
 export function minutesBetween(startAt: string | undefined, endAt: string | undefined): number | undefined {
   if (!startAt || !endAt) {
     return undefined;

--- a/packages/importers/test/device-providers-junction.test.ts
+++ b/packages/importers/test/device-providers-junction.test.ts
@@ -16306,6 +16306,50 @@ test("Junction migration interval coverage uses the accepted canonical end", () 
   );
 });
 
+test("Junction migration interval coverage preserves provider timestamp acceptance", () => {
+  const canonicalEnd = "2026-08-12T10:00:00.000Z";
+  for (const endAt of [
+    "2026-08-12T12:00:00+02:00",
+    "Wed, 12 Aug 2026 10:00:00 GMT",
+    new Date(canonicalEnd),
+    Date.parse(canonicalEnd),
+  ]) {
+    assert.deepEqual(deriveJunctionCanonicalCoverageEvidence([{
+      dataOrigin: { sourceProviderSlug: "fitbit" },
+      externalRef: { resourceType: "junction-fitbit-sleep" },
+      fields: { endAt },
+      kind: "sleep_session",
+      occurredAt: "2026-08-12T02:00:00.000Z",
+    }]), [{
+      coverageBoundary: canonicalEnd,
+      resource: "sleep",
+      sourceProviderSlug: "fitbit",
+    }]);
+  }
+
+  for (const endAt of ["invalid", {}, new Date(Number.NaN), Number.NaN]) {
+    assert.deepEqual(deriveJunctionCanonicalCoverageEvidence([{
+      dataOrigin: { sourceProviderSlug: "fitbit" },
+      externalRef: { resourceType: "junction-fitbit-sleep" },
+      fields: { endAt },
+      kind: "sleep_session",
+      occurredAt: "2026-08-12T02:00:00.000Z",
+    }]), []);
+  }
+
+  assert.deepEqual(deriveJunctionCanonicalCoverageEvidence([{
+    dataOrigin: { sourceProviderSlug: "fitbit" },
+    externalRef: { resourceType: "junction-fitbit-workouts" },
+    fields: { workout: { endedAt: "invalid" } },
+    kind: "activity_session",
+    occurredAt: canonicalEnd,
+  }]), [{
+    coverageBoundary: canonicalEnd,
+    resource: "workouts",
+    sourceProviderSlug: "fitbit",
+  }]);
+});
+
 test("Junction migration keeps active Fitbit facts and admits successor only after each fence", () => {
   const payload = normalizeJunctionSnapshot({
     canonicalCoverageFence: {


### PR DESCRIPTION
## Why and outcome

Junction raw-record normalization also owned accepted-event coverage and migration cutover admission. Move that policy into `junction-canonical-coverage.ts` so coverage derivation, provider-day closure, and fence admission can be reviewed together.

The snapshot importer still derives coverage from the canonical writer's returned events. Normalization still filters the original event array in place before authoritative-set finalization. Public exports and timestamp acceptance remain compatible.

## Product UX

- Effort: Not applicable; internal importer extraction with unchanged member behavior.
- Result: Not applicable.
- Walkthrough: Existing provider-day closure and successor-fence journeys are covered by the importer and device-sync tests. No UI, reply, or permission flow changes.

## Evidence

- Direct: Importer Junction and package-boundary suites passed, 263 tests; importer cancellation selection passed, 2 tests; device-sync migration/history/cancellation selection passed, 10 tests.
- Coverage: Existing canonical-import and successor-fence cases cover accepted-event ownership, provider timezone/DST, returned event order, and migration admission. The added public coverage test protects permissive timestamps and workout timestamp fallback. Existing cancellation cases protect deterministic continuation and committed progress.
- `pnpm --filter @murphai/importers exec vitest run --config vitest.config.ts --no-coverage --maxWorkers=2 test/device-providers-junction.test.ts test/package-boundary.test.ts` — passed.
- `pnpm --filter @murphai/importers exec vitest run --config vitest.config.ts --no-coverage --maxWorkers=1 test/device-providers.test.ts -t 'createImporters.*(abort|signal|snapshot progress)'` — passed.
- `pnpm --filter @murphai/device-syncd exec vitest run --config vitest.config.ts --no-coverage --maxWorkers=1 test/junction-provider-history.test.ts test/junction-provider-backfill.test.ts test/junction-provider-workout-stream.test.ts -t '(hosted bounded summaries.*(coverage|Fitbit)|legacy coverage|cancellation|migration|historical coverage does not)'` — passed.
- `pnpm --filter @murphai/importers typecheck` and `pnpm --filter @murphai/device-syncd typecheck` — passed.
- `pnpm --filter @murphai/importers build` — passed, including emitted public coverage reexports.
- `git diff --check` — passed. Text comparison confirms unchanged moved algorithm bodies and timestamp leaves, except for narrowing the fence argument to the existing event array. The canonical import bridge changes only its coverage import.
- Parent candidate review passed.

- Exact-head CI: Required checks and Temporal compatibility passed on the reviewed head; GitHub reports clean mergeability.
- Final review: Parent candidate review and ReviewGPT round 1 passed with no findings on `4f749f14de4f47ab7bc5ab6c7cdeaa35cc358aab`; the response hash, committed-turn identity, and `gpt-6-pro` model attestation were verified.

## Non-obvious affected surfaces

The existing shared normalization module now owns the unchanged permissive timestamp parser and timestamp maximum functions used by both coverage and the Junction normalizer. Its strict `toIso` behavior is unchanged. The canonical writer's cancellation signal and accepted-result handling remain intact.

## Architecture and reuse

- Existing systems reused: Junction resource boundary/day classification, source normalization, shared normalization primitives, the canonical import writer, and device-sync migration persistence.
- New logic: None; coverage and fence algorithms retain their existing behavior.
- New abstractions: One internal module owning canonical-event coverage and cutover admission. It accepts event facts, without the broader normalization context or store access.
- Complexity intentionally avoided: No provider diagnostics split, per-resource normalization modules, public subpath, dependency, schema, callback framework, or additional state owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base b2a559812972d70644cffb2bf43923fc9211047d`. New coverage module maximum 16, with zero added debt.
- Hotspots: The unchanged normalizer retains `buildJunctionDailyTimeseriesAggregates` (98), `pushJunctionWorkoutStreamFeature` (33), `resolveJunctionSparseTimeseriesTimestamp` (32), `pushMenstrualCycleSummary` (31), `parseJunctionSparseTimeseriesRecord` (29), `assertJunctionSparseCalendarRepairRowsValid` (27), `buildRawResourcePayload` (27), `pushJunctionSparseTimeseriesRecords` (26), `pushJunctionSparseIntervalReadings` (25), `normalizeDistanceKilometers` (23), and `pushJunctionDailyTimeseriesAggregateArtifacts` (22).
- Agent judgment: Coverage is one cohesive canonical-event policy. Splitting the remaining normalization functions is outside this proven seam; their existing shared identity and evidence state does not justify further extraction here.

## Hot reply path impact

- Path status: Not applicable; the change relocates synchronous importer policy without changing foreground routing or scheduling.
- Database calls: None added or moved onto the path.
- Network/provider calls: None added or moved onto the path.
- Other awaited latency: None added or moved onto the path.
- Before/after proof: Moved algorithm bodies match the base, and existing composed import/cancellation tests pass. No latency claim is made.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged for individual and group runtimes.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run; no prompt, tool, provider-input, or runtime assembly surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal module extraction preserves public exports, persisted shapes, runtime protocols, and canonical write behavior. It introduces no coordinated deployment or new rollback floor.

## Change-shape breakdown

Classification rule: Implementation files are source, test files are tests, and the README plus completed plan are docs. No binary or generated files changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 338 | 310 |
| Tests / fixtures | 44 | 0 |
| Docs | 73 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **455** | **310** |

## Changelog

- Changelog: not applicable
- Reason: Internal ownership extraction with unchanged member-visible behavior.

ReviewGPT first-reviewed head: 4f749f14de4f47ab7bc5ab6c7cdeaa35cc358aab
ReviewGPT context sensitivity: sensitive
Reason: Relocates canonical accepted-event coverage and migration fence policy.

