### PR TITLE
refactor: remove dead computer failure plumbing

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-simplify-computer-failures.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-simplify-computer-failures.md
@@ -1,0 +1,58 @@
+# Remove dead computer failure plumbing
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+- Remove unused computer-adapter parameters and redundant result state while preserving every tool request, response, failure classification, and effect.
+
+## Success criteria
+
+- The adapter has one actual uncertainty policy, no unread outcome flag, and no unused pause finish path.
+- Focused deterministic transport/error tests, assistant-engine typecheck, complexity guard, and source/privacy review pass.
+- The original session owns final candidate review, Ready admission, ReviewGPT, and CI after this lane opens a draft PR.
+
+## Scope
+
+- In scope: private computer adapter functions in dynamic-tools.ts, focused tests, and implementation evidence.
+- Out of scope: tool schemas/descriptions, transport or provider contracts, sanitizers, retries, pause locking, phone calls, and other module extractions.
+
+## Constraints
+
+- Keep known failures distinct from uncertain execution. Uncoded 5xx and the three existing browser-execution error codes remain uncertain; other coded failures remain known.
+- Keep one POST per accepted tool operation, the original abort signal and body, no automatic retry or finish, and unchanged diagnostics.
+- Keep web-owned browser state and assistant-codex pause locking with their current owners. No new abstraction, dependency, state, or deployed protocol.
+
+## Risks and mitigations
+
+1. An uncertain failure must not become permission to retry blindly. Exact result-text matrices cover transport, JSON-read, coded, uncoded, and malformed-response failures.
+2. Pause must retain the member-gated handoff and never call finish after failure. Existing composed tests protect its sanitization and single-call behavior.
+3. Failure telemetry must preserve its finite classification. Direct tests compare failureDiagnostic and the outer runtime-issue projection.
+
+## Tasks
+
+1. Prove private callers, constant policy arguments, duplicate branch, unused finish path, and current owners.
+2. Add focused outcome matrices; delete the proven dead plumbing without reorganizing the adapter.
+3. Run focused tests, package typecheck, complexity review, and full diff/privacy checks.
+4. Archive implementation evidence, commit with neutral identity, push and open a draft PR for the original completion owner.
+
+## Decisions
+
+- Base: b80bd40f84d1b367c1810e2fe046e3089cc28aa4.
+- All five computer operations enable the same uncertainty policy. The returned unknownOutcome flag is read only by identical pause branches and never reaches the model or telemetry.
+- The unused finish path uses the same pure route encoding as the real pause path; removing it does not remove an effect or input validation.
+- The assistant verification skill was read. Live-model proof is not applicable to this cleanup: tool schemas, model-visible strings and decoded values, authority, effect restrictions, and request ordering are unchanged. Deterministic composed tests and source review prove the removal.
+- Internal refactor: no member-visible changelog item or initial provider-input measurement is applicable.
+
+## Verification
+
+- Passed: `MURPH_VITEST_MAX_WORKERS=2 pnpm --filter @murphai/assistant-engine test test/assistant-codex-computer-tools.test.ts` — 61 tests, including 26 new outcome-matrix cases.
+- Passed: `MURPH_TSC_PACKAGE_CHECKERS=2 pnpm --filter @murphai/assistant-engine typecheck`.
+- Passed: `pnpm complexity:diff --base b80bd40f84d1b367c1810e2fe046e3089cc28aa4` — debt 534 and maximum 189 unchanged; thirteen unrelated dispatch/domain hotspots reviewed and kept outside this focused deletion.
+- Passed: parent source/test candidate review, full diff review, and `git diff --check`. Production source has a net deletion of 44 lines.
+- Passed: frozen dependency install; Frog list inspected and no new workaround or entry needed.
+- Live-model proof: not applicable; no model-visible contract or behavior changes, and no live pass claimed.
+- Original completion owner retains final candidate admission, exact-head CI, and ReviewGPT.
+Completed: 2026-09-10

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -3751,7 +3751,6 @@ async function dispatchMurphDynamicToolRequest(
           runId,
         }),
         sanitizer: 'act',
-        unknownOutcomeOnTransportError: true,
       })
     }
     case 'computer-os-control': {
@@ -3765,7 +3764,6 @@ async function dispatchMurphDynamicToolRequest(
           runId,
         }),
         sanitizer: 'os-control',
-        unknownOutcomeOnTransportError: true,
       })
     }
     case 'computer-pause-for-user': {
@@ -3779,10 +3777,6 @@ async function dispatchMurphDynamicToolRequest(
           ),
         } satisfies HostedComputerPauseForUserRequest,
         fetchImpl: input.fetchImpl,
-        finishPath: buildHostedComputerRunOperationPath({
-          operation: 'finish',
-          runId,
-        }),
         path: buildHostedComputerRunOperationPath({
           operation: 'pause-for-user',
           runId,
@@ -3803,7 +3797,6 @@ async function dispatchMurphDynamicToolRequest(
           runId,
         }),
         sanitizer: 'finish',
-        unknownOutcomeOnTransportError: true,
       })
     }
   }
@@ -6622,17 +6615,10 @@ async function executeHostedComputerPauseForUserTool(input: {
   abortSignal: AbortSignal | null
   body: HostedComputerPauseForUserRequest
   fetchImpl: typeof fetch
-  finishPath: string
   path: string
 }): Promise<MurphDynamicToolExecutionResult> {
-  const apiResult = await callHostedComputerApi({
-    ...input,
-    unknownOutcomeOnTransportError: true,
-  })
+  const apiResult = await callHostedComputerApi(input)
   if (!apiResult.ok) {
-    if (apiResult.unknownOutcome) {
-      return { ...toolTextResult(false, apiResult.errorText), ...toolFailureMetadata(apiResult) }
-    }
     return { ...toolTextResult(false, apiResult.errorText), ...toolFailureMetadata(apiResult) }
   }
 
@@ -6655,7 +6641,6 @@ async function executeHostedComputerOpenTool(input: {
     fetchImpl: input.fetchImpl,
     path: HOSTED_COMPUTER_RUNS_PATH,
     sanitizer: 'open',
-    unknownOutcomeOnTransportError: true,
   })
 }
 
@@ -6681,7 +6666,6 @@ async function executeHostedComputerApiTool(input: {
   fetchImpl: typeof fetch
   path: string
   sanitizer: HostedComputerToolPayloadSanitizer
-  unknownOutcomeOnTransportError: boolean
 }): Promise<MurphDynamicToolExecutionResult> {
   const apiResult = await callHostedComputerApi(input)
   return apiResult.ok
@@ -6697,10 +6681,9 @@ async function callHostedComputerApi(input: {
   body: unknown
   fetchImpl: typeof fetch
   path: string
-  unknownOutcomeOnTransportError?: boolean
 }): Promise<
   | { ok: true; payload: unknown }
-  | { ok: false; errorText: string; unknownOutcome: boolean; failureDiagnostic: ToolFailureDiagnostic }
+  | { ok: false; errorText: string; failureDiagnostic: ToolFailureDiagnostic }
 > {
   const payload = JSON.stringify(input.body ?? {})
 
@@ -6718,15 +6701,11 @@ async function callHostedComputerApi(input: {
     )
 
     if (!response.ok) {
-      const error = await readHostedComputerApiError({
-        response,
-        unknownOutcomeOnFailure: input.unknownOutcomeOnTransportError ?? false,
-      })
+      const errorText = await readHostedComputerApiErrorText(response)
       return {
         failureDiagnostic: toolFailureDiagnostic('reported_failure', { status: response.status }),
-        errorText: error.text,
+        errorText,
         ok: false,
-        unknownOutcome: error.unknownOutcome,
       }
     }
 
@@ -6737,20 +6716,13 @@ async function callHostedComputerApi(input: {
   } catch (error) {
     return {
       failureDiagnostic: toolFailureDiagnostic('handler_exception', error),
-      errorText: input.unknownOutcomeOnTransportError
-        ? HOSTED_COMPUTER_UNKNOWN_OUTCOME_TEXT
-        : 'computer API is unavailable',
+      errorText: HOSTED_COMPUTER_UNKNOWN_OUTCOME_TEXT,
       ok: false,
-      unknownOutcome: input.unknownOutcomeOnTransportError === true,
     }
   }
 }
 
-async function readHostedComputerApiError(input: {
-  response: Response
-  unknownOutcomeOnFailure: boolean
-}): Promise<{ text: string; unknownOutcome: boolean }> {
-  const { response } = input
+async function readHostedComputerApiErrorText(response: Response): Promise<string> {
   const fallback = `computer API failed with status ${response.status}`
   try {
     const payload = await response.json()
@@ -6762,33 +6734,23 @@ async function readHostedComputerApiError(input: {
     if (isUnknownComputerOutcomeError({
       code,
       status: response.status,
-      unknownOutcomeOnFailure: input.unknownOutcomeOnFailure,
     })) {
-      return {
-        text: appendHostedComputerApiErrorDetail(
-          HOSTED_COMPUTER_UNKNOWN_OUTCOME_TEXT,
-          { code, details, message },
-        ),
-        unknownOutcome: true,
-      }
+      return appendHostedComputerApiErrorDetail(
+        HOSTED_COMPUTER_UNKNOWN_OUTCOME_TEXT,
+        { code, details, message },
+      )
     }
     if (code && message) {
-      return {
-        text: appendHostedComputerApiErrorDetail(
-          `${fallback}: ${code}: ${message}`,
-          { code: null, details, message: null },
-        ),
-        unknownOutcome: false,
-      }
+      return appendHostedComputerApiErrorDetail(
+        `${fallback}: ${code}: ${message}`,
+        { code: null, details, message: null },
+      )
     }
     if (code) {
-      return {
-        text: appendHostedComputerApiErrorDetail(
-          `${fallback}: ${code}`,
-          { code: null, details, message: null },
-        ),
-        unknownOutcome: false,
-      }
+      return appendHostedComputerApiErrorDetail(
+        `${fallback}: ${code}`,
+        { code: null, details, message: null },
+      )
     }
   } catch {
     // Ignore non-JSON error bodies; hosted web route helpers keep safe details in JSON.
@@ -6797,12 +6759,11 @@ async function readHostedComputerApiError(input: {
   if (isUnknownComputerOutcomeError({
     code: null,
     status: response.status,
-    unknownOutcomeOnFailure: input.unknownOutcomeOnFailure,
   })) {
-    return { text: HOSTED_COMPUTER_UNKNOWN_OUTCOME_TEXT, unknownOutcome: true }
+    return HOSTED_COMPUTER_UNKNOWN_OUTCOME_TEXT
   }
 
-  return { text: fallback, unknownOutcome: false }
+  return fallback
 }
 
 function appendHostedComputerApiErrorDetail(
@@ -6887,12 +6848,7 @@ function readHostedComputerApiErrorDetailLine(
 function isUnknownComputerOutcomeError(input: {
   code: string | null
   status: number
-  unknownOutcomeOnFailure: boolean
 }): boolean {
-  if (!input.unknownOutcomeOnFailure) {
-    return false
-  }
-
   if (!input.code) {
     return input.status >= 500
   }

--- a/packages/assistant-engine/test/assistant-codex-computer-tools.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-computer-tools.test.ts
@@ -696,6 +696,100 @@ describe("murph computer dynamic tools", () => {
     );
   });
 
+  describe.each([
+    { kind: "computer-open", args: { startUrl: null } },
+    { kind: "computer-act", args: { code: "return null;", runId: "run_123", timeoutMs: 1000 } },
+    { kind: "computer-os-control", args: { action: "pressKey", durationMs: 0, keys: ["Return"], runId: "run_123" } },
+    { kind: "computer-pause-for-user", args: {
+      handoffPurpose: "manual_browser_help", pauseDeliveryContext: null,
+      reason: "final_confirmation", runId: "run_123", suggestedReply: "done",
+    } },
+    { kind: "computer-finish-run", args: { outcome: "completed", runId: "run_123" } },
+  ] satisfies MurphDynamicToolRequest[])("$kind uncertain failures", (request) => {
+    it.each(["transport", "success-json", "uncoded-server"] as const)(
+      "preserves uncertain %s output, diagnostics and one request",
+      async (failure) => {
+        const controller = new AbortController();
+        const fetchImpl = vi.fn(async (): Promise<Response> => {
+          if (failure === "transport") throw new Error("synthetic transport failure");
+          return failure === "success-json"
+            ? new Response("not JSON", { status: 200 })
+            : jsonResponse({}, 500);
+        });
+        const progressDelivery = createProgressDelivery();
+        const result = await executeMurphDynamicToolRequest({
+          abortSignal: controller.signal,
+          env: {}, fetchImpl, hostedToolContext: createHostedToolContext(),
+          nextUsageOrdinal: () => 1, progressDelivery, request,
+        });
+        const diagnostic = failure === "uncoded-server"
+          ? { errorCategory: "unavailable", failureReason: "reported_failure", failureStage: "result" }
+          : { errorCategory: "unknown", failureReason: "handler_exception", failureStage: "execution" };
+        expect(result.rpcResult).toEqual({
+          success: false,
+          contentItems: [{ type: "inputText", text:
+            "computer API outcome is unknown after a transport or browser execution failure; call computer_open before retrying Playwright code or taking another step" }],
+        });
+        expect(result.failureDiagnostic).toEqual(diagnostic);
+        expect(result.runtimeIssueInputs).toEqual([expect.objectContaining({
+          operation: request.kind,
+          details: { ...diagnostic, diagnosticRole: "classification", requestKind: request.kind },
+        })]);
+        expect(fetchImpl).toHaveBeenCalledExactlyOnceWith(
+          expect.any(String),
+          expect.objectContaining({ method: "POST", signal: controller.signal }),
+        );
+        expect(progressDelivery.send).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it.each([
+    { status: 400, body: "not JSON", expected: "computer API failed with status 400" },
+    { status: 500, body: "not JSON", expected: "uncertain" },
+    { status: 400, body: {}, expected: "computer API failed with status 400" },
+    { status: 500, body: {}, expected: "uncertain" },
+    { status: 500, body: { error: { message: "synthetic backend message" } },
+      expected: "uncertain; backend error: synthetic backend message" },
+    { status: 500, body: { error: { code: "KNOWN_CONFIGURATION_FAILURE", message: "synthetic backend message" } },
+      expected: "computer API failed with status 500: KNOWN_CONFIGURATION_FAILURE: synthetic backend message" },
+    { status: 400, body: { error: { code: "KNOWN_CONFIGURATION_FAILURE" } },
+      expected: "computer API failed with status 400: KNOWN_CONFIGURATION_FAILURE" },
+    { status: 500, body: { error: { code: "KNOWN_CONFIGURATION_FAILURE", details: { timeoutMs: 1000 } } },
+      expected: "computer API failed with status 500: KNOWN_CONFIGURATION_FAILURE\nbackend details:\ntimeoutMs: 1000" },
+    { status: 400, body: { error: { code: "HOSTED_COMPUTER_EVAL_FAILED" } },
+      expected: "uncertain; backend error: HOSTED_COMPUTER_EVAL_FAILED" },
+    { status: 400, body: { error: { code: "HOSTED_COMPUTER_ACTION_STATE_INVALID" } },
+      expected: "uncertain; backend error: HOSTED_COMPUTER_ACTION_STATE_INVALID" },
+    { status: 400, body: { error: { code: "HOSTED_COMPUTER_OS_CONTROL_FAILED" } },
+      expected: "uncertain; backend error: HOSTED_COMPUTER_OS_CONTROL_FAILED" },
+  ])("preserves status/code precedence for $status $body", async ({ status, body, expected }) => {
+    const fetchImpl = vi.fn(async (): Promise<Response> =>
+      typeof body === "string" ? new Response(body, { status }) : jsonResponse(body, status)
+    );
+    const result = await executeMurphDynamicToolRequest({
+      env: {}, fetchImpl, hostedToolContext: createHostedToolContext(),
+      nextUsageOrdinal: () => 1, progressDelivery: null,
+      request: {
+        kind: "computer-act",
+        args: { code: "return null;", runId: "run_123", timeoutMs: 1000 },
+      },
+    });
+    expect(result.rpcResult).toEqual({
+      success: false,
+      contentItems: [{ type: "inputText", text: expected.replace(
+        /^uncertain/u,
+        "computer API outcome is unknown after a transport or browser execution failure; call computer_open before retrying Playwright code or taking another step",
+      ) }],
+    });
+    expect(result.failureDiagnostic).toEqual({
+      errorCategory: status === 400 ? "invalid_input" : "unavailable",
+      failureReason: "reported_failure",
+      failureStage: "result",
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
   it("includes redacted browser execution details in unknown-outcome action failures", async () => {
     const fetchImpl = vi.fn(async (): Promise<Response> =>
       jsonResponse({


### PR DESCRIPTION
## Why and outcome

The computer adapter carried an unused pause finish path, a policy argument that every caller set to true, and an outcome flag whose only consumer returned identical results in both branches. Remove this dead plumbing and let the private error reader return its existing text directly.

Known backend failures and uncertain execution retain the same text, diagnostics, requests, sanitization, and pause behavior. Production source decreases by 44 lines without adding an owner or abstraction.

## Product UX

- Effort: Not applicable — internal behavior-preserving cleanup.
- Result: Not applicable — tool availability, messages, effects, authority, and recovery guidance are unchanged.
- Walkthrough: Each computer operation makes the same request. Transport or ambiguous browser failures retain the existing instruction to reopen before taking another step; known coded failures retain their backend detail. Pause keeps its handoff and never automatically finishes the run.

## Evidence

- Direct: `MURPH_VITEST_MAX_WORKERS=2 pnpm --filter @murphai/assistant-engine test test/assistant-codex-computer-tools.test.ts` — 61 tests passed.
- Typecheck: `MURPH_TSC_PACKAGE_CHECKERS=2 pnpm --filter @murphai/assistant-engine typecheck` — passed.
- Coverage: Fifteen new cases cover transport, successful-response JSON decoding, and uncoded server failures across all five operations. Eleven new status/code cases preserve precedence, malformed error-body handling, exact result text, finite diagnostics, and single-call behavior. Existing tests cover request bodies, URL sanitization, hosted availability, handoffs, and no automatic finish after uncertain pause.
- Review: Parent source/test review passed. Full diff and privacy/whitespace review passed.
- Live assistant proof: Not applicable after applying the skill trigger. This deletion preserves model-visible tool contracts and result text, effect restrictions, and ordering; success does not depend on changed model behavior. No provider call was made or live pass claimed.
- Final gates: Required exact-head CI, Ready admission, and ReviewGPT remain with the original completion owner.

## Non-obvious affected surfaces

Failure telemetry still receives the same `failureDiagnostic` and outer runtime-issue classification. The deleted outcome flag was private and never reached either RPC output or telemetry. Assistant-Codex retains same-turn pause locking; Web retains browser state and human-handoff ownership.

## Architecture and reuse

- Existing systems reused: The current computer adapter, hosted route builder, payload sanitizers, and shared tool-failure diagnostics.
- New logic: None; remove unreachable policy alternatives, unused result state, an identical branch, and an unread argument.
- New abstractions: None; the existing private error reader returns a string.
- Complexity intentionally avoided: No new adapter module, generalized transport wrapper, sanitizer mode, retry path, or browser-state owner.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff --base b80bd40f84d1b367c1810e2fe046e3089cc28aa4`.
- Hotspots: Thirteen unchanged functions remain above 20: `dispatchMurphDynamicToolRequest` 189, `executeGroupTool` 167, `readMurphDynamicToolRequest` 80, `executeSendPhysicalNoteDynamicTool` 65, `executeGenerateImageDynamicTool` 57, `parseGroupArguments` 44, `executeCreatePhoneCallDynamicTool` 41, `executeResolvePhysicalNoteDynamicTool` 36, `executeGroupEmailEffect` 26, `executeClinicalRecordsConnectLinkDynamicTool` 23, `executeAssistantConfigurationTool` 23, `classifyGroupToolFailure` 22, and `groupSharedWorkoutsModelProjection` 21.
- Agent judgment: Complexity debt remains 534 and the maximum remains 189. The computer cleanup removes dead branches below the threshold. The remaining functions own dispatch, domain authority/effects, parsing, or group projection; their separate ownership questions do not justify widening this deletion. Keep the current computer adapter coherent.

## Hot reply path impact

- Path status: Touched during existing synchronous tool-result projection after an existing computer request.
- Database calls: None added or moved.
- Network/provider calls: None added or moved. Each executed operation retains one POST to the same endpoint, with the same body and abort signal; no retry or automatic finish is added.
- Other awaited latency: None added or moved; the existing response JSON read remains.
- Before/after proof: Focused dispatch tests assert exact text/diagnostics and one fetch across five operations; existing request-body and pause tests remain green.

## Murph initial provider input impact

Not applicable for individual or group runtime: no prompt builder, instruction, tool schema, advertisement, or initial context changed. Subsequent computer tool results are also preserved by exact deterministic assertions.

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged; existing result text and sanitization are preserved.
- Measurement method: Not run — no provider-input surface changed; no measured zero is claimed.

## Deployment concerns

- Deployment: not applicable
- Reason: No deployed request/response protocol, persisted schema, browser-state transition, authority boundary, or rollout ordering changes. Existing and updated bundles use the same external contracts.

## Change-shape breakdown

Classification rule: Production TypeScript is source, test files are tests, and the completed execution plan is documentation. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 20 | 64 |
| Tests / fixtures | 94 | 0 |
| Docs | 58 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **172** | **64** |

## Changelog

- Changelog: not applicable
- Reason: Internal deletion preserves member-visible behavior.


## ReviewGPT

ReviewGPT first-reviewed head: 3a9f1507b78131fafb9c3bd56805b5e130c1f09b
ReviewGPT context sensitivity: sensitive
Reason: Computer-tool execution and diagnostic boundaries, with unchanged public behavior.

## Final review evidence

- Parent candidate review: passed; no unresolved findings.
- ReviewGPT round 1: PASS on `3a9f1507b78131fafb9c3bd56805b5e130c1f09b`, with no qualifying findings. The full-snapshot response inspected the changed ownership boundary, callers, and regression coverage.
- Acceptance: exact submitted turn, response hash, completion marker, and `gpt-6-pro` model metadata verified (Apollo; approximately 323.6 seconds from send to captured response). Round-1 baseline and empty remediation deltas verified through canonical reconstruction after automatic attachment cleanup.
- Response SHA-256: `e4a25d20c234ea3e9f4632eed5be1c021fa33da36a18d0cebec7ba6ebc288e90`.
- Integration: conflict-free against `006ce0768111cac657518a79f3074b81ce97b4db`; the seven cleanup PRs have no overlapping authored paths.
