### PR TITLE
perf: reuse fresh member state during mailbox fetch

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-10-mailbox-member-read.md
+++ b/agent-docs/exec-plans/active/2026-09-10-mailbox-member-read.md
@@ -1,0 +1,42 @@
+# Reuse fresh member state during mailbox fetch
+
+## Outcome and invariants
+
+Remove repeated member queries from ordinary mailbox fetching. Web remains the
+owner of current access, consent, billing and usage; no state survives the request.
+Suspension, group participant authority, usage denial confirmation and mailbox
+watermarks retain their existing behavior. No provider input changes.
+
+## Evidence and design
+
+The fetch route reads access, the runtime usage adapter rereads consent/access,
+and the allowance reader rereads billing/credits. Their existing owners can accept
+one typed member projection loaded by the fetch boundary. Keep usage-period reads
+and authoritative denial confirmation with the allowance owner. Do not cache
+Prisma calls or introduce another gate owner. Group participant and Family billing
+reads remain where current authority requires them.
+
+## Verification and delivery
+
+- Prove the composed route uses one member read on ordinary allow and reloads on
+  the next request; exercise consent withdrawal, suspension, group access,
+  exhaustion confirmation, empty/system/consumed replay and provider selection.
+- Run focused Web tests, Web typecheck and complexity guard; review the full diff.
+- Publish a separate draft PR, finish required review and exact-head CI, then
+  leave it merge ready. This Web-only projection change preserves the wire
+  contract and needs no deployment ordering or persisted migration.
+
+## Progress
+
+- Implemented explicit request-local projection reuse at existing readers. The
+  mutating mode cannot accept a projection; read-first denial confirmation always
+  reloads through its existing owner. No cache or new service was introduced.
+- Product UX Patch: less repeated work before processing; individual and group
+  conversation plus empty/system/replay and revoked-access paths covered. Ready
+  at the tested fetch boundary; live typing latency requires deployment evidence.
+- 241 focused Web cases passed, including a composed real-route/gate proof of one
+  member read and next-request consent/suspension/deletion changes. Existing group
+  and Family allowance cases pass. Full Web typecheck passed before final proof
+  additions; final prepared typecheck and changelog SSR proof are running.
+- Complexity guard passed; all five reported >20 hotspots are unchanged allowance
+  pricing/period functions outside this correction. Final review and CI pending.

--- a/agent-docs/exec-plans/active/2026-09-10-mailbox-member-read.md
+++ b/agent-docs/exec-plans/active/2026-09-10-mailbox-member-read.md
@@ -36,7 +36,7 @@ reads remain where current authority requires them.
   at the tested fetch boundary; live typing latency requires deployment evidence.
 - 241 focused Web cases passed, including a composed real-route/gate proof of one
   member read and next-request consent/suspension/deletion changes. Existing group
-  and Family allowance cases pass. Full Web typecheck passed before final proof
-  additions; final prepared typecheck and changelog SSR proof are running.
+  and Family allowance cases pass. Full Web typecheck, final prepared typecheck and changelog SSR proof pass;
+  the complete focused run passed 251 cases.
 - Complexity guard passed; all five reported >20 hotspots are unchanged allowance
   pricing/period functions outside this correction. Final review and CI pending.

--- a/agent-docs/exec-plans/completed/2026-09-10-mailbox-member-read.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-mailbox-member-read.md
@@ -39,4 +39,14 @@ reads remain where current authority requires them.
   and Family allowance cases pass. Full Web typecheck, final prepared typecheck and changelog SSR proof pass;
   the complete focused run passed 251 cases.
 - Complexity guard passed; all five reported >20 hotspots are unchanged allowance
-  pricing/period functions outside this correction. Final review and CI pending.
+  pricing/period functions outside this correction. Final ReviewGPT passed on 15bed5d4502a4fb37484a93885a55267bf7157a3;
+  verified requested/response model gpt-6-pro, exact response hash and capture
+  identity, full snapshot, and over six minutes of response wait. No findings.
+- Broad CI caught one incomplete group-tool member-access mock after select
+  extraction. Changed it to preserve the real exports. Its 166 cases and final
+  prepared Web typecheck pass. This isolated fixture correction and plan closure
+  do not change the reviewed production source. Exact-head CI remains the final
+  PR gate; no merge or deployment was performed.
+Status: completed
+Updated: 2026-09-10
+Completed: 2026-09-10

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -756,6 +756,18 @@ convenience.
 
 ## Current Protocol
 
+### Mailbox Fetch Member Projection
+
+Web loads one fresh member projection per mailbox fetch and passes it explicitly
+to the existing access, consent and read-first allowance owners. No projection
+survives the request. Empty, consumed-replay and system-only batches still skip
+AI usage evaluation. Conversation batches still read current usage periods;
+denials are confirmed by the mutating allowance owner with a new member read.
+Group owner/participant authority and Family sponsorship keep their canonical
+readers. Read-only group allowance derives owner access from its supplied member
+state rather than reloading the same container. Locking and spend accounting are
+unchanged. The encrypted mailbox response and runtime contract are unchanged.
+
 ### Foreground Priority Rule
 
 Fresh user conversation input has absolute priority over background hosted

--- a/apps/web/app/api/internal/hosted-mailbox/fetch/route.ts
+++ b/apps/web/app/api/internal/hosted-mailbox/fetch/route.ts
@@ -28,6 +28,8 @@ import {
 import { readOptionalJsonObject } from "@/src/lib/http";
 import { jsonOk, withJsonError } from "@/src/lib/hosted-onboarding/http";
 import { getPrisma } from "@/src/lib/prisma";
+import { hostedAiUsageMemberSelect } from "@/src/lib/hosted-execution/usage-allowance";
+import { hostedRuntimeAiMemberAccessSelect } from "@/src/lib/hosted-onboarding/member-access";
 
 const HOSTED_MAILBOX_FETCH_CALLBACK_BODY_LIMIT_BYTES = 16 * 1024;
 
@@ -35,9 +37,27 @@ export const POST = withJsonError(async (request: Request) => {
   const userId = await requireHostedCloudflareCallbackRequest(request, {
     maxBodyBytes: HOSTED_MAILBOX_FETCH_CALLBACK_BODY_LIMIT_BYTES,
   });
-  const access = await requireHostedRuntimeMailboxActiveAccess(userId);
-  const body = parseHostedMailboxFetchRequest(await readOptionalJsonObject(request));
   const prisma = getPrisma();
+  // One fresh projection supplies access, consent and read-first allowance.
+  const memberState = await prisma.hostedMember.findUnique({
+    where: { id: userId },
+    select: {
+      ...hostedRuntimeAiMemberAccessSelect,
+      ...hostedAiUsageMemberSelect,
+      assistantProviderPreference: true,
+      threadContainer: {
+        select: {
+          ...hostedRuntimeAiMemberAccessSelect.threadContainer.select,
+          monthlyUsageLimitUsdMicros: true,
+        },
+      },
+    },
+  });
+  const access = await requireHostedRuntimeMailboxActiveAccess(userId, {
+    prisma,
+    memberState,
+  });
+  const body = parseHostedMailboxFetchRequest(await readOptionalJsonObject(request));
   const fetchedAt = new Date();
   const projection = await fetchHostedRuntimeMailboxProjection({
     cursorMode: body.cursorMode ?? null,
@@ -65,6 +85,7 @@ export const POST = withJsonError(async (request: Request) => {
         consumedSeqByLane: projection.consumedSeqByLane,
         lanes: body.lanes,
         maxSeqByLane: projection.maxSeqByLane,
+        memberState: memberState ?? undefined,
         prisma,
         userId,
       })
@@ -113,11 +134,14 @@ async function readHostedRuntimeMailboxAiUsageAccess(input: {
   maxSeqByLane: Parameters<
     typeof readHostedMailboxConversationAiUsageHighWater
   >[0]["lanes"];
+  memberState: Parameters<typeof resolveHostedRuntimeAiUsageGate>[0]["memberState"];
   prisma: PrismaClient;
   userId: string;
 }): Promise<{ allowed: boolean; runningLow: boolean }> {
   const gate = await resolveHostedRuntimeAiUsageGate({
     mode: "read_first",
+    memberState: input.memberState,
+    prisma: input.prisma,
     userId: input.userId,
   });
 

--- a/apps/web/changelog/entries/2026-09-10/fewer-checks-before-message-processing.json
+++ b/apps/web/changelog/entries/2026-09-10/fewer-checks-before-message-processing.json
@@ -12,6 +12,8 @@
       "messaging",
       "reliability"
     ],
-    "sourcePullRequests": []
+    "sourcePullRequests": [
+      3192
+    ]
   }
 }

--- a/apps/web/changelog/entries/2026-09-10/fewer-checks-before-message-processing.json
+++ b/apps/web/changelog/entries/2026-09-10/fewer-checks-before-message-processing.json
@@ -1,0 +1,17 @@
+{
+  "publishedOn": "2026-09-10",
+  "order": 110,
+  "item": {
+    "id": "fewer-checks-before-message-processing",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Less waiting before message processing",
+    "summary": "Murph reuses current account information within each message fetch, reducing repeated checks before processing your message.",
+    "details": "Each new fetch still checks current access, consent and usage allowance.",
+    "relevanceTags": [
+      "messaging",
+      "reliability"
+    ],
+    "sourcePullRequests": []
+  }
+}

--- a/apps/web/src/lib/hosted-execution/usage-allowance.ts
+++ b/apps/web/src/lib/hosted-execution/usage-allowance.ts
@@ -61,6 +61,7 @@ import {
 import {
   type HostedMemberPersonAccessState,
   hostedMemberPersonAccessSelect,
+  hasActiveHostedThreadContainerAccessWithParticipants,
   readActiveHostedMemberAccess,
 } from "../hosted-onboarding/member-access";
 import { getPrisma } from "../prisma";
@@ -1510,8 +1511,42 @@ async function resolveHostedAiUsageGateWithPolicy(input: {
   });
 }
 
+export const hostedAiUsageMemberSelect = Prisma.validator<Prisma.HostedMemberSelect>()({
+  billingRef: {
+    select: {
+      currentBillingPhase: true,
+      currentBillingPlanCode: true,
+      currentCheckoutOffer: true,
+      currentPeriodEnd: true,
+      currentPeriodStart: true,
+      stripeSubscriptionLookupKey: true,
+      usagePlanTransitionAt: true,
+      usagePlanTransitionFromCode: true,
+      usagePlanTransitionKind: true,
+      usagePlanTransitionToCode: true,
+    },
+  },
+  threadContainer: {
+    select: {
+      monthlyUsageLimitUsdMicros: true,
+      owner: {
+        select: hostedMemberPersonAccessSelect,
+      },
+    },
+  },
+  billingStatus: true,
+  suspendedAt: true,
+  usageCreditBalanceUsdMicros: true,
+  usageCreditLedgerVersion: true,
+});
+
+export type HostedAiUsageMemberState = Prisma.HostedMemberGetPayload<{
+  select: typeof hostedAiUsageMemberSelect;
+}>;
+
 export async function readHostedAiUsageGate(input: {
   memberId: string;
+  memberState?: HostedAiUsageMemberState;
   now?: Date | string;
   prisma?: HostedAiUsageAllowanceClient;
 }): Promise<HostedAiUsageGateDecisionWithSource> {
@@ -1519,38 +1554,11 @@ export async function readHostedAiUsageGate(input: {
   const now = normalizeHostedAiUsageAllowanceDate(input.now ?? new Date());
 
   return runHostedAiUsageAllowanceTransaction(prisma, async (tx) => {
-    const memberState = await tx.hostedMember.findUnique({
+    const memberState = input.memberState ?? await tx.hostedMember.findUnique({
       where: {
         id: input.memberId,
       },
-      select: {
-        billingRef: {
-          select: {
-            currentBillingPhase: true,
-            currentBillingPlanCode: true,
-            currentCheckoutOffer: true,
-            currentPeriodEnd: true,
-            currentPeriodStart: true,
-            stripeSubscriptionLookupKey: true,
-            usagePlanTransitionAt: true,
-            usagePlanTransitionFromCode: true,
-            usagePlanTransitionKind: true,
-            usagePlanTransitionToCode: true,
-          },
-        },
-        threadContainer: {
-          select: {
-            monthlyUsageLimitUsdMicros: true,
-            owner: {
-              select: hostedMemberPersonAccessSelect,
-            },
-          },
-        },
-        billingStatus: true,
-        suspendedAt: true,
-        usageCreditBalanceUsdMicros: true,
-        usageCreditLedgerVersion: true,
-      },
+      select: hostedAiUsageMemberSelect,
     });
 
     if (!memberState) {
@@ -1571,13 +1579,15 @@ export async function readHostedAiUsageGate(input: {
         };
     const allowanceBillingRef = allowanceAccess.billingRef;
     const familyAccessActive = allowanceAccess.familyAccessActive;
-    const threadContainerAccessActive = await hasHostedAiUsageThreadContainerAccess({
-      container: memberState,
-      containerMemberId: input.memberId,
-      now,
-      threadContainer: memberState.threadContainer,
-      tx,
-    });
+    const threadContainerAccessActive = memberState.threadContainer
+      ? await hasActiveHostedThreadContainerAccessWithParticipants({
+          container: memberState,
+          containerMemberId: input.memberId,
+          now,
+          owner: memberState.threadContainer.owner,
+          prisma: tx,
+        })
+      : null;
 
     // Thread-container members are synthetic (`not_started` own billing):
     // their access is decided by the container branch of the allowance-period
@@ -1678,6 +1688,7 @@ export async function readHostedAiUsageGateSnapshots(input: {
 // ensure-creates the period inside the spend transaction as the backstop.
 export async function checkHostedAiUsageGate(input: {
   memberId: string;
+  memberState?: HostedAiUsageMemberState;
   now?: Date | string;
   prisma?: HostedAiUsageAllowanceClient;
 }): Promise<HostedAiUsageGateDecisionWithSource> {
@@ -1686,7 +1697,11 @@ export async function checkHostedAiUsageGate(input: {
     return decision;
   }
 
-  return resolveHostedAiUsageGate(input);
+  return resolveHostedAiUsageGate({
+    memberId: input.memberId,
+    now: input.now,
+    prisma: input.prisma,
+  });
 }
 
 function resolveHostedAiUsageInactiveGateDecision(input: {

--- a/apps/web/src/lib/hosted-mailbox/runtime-access.ts
+++ b/apps/web/src/lib/hosted-mailbox/runtime-access.ts
@@ -191,13 +191,16 @@ export function isHostedRuntimeInactiveAccessError(error: unknown): boolean {
 
 export async function requireHostedRuntimeMailboxActiveAccess(
   userId: string,
-  options: HostedRuntimeActiveAccessOptions = {},
+  options: HostedRuntimeActiveAccessOptions & {
+    memberState?: Parameters<typeof readActiveHostedMemberAccessState>[0]["memberState"];
+  } = {},
 ): Promise<{
   assistantProvider: HostedAssistantProvider;
   isThreadContainer: boolean;
 }> {
   const member = await readActiveHostedMemberAccessState({
     memberId: userId,
+    memberState: options.memberState,
     prisma: options.prisma ?? getPrisma(),
   });
   if (!member) {

--- a/apps/web/src/lib/hosted-onboarding/member-access.ts
+++ b/apps/web/src/lib/hosted-onboarding/member-access.ts
@@ -100,7 +100,7 @@ const hostedRuntimeAiPersonAccessSelect = Prisma.validator<Prisma.HostedMemberSe
   },
 });
 
-const hostedRuntimeAiMemberAccessSelect = Prisma.validator<Prisma.HostedMemberSelect>()({
+export const hostedRuntimeAiMemberAccessSelect = Prisma.validator<Prisma.HostedMemberSelect>()({
   ...hostedRuntimeAiPersonAccessSelect,
   threadContainer: {
     select: {
@@ -151,6 +151,10 @@ export type HostedMemberAccessState = HostedMemberPersonAccessState & {
 
 type HostedRuntimeAiPersonAccessState = Prisma.HostedMemberGetPayload<{
   select: typeof hostedRuntimeAiPersonAccessSelect;
+}>;
+
+export type HostedRuntimeAiMemberAccessState = Prisma.HostedMemberGetPayload<{
+  select: typeof hostedRuntimeAiMemberAccessSelect;
 }>;
 
 export type HostedRuntimeAiAccessDecision =
@@ -310,13 +314,14 @@ export async function readActiveHostedMemberAccess(input: {
 
 export async function readActiveHostedMemberAccessState(input: {
   memberId: string;
+  memberState?: (HostedMemberAccessState & { assistantProviderPreference: string | null }) | null;
   now?: Date;
   prisma?: HostedOnboardingReadClient;
 }): Promise<(HostedMemberAccessState & {
   assistantProviderPreference: string | null;
 }) | null> {
   const prisma = input.prisma ?? getPrisma();
-  const member = await prisma.hostedMember.findUnique({
+  const member = input.memberState !== undefined ? input.memberState : await prisma.hostedMember.findUnique({
     select: {
       ...hostedMemberAccessSelect,
       assistantProviderPreference: true,
@@ -454,6 +459,7 @@ export async function readActiveHostedFamilySponsorship(input: {
  */
 export async function readHostedRuntimeAiAccessDecision(input: {
   memberId: string;
+  memberState?: HostedRuntimeAiMemberAccessState;
   /**
    * Per-delivery discriminator so repeated notices to the same member rotate
    * copy variants instead of repeating one sentence verbatim. Omit to keep the
@@ -465,7 +471,7 @@ export async function readHostedRuntimeAiAccessDecision(input: {
 }): Promise<HostedRuntimeAiAccessDecision> {
   const prisma = input.prisma ?? getPrisma();
   const now = input.now ?? new Date();
-  const member = await prisma.hostedMember.findUnique({
+  const member = input.memberState !== undefined ? input.memberState : await prisma.hostedMember.findUnique({
     select: hostedRuntimeAiMemberAccessSelect,
     where: {
       id: input.memberId,

--- a/apps/web/src/lib/hosted-orchestration/runtime-usage-decision.ts
+++ b/apps/web/src/lib/hosted-orchestration/runtime-usage-decision.ts
@@ -3,8 +3,12 @@ import {
   readHostedAiUsageGate,
   resolveHostedAiUsageGate,
   type HostedAiUsageGateDecisionWithSource,
+  type HostedAiUsageMemberState,
 } from "../hosted-execution/usage-allowance";
-import { readHostedRuntimeAiAccessDecision } from "../hosted-onboarding/member-access";
+import {
+  readHostedRuntimeAiAccessDecision,
+  type HostedRuntimeAiMemberAccessState,
+} from "../hosted-onboarding/member-access";
 import { HOSTED_STARTER_USAGE_GRANT_USD_MICROS } from "../hosted-onboarding/starter-usage";
 
 export type HostedRuntimeUsageGateCheck =
@@ -24,14 +28,24 @@ export async function resolveHostedRuntimeAiUsageGate(input: {
   // "mutating" is authoritative turn admission and owns usage-period
   // bookkeeping. "read_first" stays write-free on allow and confirms denials
   // through that owner. "read_only" never writes and is for status surfaces.
-  mode: "mutating" | "read_first" | "read_only";
+
   now?: Date | string;
   prisma?: Parameters<typeof resolveHostedAiUsageGate>[0]["prisma"];
   userId: string;
-}): Promise<HostedRuntimeUsageGateCheck> {
+} & (
+  | { mode: "mutating"; memberState?: never }
+  | {
+      mode: "read_first" | "read_only";
+      // Fresh projection for this user and request only; never warm admission.
+      memberState?: HostedAiUsageMemberState & HostedRuntimeAiMemberAccessState;
+    }
+)): Promise<HostedRuntimeUsageGateCheck> {
   const now = normalizeHostedRuntimeUsageDecisionDate(input.now);
   const access = await readHostedRuntimeAiAccessDecision({
     memberId: input.userId,
+    ...(input.memberState
+      ? { memberState: input.memberState }
+      : {}),
     now,
     prisma: input.prisma,
   });
@@ -46,6 +60,9 @@ export async function resolveHostedRuntimeAiUsageGate(input: {
       : checkHostedAiUsageGate;
   const decision = await readGate({
     memberId: input.userId,
+    ...(input.memberState
+      ? { memberState: input.memberState }
+      : {}),
     now,
     prisma: input.prisma,
   });

--- a/apps/web/test/hosted-execution-usage-allowance.test.ts
+++ b/apps/web/test/hosted-execution-usage-allowance.test.ts
@@ -3979,6 +3979,21 @@ describe("resolveHostedAiUsageGate", () => {
 });
 
 describe("readHostedAiUsageGate", () => {
+  it("confirms a projected denial with freshly read billing state", async () => {
+    const oldPrisma = createGatePrisma({ spentUsdMicros: 0n, suspendedAt: new Date() });
+    const memberState = await oldPrisma.hostedMember.findUnique();
+    const prisma = createGatePrisma({ spentUsdMicros: 0n });
+
+    await expect(checkHostedAiUsageGate({
+      memberId: "member_123",
+      memberState,
+      now: "2026-03-29T12:00:00.000Z",
+      prisma: prisma as never,
+    })).resolves.toMatchObject({ allowed: true });
+    expect(prisma.hostedMember.findUnique).toHaveBeenCalledTimes(1);
+    expect(prisma.$queryRaw).toHaveBeenCalled();
+  });
+
   it("shows zero spend immediately when Pulse upgrades to Edge", async () => {
     const prisma = createGatePrisma({
       billingPlanCode: "launch_edge_monthly",

--- a/apps/web/test/hosted-group-tool.test.ts
+++ b/apps/web/test/hosted-group-tool.test.ts
@@ -101,7 +101,8 @@ vi.mock("@/src/lib/hosted-onboarding/entitlement", () => ({
   isHostedMemberSuspended: mocks.isHostedMemberSuspended,
 }));
 
-vi.mock("@/src/lib/hosted-onboarding/member-access", () => ({
+vi.mock("@/src/lib/hosted-onboarding/member-access", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/src/lib/hosted-onboarding/member-access")>()),
   readActiveHostedMemberAccess: mocks.readActiveHostedMemberAccess,
 }));
 

--- a/apps/web/test/hosted-runtime-internal-routes.test.ts
+++ b/apps/web/test/hosted-runtime-internal-routes.test.ts
@@ -410,6 +410,93 @@ describe("hosted runtime internal web routes", () => {
     expect(response.status).toBe(500);
   });
 
+  it.each(["consent", "suspension", "missing"] as const)(
+    "shares one fresh member read across the real gates and observes next-request %s revocation",
+    async (revocation) => {
+      const { resolveHostedRuntimeAiUsageGate } = await vi.importActual<
+        typeof import("@/src/lib/hosted-orchestration/runtime-usage-decision")
+      >("@/src/lib/hosted-orchestration/runtime-usage-decision");
+      mocks.resolveHostedRuntimeAiUsageGate.mockImplementation(resolveHostedRuntimeAiUsageGate);
+      const member = {
+        ...buildRuntimeMailboxAccessRecord(),
+        billingRef: {
+          currentBillingPhase: "paid",
+          currentBillingPlanCode: "launch_monthly",
+          currentCheckoutOffer: null,
+          currentPeriodStart: new Date("2026-01-01T00:00:00Z"),
+          currentPeriodEnd: new Date("2027-01-01T00:00:00Z"),
+          stripeSubscriptionLookupKey: "synthetic_subscription",
+          usagePlanTransitionAt: null,
+          usagePlanTransitionFromCode: null,
+          usagePlanTransitionKind: null,
+          usagePlanTransitionToCode: null,
+        },
+        consentGrants: [{ scope: "launch.health-data", status: "granted" }],
+        usageCreditBalanceUsdMicros: 0n,
+        usageCreditLedgerVersion: 0n,
+      };
+      mocks.hostedRuntimeMailboxMemberFindUnique.mockResolvedValue(member);
+      const periodRead = vi.fn(async () => null);
+      mocks.getPrisma.mockReturnValue({
+        ...createPrismaClientStub(),
+        hostedAiUsagePeriod: { findUnique: periodRead },
+      });
+      mocks.fetchHostedRuntimeMailboxProjection.mockResolvedValue({
+        consumedSeqByLane: [{ lane: "conversation", consumedSeq: "0" }],
+        maxSeqByLane: [{ lane: "conversation", maxSeq: "1" }],
+        items: [{
+          createdAt: FIXED_NOW,
+          dedupeKey: "synthetic-conversation",
+          expiresAt: null,
+          id: "synthetic-mailbox-item",
+          kind: "conversation.message",
+          lane: "conversation",
+          laneSeq: "1",
+          occurredAt: FIXED_NOW,
+          payloadBytes: 64,
+          payloadInlineCiphertext: "synthetic-ciphertext",
+          payloadRef: null,
+          payloadSchema: "murph.hosted-mailbox-item.v1",
+          updatedAt: FIXED_NOW,
+          userId: "member_routes_1",
+        }],
+      });
+      const fetchMailbox = () => mailboxFetchRoute.POST(jsonRequest(
+        "/api/internal/hosted-mailbox/fetch",
+        { lanes: [{ importedSeq: "0", lane: "conversation" }], limitPerLane: 1,
+          requestId: "synthetic-fetch" },
+      ));
+      const allowed = await fetchMailbox();
+      expect(allowed.status).toBe(200);
+      expect(parseHostedMailboxFetchResponse(await allowed.json()).items).toHaveLength(1);
+      expect(mocks.hostedRuntimeMailboxMemberFindUnique).toHaveBeenCalledTimes(1);
+      expect(periodRead).toHaveBeenCalledTimes(1);
+      expect(mocks.tryMarkHostedMailboxConversationAiUsageDenied).not.toHaveBeenCalled();
+
+      mocks.hostedRuntimeMailboxMemberFindUnique.mockResolvedValue(
+        revocation === "missing" ? null : {
+          ...member,
+          ...(revocation === "suspension"
+            ? { suspendedAt: new Date(FIXED_NOW) }
+            : { consentGrants: [{ scope: "launch.health-data", status: "revoked" }] }),
+        },
+      );
+      const denied = await fetchMailbox();
+      expect(mocks.hostedRuntimeMailboxMemberFindUnique).toHaveBeenCalledTimes(2);
+      expect(periodRead).toHaveBeenCalledTimes(1);
+      if (revocation === "consent") {
+        expect(denied.status).toBe(200);
+        expect(parseHostedMailboxFetchResponse(await denied.json())).toMatchObject({
+          items: [], maxSeqByLane: [{ lane: "conversation", maxSeq: "0" }],
+        });
+        expect(mocks.tryMarkHostedMailboxConversationAiUsageDenied).toHaveBeenCalledTimes(1);
+      } else {
+        expect(denied.status).toBe(403);
+        expect(mocks.fetchHostedRuntimeMailboxProjection).toHaveBeenCalledTimes(1);
+      }
+    },
+  );
+
   it("fetches mailbox DTOs by lane cursor without hydrating sidecar payload bodies", async () => {
     process.env.HOSTED_VENICE_ENABLED = "1";
     mocks.hostedRuntimeMailboxMemberFindUnique.mockResolvedValueOnce(
@@ -1402,6 +1489,8 @@ describe("hosted runtime internal web routes", () => {
     expect(mocks.readHostedActiveGroupRunningBit).not.toHaveBeenCalled();
     expect(mocks.resolveHostedRuntimeAiUsageGate).toHaveBeenCalledWith({
       mode: "read_first",
+      memberState: expect.objectContaining({ id: "member_routes_1" }),
+      prisma: expect.objectContaining({ kind: "prisma" }),
       userId: "member_routes_1",
     });
     expect(
@@ -1602,6 +1691,8 @@ describe("hosted runtime internal web routes", () => {
     });
     expect(mocks.resolveHostedRuntimeAiUsageGate).toHaveBeenCalledWith({
       mode: "read_first",
+      memberState: expect.objectContaining({ id: "member_routes_1" }),
+      prisma: expect.objectContaining({ kind: "prisma" }),
       userId: "member_routes_1",
     });
   });


### PR DESCRIPTION
## Why and outcome

A conversation mailbox fetch loaded the same member for access, again for
consent, and again for allowance. The fetch now loads one fresh projection and
passes it to those existing owners, removing two serial member reads. Group
read-only allowance also derives owner access from the loaded container.

## Product UX

- Effort: Patch.
- Result: Ready.
- Walkthrough: Ordinary messages retain current provider and usage decisions with
  less repeated work. Each request sees fresh state. Consent withdrawal,
  suspension, deletion, group/Family access, empty/system/replay and usage denial
  preserve their existing outcomes. No provider input or delivery behavior changes.

## Evidence

- Direct: The actual fetch route with real access, consent and allowance owners
  performs one member read and one period read on allow. A second request sees
  consent revocation, suspension or deletion without another period read.
- Coverage: 251 focused Web cases pass across internal routes, usage decisions,
  member access, allowance, text consent and changelog SSR. Includes denial
  confirmation with freshly changed billing state and existing group/Family cases.
- Web full typecheck and final prepared typecheck pass. The final external review passed on the original production candidate.
  An isolated mock correction passed its 166-case group-tool suite and final
  Web typecheck. All 32 applicable checks pass on the final PR head.

## Non-obvious affected surfaces

Read-only allowance and its reporting snapshot owner reuse the selected group
owner projection. Their existing tests pass; reporting RepeatableRead, mutating
admission, spend locks and usage settlement are unchanged.

## Architecture and reuse

- Existing systems reused: Canonical member-access, allowance and mailbox owners.
- New logic: Explicitly pass one fresh member projection within the fetch request.
- New abstractions: None; exported existing Prisma selects and their derived types.
- Complexity intentionally avoided: No cache, Prisma interception, global state,
  parallel gate owner, new endpoint, transaction owner or deployment toggle.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: Five existing allowance pricing/period functions remain above 20;
  none is changed. Maximum remains 31 and debt remains 23.
- Agent judgment: Shared selects avoid duplication. Mutating admission cannot
  accept a projection; a read-first denial reloads with its existing owner.

## Hot reply path impact

- Applicable: Yes. Ordinary direct conversation member reads drop from three to
  one; read-only group allowance also removes its container reload. No new
  network/provider calls, retries, timeout or fallback. Database work remains
  sequential with at most one allowance transaction/pooled connection at a time.
- Existing relational projections, bounded mailbox batches, participant queries,
  Family billing/period reads and optional group presentation remain with their
  owners. This is a top-level Prisma read count, not a claim about the adapter's
  generated SQL count or a production latency benchmark.
- Empty/system/replay batches still skip usage evaluation. Denials retain an
  authoritative mutating recheck and exact existing mailbox high-water marking.

## Murph initial provider input impact

- Individual and group: No instructions, messages, tools, provider fields or
  model input assembly changed.
- Measurement: Not run; only Web database projection reuse changes.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing and new Web responses have the same wire shape.
- Safe order: Web-only deployment; no Worker/container ordering dependency.
- Rollback floor: Unchanged; no new persisted state or schema.
- Expected exposure: Updated Web fetch requests only during ordinary rollout.
- Reversibility: Previous Web reader remains compatible with all produced data.
- Convergence proof: Same response/cursor/provider contract exercised in route tests.
- Post-deploy checks: Confirm deployed version and compare fetch latency/error
  aggregates; local tests do not establish phone typing latency.

## Change-shape breakdown

Classification rule: Production TS is source; tests are fixtures; plans, owner
contracts and release copy are docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 111 | 46 |
| Tests / fixtures | 108 | 1 |
| Docs | 83 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **302** | **47** |

## Changelog

- Changelog: updated
- Items: 2026-09-10 · fewer-checks-before-message-processing

ReviewGPT context sensitivity: sensitive
Classification reason: Hosted access, consent, usage allowance and foreground execution.

ReviewGPT first-reviewed head: 15bed5d4502a4fb37484a93885a55267bf7157a3
