### PR TITLE
refactor(health-commons): simplify catalog reference validation

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-complexity-collapse-09.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-complexity-collapse-09.md
@@ -1,0 +1,57 @@
+# Collapse Health Commons catalog validation duplication
+
+## Outcome and protected behavior
+
+Simplify the existing catalog validator without changing accepted content,
+diagnostic text or ordering, reference resolution, generated artifacts, or APIs.
+Missing secondary and safety test-plan references remain optional; declared
+measurement-path and onboarding signals retain their existing existence checks.
+
+## Evidence and design
+
+The complexity guard reports `validateHealthCommonsContent` at 79, with file
+maximum 79, debt 67, and total complexity 418. Relation type branches repeat
+target checks, named measurement fields repeat traversals, and a path map mirrors
+the canonical page map. Reuse the page map, existing assertions, and finite
+relation/field definitions to delete duplicate validation and map plumbing.
+No new state, dependency, validation framework, or product policy is needed.
+Failures remain synchronous at the existing build-time boundary; retries,
+deployment skew, and runtime authority are unaffected.
+
+## Verification and completion
+
+- [x] Characterize relation direction, optional references, and first-error order.
+- [x] Collapse duplicated validation and inspect the full diff for privacy.
+- [x] Run focused catalog tests, package typecheck/generation, and complexity guard.
+- [x] Review and prepare the scoped candidate for draft PR publication.
+
+The parent session owns candidate review, Ready, exact-head CI, and any required
+ReviewGPT round. Changelog is not applicable: build-time maintainability only.
+
+## Results
+
+Removed the mirrored key/path map, repeated relation and measurement checks,
+redundant optional-target resolution, and unused source-finding/appraisal result
+sets. The existing page map and assertions retain validation ownership.
+
+- Final guard: PASS; validator and file maximum 79 to 70, debt 67 to 58,
+  total complexity 418 to 410. Source changed by +103/-162 lines.
+- Focused catalog coverage, measurement-plan, and onboarding checks: 30 passing
+  tests across the final run and named retry. The authored-content onboarding
+  test exceeded 60 seconds under concurrent host load, then passed with the
+  invocation-only 180-second timeout; no timeout configuration changed.
+- The earlier four-file catalog run passed all 31 tests with the same timeout.
+- Package typecheck/generation passed; the direct package compiler passed again
+  after deleting unused bookkeeping.
+- Full baseline/candidate catalog deep equality passed for 8,043 entities,
+  including catalogHash and complete output. Baseline: b2a559812972d70644cffb2bf43923fc9211047d.
+- Privacy scan and git diff whitespace check passed. No new Frog entry was needed.
+- Parent candidate review approved the source direction. Exact-head CI and any
+  routed final external review remain with the parent session after draft publication.
+
+The remaining validator branches represent distinct content checks; splitting
+those merely to lower the metric is unjustified. The separate source identity
+hotspots at 21 and 27 are unchanged and outside this reference-validation seam.
+Status: completed
+Updated: 2026-09-10
+Completed: 2026-09-10

--- a/packages/health-commons/src/catalog.ts
+++ b/packages/health-commons/src/catalog.ts
@@ -35,6 +35,18 @@ export const HEALTH_COMMONS_INDEXABLE_GOAL_REQUIRED_HEADINGS = [
   "## Sources",
 ] as const;
 
+const relationTargetTypes = new Map<
+  string,
+  HealthCommonsPageFrontmatter["entityType"]
+>([
+  ["primary_biomarker", "biomarker"],
+  ["secondary_biomarker", "biomarker"],
+  ["safety_outcome", "biomarker"],
+  ["default_measurement_method", "measurement_method"],
+  ["optional_measurement_method", "measurement_method"],
+  ["measurement_upgrade", "measurement_method"],
+]);
+
 export async function buildHealthCommonsCatalog(
   options: BuildHealthCommonsCatalogOptions,
 ): Promise<HealthCommonsCatalog> {
@@ -65,18 +77,16 @@ export function buildHealthCommonsCatalogFromContent(
 }
 
 export function validateHealthCommonsContent(content: HealthCommonsContentSet): void {
-  const keys = new Map<string, string>();
   const aliases = new Map<string, string>();
   const pagesByKey = new Map<string, HealthCommonsSourcePage>();
 
   for (const page of content.pages) {
-    const existingPath = keys.get(page.frontmatter.key);
+    const existingPath = pagesByKey.get(page.frontmatter.key)?.relativePath;
     if (existingPath) {
       if (page.frontmatter.entityType !== "source_artifact") {
         throw new Error(`Duplicate health commons key ${page.frontmatter.key} in ${existingPath} and ${page.relativePath}.`);
       }
     } else {
-      keys.set(page.frontmatter.key, page.relativePath);
       pagesByKey.set(page.frontmatter.key, page);
     }
 
@@ -101,57 +111,30 @@ export function validateHealthCommonsContent(content: HealthCommonsContentSet): 
   }
 
   assertUniqueSourceIdentities(content.pages);
-  collectSourceFindingIds(content.pages, keys, pagesByKey);
-  validateEvidenceAppraisals(
-    content.evidenceAppraisals,
-    keys,
-    pagesByKey,
-  );
+  validateSourceFindings(content.pages, pagesByKey);
+  validateEvidenceAppraisals(content.evidenceAppraisals, pagesByKey);
 
   for (const page of content.pages) {
-    validateGoalTemplateReferences(page, keys, pagesByKey);
+    validateGoalTemplateReferences(page, pagesByKey);
 
     for (const relation of page.frontmatter.relations ?? []) {
-      assertTargetExists(keys, relation.target, `${page.frontmatter.key} relation ${relation.type}`);
-      if (
-        relation.type === "primary_biomarker"
-        || relation.type === "secondary_biomarker"
-        || relation.type === "safety_outcome"
-      ) {
-        assertTargetEntityType(
-          pagesByKey,
-          relation.target,
-          "biomarker",
-          `${page.frontmatter.key} relation ${relation.type}`,
-        );
-      }
-      if (
-        relation.type === "default_measurement_method"
-        || relation.type === "optional_measurement_method"
-        || relation.type === "measurement_upgrade"
-      ) {
-        assertTargetEntityType(
-          pagesByKey,
-          relation.target,
-          "measurement_method",
-          `${page.frontmatter.key} relation ${relation.type}`,
-        );
-      }
-      if (relation.type === "measures" && page.frontmatter.entityType === "measurement_method") {
-        assertTargetEntityType(
-          pagesByKey,
-          relation.target,
-          "biomarker",
-          `${page.frontmatter.key} relation measures`,
-        );
-      }
+      const expectedEntityType =
+        relation.type === "measures" && page.frontmatter.entityType === "measurement_method"
+          ? "biomarker"
+          : relationTargetTypes.get(relation.type);
+      assertTargetExists(
+        pagesByKey,
+        relation.target,
+        `${page.frontmatter.key} relation ${relation.type}`,
+        expectedEntityType,
+      );
     }
     for (const option of page.frontmatter.options ?? []) {
-      assertTargetExists(keys, option.key, `${page.frontmatter.key} disambiguation option`);
+      assertTargetExists(pagesByKey, option.key, `${page.frontmatter.key} disambiguation option`);
     }
     for (const claim of page.frontmatter.claims ?? []) {
       for (const sourceKey of claim.sourceKeys ?? []) {
-        assertTargetExists(keys, sourceKey, `${page.frontmatter.key} claim ${claim.claimId}`);
+        assertTargetExists(pagesByKey, sourceKey, `${page.frontmatter.key} claim ${claim.claimId}`);
       }
     }
     for (const group of page.frontmatter.researchLandscape?.groups ?? []) {
@@ -161,95 +144,69 @@ export function validateHealthCommonsContent(content: HealthCommonsContentSet): 
         );
       }
       for (const sourceKey of group.sourceKeys) {
-        assertTargetExists(keys, sourceKey, `${page.frontmatter.key} researchLandscape group ${group.id}`);
+        assertTargetExists(pagesByKey, sourceKey, `${page.frontmatter.key} researchLandscape group ${group.id}`);
       }
     }
     for (const plan of page.frontmatter.testPlans ?? []) {
-      assertTargetExists(keys, plan.primaryBiomarkerKey, `${page.frontmatter.key} test plan ${plan.planId}`);
+      assertTargetExists(pagesByKey, plan.primaryBiomarkerKey, `${page.frontmatter.key} test plan ${plan.planId}`);
       assertTargetEntityType(
         pagesByKey,
         plan.primaryBiomarkerKey,
         "biomarker",
         `${page.frontmatter.key} test plan ${plan.planId} primaryBiomarkerKey`,
       );
-      for (const biomarkerKey of plan.secondaryBiomarkerKeys ?? []) {
-        if (resolveHealthCommonsKey(keys, biomarkerKey)) {
+      for (const field of ["secondaryBiomarkerKeys", "safetyOutcomeKeys"] as const) {
+        for (const target of plan[field] ?? []) {
           assertTargetEntityType(
             pagesByKey,
-            biomarkerKey,
+            target,
             "biomarker",
-            `${page.frontmatter.key} test plan ${plan.planId} secondaryBiomarkerKeys`,
-          );
-        }
-      }
-      for (const safetyOutcomeKey of plan.safetyOutcomeKeys ?? []) {
-        if (resolveHealthCommonsKey(keys, safetyOutcomeKey)) {
-          assertTargetEntityType(
-            pagesByKey,
-            safetyOutcomeKey,
-            "biomarker",
-            `${page.frontmatter.key} test plan ${plan.planId} safetyOutcomeKeys`,
+            `${page.frontmatter.key} test plan ${plan.planId} ${field}`,
           );
         }
       }
     }
     for (const signal of page.frontmatter.expectedSignalDescriptions ?? []) {
-      assertTargetExists(keys, signal.biomarkerKey, `${page.frontmatter.key} expected signal description`);
-      assertTargetEntityType(
+      assertTargetExists(
         pagesByKey,
         signal.biomarkerKey,
-        "biomarker",
         `${page.frontmatter.key} expected signal description`,
+        "biomarker",
       );
     }
     for (const measuredBiomarkerKey of page.frontmatter.measurementMethod?.measuredBiomarkerKeys ?? []) {
-      assertTargetExists(keys, measuredBiomarkerKey, `${page.frontmatter.key} measurementMethod.measuredBiomarkerKeys`);
-      assertTargetEntityType(
+      assertTargetExists(
         pagesByKey,
         measuredBiomarkerKey,
-        "biomarker",
         `${page.frontmatter.key} measurementMethod.measuredBiomarkerKeys`,
+        "biomarker",
       );
     }
     for (const output of page.frontmatter.measurementMethod?.outputs ?? []) {
       if (!output.mapsToBiomarkerKey) {
         continue;
       }
-      assertTargetExists(keys, output.mapsToBiomarkerKey, `${page.frontmatter.key} measurementMethod output ${output.outputId}`);
-      assertTargetEntityType(
+      assertTargetExists(
         pagesByKey,
         output.mapsToBiomarkerKey,
-        "biomarker",
         `${page.frontmatter.key} measurementMethod output ${output.outputId}`,
+        "biomarker",
       );
     }
     for (const path of page.frontmatter.measurementPlan?.paths ?? []) {
-      for (const methodKey of path.methodKeys) {
-        assertTargetExists(keys, methodKey, `${page.frontmatter.key} measurementPlan path ${path.pathId} methodKeys`);
-        assertTargetEntityType(
-          pagesByKey,
-          methodKey,
-          "measurement_method",
-          `${page.frontmatter.key} measurementPlan path ${path.pathId} methodKeys`,
-        );
-      }
-      for (const outcomeKey of path.outcomeKeys ?? []) {
-        assertTargetExists(keys, outcomeKey, `${page.frontmatter.key} measurementPlan path ${path.pathId} outcomeKeys`);
-        assertTargetEntityType(
-          pagesByKey,
-          outcomeKey,
-          "biomarker",
-          `${page.frontmatter.key} measurementPlan path ${path.pathId} outcomeKeys`,
-        );
-      }
-      for (const safetyOutcomeKey of path.safetyOutcomeKeys ?? []) {
-        assertTargetExists(keys, safetyOutcomeKey, `${page.frontmatter.key} measurementPlan path ${path.pathId} safetyOutcomeKeys`);
-        assertTargetEntityType(
-          pagesByKey,
-          safetyOutcomeKey,
-          "biomarker",
-          `${page.frontmatter.key} measurementPlan path ${path.pathId} safetyOutcomeKeys`,
-        );
+      for (const [field, targets, entityType] of [
+        ["methodKeys", path.methodKeys, "measurement_method"],
+        ["outcomeKeys", path.outcomeKeys ?? [], "biomarker"],
+        ["safetyOutcomeKeys", path.safetyOutcomeKeys ?? [], "biomarker"],
+      ] as const) {
+        for (const target of targets) {
+          assertTargetExists(
+            pagesByKey,
+            target,
+            `${page.frontmatter.key} measurementPlan path ${path.pathId} ${field}`,
+            entityType,
+          );
+        }
       }
     }
     const onboardingTestPlanId = page.frontmatter.experimentOnboarding?.planDefaults?.testPlanId;
@@ -261,12 +218,12 @@ export function validateHealthCommonsContent(content: HealthCommonsContentSet): 
         `${page.frontmatter.key} experimentOnboarding planDefaults.testPlanId points to missing test plan ${onboardingTestPlanId}.`,
       );
     }
-    validateExperimentOnboardingAdaptationPolicy(page, keys, pagesByKey);
+    validateExperimentOnboardingAdaptationPolicy(page, pagesByKey);
     if (page.frontmatter.lineage?.forkOf) {
-      assertTargetExists(keys, page.frontmatter.lineage.forkOf, `${page.frontmatter.key} lineage forkOf`);
+      assertTargetExists(pagesByKey, page.frontmatter.lineage.forkOf, `${page.frontmatter.key} lineage forkOf`);
     }
     for (const sourcePersonKey of page.frontmatter.attribution?.sourcePersonKeys ?? []) {
-      assertTargetExists(keys, sourcePersonKey, `${page.frontmatter.key} attribution sourcePersonKeys`);
+      assertTargetExists(pagesByKey, sourcePersonKey, `${page.frontmatter.key} attribution sourcePersonKeys`);
     }
   }
 
@@ -274,16 +231,16 @@ export function validateHealthCommonsContent(content: HealthCommonsContentSet): 
   validateGoalBodyLinks(content.pages, content.redirects, pagesByKey);
 
   for (const redirect of content.redirects) {
-    if (keys.has(redirect.from)) {
+    if (pagesByKey.has(redirect.from)) {
       throw new Error(`Redirect source ${redirect.from} is also an active health commons page.`);
     }
-    assertTargetExists(keys, redirect.to, `redirect ${redirect.from}`);
+    assertTargetExists(pagesByKey, redirect.to, `redirect ${redirect.from}`);
   }
 
   for (const change of content.changes) {
-    assertTargetExists(keys, change.entityKey, `change ${change.changeId}`);
+    assertTargetExists(pagesByKey, change.entityKey, `change ${change.changeId}`);
     for (const sourceKey of change.sourceKeys ?? []) {
-      assertTargetExists(keys, sourceKey, `change ${change.changeId}`);
+      assertTargetExists(pagesByKey, sourceKey, `change ${change.changeId}`);
     }
   }
 
@@ -296,7 +253,7 @@ export function validateHealthCommonsContent(content: HealthCommonsContentSet): 
       }
       artifactIds.set(artifact.artifactId, manifest.manifestKey);
       if (artifact.sourceKey) {
-        assertTargetExists(keys, artifact.sourceKey, `artifact ${artifact.artifactId}`);
+        assertTargetExists(pagesByKey, artifact.sourceKey, `artifact ${artifact.artifactId}`);
         assertTargetEntityType(pagesByKey, artifact.sourceKey, "source_artifact", `artifact ${artifact.artifactId} sourceKey`);
       }
     }
@@ -309,7 +266,6 @@ export function validateHealthCommonsContent(content: HealthCommonsContentSet): 
 
 function validateGoalTemplateReferences(
   page: HealthCommonsSourcePage,
-  keys: ReadonlyMap<string, string>,
   pagesByKey: ReadonlyMap<string, HealthCommonsSourcePage>,
 ): void {
   if (page.frontmatter.entityType !== "goal_template" || !page.frontmatter.goal) {
@@ -321,22 +277,20 @@ function validateGoalTemplateReferences(
 
   const parentGoalKey = page.frontmatter.goal.parentGoalKey;
   if (parentGoalKey) {
-    assertTargetExists(keys, parentGoalKey, `${page.frontmatter.key} goal.parentGoalKey`);
-    assertTargetEntityType(
+    assertTargetExists(
       pagesByKey,
       parentGoalKey,
-      "goal_template",
       `${page.frontmatter.key} goal.parentGoalKey`,
+      "goal_template",
     );
   }
 
   for (const sourceKey of page.frontmatter.goal.evidenceSourceKeys) {
-    assertTargetExists(keys, sourceKey, `${page.frontmatter.key} goal.evidenceSourceKeys`);
-    assertTargetEntityType(
+    assertTargetExists(
       pagesByKey,
       sourceKey,
-      "source_artifact",
       `${page.frontmatter.key} goal.evidenceSourceKeys`,
+      "source_artifact",
     );
   }
 }
@@ -626,11 +580,10 @@ function computeRevision(frontmatter: HealthCommonsPageFrontmatter, body: string
   };
 }
 
-function collectSourceFindingIds(
+function validateSourceFindings(
   pages: readonly HealthCommonsSourcePage[],
-  keys: ReadonlyMap<string, string>,
   pagesByKey: ReadonlyMap<string, HealthCommonsSourcePage>,
-): ReadonlySet<string> {
+): void {
   const findingIds = new Map<string, string>();
 
   for (const page of pages) {
@@ -640,8 +593,12 @@ function collectSourceFindingIds(
         throw new Error(`Duplicate source finding ${finding.findingId} on ${existingPageKey} and ${page.frontmatter.key}.`);
       }
       const declaredSourceKey = stripRevision(finding.sourceKey ?? page.frontmatter.key);
-      assertTargetExists(keys, declaredSourceKey, `${page.frontmatter.key} sourceFindings ${finding.findingId} sourceKey`);
-      assertTargetEntityType(pagesByKey, declaredSourceKey, "source_artifact", `${page.frontmatter.key} sourceFindings ${finding.findingId} sourceKey`);
+      assertTargetExists(
+        pagesByKey,
+        declaredSourceKey,
+        `${page.frontmatter.key} sourceFindings ${finding.findingId} sourceKey`,
+        "source_artifact",
+      );
       if (declaredSourceKey !== page.frontmatter.key) {
         throw new Error(
           `${page.frontmatter.key} sourceFindings ${finding.findingId} belongs to ${declaredSourceKey}; source-owned findings must live on their owning source page.`,
@@ -650,8 +607,6 @@ function collectSourceFindingIds(
       findingIds.set(finding.findingId, page.frontmatter.key);
     }
   }
-
-  return new Set(findingIds.keys());
 }
 
 function assertSourceFindingArtifactReferences(
@@ -684,22 +639,24 @@ function assertSourceFindingArtifactReferences(
 
 function validateEvidenceAppraisals(
   appraisals: readonly HealthCommonsEvidenceAppraisal[],
-  keys: ReadonlyMap<string, string>,
   pagesByKey: ReadonlyMap<string, HealthCommonsSourcePage>,
-): ReadonlySet<string> {
+): void {
   const appraisalKeys = new Map<string, string>();
-  const appraisalMatches = new Set<string>();
 
   for (const appraisal of appraisals) {
     const existingKeyPath = appraisalKeys.get(appraisal.key);
     if (existingKeyPath) {
-      throw new Error(`Duplicate evidence appraisal key ${appraisal.key} in ${existingKeyPath} and ${keys.get(appraisal.targetKey) ?? appraisal.targetKey}.`);
+      throw new Error(`Duplicate evidence appraisal key ${appraisal.key} in ${existingKeyPath} and ${pagesByKey.get(appraisal.targetKey)?.relativePath ?? appraisal.targetKey}.`);
     }
-    appraisalKeys.set(appraisal.key, keys.get(appraisal.targetKey) ?? appraisal.targetKey);
+    appraisalKeys.set(appraisal.key, pagesByKey.get(appraisal.targetKey)?.relativePath ?? appraisal.targetKey);
 
-    assertTargetExists(keys, appraisal.sourceKey, `evidence appraisal ${appraisal.key} sourceKey`);
-    assertTargetEntityType(pagesByKey, appraisal.sourceKey, "source_artifact", `evidence appraisal ${appraisal.key} sourceKey`);
-    assertTargetExists(keys, appraisal.targetKey, `evidence appraisal ${appraisal.key} targetKey`);
+    assertTargetExists(
+      pagesByKey,
+      appraisal.sourceKey,
+      `evidence appraisal ${appraisal.key} sourceKey`,
+      "source_artifact",
+    );
+    assertTargetExists(pagesByKey, appraisal.targetKey, `evidence appraisal ${appraisal.key} targetKey`);
 
     const targetPage = pagesByKey.get(stripRevision(appraisal.targetKey));
     if (targetPage && targetPage.frontmatter.entityType !== appraisal.targetKind) {
@@ -708,23 +665,24 @@ function validateEvidenceAppraisals(
       );
     }
     for (const endpointKey of appraisal.endpointKeys ?? []) {
-      if (keys.has(stripRevision(endpointKey))) {
+      if (pagesByKey.has(stripRevision(endpointKey))) {
         assertTargetEntityType(pagesByKey, endpointKey, "biomarker", `evidence appraisal ${appraisal.key} endpointKeys`);
       }
     }
-    appraisalMatches.add(evidenceAppraisalMatchKey(appraisal.sourceKey, appraisal.targetKey, appraisal.groupId));
   }
-
-  return appraisalMatches;
 }
 
-function evidenceAppraisalMatchKey(sourceKey: string, targetKey: string, groupId: string): string {
-  return `${stripRevision(sourceKey)}\u0000${stripRevision(targetKey)}\u0000${groupId}`;
-}
-
-function assertTargetExists(keys: ReadonlyMap<string, string>, target: string, context: string): void {
-  if (!resolveHealthCommonsKey(keys, target)) {
+function assertTargetExists(
+  pagesByKey: ReadonlyMap<string, HealthCommonsSourcePage>,
+  target: string,
+  context: string,
+  expectedEntityType?: HealthCommonsPageFrontmatter["entityType"],
+): void {
+  if (!resolveHealthCommonsKey(pagesByKey, target)) {
     throw new Error(`${context} points to missing health commons target ${target}.`);
+  }
+  if (expectedEntityType) {
+    assertTargetEntityType(pagesByKey, target, expectedEntityType, context);
   }
 }
 
@@ -770,7 +728,6 @@ function assertTargetEntityType(
 
 function validateExperimentOnboardingAdaptationPolicy(
   page: HealthCommonsSourcePage,
-  keys: ReadonlyMap<string, string>,
   pagesByKey: ReadonlyMap<string, HealthCommonsSourcePage>,
 ): void {
   const onboarding = page.frontmatter.experimentOnboarding;
@@ -809,31 +766,15 @@ function validateExperimentOnboardingAdaptationPolicy(
     );
   }
 
-  for (const signalKey of measurementPlan.requiredSignals ?? []) {
-    assertTargetExists(
-      keys,
-      signalKey,
-      `${page.frontmatter.key} experimentOnboarding adaptationPolicy.measurementPlan.requiredSignals`,
-    );
-    assertTargetEntityType(
-      pagesByKey,
-      signalKey,
-      "biomarker",
-      `${page.frontmatter.key} experimentOnboarding adaptationPolicy.measurementPlan.requiredSignals`,
-    );
-  }
-  for (const signalKey of measurementPlan.optionalSignals ?? []) {
-    assertTargetExists(
-      keys,
-      signalKey,
-      `${page.frontmatter.key} experimentOnboarding adaptationPolicy.measurementPlan.optionalSignals`,
-    );
-    assertTargetEntityType(
-      pagesByKey,
-      signalKey,
-      "biomarker",
-      `${page.frontmatter.key} experimentOnboarding adaptationPolicy.measurementPlan.optionalSignals`,
-    );
+  for (const field of ["requiredSignals", "optionalSignals"] as const) {
+    for (const signalKey of measurementPlan[field] ?? []) {
+      assertTargetExists(
+        pagesByKey,
+        signalKey,
+        `${page.frontmatter.key} experimentOnboarding adaptationPolicy.measurementPlan.${field}`,
+        "biomarker",
+      );
+    }
   }
 }
 

--- a/packages/health-commons/test/catalog-coverage.test.ts
+++ b/packages/health-commons/test/catalog-coverage.test.ts
@@ -143,6 +143,94 @@ const artifactManifest = {
 } satisfies HealthCommonsArtifactManifest;
 
 describe("@murphai/health-commons catalog coverage", () => {
+  const validatePages = (...pages: HealthCommonsSourcePage[]): void => {
+    validateHealthCommonsContent({
+      artifactManifests: [], changes: [], evidenceAppraisals: [], redirects: [], pages,
+    });
+  };
+
+  it.each([
+    ["primary_biomarker", "biomarker", measurementMethodPage],
+    ["secondary_biomarker", "biomarker", measurementMethodPage],
+    ["safety_outcome", "biomarker", measurementMethodPage],
+    ["default_measurement_method", "measurement_method", biomarkerPage],
+    ["optional_measurement_method", "measurement_method", biomarkerPage],
+    ["measurement_upgrade", "measurement_method", biomarkerPage],
+  ] as const)("preserves target checks for %s relations", (type, expectedType, wrongTarget) => {
+    const page = protocolPage("protocol_variant:example", "example");
+    page.frontmatter.relations = [{ type, target: "biomarker:missing" }];
+    expect(() => validatePages(biomarkerPage, measurementMethodPage, page)).toThrow(
+      `protocol_variant:example relation ${type} points to missing health commons target biomarker:missing.`,
+    );
+    page.frontmatter.relations = [{ type, target: wrongTarget.frontmatter.key }];
+    expect(() => validatePages(biomarkerPage, measurementMethodPage, page)).toThrow(
+      `protocol_variant:example relation ${type} must point to ${expectedType}, but ${wrongTarget.frontmatter.key} is ${wrongTarget.frontmatter.entityType}.`,
+    );
+    const correctTarget = expectedType === "biomarker" ? biomarkerPage : measurementMethodPage;
+    page.frontmatter.relations = [{ type, target: `${correctTarget.frontmatter.key}@revision` }];
+    expect(() => validatePages(biomarkerPage, measurementMethodPage, page)).not.toThrow();
+  });
+
+  it("constrains measures targets only when the source is a measurement method", () => {
+    const method = structuredClone(measurementMethodPage);
+    method.frontmatter.relations = [{ type: "measures", target: method.frontmatter.key }];
+    expect(() => validatePages(biomarkerPage, method)).toThrow(
+      "measurement_method:example relation measures must point to biomarker, but measurement_method:example is measurement_method.",
+    );
+    method.frontmatter.relations = [{ type: "measures", target: "biomarker:example@revision" }];
+    const page = protocolPage("protocol_variant:example", "example");
+    page.frontmatter.relations = [
+      { type: "measures", target: method.frontmatter.key },
+      { type: "custom_relation", target: method.frontmatter.key },
+    ];
+    expect(() => validatePages(biomarkerPage, method, page)).not.toThrow();
+  });
+
+  it("allows missing optional test-plan targets and checks secondary targets before safety targets", () => {
+    const page = protocolPage("protocol_variant:example", "example");
+    const plan = page.frontmatter.testPlans![0]!;
+    plan.secondaryBiomarkerKeys = ["biomarker:missing-secondary"];
+    plan.safetyOutcomeKeys = ["biomarker:missing-safety"];
+    expect(() => validatePages(biomarkerPage, measurementMethodPage, page)).not.toThrow();
+
+    plan.secondaryBiomarkerKeys.push("measurement_method:example@revision");
+    plan.safetyOutcomeKeys.push("measurement_method:example");
+    expect(() => validatePages(biomarkerPage, measurementMethodPage, page)).toThrow(
+      "protocol_variant:example test plan example-plan secondaryBiomarkerKeys must point to biomarker, but measurement_method:example@revision is measurement_method.",
+    );
+    plan.secondaryBiomarkerKeys = [];
+    expect(() => validatePages(biomarkerPage, measurementMethodPage, page)).toThrow(
+      "protocol_variant:example test plan example-plan safetyOutcomeKeys must point to biomarker, but measurement_method:example is measurement_method.",
+    );
+  });
+
+  it("requires declared measurement-path targets in method, outcome, then safety order", () => {
+    const page = protocolPage("protocol_variant:example", "example");
+    const measurementPath = {
+      pathId: "example", label: "Example", tier: "optional_home" as const, required: true,
+      methodKeys: ["measurement_method:missing"],
+      outcomeKeys: ["biomarker:missing-outcome"],
+      safetyOutcomeKeys: ["biomarker:missing-safety"],
+    };
+    page.frontmatter.measurementPlan = {
+      schemaVersion: "murph.commons.measurement-plan.v1", defaultPathId: "example",
+      paths: [measurementPath],
+    };
+    expect(() => validatePages(biomarkerPage, measurementMethodPage, page)).toThrow(
+      "protocol_variant:example measurementPlan path example methodKeys points to missing health commons target measurement_method:missing.",
+    );
+    measurementPath.methodKeys = ["measurement_method:example@revision"];
+    expect(() => validatePages(biomarkerPage, measurementMethodPage, page)).toThrow(
+      "protocol_variant:example measurementPlan path example outcomeKeys points to missing health commons target biomarker:missing-outcome.",
+    );
+    measurementPath.outcomeKeys = ["biomarker:example@revision"];
+    expect(() => validatePages(biomarkerPage, measurementMethodPage, page)).toThrow(
+      "protocol_variant:example measurementPlan path example safetyOutcomeKeys points to missing health commons target biomarker:missing-safety.",
+    );
+    measurementPath.safetyOutcomeKeys = ["biomarker:example"];
+    expect(() => validatePages(biomarkerPage, measurementMethodPage, page)).not.toThrow();
+  });
+
   it("covers the collection and sorting helpers", () => {
     expect(
       collectArtifactPointers([artifactManifest]).map(({ artifact }) => artifact.artifactId),


### PR DESCRIPTION
## Why and outcome

Health Commons catalog validation repeats target-type branches, measurement traversals, and a key/path map that mirrors the canonical page map. This refactor uses the existing page map and assertions, a finite relation-target lookup, and ordered field traversals. It also removes ignored validation result sets and an unused appraisal-key builder.

Accepted content, error text and ordering, optional-reference behavior, relation direction, and generated output remain unchanged. The validator falls from cyclomatic complexity 79 to 70; authored source shrinks by 59 lines without splitting the function to move its score elsewhere.

## Product UX

- Effort: Not applicable — internal build-time maintainability change.
- Result: Not applicable.
- Walkthrough: Content authors receive the same diagnostics; consumers receive the same catalog. No member journey, content, or API changes.

## Evidence

- Direct: Baseline/candidate deep equality passed for the complete catalog of 8,043 entities, including the unchanged catalogHash. Baseline commit: b2a559812972d70644cffb2bf43923fc9211047d. Both builders received the same parsed authored content.
- Coverage: Final catalog-coverage, catalog.measurement-plan, and catalog.experiment-onboarding tests passed all 30 cases across the focused run and named retry. The new characterization covers all six constrained relation types, direction-sensitive measures, custom relations, revision-qualified keys, optional test-plan targets, and first-error ordering.
- Focused command: `pnpm exec vitest run --config packages/health-commons/vitest.config.ts --no-coverage packages/health-commons/test/catalog-coverage.test.ts packages/health-commons/test/catalog.measurement-plan.test.ts packages/health-commons/test/catalog.experiment-onboarding.test.ts` — 29 passed; the authored-content onboarding case exceeded its existing 60-second limit under concurrent host load.
- Focused retry: `pnpm exec vitest run --config packages/health-commons/vitest.config.ts --no-coverage --testTimeout=180000 packages/health-commons/test/catalog.experiment-onboarding.test.ts -t 'keeps psyllium lab defaults out of daily LDL-C run-in windows'` — passed. No repository timeout setting changed.
- Typecheck: `pnpm --dir packages/health-commons typecheck` passed, including generation. After the final unused-bookkeeping deletion, `node ../../scripts/run-typescript.mjs package -p tsconfig.typecheck.json --pretty false` passed from the package directory.
- The earlier four-file catalog run also passed all 31 tests with the invocation-only 180-second timeout. Final complete-output equivalence covers the subsequent deletion of unused validation results.
- Privacy scan and `git diff --check` passed. Parent source review approved the direction. Required exact-head CI is tracked in GitHub checks; completed external review evidence is below.

## Non-obvious affected surfaces

Goal-template, source-finding, evidence-appraisal, redirect, artifact, and onboarding reference checks now read the existing page map. Full catalog equivalence and the existing validation suites cover those consumers; source identity normalization is unchanged.

## Architecture and reuse

- Existing systems reused: The canonical page lookup, reference resolver, target assertions, and Health Commons content contracts.
- New logic: No new content policy; existing relation and measurement rules are expressed once, preserving their order and diagnostics.
- New abstractions: One private finite relation-target lookup; the existing existence assertion accepts an optional expected type. No new validation owner or framework.
- Complexity intentionally avoided: Deleted the mirrored path map, redundant optional-target resolution, duplicate assertion pairs, ignored result sets, and unused appraisal matching key builder.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base b2a559812972d70644cffb2bf43923fc9211047d --head HEAD -- packages/health-commons/src/catalog.ts`; file debt 67 to 58 and maximum 79 to 70. Total complexity falls from 418 to 410.
- Hotspots: `validateHealthCommonsContent` falls from 79 to 70. Its remaining branches perform distinct content checks. `collectSourceIdentityKeys` at 21 and `collectSourceIdentifierFields` at 27 are unchanged identity-normalization owners.
- Agent judgment: The change removes actual state and duplication. Further splitting merely to reduce the metric would hide the remaining validation policies, so it is outside this reference-validation seam.

## Hot reply path impact

- Path status: Not applicable — build-time catalog validation; runtime output is identical.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None added to the foreground path.
- Before/after proof: Complete generated catalog equality; no runtime call path changed.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no prompts, tools, provider-input assembly, or generated content changed.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed; complete catalog output equality was proved.

## Deployment concerns

- Deployment: not applicable
- Reason: Behavior-preserving build-time validation refactor with identical generated output; no runtime protocol, persisted schema, or deploy ordering changes.

## Change-shape breakdown

Classification rule: Package src is source, package test is tests, and the execution plan is docs. No binary, generated, or configuration files are committed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 103 | 162 |
| Tests / fixtures | 88 | 0 |
| Docs | 57 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **248** | **162** |

## Changelog

- Changelog: not applicable
- Reason: Internal catalog-validator maintainability; accepted content and generated output are unchanged.

ReviewGPT first-reviewed head: 352677f030ddafbc4103a1f748cb267009a804c8
ReviewGPT context sensitivity: sensitive
Sensitivity reason: Catalog validation spans authored-content identity and typed-reference boundaries.

## Final review evidence

- Round 1: PASS on 352677f030ddafbc4103a1f748cb267009a804c8; zero findings received, accepted, or rejected.
- Scope and identity: Full immutable snapshot and diff reviewed; response hashes, captured turn, model, and exact head were verified.
- Model and lane: gpt-6-pro on hercules. The successful wrapper enforced at least 270 seconds; exact elapsed time was not persisted.
- Tooling retries: None.
