### PR TITLE
Let empty runtime wakes finish checkpointed device work

### DIFF
--- a/.agents/friction-log/20260910140154-concurrent-device-import/friction.md
+++ b/.agents/friction-log/20260910140154-concurrent-device-import/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Concurrent device-import proof times out before its foreground assertion'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The concurrent device-import integration proof should allow its two-reply setup to finish on the shared-host verification profile, then enforce its separate model-to-delivery latency and checkpoint ordering assertions.
+
+## Current Behavior
+
+The five-second outer wait expires during canonical import or before the second reply under local contention. Two isolated repetitions failed before entering the projection code under test. Source transformation also took over two minutes, although the test scenario itself remains bounded.
+
+## Possible Solution
+
+Use the existing twenty-second runtime completion allowance for the two-reply orchestration gate. Preserve the independent two-second model-to-delivery assertion and all event-order checks.
+
+## Minimal Reproducible Example
+
+Run the assistant-runtime concurrent-device-import integration test with the acknowledgment and empty-wake scenarios on a busy shared development host. The outer wait can reject while device import and the first foreground pass are still progressing.
+
+## Context
+
+This obscured the result of a deterministic checkpoint-starvation regression. The production failure reproduces through a bounded checkpoint-count assertion separately from this test-harness deadline.

--- a/agent-docs/exec-plans/active/2026-09-10-device-completion-starvation.md
+++ b/agent-docs/exec-plans/active/2026-09-10-device-completion-starvation.md
@@ -1,0 +1,35 @@
+# Prevent device completion starvation after checkpoint
+
+Status: active
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Outcome and invariant
+
+Complete accepted device work after its successful checkpoint without repeated background wakes postponing the completion record. Preserve real foreground input priority, exact mailbox ownership, checkpoint fencing, projection requirements, and retry durability.
+
+## Owner and evidence
+
+The runtime owns pending and ready checkpoint callbacks. System-mailbox records own unfinished device work; Web owns committed handling progress. The reproduced gap is an empty notification preempting the post-checkpoint projection offer. Its foreground pass selects a fresh system wake and dirties the runtime before ready completion callbacks drain. Both a callback regression and the real concurrent device-import integration fail at a bounded checkpoint-count assertion on the base. Reuse the existing complete-lane high-water proof to consume empty notifications while preserving local work and foreground preemption.
+
+## Scope and approach
+
+Reproduce through the existing runtime entrypoint and synthetic device ports. Prefer correcting wake derivation or ordering existing work over another queue, timer, flag, or persisted owner. Keep production data and identifiers out of fixtures and review artifacts. No production recovery, merge, or deployment is included in this PR task.
+
+## Product UX
+
+Outcome: Completed wearable imports finish their acknowledgement promptly.
+Reaches: Background-only imports, imports alongside conversations, and checkpoint/retry recovery.
+Proof: Synthetic completion and canonical mailbox readback, foreground delivery ordering, failed checkpoint suppression, and focused runtime tests. Model instructions and reply meaning are unchanged; deterministic scheduling proof owns this patch.
+
+## Tasks
+
+1. Reproduce the callback starvation and isolate its causal branch.
+2. Apply the smallest correction and prove completion, foreground priority, and failure recovery.
+3. Run relevant tests, typecheck, complexity and documentation checks; review the complete diff.
+4. Add the member-facing changelog, commit, open a draft PR, and mark the proven candidate Ready.
+5. Run required ReviewGPT concurrently with exact-head CI; resolve supported findings and failures, close this plan, and leave a green PR.
+
+## Verification
+
+Local reproduction established in two tests before the fix. The callback regression passes after the fix; isolated device and adjacent priority verification are in progress. CI and ReviewGPT remain required. The public/private runtime protocol and durable data format must remain compatible without migration.

--- a/agent-docs/exec-plans/completed/2026-09-10-device-completion-starvation.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-device-completion-starvation.md
@@ -1,6 +1,6 @@
 # Prevent device completion starvation after checkpoint
 
-Status: active
+Status: completed
 Created: 2026-09-10
 Updated: 2026-09-10
 
@@ -32,4 +32,12 @@ Proof: Synthetic completion and canonical mailbox readback, foreground delivery 
 
 ## Verification
 
-Local reproduction established in two tests before the fix. The callback regression passes after the fix; isolated device and adjacent priority verification are in progress. CI and ReviewGPT remain required. The public/private runtime protocol and durable data format must remain compatible without migration.
+- Corrected real device-import fixture: the same synthetic scenario fails against base `b80bd40f84d1` at its fourth idle snapshot with no acknowledgment, and passes with the patch. The base source was restored only for the negative check and the patched source was restored afterward.
+- Callback regression: caught-up empty wakes complete without another assistant pass; incomplete and unknown high-water evidence preserve foreground service. All three pass.
+- Adjacent focused cases pass: interrupted acknowledgment, durable effects after successful checkpoint, repeated device wakes, incomplete prefix, failed classification, shutdown during projection, and foreground delivery during an owned projection. The original checkpoint-wakes suite also passed.
+- Assistant-runtime and Web typechecks pass. Changelog generation and all 10 focused archive tests pass.
+- Complexity guard passes with unchanged debt 547 and maximum 252. Existing owner hotspots were reviewed; no new state owner or protocol is needed.
+- Parent review confirms synthetic fixtures, no private evidence in artifacts, and preserved checkpoint/acknowledgment order. The two-reply test setup allowance increased to 20 seconds after reproduced shared-host timeouts; its independent two-second delivery bound remains unchanged. The Frog record is included.
+
+Implementation and local verification are complete. PR #3196 owns the remaining exact-head CI and required ReviewGPT gates; these are pending at candidate closure and must pass before the PR task is reported complete. Merge and deployment remain outside scope.
+Completed: 2026-09-10

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -378,9 +378,12 @@ every visible item is a system-lane `device-sync.wake`. This includes dirty,
 connection, disconnect, manual-reconcile, and scheduled-reconcile maintenance;
 none is human conversation work. A full page whose high-water lies beyond its
 visible suffix is incomplete and remains foreground work because later rows are
-not yet classified. A conversation row, another system kind, an empty or
-uninspectable prefix, or a failed classification fetch likewise remains
-foreground. A successful classification prefetch is reused by the foreground
+not yet classified. A completely empty response that proves every fetched lane
+is caught up is consumed without preempting projection or scheduling another
+assistant pass when no local state mutation, ready image completion, or owner
+handoff requires service; otherwise repeated notifications can starve
+checkpoint-backed completion. A conversation row, another system kind, an incomplete or
+uninspectable prefix, or a failed classification fetch remains foreground. A successful classification prefetch is reused by the foreground
 import instead of fetched a second time. An invocation that exhausts its mailbox
 budget returns the existing durable continuation before making another
 projection offer. Once graceful shutdown is observed, the retiring runtime

--- a/apps/web/changelog/entries/2026-09-10/wearable-import-completion.json
+++ b/apps/web/changelog/entries/2026-09-10/wearable-import-completion.json
@@ -1,0 +1,19 @@
+{
+  "publishedOn": "2026-09-10",
+  "order": 100,
+  "item": {
+    "id": "wearable-import-completion",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Wearable imports finish more reliably",
+    "summary": "Repeated background notifications no longer delay the final step of a completed wearable import.",
+    "details": "Your messages still take priority while Murph finishes syncing your data.",
+    "relevanceTags": [
+      "devices",
+      "reliability"
+    ],
+    "sourcePullRequests": [
+      3196
+    ]
+  }
+}

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -5052,7 +5052,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
     };
     let vaultShareWakeClassificationOrdinal = 0;
     const invocationWorkspaceVersion = input.request.workspaceVersion;
-    const invocationProcessingMode = input.request.processingMode ?? "default";
+    const invocationProcessingMode = input.request.processingMode;
     const offerHostedVaultShareProjectionDuringIdle = async (input: {
       deferDeviceSyncWakes?: boolean;
       deferredDeviceSyncWake?: HostedVaultShareOfferWake | null;
@@ -5102,7 +5102,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
           && !runtimeStateDirty
           && !imageGenerationController?.hasCompleted()
           && (latencySeed.requestedProcessingMode == null
-            || latencySeed.requestedProcessingMode === invocationProcessingMode)
+            || latencySeed.requestedProcessingMode === (invocationProcessingMode ?? "default"))
           && classification.caughtUpToEveryLaneHighWater
         ) {
           return { mayWaitForProjection: true, wake: null };

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -5008,6 +5008,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
       latencySeed: HostedRuntimeWakeLatencySeed;
       requestId: string;
     }): Promise<{
+      caughtUpToEveryLaneHighWater: boolean;
       containsOnlyBrowserVaultRefreshWakes: boolean;
       containsOnlyDeviceSyncWakes: boolean;
       wake: HostedVaultShareOfferWake;
@@ -5024,6 +5025,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
             initialMailboxPrefetch,
           );
         return {
+          caughtUpToEveryLaneHighWater: inspection.caughtUpToEveryLaneHighWater,
           containsOnlyBrowserVaultRefreshWakes:
             inspection.containsOnlyBrowserVaultRefreshWakes,
           containsOnlyDeviceSyncWakes:
@@ -5035,8 +5037,9 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
           },
         };
       } catch {
-        // Empty, mixed, or uninspectable wakes preserve foreground priority.
+        // Failed classification preserves foreground priority.
         return {
+          caughtUpToEveryLaneHighWater: false,
           containsOnlyBrowserVaultRefreshWakes: false,
           containsOnlyDeviceSyncWakes: false,
           wake: {
@@ -5049,6 +5052,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
     };
     let vaultShareWakeClassificationOrdinal = 0;
     const invocationWorkspaceVersion = input.request.workspaceVersion;
+    const invocationProcessingMode = input.request.processingMode ?? "default";
     const offerHostedVaultShareProjectionDuringIdle = async (input: {
       deferDeviceSyncWakes?: boolean;
       deferredDeviceSyncWake?: HostedVaultShareOfferWake | null;
@@ -5068,7 +5072,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
         latencySeed: HostedRuntimeWakeLatencySeed,
       ): Promise<{
         mayWaitForProjection: boolean;
-        wake: HostedVaultShareOfferWake;
+        wake: HostedVaultShareOfferWake | null;
       }> => {
         const foregroundWake = {
           deferredForProjection: false,
@@ -5090,6 +5094,19 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
           requestId:
             `${requestId}:vault-share-wake-classify:${vaultShareWakeClassificationOrdinal}`,
         });
+        // A fully caught-up empty prefix is a notification, not new work.
+        // Retaining it as a foreground wake would dirty the runtime again
+        // before checkpoint-backed completions can drain.
+        if (
+          !shutdownWasSignaled()
+          && !runtimeStateDirty
+          && !imageGenerationController?.hasCompleted()
+          && (latencySeed.requestedProcessingMode == null
+            || latencySeed.requestedProcessingMode === invocationProcessingMode)
+          && classification.caughtUpToEveryLaneHighWater
+        ) {
+          return { mayWaitForProjection: true, wake: null };
+        }
         return {
           mayWaitForProjection:
             !shutdownWasSignaled()
@@ -5101,9 +5118,9 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
         };
       };
       const rememberDeferredDeviceSyncWake = (
-        wake: HostedVaultShareOfferWake,
+        wake: HostedVaultShareOfferWake | null,
       ): void => {
-        deferredDeviceSyncWake = wake;
+        if (wake) deferredDeviceSyncWake = wake;
       };
       const runtimeWakeSignal = options.runtimeWakeSignal ?? null;
       const consumePendingProjectionWake = async (): Promise<

--- a/packages/assistant-runtime/test/hosted-runtime-concurrent-device-import.integration.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-concurrent-device-import.integration.test.ts
@@ -56,6 +56,7 @@ test.each(["completed", "stalled", "absent", "persistent", "cold", "acknowledgme
   const releaseDownload = createDeferred<void>();
   const dirtyAcks: Parameters<HostedRuntimeDeviceSyncPort["ackDirtyStateProcessed"]>[0][] = [];
   let replySent = false;
+  let idleSnapshotCount = 0;
   let modelFinishedAt = 0;
   const connectionId = "synthetic-concurrent-connection";
   const deviceItem = createMailboxItem({
@@ -256,8 +257,9 @@ test.each(["completed", "stalled", "absent", "persistent", "cold", "acknowledgme
       {
         vaultRoot, runtimeWakeSignal, signal: controller.signal,
         async createCheckpointSnapshot() {
+          idleSnapshotCount += 1;
           if (scenario === "empty-wake") {
-            assert.ok(checkpointRequests.length < 4, "Empty wakes starved the device completion acknowledgment.");
+            assert.ok(idleSnapshotCount <= 3, "Empty wakes starved the device completion acknowledgment.");
           }
           if (completesBeforeReply || persistent) await releaseSnapshot.promise;
           events.push("snapshot.completed");
@@ -331,7 +333,7 @@ test.each(["completed", "stalled", "absent", "persistent", "cold", "acknowledgme
       await withRealTimeout(Promise.race([
         secondReply.promise,
         runtimeCompletion.then(() => assert.fail("Runtime exited before the second reply.")),
-      ]), 5_000, () => events.join(","));
+      ]), 20_000, () => events.join(","));
       assert.equal(dirtyAcks.length, 0);
       if (persistent) {
         assert.equal(events.includes("provider.aborted"), false, events.join(","));

--- a/packages/assistant-runtime/test/hosted-runtime-concurrent-device-import.integration.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-concurrent-device-import.integration.test.ts
@@ -38,8 +38,8 @@ import * as maintenanceCancellation from "../src/hosted-runtime/background-maint
 import { HOSTED_DEVICE_SYNC_PASS_TIMEOUT_MS } from "../src/hosted-runtime/device-sync-maintenance-limits.ts";
 import { readHostedSystemMailboxState } from "../src/hosted-runtime/system-mailbox-state.ts";
 
-test.each(["completed", "stalled", "absent", "persistent", "cold", "acknowledgment"] as const)("preserves foreground delivery with a %s concurrent device import", async (scenario) => {
-  const completesBeforeReply = scenario === "completed" || scenario === "acknowledgment";
+test.each(["completed", "stalled", "absent", "persistent", "cold", "acknowledgment", "empty-wake"] as const)("preserves foreground delivery with a %s concurrent device import", async (scenario) => {
+  const completesBeforeReply = scenario === "completed" || scenario === "acknowledgment" || scenario === "empty-wake";
   const persistent = scenario === "persistent" || scenario === "cold";
   const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-concurrent-device-import-"));
   const controller = new AbortController();
@@ -226,6 +226,17 @@ test.each(["completed", "stalled", "absent", "persistent", "cold", "acknowledgme
     };
     const basePlatform = createPlatform({
       artifactBytesByHash,
+      ...(scenario === "empty-wake" ? {
+        vaultSharePort: {
+          async listActiveProjectionScopes() {
+            vi.setSystemTime(Date.now() + 1_000);
+            runtimeWakeSignal.notify();
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            return { projectionKinds: [], projectionScopes: [] };
+          },
+          async deliver() { throw new Error("No projection scopes are active."); },
+        },
+      } : {}),
       mailboxPort: createMailboxPort({ events, items }),
       workspacePort: createWorkspacePort({ checkpointRequests, events, workspace: createWorkspaceState() }),
       deviceSyncPort,
@@ -245,6 +256,9 @@ test.each(["completed", "stalled", "absent", "persistent", "cold", "acknowledgme
       {
         vaultRoot, runtimeWakeSignal, signal: controller.signal,
         async createCheckpointSnapshot() {
+          if (scenario === "empty-wake") {
+            assert.ok(checkpointRequests.length < 4, "Empty wakes starved the device completion acknowledgment.");
+          }
           if (completesBeforeReply || persistent) await releaseSnapshot.promise;
           events.push("snapshot.completed");
           return { snapshotRef: createBundleRef({

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-checkpoint-wakes.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-checkpoint-wakes.test.ts
@@ -147,12 +147,14 @@ describe("hosted workspace runtime entrypoint", () => {test("runs deferred durab
     }
   });
 
-  test("empty projection wakes cannot starve a checkpointed completion", async () => {
+  test.each(["caught-up", "incomplete", "unknown"] as const)("classifies %s empty projection wakes before completing checkpointed work", async (coverage) => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-ready-completion-"));
     const events: string[] = [];
     const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
     const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
     let assistantPasses = 0;
+    let scopeReads = 0;
+    const mailboxPort = createMailboxPort({ events, items: [] });
     const durableEffect = vi.fn(async () => {
       events.push("completion");
       return { requiresFollowUpCheckpoint: true };
@@ -170,11 +172,26 @@ describe("hosted workspace runtime entrypoint", () => {test("runs deferred durab
           return { snapshotRef: createBundleRef({ hash: "a".repeat(64), key: "users/bundles/member-synthetic/ready-completion.bundle.json", size: 512 }) };
         },
         platform: createPlatform({
-          mailboxPort: createMailboxPort({ events, items: [] }),
+          mailboxPort: {
+            ...mailboxPort,
+            async fetch(request) {
+              const response = await mailboxPort.fetch(request);
+              if (scopeReads === 1 && coverage !== "caught-up") {
+                return {
+                  ...response,
+                  maxSeqByLane: coverage === "unknown" ? [] : response.maxSeqByLane.map((entry) => ({
+                    ...entry, maxSeq: entry.lane === "conversation" ? "1" : entry.maxSeq,
+                  })),
+                };
+              }
+              return response;
+            },
+          },
           workspacePort: createWorkspacePort({ checkpointRequests, events, workspace: createWorkspaceState() }),
           vaultSharePort: {
             async listActiveProjectionScopes() {
-              runtimeWakeSignal.notify();
+              scopeReads += 1;
+              if (coverage === "caught-up" || scopeReads === 1) runtimeWakeSignal.notify();
               await new Promise((resolve) => setTimeout(resolve, 10));
               return { projectionKinds: [], projectionScopes: [] };
             },
@@ -198,7 +215,7 @@ describe("hosted workspace runtime entrypoint", () => {test("runs deferred durab
         },
       });
       assert.equal(durableEffect.mock.calls.length, 1);
-      assert.equal(assistantPasses, 1);
+      assert.equal(assistantPasses, coverage === "caught-up" ? 1 : 2);
       assert.ok(events.indexOf("workspace.checkpoint") < events.indexOf("completion"));
     } finally {
       await removeTempRoot(vaultRoot);

--- a/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-checkpoint-wakes.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-workspace-entrypoint-checkpoint-wakes.test.ts
@@ -147,6 +147,64 @@ describe("hosted workspace runtime entrypoint", () => {test("runs deferred durab
     }
   });
 
+  test("empty projection wakes cannot starve a checkpointed completion", async () => {
+    const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-ready-completion-"));
+    const events: string[] = [];
+    const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+    const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
+    let assistantPasses = 0;
+    const durableEffect = vi.fn(async () => {
+      events.push("completion");
+      return { requiresFollowUpCheckpoint: true };
+    });
+    try {
+      await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+      await runHostedWorkspaceRuntimeJobInProcess(createWorkspaceRuntimeJobInput({
+        request: { idleCheckpointDelayMs: 1 },
+      }), {
+        vaultRoot,
+        runtimeWakeSignal,
+        async importItem() { return { status: "imported" }; },
+        async createCheckpointSnapshot() {
+          assert.ok(checkpointRequests.length < 4, "Ready completion was starved by empty wake checkpoint churn.");
+          return { snapshotRef: createBundleRef({ hash: "a".repeat(64), key: "users/bundles/member-synthetic/ready-completion.bundle.json", size: 512 }) };
+        },
+        platform: createPlatform({
+          mailboxPort: createMailboxPort({ events, items: [] }),
+          workspacePort: createWorkspacePort({ checkpointRequests, events, workspace: createWorkspaceState() }),
+          vaultSharePort: {
+            async listActiveProjectionScopes() {
+              runtimeWakeSignal.notify();
+              await new Promise((resolve) => setTimeout(resolve, 10));
+              return { projectionKinds: [], projectionScopes: [] };
+            },
+            async deliver() { return { status: "delivered" }; },
+          },
+        }),
+        async runAssistantPhase() {
+          assistantPasses += 1;
+          return {
+            progressed: true,
+            checkpointReason: "assistant_runtime_commit",
+            nextWakeAt: new Date().toISOString(),
+            nextWakeReason: "device-sync.reconcile",
+            ...(assistantPasses === 1 ? {
+              afterCheckpoint: async () => ({
+                checkpointReason: "system_mailbox_receipt",
+                afterDurableCheckpoint: durableEffect,
+              }),
+            } : {}),
+          };
+        },
+      });
+      assert.equal(durableEffect.mock.calls.length, 1);
+      assert.equal(assistantPasses, 1);
+      assert.ok(events.indexOf("workspace.checkpoint") < events.indexOf("completion"));
+    } finally {
+      await removeTempRoot(vaultRoot);
+    }
+  });
+
   test("checkpoint-gated due projected wakes wait for the idle delay before service", async () => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-workspace-entrypoint-"));
     const events: string[] = [];


### PR DESCRIPTION
## Why and outcome

Repeated runtime notifications can interrupt a post-checkpoint sharing projection even when bounded mailbox reads prove both lanes are caught up. The empty foreground pass then selects a fresh system wake and dirties the workspace before ready device-completion callbacks drain, causing repeated idle snapshots without acknowledgment.

Consume fully caught-up empty notifications through the existing lane high-water proof. Preserve preemption for actual mailbox work, incomplete or failed reads, local mutations, ready images, shutdown, and owner handoff. No durable state or protocol changes.

## Product UX

- Effort: Patch.
- Result: Ready.
- Walkthrough: Completed wearable imports finish their acknowledgment despite repeated empty notifications. Current conversations retain priority. Background-only completion, two replies alongside a real device import, interrupted acknowledgment, and incomplete mailbox evidence are covered. No prompt or reply-meaning change.

## Evidence

- Direct: The corrected concurrent device-import regression fails against base `b80bd40f84d1` after a fourth idle snapshot without acknowledgment and passes with this patch. The callback regression independently reproduces the same starvation. Fixtures are synthetic; no private production records are included.
- Coverage: Focused entrypoint checks cover caught-up, incomplete and unknown empty prefixes; acknowledgment interruption; durable effects after successful checkpoints; repeated device wakes; failed classification; shutdown during projection; and real foreground delivery during an owned projection.
- Runtime tests: `pnpm --dir packages/assistant-runtime exec vitest run --config vitest.config.ts --isolate=true --no-coverage --maxWorkers=1` with the checkpoint-wakes, concurrent-device-import, foreground-input, and wake-gates files and focused scenario filters. Passing isolated reruns replace the initial orchestration-timeout failures.
- Typechecks: `pnpm --dir packages/assistant-runtime typecheck`; `pnpm --dir apps/web typecheck`.
- Changelog: generation and `pnpm exec vitest run --config apps/web/vitest.config.ts apps/web/test/changelog-page.test.tsx --maxWorkers=1` (10 passing tests).
- Final review: [ReviewGPT Round 1](https://chatgpt.com/c/6aa2f295-c1c8-83ea-a12f-77b0a6022501) **PASS** on `c3987da5558546da2ad97b81f1f7213e9578c567`; no qualifying findings. Independent synthetic helper checks supplement the local integration evidence.
- Final CI: Build, typecheck, package coverage, Web tests, fixture, host, billing, and Temporal checks passed on `c3987da5558546da2ad97b81f1f7213e9578c567`. [Exact-head CI results](https://github.com/cobuildwithus/murph/pull/3196/checks).

## Non-obvious affected surfaces

The shared projection classifier must not suppress empty responses whose high-water evidence is incomplete or absent. Separate composed cases retain foreground service for both. The device integration setup now allows 20 seconds for two replies on shared hosts; the independent two-second model-to-delivery assertion and event-order checks are unchanged. The observed harness friction is recorded with the task.

## Architecture and reuse

- Existing systems reused: Bounded mailbox prefetch, lane high-water inspection, owned projection stages, and the pending/ready durable callback queues.
- New logic: Consume an empty notification only with complete mailbox evidence and no local-work, image-completion, shutdown, or handoff reason to yield.
- New abstractions: None; expose an existing inspection result to the existing classifier.
- Complexity intentionally avoided: No new queue, timer, persisted marker, polling loop, or acknowledgment owner.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`; debt 547 → 547, maximum 252 → 252.
- Hotspots: 22 existing functions remain above 20. The projection owner remains 22; the changed nested classifier remains below 20. Reviewed the enclosing runtime owner, projection-stage wait, durable-effect drain, foreground passes, and dirty/clean checkpoint paths. Their ordering and state ownership remain unchanged.
- Agent judgment: A broad runtime refactor would obscure this small evidence-based guard; no additional abstraction is justified.

## Hot reply path impact

- Path status: No new work on accepted-message → provider → durable reply handoff. This changes idle projection wake classification.
- Database calls: None added or moved onto the reply path.
- Network/provider calls: None added or moved. Reuse the existing bounded mailbox fetch; complete empty notifications avoid an unnecessary assistant pass.
- Other awaited latency: None added.
- Before/after proof: Real device-import fixture preserves two foreground replies before idle snapshot/acknowledgment, plus the independent model-to-delivery bound. Existing owned-projection foreground and incomplete-prefix cases pass.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: assembled instructions, tool schemas, generated guidance, history, and provider request construction are unchanged. No provider-input measurement was needed for this scheduling-only correction.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: Content-only changelog fragment; production presentation is unchanged. Focused archive tests server-render the authored copy.
- Coverage: No renderer, styles, interaction, or visual changes; repository content-only proof applies.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old/new runtime images use identical mailbox, checkpoint, projection, and completion-record formats; Web and Worker interfaces are unchanged.
- Safe order: Normal runtime-image rollout. No migration or coordinated Web/Worker release required.
- Rollback floor: No new persisted format; the prior image can read the same state, although it retains the empty-notification stall.
- Expected exposure: Default runtimes receiving repeated empty notifications during post-checkpoint projection. Existing warm runtimes keep their loaded behavior until replaced.
- Reversibility: Runtime image change only, using the normal separately authorized release process.
- Convergence proof: Base failure and patched success use identical persisted-state owners and port fixtures; the patch changes only notification classification, not serialization or control APIs.
- Post-deploy checks: Confirm runtime release adoption; compare stalled imported-but-unhandled system heads and repeated idle snapshots; verify completed device records advance handled frontiers. No production mutation was performed for this PR.

## Change-shape breakdown

Classification: runtime implementation as source; test paths as tests; plan/protocol/Frog records as docs; changelog JSON as authored content. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 21 | 4 |
| Tests / fixtures | 94 | 3 |
| Docs | 73 | 3 |
| Config / tooling | 0 | 0 |
| Generated / other | 19 | 0 |
| **Total** | **207** | **10** |

## Changelog

- Changelog: updated
- Items: 2026-09-10 · wearable-import-completion

ReviewGPT context sensitivity: sensitive
Classification reason: Hosted runtime scheduling and checkpoint-backed external completion ordering.

ReviewGPT first-reviewed head: c3987da5558546da2ad97b81f1f7213e9578c567
