### PR TITLE
Complete generated-image retention after hosted media expires

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -2870,11 +2870,20 @@ Last verified: 2026-09-04
   classification; the six per-pass `blockedCaptureCounts` start at zero and stay
   ephemeral. The warning emits all six counts, which sum to the blocked total.
   These describe the caught code, not a diagnosed production cause: changed or
-  absent image bytes share the precondition category; `VAULT_FILE_MISSING` stays
+  unreported absent image bytes share the precondition category; `VAULT_FILE_MISSING` stays
   separate. No error objects, messages, IDs, paths, or arbitrary keys enter these
   details. Successful passes stay silent; warning frequency, abort/unknown-error
   propagation, protection, batching, canonical writes, and retention/retry timing
   are unchanged.
+- A due generated-image capture whose exact attachment path is reported missing
+  by the hosted materializer can complete canonical retirement without restoring
+  expired bytes. Core still validates the generated-image event, manifest owner,
+  path and original attachment hash. A present file must match that hash even if
+  reported missing. Absent files receive a create-only raw tombstone; present
+  files retain their inspected-preimage replacement guard. The existing receipt
+  format replays both forms idempotently and rejects conflicting bytes. Already
+  absent bytes contribute zero to retired-byte counts. Unreported loss, invalid
+  metadata, protected captures and fresh captures keep their existing disposition.
 - Scheduled group Assistant Ask stays inside the ordinary scheduled Codex turn:
   start the selected requests, then use ordinary shell waits and exact replay to
   poll every accepted request until it returns completed or unavailable. The

--- a/agent-docs/exec-plans/active/2026-09-10-generated-image-retention-expiry-fix.md
+++ b/agent-docs/exec-plans/active/2026-09-10-generated-image-retention-expiry-fix.md
@@ -1,0 +1,81 @@
+# Complete generated-image cleanup after hosted expiry
+
+Status: active
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+- Complete due generated-image capture retirement after the hosted media owner
+  expires its bytes, preserving canonical ownership and guarded writes.
+
+## Success criteria
+
+- Reproduce the composed warm/cold expiry failure before the fix.
+- Retire valid, materializer-reported missing images without fetching expired
+  bytes; preserve rejection of changed bytes and invalid metadata.
+- Pass focused tests, relevant typechecks, parent review, final ReviewGPT and
+  required exact-head CI; open a PR without merging or deploying it.
+
+## Scope
+
+- In scope: core retention's existing materializer result, canonical receipt
+  semantics, focused regressions, and the owning reliability contract.
+- Out of scope: retention policy changes, new schedulers, production repair,
+  delivery replay, and unrelated work in other checkouts.
+
+## Constraints
+
+- Reuse the existing missing-path report and canonical create/replace receipts.
+  Keep absent bytes distinct from a mismatched existing file. Validate the
+  manifest against the immutable event before creating a tombstone.
+- Product UX patch: Outcome — complete the existing 14-day retirement promise.
+  Reaches — warm and restored hosted workspaces with expired generated images.
+  Proof — canonical deleted readback, idempotence, replay and negative cases.
+
+## Risks and mitigations
+
+1. Missing bytes alone could hide corruption. Require the existing materializer
+   to report the exact path missing and validate original event/manifest identity.
+2. A file appearing during commit could be overwritten. Use create-only raw
+   writes for an absent preimage and retain guarded replacement for present bytes.
+3. Historical warnings can also represent changed bytes. Do not claim every
+   production warning is the reproduced expiry case or bypass hash checks.
+
+## Tasks
+
+1. Trace and reproduce hosted expiry through the actual materializer.
+2. Correct core consumption of its result and prove canonical recovery.
+3. Review, document, commit and open the verified PR.
+
+## Decisions
+
+- Hosted media and core both use the original capture's 14-day cutoff. The
+  materializer deletes/declines expired bytes and reports their path missing;
+  core currently discards that result and fails its original-byte precondition.
+- No persisted schema or new runtime owner is required. Existing create-only
+  raw receipts reject conflicting bytes and support idempotent replay.
+
+## Verification
+
+- Focused generated-image retention, hosted artifact and receipt replay tests;
+  core/runtime typechecks; privacy, complexity and documentation guards.
+- Expected: no recheck wake after valid expiry cleanup, no media resurrection,
+  and unchanged fail-closed behavior for unreported loss or metadata mismatch.
+
+## Candidate evidence
+
+- At base `62609d5a09bf169eacd6e8be108e26fd41275035`, the missing-image core
+  regression and both real-materializer warm/cold-shaped regressions failed:
+  one blocked capture, zero retirement, and another daily wake.
+- After correction, all 21 core retention tests and all 63 hosted artifact/idle
+  maintenance tests pass. Both new composed cases make zero media GET calls.
+- Full canonical receipt replay creates the absent tombstone, remains
+  idempotent, and rejects conflicting bytes. Negative cases retain live metadata
+  for unreported absence, changed bytes, mismatched manifest hash and wrong owner.
+- Both core and assistant-runtime typechecks pass; all 10 changelog rendering
+  tests, privacy and docs-drift checks pass. Complexity remains debt 3 / max 23;
+  candidate materialization belongs in the existing preparation owner.
+- Parent reviewed the full diff: one production owner changed, no provider
+  input, foreground path, scheduler, persisted format or retry-policy additions.
+- Final ReviewGPT, exact-head CI and plan closure remain pending for the PR.

--- a/agent-docs/exec-plans/completed/2026-09-10-generated-image-retention-expiry-fix.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-generated-image-retention-expiry-fix.md
@@ -1,6 +1,6 @@
 # Complete generated-image cleanup after hosted expiry
 
-Status: active
+Status: completed
 Created: 2026-09-10
 Updated: 2026-09-10
 
@@ -78,4 +78,14 @@ Updated: 2026-09-10
   candidate materialization belongs in the existing preparation owner.
 - Parent reviewed the full diff: one production owner changed, no provider
   input, foreground path, scheduler, persisted format or retry-policy additions.
-- Final ReviewGPT, exact-head CI and plan closure remain pending for the PR.
+- PR #3170 final ReviewGPT passed at
+  `4f7288efa46d4a05cd262668d5434e5a3fc4af3e` with zero qualifying findings.
+  The capture verified the actual `gpt-6-pro` response. The reviewer checked
+  ownership, protection, commit rollback, replay, accounting and retry boundaries;
+  it did not independently execute runtime tests.
+- Parent final review accepted the unchanged production patch. Plan closure and
+  this historical evidence are the only final changes; no new review is needed.
+- Required CI was still queued when this plan was archived. Final-head CI and
+  current-base mergeability remain PR completion gates, recorded in the PR body.
+  This PR is for human review and deployment; no merge or deployment occurred.
+Completed: 2026-09-10

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -29,6 +29,10 @@ This is a directory, not a second copy of the system contracts. Start with
 owners relevant to the task. A row's date is its recorded verification date,
 not a guarantee that every claim was checked in this cleanup.
 
+Generated-image retirement after hosted media expiry is owned by
+`agent-docs/RELIABILITY.md`; implementation and verification are tracked in
+`agent-docs/exec-plans/active/2026-09-10-generated-image-retention-expiry-fix.md`.
+
 ## Canonical Docs
 
 | Path | Purpose | Source of truth | Criticality | Last verified |

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -31,7 +31,7 @@ not a guarantee that every claim was checked in this cleanup.
 
 Generated-image retirement after hosted media expiry is owned by
 `agent-docs/RELIABILITY.md`; implementation and verification are tracked in
-`agent-docs/exec-plans/active/2026-09-10-generated-image-retention-expiry-fix.md`.
+`agent-docs/exec-plans/completed/2026-09-10-generated-image-retention-expiry-fix.md`.
 
 ## Canonical Docs
 

--- a/apps/web/changelog/entries/2026-09-10/generated-image-expiry-cleanup.json
+++ b/apps/web/changelog/entries/2026-09-10/generated-image-expiry-cleanup.json
@@ -1,0 +1,14 @@
+{
+  "publishedOn": "2026-09-10",
+  "order": 100,
+  "item": {
+    "id": "generated-image-expiry-cleanup",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Complete cleanup for expired generated images",
+    "summary": "Generated-image captures can finish their scheduled cleanup even when the image itself has already expired.",
+    "details": "Cleanup keeps the existing 14-day retention window and does not restore expired images.",
+    "relevanceTags": ["privacy", "images"],
+    "sourcePullRequests": []
+  }
+}

--- a/apps/web/changelog/entries/2026-09-10/generated-image-expiry-cleanup.json
+++ b/apps/web/changelog/entries/2026-09-10/generated-image-expiry-cleanup.json
@@ -9,6 +9,6 @@
     "summary": "Generated-image captures can finish their scheduled cleanup even when the image itself has already expired.",
     "details": "Cleanup keeps the existing 14-day retention window and does not restore expired images.",
     "relevanceTags": ["privacy", "images"],
-    "sourcePullRequests": []
+    "sourcePullRequests": [3170]
   }
 }

--- a/packages/assistant-runtime/test/hosted-runtime-artifacts.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-artifacts.test.ts
@@ -9,10 +9,13 @@ import path from "node:path";
 import { expect, test, vi } from "vitest";
 import {
   addCapture,
+  addCaptureWithLookup,
   applyCanonicalWriteBatch,
   appendJsonlRecord,
   initializeVault,
+  findCaptureByLookup,
   readEvent,
+  runGeneratedImageCaptureRetention,
   upsertEvent,
   withHostedCanonicalWritePort,
   type HostedCanonicalWritePersistenceInput,
@@ -55,6 +58,72 @@ import {
   publishHostedWorkspaceMediaReferencesForSnapshot,
   readHostedMediaReferenceCatalogue,
 } from "../src/hosted-runtime/media-references.ts";
+
+test.each(["warm", "restored"])("retires an expired generated capture in a %s workspace", async (workspace) => {
+  const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-expired-generated-capture-"));
+  const recordedAt = "2030-01-01T00:00:00.000Z";
+  const expiresAt = "2030-01-15T00:00:00.000Z";
+  const clock = vi.spyOn(Date, "now").mockReturnValue(Date.parse(recordedAt));
+  try {
+    await initializeVault({ vaultRoot, title: "Generated capture expiry", timezone: "UTC" });
+    const sourcePath = path.join(vaultRoot, "source.png");
+    await writeFile(sourcePath, "synthetic image payload");
+    const capture = await addCaptureWithLookup({
+      vaultRoot,
+      lookupKey: "generated:hosted-expiry",
+      lookupAttachmentRole: "media_1",
+      attachments: [{ role: "media_1", sourcePath }],
+      draft: {
+        recordedAt,
+        occurredAt: recordedAt,
+        source: "derived",
+        tags: ["assistant-generated-image", "generated-image"],
+        title: "Synthetic generated capture",
+        note: "Synthetic retention proof.",
+      },
+      rawImport: {
+        importKind: "capture",
+        importedAt: recordedAt,
+        source: "murph.generate_image",
+        provenance: { generatedImage: { schema: "murph.generated-image.v1" } },
+      },
+    });
+    const attachmentRef = capture.event.attachments![0]!.relativePath;
+    const { mediaStore, getCalls } = createHostedRuntimeMediaStoreStub();
+    await publishHostedWorkspaceMediaReferencesForSnapshot({ mediaStore, vaultRoot });
+    expect((await readHostedMediaReferenceCatalogue({ vaultRoot })).entries)
+      .toEqual([expect.objectContaining({ relativePath: attachmentRef, expiresAt })]);
+    // Hosted snapshots omit externalized bytes; the warm path still has them.
+    if (workspace === "restored") await rm(path.join(vaultRoot, attachmentRef));
+    clock.mockReturnValue(Date.parse(expiresAt));
+    const { artifactStore } = createHostedRuntimeArtifactStoreStub();
+    const materialize = createHostedArtifactMaterializer({
+      artifactResolver: createHostedArtifactResolver({ artifactStore }),
+      bundles: [],
+      materializedArtifactPaths: new Set(),
+      mediaStore,
+      operatorHomeRoot: path.join(vaultRoot, ".operator-home"),
+      vaultRoot,
+    });
+    const materializeCandidatePaths = async (paths: readonly string[]) => {
+      const result = await materialize(paths);
+      return { missingStoredPaths: [...result.missingArtifactPaths].map((key) => key.slice("vault:".length)) };
+    };
+    const input = { vaultRoot, now: new Date(expiresAt), materializeCandidatePaths };
+    expect(await runGeneratedImageCaptureRetention(input)).toMatchObject({
+      blockedCaptureCount: 0, retiredCaptureCount: 1, retiredByteCount: 0, nextEligibleAt: null,
+    });
+    expect(getCalls).toHaveLength(0);
+    expect(await findCaptureByLookup({ vaultRoot, lookupKey: "generated:hosted-expiry" }))
+      .toMatchObject({ status: "deleted" });
+    expect(await runGeneratedImageCaptureRetention(input)).toMatchObject({
+      blockedCaptureCount: 0, retiredCaptureCount: 0, nextEligibleAt: null,
+    });
+  } finally {
+    clock.mockRestore();
+    await rm(vaultRoot, { recursive: true, force: true });
+  }
+});
 
 test("hosted artifact resolver caches repeated reads by artifact hash", async () => {
   const bytes = new Uint8Array([1, 2, 3]);

--- a/packages/core/src/domains/events/generated-image-capture-retention.ts
+++ b/packages/core/src/domains/events/generated-image-capture-retention.ts
@@ -63,7 +63,9 @@ type GeneratedImageRetentionBlockedCaptureCode =
   keyof typeof EMPTY_GENERATED_IMAGE_RETENTION_BLOCKED_CAPTURE_COUNTS;
 
 export interface RunGeneratedImageCaptureRetentionInput {
-  materializeCandidatePaths?: ((storedPaths: readonly string[]) => Promise<unknown>) | null;
+  materializeCandidatePaths?: ((
+    storedPaths: readonly string[],
+  ) => Promise<{ missingStoredPaths?: Iterable<string> } | void>) | null;
   maxCaptures?: number;
   now?: Date;
   protectedCaptureIds?: Iterable<string>;
@@ -95,7 +97,7 @@ interface GeneratedImageRetentionCandidate {
   lookupKeyHash: string;
   manifest: ManifestSnapshot;
   nextEventRecord: EventRecord | null;
-  originalReceipt: CommittedPayloadReceipt;
+  originalReceipt: CommittedPayloadReceipt | null;
   tombstoneContent: string;
 }
 
@@ -233,14 +235,11 @@ async function runGeneratedImageCaptureRetentionLocked(
         hasMoreEligibleCaptures = true;
         break;
       }
-      await input.materializeCandidatePaths?.([
-        lookup.attachmentRef,
-        ...(lookup.manifestPath ? [lookup.manifestPath] : []),
-      ]);
       candidate = await prepareRetentionCandidate({
         latest: latest.record,
         lookup,
         lookupKeyHash,
+        materializeCandidatePaths: input.materializeCandidatePaths,
         now: input.now,
         origin,
         signal: input.signal,
@@ -267,7 +266,7 @@ async function runGeneratedImageCaptureRetentionLocked(
     });
     lookupIndex = committed.lookupIndex;
     lookupReceipt = committed.lookupReceipt;
-    retiredByteCount += candidate.originalReceipt.byteLength;
+    retiredByteCount += candidate.originalReceipt?.byteLength ?? 0;
     retiredCaptureCount += 1;
     if (candidate.nextEventRecord) {
       ledgerRecords.get(candidate.ledgerFile)?.push(candidate.nextEventRecord);
@@ -315,8 +314,9 @@ async function commitRetentionCandidate(input: {
         input.candidate.tombstoneContent,
         {
           allowRaw: true,
-          expectedTargetReceipt: input.candidate.originalReceipt,
-          overwrite: true,
+          ...(input.candidate.originalReceipt
+            ? { expectedTargetReceipt: input.candidate.originalReceipt, overwrite: true }
+            : { overwrite: false }),
         },
       );
       await batch.stageTextWrite(
@@ -374,11 +374,16 @@ async function prepareRetentionCandidate(input: {
   latest: EventRecord;
   lookup: StoredCaptureLookup;
   lookupKeyHash: string;
+  materializeCandidatePaths: RunGeneratedImageCaptureRetentionInput["materializeCandidatePaths"];
   now: Date;
   origin: EventRecord;
   signal?: AbortSignal | null;
   vaultRoot: string;
 }): Promise<GeneratedImageRetentionCandidate> {
+  const materialized = await input.materializeCandidatePaths?.([
+    input.lookup.attachmentRef,
+    ...(input.lookup.manifestPath ? [input.lookup.manifestPath] : []),
+  ]);
   throwIfGeneratedImageRetentionAborted(input.signal);
   const attachment = input.origin.attachments?.find(
     (candidate) => candidate.relativePath === input.lookup.attachmentRef,
@@ -395,8 +400,9 @@ async function prepareRetentionCandidate(input: {
     input.lookup.attachmentRef,
   );
   if (
-    !originalIntegrity ||
-    originalIntegrity.sha256 !== attachment.sha256
+    originalIntegrity
+      ? originalIntegrity.sha256 !== attachment.sha256
+      : !new Set(materialized?.missingStoredPaths).has(input.lookup.attachmentRef)
   ) {
     throw new VaultError(
       "GENERATED_IMAGE_RETENTION_PRECONDITION_FAILED",
@@ -415,8 +421,8 @@ async function prepareRetentionCandidate(input: {
   if (
     !artifact ||
     artifact.relativePath !== input.lookup.attachmentRef ||
-    artifact.byteSize !== originalIntegrity.byteSize ||
-    artifact.sha256 !== originalIntegrity.sha256
+    (originalIntegrity !== null && artifact.byteSize !== originalIntegrity.byteSize) ||
+    artifact.sha256 !== attachment.sha256
   ) {
     throw new VaultError(
       "GENERATED_IMAGE_RETENTION_MANIFEST_INVALID",
@@ -455,7 +461,7 @@ async function prepareRetentionCandidate(input: {
     nextEventRecord: isDeletedEventSpineRecord(input.latest)
       ? null
       : buildDeletedEventTombstone(input.latest, input.now),
-    originalReceipt: toCommittedReceipt(originalIntegrity),
+    originalReceipt: originalIntegrity ? toCommittedReceipt(originalIntegrity) : null,
     tombstoneContent,
   };
 }

--- a/packages/core/test/generated-image-capture-retention.test.ts
+++ b/packages/core/test/generated-image-capture-retention.test.ts
@@ -1,16 +1,19 @@
 import path from "node:path";
 import { tmpdir } from "node:os";
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   addCaptureWithLookup,
+  applyHostedCanonicalWriteReceipt,
   findCaptureByLookup,
   initializeVault,
   readJsonlRecords,
   runGeneratedImageCaptureRetention,
   validateVault,
+  withHostedCanonicalWritePort,
+  type HostedCanonicalWritePersistenceInput,
   VaultError,
 } from "@murphai/core";
 
@@ -98,6 +101,99 @@ async function readLookupIndex(vaultRoot: string): Promise<{
 }
 
 describe("generated image capture retention", () => {
+  it("retires a due image reported missing by the materializer without counting absent bytes", async () => {
+    const vaultRoot = await createTempVault();
+    const capture = await addGeneratedCapture({
+      lookupKey: "generated:expired-hosted-image",
+      recordedAt: "2026-07-01T12:00:00.000Z",
+      vaultRoot,
+    });
+    const attachmentRef = capture.event.attachments![0]!.relativePath;
+    await rm(path.join(vaultRoot, attachmentRef));
+    const replayRoot = await createTempVault();
+    await cp(vaultRoot, replayRoot, { recursive: true });
+    const persisted: HostedCanonicalWritePersistenceInput[] = [];
+    const input = {
+      now: new Date("2026-07-15T12:00:00.000Z"),
+      vaultRoot,
+      materializeCandidatePaths: async () => ({ missingStoredPaths: [attachmentRef] }),
+    };
+
+    await expect(withHostedCanonicalWritePort({
+      async persistCanonicalWrite(write) { persisted.push(write); },
+    }, () => runGeneratedImageCaptureRetention(input))).resolves.toMatchObject({
+      blockedCaptureCount: 0,
+      retiredByteCount: 0,
+      retiredCaptureCount: 1,
+      nextEligibleAt: null,
+    });
+    await expect(findCaptureByLookup({
+      vaultRoot,
+      lookupKey: "generated:expired-hosted-image",
+    })).resolves.toMatchObject({ status: "deleted" });
+    const tombstone = JSON.parse(await readFile(path.join(vaultRoot, attachmentRef), "utf8"));
+    expect(tombstone.reason).toBe("generated_image_retention");
+    expect((await validateVault({ vaultRoot })).valid).toBe(true);
+    expect(persisted).toHaveLength(1);
+    const write = persisted[0]!;
+    expect(write.receipt.actions[0]).toMatchObject({
+      kind: "text_upsert", targetRelativePath: attachmentRef, effect: "create", allowRaw: true,
+    });
+    const replay = () => applyHostedCanonicalWriteReceipt({
+      vaultRoot: replayRoot,
+      receipt: write.receipt,
+      readPayload: async (ref) => write.payloads.find((payload) => payload.sha256 === ref.sha256)?.bytes ?? null,
+    });
+    await replay();
+    await replay();
+    expect(await findCaptureByLookup({ vaultRoot: replayRoot, lookupKey: "generated:expired-hosted-image" }))
+      .toMatchObject({ status: "deleted" });
+    await writeFile(path.join(replayRoot, attachmentRef), "unexpected bytes");
+    await expect(replay()).rejects.toMatchObject({ code: "HOSTED_CANONICAL_WRITE_RAW_CONFLICT" });
+    expect(await readFile(path.join(replayRoot, attachmentRef), "utf8")).toBe("unexpected bytes");
+    await expect(runGeneratedImageCaptureRetention(input)).resolves.toMatchObject({
+      blockedCaptureCount: 0,
+      retiredCaptureCount: 0,
+      nextEligibleAt: null,
+    });
+  });
+
+  it.each(["unreported", "changed", "manifest-hash", "manifest-owner"])(
+    "does not let the missing-path report bypass %s validation",
+    async (scenario) => {
+      const vaultRoot = await createTempVault();
+      const lookupKey = `generated:missing-${scenario}`;
+      const capture = await addGeneratedCapture({
+        lookupKey, recordedAt: "2026-07-01T12:00:00.000Z", vaultRoot,
+      });
+      const attachmentRef = capture.event.attachments![0]!.relativePath;
+      if (scenario === "changed") {
+        await writeFile(path.join(vaultRoot, attachmentRef), "changed bytes");
+      } else {
+        await rm(path.join(vaultRoot, attachmentRef));
+      }
+      const manifestPath = path.join(vaultRoot, capture.manifestPath!);
+      const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+      if (scenario === "manifest-hash") manifest.artifacts[0].sha256 = "0".repeat(64);
+      if (scenario === "manifest-owner") manifest.owner.id = "another-capture";
+      await writeFile(manifestPath, JSON.stringify(manifest));
+      const result = await runGeneratedImageCaptureRetention({
+        vaultRoot, now: new Date("2026-07-15T12:00:00.000Z"),
+        materializeCandidatePaths: async () => ({
+          missingStoredPaths: scenario === "unreported" ? ["raw/unrelated.png"] : [attachmentRef],
+        }),
+      });
+      expect(result).toMatchObject({ blockedCaptureCount: 1, retiredCaptureCount: 0 });
+      expect(await findCaptureByLookup({ vaultRoot, lookupKey })).toMatchObject({ status: "live" });
+      expect(await readFile(manifestPath, "utf8")).toBe(JSON.stringify(manifest));
+      if (scenario === "changed") {
+        expect(await readFile(path.join(vaultRoot, attachmentRef), "utf8")).toBe("changed bytes");
+      } else {
+        await expect(readFile(path.join(vaultRoot, attachmentRef))).rejects.toMatchObject({ code: "ENOENT" });
+      }
+    },
+  );
+
   it("is a no-op when an empty checkpoint workspace has no lookup index", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-empty-retention-"));
     cleanupPaths.push(vaultRoot);


### PR DESCRIPTION
## Why and outcome

Hosted media expires generated images at the same 14-day cutoff used by capture retention. The materializer then reports the image missing, but retention discards that result and requires the original bytes, leaving the capture live and scheduling another daily retry.

Retention now consumes the existing missing-path report, validates the canonical event and manifest, and creates the ordinary tombstone without restoring expired bytes. A present image must still match its original hash; an absent image contributes zero retired bytes. No scheduler, retention window, persisted format or provider operation changes.

## Product UX

- Effort: Patch restoring the existing generated-image cleanup promise.
- Result: Ready based on focused canonical and composed materializer proof; production recovery remains a post-deployment check.
- Walkthrough: Due warm workspaces and workspaces whose externalized image is absent both finish cleanup. Fresh/protected captures remain deferred. Changed bytes, unreported file loss and invalid metadata remain blocked.

## Evidence

- Direct: The new core missing-image case and both warm/cold-shaped hosted materializer cases failed before the fix with one blocked capture, zero retired captures and another daily wake. They pass after the fix with deleted lookup readback, no recheck wake and zero media GETs.
- Coverage: 21 core retention tests and 63 hosted artifact/idle-maintenance tests pass. The emitted create-only raw receipt replays against the missing-image base, remains idempotent, and rejects conflicting bytes. Negative cases cover unreported absence, changed bytes, wrong manifest hash and wrong owner.
- Commands: `pnpm --filter @murphai/core exec vitest run --config vitest.config.ts --no-coverage test/generated-image-capture-retention.test.ts`; `pnpm --filter @murphai/assistant-runtime exec vitest run --config vitest.config.ts --no-coverage test/hosted-runtime-artifacts.test.ts test/hosted-runtime-idle-maintenance.test.ts`.
- Core and assistant-runtime typechecks pass. `pnpm logs:guard`, `pnpm docs:drift`, `git diff --check` and 10 changelog rendering tests pass. The final candidate also reran the affected core suite and the two composed expiry cases after moving materialization into candidate preparation.
- Final ReviewGPT: PASS at `4f7288efa46d4a05cd262668d5434e5a3fc4af3e`, zero qualifying findings; actual model `gpt-6-pro` verified. It independently inspected the source and receipt boundaries but did not run tests. Final head `e2c15e07ed92c683e3e93d3d27c1c6c0ff92d95f` changes only plan closure/documentation from that reviewed head. Required exact-head CI passed: [CLI host matrix (macos-latest)](https://github.com/cobuildwithus/murph/actions/runs/34504078746/job/102961889274), [CLI host matrix (ubuntu-24.04)](https://github.com/cobuildwithus/murph/actions/runs/34504078746/job/102961889257), [Release checks (ubuntu)](https://github.com/cobuildwithus/murph/actions/runs/34504078746/job/102968126554), [Required hosted Stripe billing boundary](https://github.com/cobuildwithus/murph/actions/runs/34504078740/job/102963439457). Current-main mergeability was reverified. The separate [Temporal compatibility run](https://github.com/cobuildwithus/murph/actions/runs/34504536078) also passed on the final head. All current required checks and the additional Temporal compatibility proof are green.

## Non-obvious affected surfaces

The hosted canonical receipt replay owner receives its existing create-only raw text action when the preimage is absent, rather than a guarded replacement. The composed receipt test verifies replay and conflicting-byte rejection using the unchanged reader. No wire fields or receipt schemas are added.

## Architecture and reuse

- Existing systems reused: Hosted materializer missing-path reports, core generated-image ownership validation, canonical write batches and existing raw create/replace receipt replay.
- New logic: Permit retirement of an absent due image only when its exact path is reported missing; keep manifest/event checks and create-only write protection.
- New abstractions: None; the existing candidate preparation function consumes the result and the candidate's nullable receipt describes an absent preimage.
- Complexity intentionally avoided: No new queue, retry mechanism, storage owner, migration, fallback fetch or retention policy.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base origin/main`; production source +20/-14.
- Hotspots: `runGeneratedImageCaptureRetentionLocked` remains 23 with debt 3, unchanged from base. Materialization and its result belong together in the existing candidate preparation owner.
- Agent judgment: The correction stays in one production file and reuses current commit/replay guards. Further loop refactoring would add unrelated scope.

## Hot reply path impact

- Path status: Not applicable; only due generated-image maintenance changes.
- Database calls: None added or moved onto the foreground path.
- Network/provider calls: None added; the composed expired-media cases make zero GET calls.
- Other awaited latency: The same candidate materialization call moves into preparation without changing its ordering relative to validation.
- Before/after proof: The existing idle-maintenance suite preserves foreground interruption and protected-capture behavior.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no prompts, tool schemas, routing, provider-visible fields or initial request assembly change. Assembled instructions, tool guidance and other provider input remain unchanged; full-input measurement is not applicable.

## Design proof

- Design page: [Existing changelog archive](https://www.withmurph.ai/screenshots/ops#changelog-archive).
- Evidence: Content-only fragment; existing presentation reference returned HTTP 200. `pnpm --dir apps/web test -- changelog-page.test.tsx` passes all 10 tests.
- Coverage: The production archive component renders the authored copy; no renderer, layout, style or interaction changes.

ReviewGPT first-reviewed head: 4f7288efa46d4a05cd262668d5434e5a3fc4af3e
ReviewGPT context sensitivity: sensitive
Classification reason: Canonical raw retirement and hosted receipt replay are privacy and persistence boundaries.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing readers accept the same create-only and guarded-replacement receipts. Older runners keep their previous missing-byte behavior; new runners can finish that cleanup.
- Safe order: Ship the corrected runner bundle through the normal hosted rollout; no Web, Worker protocol or database migration order is required.
- Rollback floor: Existing canonical create-only raw receipt support; this PR adds no schema or semantic reader floor.
- Expected exposure: Old containers may continue reporting a blocked capture during the rollout; their existing daily retry remains available.
- Reversibility: Reverting the runner restores the prior missing-byte limitation without changing already-retired canonical records.
- Convergence proof: The focused test sends the new writer's actual receipt through the unchanged reader, including repeat and conflicting-byte cases. Fleet convergence is a deployment check, not claimed here.
- Post-deploy checks: Verify runner convergence and inspect the existing retention reason counts and due-work progression. Do not equate every byte-precondition warning with the reproduced expiry case.

## Change-shape breakdown

Source +20/-14; tests/fixtures +166/-1; docs +105/-1; config/tooling +0/-0; authored changelog content +14/-0; generated files +0/-0. Total +305/-16 across seven files; no binaries.

## Changelog

- Changelog: updated
- Items: 2026-09-10 · generated-image-expiry-cleanup
