### PR TITLE
refactor(query): consolidate experiment adherence counts

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-complexity-experiment-adherence.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-complexity-experiment-adherence.md
@@ -1,0 +1,66 @@
+# Collapse server experiment adherence count selection
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal and protected behavior
+
+Simplify the query-owned experiment adherence summary while preserving target
+selection, calendar and noncalendar session counts, confidence, expected progress,
+status, and session evidence IDs. Canonical input remains read-only.
+
+## Evidence and design
+
+`buildAdherenceSummary` has cyclomatic complexity 67. It independently selects
+occurrence, calendar, or noncalendar counts for confidence, completion totals,
+and expectations. Resolve the applicable count result once through existing
+adherence counters and derive the summary from that result. Keep calendar
+construction before selection so invalid calendar inputs retain existing failure
+behavior. No persisted state, public contract, dependencies, or authority change.
+
+## Scope and decisions
+
+- Source: `packages/query/src/experiments.ts` and focused experiment tests.
+- Baseline: `b0a945bb87e20755d1cbbcfb3c32ec02c8f12fec`.
+- Preserve the independent browser projection owner unchanged.
+- Internal refactor; no member-facing changelog or new interaction is required.
+- Root completion owner reviews the draft PR and owns readiness and final gates.
+
+## Risks and mitigation
+
+- Ambiguous targets must keep zero counts and unknown status; calendar rollups
+  must use only their selected target's cells.
+- Linked-event calendars constrain evidence IDs while metric and noncalendar
+  targets retain existing evidence-list behavior. Cover these combinations.
+- Optional confidence and partial fields retain their current omission rules.
+
+## Tasks
+
+1. Resolve one applicable adherence count source.
+2. Run focused characterization, consumer tests, query typecheck, and guard.
+3. Inspect privacy/diff, close this plan, commit, and open a draft PR.
+
+## Verification
+
+- The new public-query characterization passed against the unchanged baseline
+  implementation before replaying it on the final candidate.
+- `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage
+  test/experiment-analysis.test.ts test/experiment-adherence.test.ts
+  test/experiment-repeated-cadence-counts.test.ts
+  test/browser-vault-experiment-results.test.ts
+  test/experiment-open-ended-outcomes.test.ts`: 5 files and 215 tests passed.
+- `pnpm --dir packages/query typecheck`: passed.
+- `pnpm complexity:diff --base b0a945bb87e20755d1cbbcfb3c32ec02c8f12fec
+  -- packages/query/src/experiments.ts`: passed. Summary complexity 67 to 31;
+  private count helper 8; file maximum 67 to 47; debt 78 to 42; total 801 to 773.
+- Remaining hotspots were inspected: unchanged coverage summary 47 and metric
+  callback 24; the adherence summary retains explicit status precedence and
+  optional-field rules. No further extraction is warranted in this scope.
+- `git diff --check` and inspection of source, tests, plan, and PR text passed.
+  No private identifiers or unrelated changes were found.
+- `scripts/frog list` was reviewed; no task-actionable friction entry was needed.
+- Root completion owner reviewed the proposed count ownership and confirmed the
+  target-resolution and null-counter invariants. Draft readiness, exact-head CI,
+  and final review remain with that owner.
+Completed: 2026-09-10

--- a/packages/query/src/experiments.ts
+++ b/packages/query/src/experiments.ts
@@ -34,6 +34,7 @@ import {
   resolveExperimentAdherenceTargets,
   resolveEffectiveExperimentLinkedEventMissingPolicy,
   resolveInterventionSessionLocalDate,
+  type AdherenceSessionCounts,
   type ExperimentAdherenceCalendarResult,
   type ExperimentAdherenceObservation,
 } from "./experiment-adherence.ts";
@@ -823,56 +824,18 @@ function buildAdherenceCalendarFromContext(
 
 function buildAdherenceSummary(context: ExperimentSummaryContext): ExperimentProgressSummary["adherence"] {
   const targets = resolveAdherenceTargets(context);
-  const rollupTarget = resolveExperimentAdherenceRollupTarget(targets);
-  const hasAmbiguousTargets = targets.length > 1 && !rollupTarget;
+  const progressTarget = resolveExperimentAdherenceRollupTarget(targets);
+  const hasAmbiguousTargets = targets.length > 1 && !progressTarget;
   const targetSessions =
-    rollupTarget?.rollup?.targetCompletions ??
+    progressTarget?.rollup?.targetCompletions ??
     (hasAmbiguousTargets ? null : context.frontmatter.runPlan?.targetSessions ?? null);
   const minimumUsefulSessions =
-    rollupTarget?.rollup?.minimumUsefulCompletions ??
+    progressTarget?.rollup?.minimumUsefulCompletions ??
     (hasAmbiguousTargets ? null : context.frontmatter.runPlan?.minimumUsefulSessions ?? null);
-  const progressTarget = hasAmbiguousTargets ? null : rollupTarget ?? targets[0] ?? null;
   const adherenceCalendar = buildAdherenceCalendarFromContext(context);
-  const rollupCells = progressTarget?.calendar && rollupTarget && adherenceCalendar
-    ? adherenceCalendar.cells.filter((cell) => cell.targetId === rollupTarget.targetId)
-    : null;
-  const progressObservations = progressTarget
-    ? buildAdherenceObservations(context, [progressTarget])
-    : [];
-  const progressCells = progressTarget?.calendar
-    ? rollupCells ?? adherenceCalendar?.cells ?? []
-    : [];
-  const occurrenceCounts =
-    progressTarget?.calendar && progressTarget.evidence.kind === "linkedEventCount"
-      ? countCalendarAdherenceSessions({
-          asOf: context.asOf,
-          cells: progressCells,
-          observations: progressObservations,
-          target: progressTarget,
-        })
-      : null;
-  const progressCounts = occurrenceCounts ??
-    (progressTarget && !progressTarget.calendar
-      ? countCompletedAdherenceSessions({
-          asOfDate: context.asOf,
-          observations: progressObservations,
-          target: progressTarget,
-          windows: buildWindowSummary(context.frontmatter),
-        })
-      : null);
-  const confidenceCounts = !hasAmbiguousTargets && progressTarget?.calendar
-    ? occurrenceCounts ?? countAdherenceConfidenceSessions({
-        cells: progressCells,
-        observations: progressObservations,
-      })
-    : progressCounts ?? {
-        sensedSessions: 0,
-        confirmedSessions: 0,
-        assumedSessions: 0,
-      };
-
-  const countedLoggedEvidenceIds = occurrenceCounts
-    ? new Set(occurrenceCounts.loggedEvidenceIds)
+  const counts = countProgressAdherence(context, progressTarget, adherenceCalendar);
+  const countedLoggedEvidenceIds = counts.loggedEvidenceIds
+    ? new Set(counts.loggedEvidenceIds)
     : null;
   const sessionEventIds = context.events
     .filter(isCompletedSessionEvent)
@@ -882,36 +845,15 @@ function buildAdherenceSummary(context: ExperimentSummaryContext): ExperimentPro
     )
     .map((event) => event.entityId);
 
-  let completedSessions = 0;
-  let partialSessions = 0;
-  if (!hasAmbiguousTargets) {
-    if (occurrenceCounts) {
-      completedSessions = occurrenceCounts.completedSessions;
-      partialSessions = occurrenceCounts.partialSessions;
-    } else if (progressTarget?.calendar) {
-      completedSessions = progressCells.filter(
-        (cell) => cell.status === "satisfied" || cell.status === "assumed",
-      ).length;
-      partialSessions = progressCells.filter((cell) => cell.status === "partial").length;
-    } else {
-      completedSessions = progressCounts?.completedSessions ?? 0;
-      partialSessions = progressCounts?.partialSessions ?? 0;
-    }
-  }
-
+  const { completedSessions, partialSessions } = counts;
   const loggedSessions = completedSessions + partialSessions;
   const expectedSessionsByNow = hasAmbiguousTargets
     ? null
-    : occurrenceCounts
-      ? occurrenceCounts.expectedSessionsByNow
-      : progressTarget?.calendar && adherenceCalendar
-        ? (rollupCells ?? adherenceCalendar.cells)
-            .filter((cell) => cell.status !== "scheduled").length
-        : computeExpectedSessionsByNow(
-            context.frontmatter,
-            context.asOf,
-            targetSessions,
-          );
+    : counts.expectedSessionsByNow ?? computeExpectedSessionsByNow(
+        context.frontmatter,
+        context.asOf,
+        targetSessions,
+      );
   const evidence = buildProgressAdherenceEvidence(progressTarget);
 
   let status: ExperimentAdherenceStatus = "unknown";
@@ -946,17 +888,63 @@ function buildAdherenceSummary(context: ExperimentSummaryContext): ExperimentPro
     status,
     targetSessions,
   };
-  if (confidenceCounts.sensedSessions > 0) {
-    summary.sensedSessions = confidenceCounts.sensedSessions;
+  if (counts.sensedSessions > 0) {
+    summary.sensedSessions = counts.sensedSessions;
   }
-  if (confidenceCounts.confirmedSessions > 0) {
-    summary.confirmedSessions = confidenceCounts.confirmedSessions;
+  if (counts.confirmedSessions > 0) {
+    summary.confirmedSessions = counts.confirmedSessions;
   }
-  if (confidenceCounts.assumedSessions > 0) {
-    summary.assumedSessions = confidenceCounts.assumedSessions;
+  if (counts.assumedSessions > 0) {
+    summary.assumedSessions = counts.assumedSessions;
   }
 
   return summary;
+}
+
+interface ExperimentProgressAdherenceCounts extends Pick<
+  AdherenceSessionCounts,
+  "completedSessions" | "partialSessions" | "sensedSessions" | "confirmedSessions" | "assumedSessions"
+> {
+  expectedSessionsByNow?: number;
+  loggedEvidenceIds?: readonly string[];
+}
+
+function countProgressAdherence(
+  context: ExperimentSummaryContext,
+  target: QueryExperimentAdherenceTarget | null,
+  calendar: ExperimentAdherenceCalendarResult | null,
+): ExperimentProgressAdherenceCounts {
+  const observations = target ? buildAdherenceObservations(context, [target]) : [];
+  if (!target?.calendar) {
+    return countCompletedAdherenceSessions({
+      asOfDate: context.asOf,
+      observations,
+      target,
+      windows: buildWindowSummary(context.frontmatter),
+    });
+  }
+
+  const progressCells = (calendar?.cells ?? [])
+    .filter((cell) => cell.targetId === target.targetId);
+  if (target.evidence.kind === "linkedEventCount") {
+    return countCalendarAdherenceSessions({
+      asOf: context.asOf,
+      cells: progressCells,
+      observations,
+      target,
+    });
+  }
+
+  return {
+    ...countAdherenceConfidenceSessions({ cells: progressCells, observations }),
+    completedSessions: progressCells.filter(
+      (cell) => cell.status === "satisfied" || cell.status === "assumed",
+    ).length,
+    partialSessions: progressCells.filter((cell) => cell.status === "partial").length,
+    expectedSessionsByNow: calendar
+      ? progressCells.filter((cell) => cell.status !== "scheduled").length
+      : undefined,
+  };
 }
 
 function buildProgressAdherenceEvidence(

--- a/packages/query/test/experiment-analysis.test.ts
+++ b/packages/query/test/experiment-analysis.test.ts
@@ -4492,3 +4492,119 @@ test("experiment outcome reports sparse primary data as medium-confidence incomp
   assert.match(outcome.conclusion.plainLanguage, /not enough primary biomarker data/u);
   assert.equal(outcome.protocolRef, null);
 });
+
+test("experiment adherence selects one count source while preserving evidence and ambiguity", () => {
+  const experimentId = "exp_01JNV4458HYPP53JDQCBP1QJFM";
+  const slug = "count-source-selection";
+  const completedId = "evt_01JNV45RHN0TQ9ZXE0A7YSE5A1";
+  const partialId = "evt_01JNV45RHN0TQ9ZXE0A7YSE5A2";
+  const offCalendarId = "evt_01JNV45RHN0TQ9ZXE0A7YSE5A3";
+  const target: ExperimentAdherenceTarget = {
+    targetId: "sessions",
+    label: "Sessions",
+    phase: "intervention",
+    evidence: {
+      kind: "linkedEventCount",
+      eventKind: "intervention_session",
+      missing: "unknown",
+    },
+    rollup: { targetCompletions: 2, minimumUsefulCompletions: 1 },
+  };
+  const calendar = {
+    kind: "explicitDates",
+    timeZone: "UTC",
+    dates: [{ localDate: "2026-06-01" }, { localDate: "2026-06-02" }],
+  } as const;
+  const sessions = [
+    makeSession({
+      entityId: completedId,
+      experimentId,
+      experimentSlug: slug,
+      occurredAt: "2026-06-01T12:00:00.000Z",
+    }),
+    makeSession({
+      entityId: partialId,
+      experimentId,
+      experimentSlug: slug,
+      occurredAt: "2026-06-02T12:00:00.000Z",
+      sessionStatus: "partial",
+    }),
+    makeSession({
+      entityId: offCalendarId,
+      experimentId,
+      experimentSlug: slug,
+      occurredAt: "2026-06-03T12:00:00.000Z",
+    }),
+  ];
+  const summarize = (adherenceTargets: readonly ExperimentAdherenceTarget[]) => {
+    const vault = createVaultReadModel({
+      vaultRoot: "/virtual/experiment-count-source-selection",
+      metadata: { timezone: "UTC" },
+      entities: [
+        makeExperiment("active", {
+          experimentId,
+          slug,
+          commonsProtocolRef: null,
+          effectiveProtocolSnapshot: null,
+          runPlan: {
+            baselineStart: "2026-05-31",
+            baselineEnd: "2026-05-31",
+            interventionStart: "2026-06-01",
+            interventionEnd: "2026-06-03",
+            targetSessions: 9,
+            minimumUsefulSessions: 7,
+            adherenceTargets,
+          },
+        }),
+        ...sessions,
+      ],
+    });
+    return summarizeExperimentProgress(vault, slug, { asOf: "2026-06-03" }).adherence;
+  };
+  const calendarTarget: ExperimentAdherenceTarget = {
+    ...target,
+    calendar: { ...calendar, dates: [...calendar.dates] },
+  };
+  const secondaryTarget: ExperimentAdherenceTarget = {
+    ...calendarTarget,
+    targetId: "secondary",
+    rollup: undefined,
+    calendar: {
+      kind: "explicitDates",
+      timeZone: "UTC",
+      dates: [{ localDate: "2026-06-03" }],
+    },
+  };
+
+  assert.deepEqual(summarize([calendarTarget, secondaryTarget]), {
+    completedSessions: 1,
+    partialSessions: 1,
+    evidence: { eventKind: "intervention_session" },
+    expectedSessionsByNow: 2,
+    loggedSessions: 2,
+    minimumUsefulSessions: 1,
+    sessionEventIds: [completedId, partialId],
+    status: "met_target",
+    targetSessions: 2,
+  });
+  assert.deepEqual(summarize([target]), {
+    completedSessions: 2,
+    partialSessions: 1,
+    evidence: { eventKind: "intervention_session" },
+    expectedSessionsByNow: 2,
+    loggedSessions: 3,
+    minimumUsefulSessions: 1,
+    sessionEventIds: [completedId, partialId, offCalendarId],
+    status: "met_target",
+    targetSessions: 2,
+  });
+  assert.deepEqual(summarize([{ ...calendarTarget, rollup: undefined }, secondaryTarget]), {
+    completedSessions: 0,
+    expectedSessionsByNow: null,
+    loggedSessions: 0,
+    minimumUsefulSessions: null,
+    sessionEventIds: [completedId, partialId, offCalendarId],
+    status: "unknown",
+    targetSessions: null,
+  });
+});


### PR DESCRIPTION
## Why and outcome

Experiment adherence summaries independently selected calendar, occurrence, or noncalendar counts for confidence, totals, and expected progress. Select that count result once using the existing adherence counters, then derive the public summary from it. Preserve target selection, statuses, optional fields, and evidence IDs.

## Product UX

- Effort: Not applicable — internal query refactor with unchanged public output.
- Result: Not applicable.
- Walkthrough: Existing experiment progress and outcome consumers retain the same values and evidence.

## Evidence

- Direct: The new characterization passed against the original implementation and the final candidate; 215 tests passed across five focused files. `pnpm --dir packages/query typecheck` and `git diff --check` passed.
- Coverage: The new public-query characterization preserves selected-rollup calendar counts, partial and off-calendar evidence, noncalendar counts, ambiguous targets, and optional-field omission. Existing focused suites cover repeated occurrences, grace windows, confidence, activity evidence, outcome analysis, and browser result parity.

Focused test command:

```sh
pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage \
  test/experiment-analysis.test.ts test/experiment-adherence.test.ts \
  test/experiment-repeated-cadence-counts.test.ts \
  test/browser-vault-experiment-results.test.ts \
  test/experiment-open-ended-outcomes.test.ts
```

## Non-obvious affected surfaces

Outcome confidence and follow-up decisions consume the same server summary; existing experiment analysis and repeated-cadence tests cover those consumers. Browser experiment source is unchanged and browser result tests remain included.

## Architecture and reuse

- Existing systems reused: Query-owned target resolution, calendar construction, and the existing occurrence, noncalendar, and confidence counters.
- New logic: None; the same counts and summary fields are derived with one source-selection step.
- New abstractions: One private count-selection helper and its structural return type. No shared interface or state owner is added.
- Complexity intentionally avoided: Removed duplicated count-source selection, redundant target fallback, and separate completion bookkeeping without adding a registry or framework.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base b0a945bb87e20755d1cbbcfb3c32ec02c8f12fec -- packages/query/src/experiments.ts`.
- Hotspots: `buildAdherenceSummary` 67 → 31; the private count-selection helper is 8. File maximum 67 → 47; debt above 20 is 78 → 42; total complexity 801 → 773. Remaining unchanged hotspots are `buildCoverageSummary` (47) and the `buildExperimentSessionMetricPoints` field callback (24).
- Agent judgment: This deletes repeated decisions across one existing query owner. The remaining adherence status precedence and optional-field construction stay explicit. Further extraction solely to lower the function score would not improve this seam.

## Hot reply path impact

- Path status: Not applicable — this changes pure query-summary count selection.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved.
- Before/after proof: Source inspection and focused public-query output tests.

## Murph initial provider input impact

Not applicable for individual and group Murph: no prompt, tool/schema, generated guidance, wrapper, or provider-input assembly surface changes. No token or byte measurement is claimed.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Pure internal refactor with no persisted format, wire contract, dependency, migration, or rollout-order change.

## Change-shape breakdown

Classification rule: Query implementation is source, the characterization is tests, and the completed execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 66 | 78 |
| Tests / fixtures | 116 | 0 |
| Docs | 66 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **248** | **78** |

## Changelog

- Changelog: not applicable
- Reason: Internal maintainability refactor preserving member-visible behavior.

ReviewGPT first-reviewed head: c433aaa46bb1ea88519372848c32c764656a29a3
ReviewGPT context sensitivity: sensitive
Sensitivity reason: Experiment adherence projection carries health-data target selection, confidence, and evidence semantics.

## Final review evidence

- Round 1: PASS on c433aaa46bb1ea88519372848c32c764656a29a3; zero findings received, accepted, or rejected.
- Scope and identity: Full immutable snapshot and diff reviewed; response hashes, captured turn, model, and exact head were verified.
- Model and lane: gpt-6-pro on vonneumann. The successful wrapper enforced at least 270 seconds; exact elapsed time was not persisted.
- Tooling retries: An earlier response finished below the required duration and remained diagnostic-only. The fresh review retried round 1 on the same head.

## CI timing-test evidence

The initial Web test shard 2/4 attempt timed out in the existing test named `overflow experiment routes derive demand from the immutable legacy outcome`. An isolated replay passed on this unchanged head (1 passed, 70 skipped). The failing test and its five browser-path owner files are byte-identical to base and do not call the modified server adherence summary. The identical timeout was previously recorded for #3104 in `.agents/friction-log/20260909125627-browser-vault-overflow/friction.md`. The precise timing cause remains unproven; GitHub Actions records the full-shard result.
