### PR TITLE
refactor(vault-usecases): consolidate experiment edit options

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-simplify-experiment-options.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-simplify-experiment-options.md
@@ -1,0 +1,50 @@
+# Consolidate pure experiment edit options
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+Place experiment edit option compilation beside the existing onboarding option builders, preserving canonical output and failure ordering.
+
+## Scope and invariants
+
+- Move pure protocol-reference, run-logging, analysis, primary-outcome, and date builders with their validators into `experiment-onboarding-options.ts`.
+- Reuse existing text, stable-ID, list, and compaction primitives. Keep measurement-anchor parsing with `option-utils.ts`.
+- Preserve public service fields and input types. No new package entrypoint or state owner.
+- Keep schedule file reads, patch admission, current frontmatter reads, canonical locks, and updates in `experiment-journal-vault.ts`; retain dates, logging, then schedule evaluation.
+- No product behavior, persisted format, permission, prompt, or tool-schema change.
+
+## Tasks
+
+1. Move the closed pure builder cluster and inspect exact source equivalence.
+2. Run focused onboarding and CLI edit integration tests, package typechecks, complexity and boundary checks.
+3. Review the scoped diff and privacy, close this implementation plan, commit, push, and open a draft PR.
+
+## Verification
+
+- Focused vault-usecases onboarding schedule suite and CLI experiment phase-two integration cases.
+- Vault-usecases and CLI typechecks; workspace boundaries, complexity diff, and doc drift.
+- Compare moved function ASTs and unchanged orchestration against base `b80bd40f84d1b367c1810e2fe046e3089cc28aa4`.
+- Parent owns candidate/final review, Ready admission, ReviewGPT, and required CI.
+
+## Risks and decisions
+
+- Error order is observable: preserve calls in their original positions, including schedule reads after date/logging validation.
+- Existing option builder primitives are reused; no general compiler abstraction or callback injection.
+- Internal refactor only: no changelog or provider-input measurement applies.
+
+## Results
+
+- Fourteen moved top-level function ASTs and all 100 retained function ASTs match the pinned base. The existing options compaction helper now has the same generic return type and AST as the prior usecase primitive.
+- The usecase input interface moved unchanged in field shape, using the equivalent contracts `ExperimentStatus` type; its original export is retained. Shared service field consolidation is intentionally outside this PR.
+- Six onboarding schedule tests passed. The first cold run exceeded the existing 60-second deadline during transformation; the unchanged rerun passed without timeout changes.
+- Vault-usecases and CLI source typechecks passed; workspace boundaries, complexity diff, doc drift, and whitespace checks passed.
+- Complexity recognizes 16 moved frames. Primary-outcome (37) and analysis-plan (23) branch counts are unchanged; unrelated locked update, session, schema, and safety hotspots stay intact.
+- Parent candidate source review independently confirmed the 14 moves, 100 retained functions, and absence of a runtime back-edge.
+- CLI protocol-backed integration requires local public Health Commons generated artifacts. The package-owned generator prepared them inside this worktree; no graph build or sibling artifact reuse occurred.
+- Focused CLI edit mapping, canonical write order/failure cutoffs, and edit/checkpoint/stop lifecycle scenarios all passed (3 selected; 42 unrelated scenarios skipped).
+- Frozen dependency installation and Frog list succeeded; no new repository friction entry was needed.
+- This plan records implementation proof only; the completion parent owns Ready, final review, CI, and merge decisions.
+Completed: 2026-09-10

--- a/packages/vault-usecases/README.md
+++ b/packages/vault-usecases/README.md
@@ -31,6 +31,12 @@ When an exact read feeds a mutation, carry the observed lifecycle revision or
 source revision into the canonical core writer rather than treating projection
 state as write authority.
 
+Experiment edit option compilation lives in `src/experiment-onboarding-options.ts`
+alongside onboarding capture and assistant-support options. The pure builders
+validate protocol references, run logging, analysis, and dates. The experiment
+usecase owns schedule-file reads, current frontmatter, canonical locking, and
+updates, preserving date and logging validation before schedule reads.
+
 ## Clinical FHIR snapshots
 
 `@murphai/vault-usecases/clinical-records` is the explicit execution seam for a

--- a/packages/vault-usecases/src/experiment-onboarding-options.ts
+++ b/packages/vault-usecases/src/experiment-onboarding-options.ts
@@ -2,6 +2,13 @@ import {
   HEALTH_COMMONS_EXPERIMENT_ONBOARDING_CAUTION_LEVELS,
   HEALTH_COMMONS_EXPERIMENT_ONBOARDING_MISSED_LOG_POLICIES,
   HEALTH_COMMONS_EXPERIMENT_ONBOARDING_POSITIVE_DISPOSITIONS,
+  commonsProtocolRefSchema,
+  experimentAnalysisPlanSchema,
+  experimentExpectedDirectionsSchema,
+  experimentFrontmatterSchema,
+  experimentPrimaryOutcomeSchema,
+  experimentRunLoggingSchema,
+  healthCommonsKeySchema,
   experimentAssistantSupportSchema,
   experimentOnboardingCaptureSchema,
   experimentOnboardingSafetySchema,
@@ -10,11 +17,20 @@ import {
   type ExperimentAssistantSupport,
   type ExperimentOnboardingCapture,
   type ExperimentOnboardingSafety,
+  type ExperimentOutcomeStatistic,
+  type ExperimentPrimaryOutcome,
+  type ExperimentRunScheduleIntent,
+  type ExperimentStatus,
   type JsonValue,
 } from '@murphai/contracts'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
 import * as z from '@murphai/contracts/zod-runtime'
 import type { JsonObject } from './health-cli-method-types.js'
+import { localDateSchema } from '@murphai/operator-config/vault-cli-contracts'
+import {
+  normalizeExperimentMeasurementAnchorFlagOption,
+  normalizeExperimentPlannedMeasurementFlagOption,
+} from './option-utils.js'
 
 const experimentCheckInCadenceSchema = z.enum(['none', 'daily', 'every_3_days', 'weekly'])
 const experimentNotificationStyleSchema = z.enum([
@@ -40,6 +56,58 @@ export interface ExperimentAssistantSupportOptions {
   notificationStyle?: z.infer<typeof experimentNotificationStyleSchema>
   missedLogFollowup?: (typeof HEALTH_COMMONS_EXPERIMENT_ONBOARDING_MISSED_LOG_POLICIES)[number]
   weeklyDigestEnabled?: boolean
+}
+
+const experimentSignalDirectionSchema = z.enum(['increase', 'decrease', 'stabilize'])
+type ExperimentFrontmatterValue = z.infer<typeof experimentFrontmatterSchema>
+type CommonsProtocolRefValue = z.infer<typeof commonsProtocolRefSchema>
+type ExperimentRunLoggingValue = z.infer<typeof experimentRunLoggingSchema>
+type ExperimentAnalysisPlanValue = z.infer<typeof experimentAnalysisPlanSchema>
+
+export interface ApplyExperimentOnboardingRecordInput
+  extends ExperimentOnboardingCaptureOptions,
+    ExperimentAssistantSupportOptions {
+  vault: string
+  lookup: string
+  status?: ExperimentStatus
+  protocolKey?: string
+  pageRevisionId?: string
+  runSpecRevisionId?: string
+  testPlanId?: string
+  baselineStart?: string
+  baselineEnd?: string
+  baselineDays?: number
+  interventionStart?: string
+  interventionEnd?: string
+  interventionDays?: number
+  modality?: string
+  schedule?: ExperimentRunScheduleIntent
+  scheduleInputFile?: string
+  scheduleKind?: ExperimentRunScheduleIntent['kind']
+  scheduleCron?: string
+  scheduleLocalTime?: string
+  scheduleTimeZone?: string
+  dose?: string
+  sessionsPerWeek?: number
+  targetSessions?: number
+  minimumUsefulSessions?: number
+  sessionField?: readonly string[]
+  confounderField?: readonly string[]
+  stopCondition?: readonly string[]
+  primaryBiomarkerKey?: string
+  primaryOutcomeKey?: string
+  primaryOutcomeKind?: ExperimentPrimaryOutcome['kind']
+  primaryOutcomeLabel?: string
+  primaryOutcomeSessionField?: string
+  primaryOutcomeSourceMetricKey?: string
+  primaryOutcomeUnit?: string
+  comparisonStatistic?: ExperimentOutcomeStatistic
+  secondaryBiomarkerKey?: readonly string[]
+  desiredDirection?: z.infer<typeof experimentSignalDirectionSchema>
+  expectedDirection?: readonly string[]
+  analysisAnchor?: readonly string[]
+  plannedMeasurement?: readonly string[]
+  analysisNote?: readonly string[]
 }
 
 export function buildExperimentOnboardingCaptureFromOptions(
@@ -325,5 +393,519 @@ function uniqueStrings(values: readonly string[]) {
 function compactObject<TRecord extends Record<string, unknown>>(record: TRecord) {
   return Object.fromEntries(
     Object.entries(record).filter(([, value]) => value !== undefined),
+  ) as TRecord
+}
+
+export function buildCommonsProtocolRefForOnboardingApply(
+  input: ApplyExperimentOnboardingRecordInput,
+  existing: ExperimentFrontmatterValue['commonsProtocolRef'],
+): CommonsProtocolRefValue | undefined {
+  const touched =
+    input.protocolKey !== undefined ||
+    input.pageRevisionId !== undefined ||
+    input.runSpecRevisionId !== undefined ||
+    input.testPlanId !== undefined
+
+  if (!touched) {
+    return undefined
+  }
+
+  const key =
+    input.protocolKey === undefined
+      ? existing?.key
+      : normalizeProtocolKeyOption(input.protocolKey, 'protocol-key')
+  const pageRevisionId =
+    input.pageRevisionId === undefined
+      ? existing?.pageRevisionId
+      : normalizeSha256RevisionOption(input.pageRevisionId, 'page-revision-id')
+  const runSpecRevisionId =
+    input.runSpecRevisionId === undefined
+      ? existing?.runSpecRevisionId
+      : normalizeSha256RevisionOption(input.runSpecRevisionId, 'run-spec-revision-id')
+  const testPlanId =
+    input.testPlanId === undefined
+      ? existing?.testPlanId
+      : normalizeStableIdOption(input.testPlanId, 'test-plan-id')
+
+  if (!key || !pageRevisionId || !runSpecRevisionId) {
+    throw new VaultCliError(
+      'invalid_payload',
+      'Applying a protocol reference requires --protocol-key, --page-revision-id, and --run-spec-revision-id unless the experiment already has them.',
+    )
+  }
+
+  return commonsProtocolRefSchema.parse(
+    compactObject({
+      key,
+      pageRevisionId,
+      runSpecRevisionId,
+      testPlanId,
+    }),
   )
+}
+
+export function buildRunLoggingForOnboardingApply(
+  input: ApplyExperimentOnboardingRecordInput,
+  existing: ExperimentRunLoggingValue | undefined,
+): ExperimentRunLoggingValue | undefined {
+  const sessionFields = normalizeStableIdListOption(input.sessionField, 'session-field')
+  const confounderFields = normalizeStableIdListOption(
+    input.confounderField,
+    'confounder-field',
+  )
+
+  if (sessionFields === undefined && confounderFields === undefined) {
+    return undefined
+  }
+
+  const next = compactObject({
+    ...(existing ?? {}),
+    ...(sessionFields === undefined ? {} : { sessionFields }),
+    ...(confounderFields === undefined ? {} : { confounderFields }),
+  })
+
+  if (!Array.isArray(next.sessionFields) || next.sessionFields.length === 0) {
+    throw new VaultCliError(
+      'invalid_payload',
+      '--confounder-field requires --session-field unless the experiment already has runPlan.logging.sessionFields.',
+    )
+  }
+
+  return experimentRunLoggingSchema.parse(next)
+}
+
+export function buildAnalysisPlanForOnboardingApply(
+  input: ApplyExperimentOnboardingRecordInput,
+  existing: ExperimentFrontmatterValue['analysisPlan'],
+): ExperimentAnalysisPlanValue | undefined {
+  if (
+    input.primaryOutcomeKey !== undefined &&
+    input.primaryBiomarkerKey !== undefined
+  ) {
+    throw new VaultCliError(
+      'invalid_option',
+      'experiment edit accepts either --primary-outcome-key or the legacy --primary-biomarker-key, not both.',
+    )
+  }
+  const patch: Partial<ExperimentAnalysisPlanValue> = {}
+  const normalizedPrimaryKey = input.primaryBiomarkerKey === undefined
+    ? undefined
+    : normalizeHealthCommonsKeyOption(
+        input.primaryBiomarkerKey,
+        'primary-biomarker-key',
+      )
+
+  if (normalizedPrimaryKey !== undefined && existing?.primaryOutcome === undefined) {
+    patch.primaryBiomarkerKey = normalizedPrimaryKey
+  }
+
+  const primaryOutcome = buildPrimaryOutcomeForOnboardingApply(
+    input,
+    existing?.primaryOutcome,
+    normalizedPrimaryKey ?? existing?.primaryBiomarkerKey,
+  )
+  if (primaryOutcome !== undefined) {
+    patch.primaryOutcome = primaryOutcome
+  }
+
+  const secondaryBiomarkerKeys = normalizeHealthCommonsKeyListOption(
+    input.secondaryBiomarkerKey,
+    'secondary-biomarker-key',
+  )
+  if (secondaryBiomarkerKeys !== undefined) {
+    patch.secondaryBiomarkerKeys = secondaryBiomarkerKeys
+  }
+
+  if (input.desiredDirection !== undefined) {
+    patch.desiredDirection = experimentSignalDirectionSchema.parse(input.desiredDirection)
+  }
+
+  const expectedDirections = normalizeExpectedDirectionEntriesOption(
+    input.expectedDirection,
+    existing?.expectedDirections,
+  )
+  if (expectedDirections !== undefined) {
+    patch.expectedDirections = expectedDirections
+  }
+
+  const measurementAnchors = normalizeExperimentMeasurementAnchorFlagOption(
+    input.analysisAnchor,
+    existing?.measurementAnchors,
+  )
+  if (measurementAnchors !== undefined) {
+    patch.measurementAnchors = measurementAnchors
+  }
+
+  const plannedMeasurements = normalizeExperimentPlannedMeasurementFlagOption(
+    input.plannedMeasurement,
+    existing?.plannedMeasurements,
+  )
+  if (plannedMeasurements !== undefined) {
+    patch.plannedMeasurements = plannedMeasurements
+  }
+
+  const notes = normalizeTextListOption(input.analysisNote, 'analysis-note')
+  if (notes !== undefined) {
+    patch.notes = notes
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return undefined
+  }
+
+  const next = compactObject({
+    ...(existing ?? {}),
+    ...patch,
+  })
+  if (primaryOutcome !== undefined) {
+    delete next.primaryBiomarkerKey
+  }
+  return experimentAnalysisPlanSchema.parse(next)
+}
+
+function buildPrimaryOutcomeForOnboardingApply(
+  input: ApplyExperimentOnboardingRecordInput,
+  existing: ExperimentPrimaryOutcome | undefined,
+  legacyKey: string | undefined,
+): ExperimentPrimaryOutcome | undefined {
+  const touched =
+    input.primaryOutcomeKey !== undefined ||
+    (input.primaryBiomarkerKey !== undefined && existing !== undefined) ||
+    input.primaryOutcomeKind !== undefined ||
+    input.primaryOutcomeLabel !== undefined ||
+    input.comparisonStatistic !== undefined ||
+    input.primaryOutcomeSessionField !== undefined ||
+    input.primaryOutcomeSourceMetricKey !== undefined ||
+    input.primaryOutcomeUnit !== undefined
+  if (!touched) {
+    return undefined
+  }
+
+  const kind = input.primaryOutcomeKind ?? existing?.kind ?? 'metric'
+  const key =
+    input.primaryOutcomeKey === undefined
+      ? input.primaryBiomarkerKey === undefined
+        ? existing?.key ?? legacyKey
+        : normalizeHealthCommonsKeyOption(
+            input.primaryBiomarkerKey,
+            'primary-biomarker-key',
+          )
+      : normalizeHealthCommonsKeyOption(
+          input.primaryOutcomeKey,
+          'primary-outcome-key',
+        )
+  if (!key) {
+    throw new VaultCliError(
+      'invalid_option',
+      'A configured primary outcome requires --primary-outcome-key as its stable outcome key.',
+    )
+  }
+  const label =
+    input.primaryOutcomeLabel === undefined
+      ? existing?.label
+      : normalizeRequiredTextOption(
+          input.primaryOutcomeLabel,
+          'primary-outcome-label',
+        )
+  if (kind === 'structured_review') {
+    if (
+      input.comparisonStatistic !== undefined ||
+      input.primaryOutcomeSessionField !== undefined ||
+      input.primaryOutcomeSourceMetricKey !== undefined ||
+      input.primaryOutcomeUnit !== undefined
+    ) {
+      throw new VaultCliError(
+        'invalid_option',
+        'Comparison and metric-capture options are only valid for metric outcomes.',
+      )
+    }
+    return experimentPrimaryOutcomeSchema.parse(
+      compactObject({ kind, key, label }),
+    )
+  }
+
+  if (
+    input.primaryOutcomeSessionField !== undefined &&
+    input.primaryOutcomeSourceMetricKey !== undefined
+  ) {
+    throw new VaultCliError(
+      'invalid_option',
+      'A metric outcome cannot use both a session field and a derived source metric.',
+    )
+  }
+  if (
+    input.primaryOutcomeUnit !== undefined &&
+    input.primaryOutcomeSessionField === undefined
+  ) {
+    throw new VaultCliError(
+      'invalid_option',
+      '--primary-outcome-unit requires --primary-outcome-session-field.',
+    )
+  }
+  const existingStatistic = existing?.kind === 'metric' ? existing.statistic : undefined
+  const existingCapture = existing?.kind === 'metric' ? existing.capture : undefined
+  const capture = input.primaryOutcomeSessionField !== undefined
+    ? {
+        kind: 'session_field' as const,
+        fieldId: normalizeStableIdOption(
+          input.primaryOutcomeSessionField,
+          'primary-outcome-session-field',
+        ),
+        unit: input.primaryOutcomeUnit === undefined
+          ? undefined
+          : normalizeRequiredTextOption(
+              input.primaryOutcomeUnit,
+              'primary-outcome-unit',
+            ),
+      }
+    : input.primaryOutcomeSourceMetricKey !== undefined
+      ? {
+          kind: 'derived_metric' as const,
+          sourceMetricKey: normalizeRequiredTextOption(
+            input.primaryOutcomeSourceMetricKey,
+            'primary-outcome-source-metric-key',
+          ),
+        }
+      : existingCapture
+  return experimentPrimaryOutcomeSchema.parse(compactObject({
+    kind,
+    key,
+    label,
+    statistic: input.comparisonStatistic ?? existingStatistic,
+    capture,
+  }))
+}
+
+export function buildRunPlanDatePatch(input: ApplyExperimentOnboardingRecordInput) {
+  let baselineStart = normalizeLocalDateOption(input.baselineStart, 'baseline-start')
+  let baselineEnd = normalizeLocalDateOption(input.baselineEnd, 'baseline-end')
+  let interventionStart = normalizeLocalDateOption(
+    input.interventionStart,
+    'intervention-start',
+  )
+  let interventionEnd = normalizeLocalDateOption(input.interventionEnd, 'intervention-end')
+
+  if (input.baselineDays !== undefined) {
+    if (input.baselineDays < 0) {
+      throw new VaultCliError('invalid_option', '--baseline-days must be zero or greater.')
+    }
+
+    if (input.baselineDays === 0) {
+      baselineStart = undefined
+      baselineEnd = undefined
+    } else {
+      if (baselineStart) {
+        baselineEnd = mergeComputedDate(
+          baselineEnd,
+          addLocalDays(baselineStart, input.baselineDays - 1, 'baseline-start'),
+          'baseline-end',
+          'baseline-days',
+        )
+      } else if (baselineEnd) {
+        baselineStart = addLocalDays(baselineEnd, 1 - input.baselineDays, 'baseline-end')
+      } else if (interventionStart) {
+        baselineEnd = addLocalDays(interventionStart, -1, 'intervention-start')
+        baselineStart = addLocalDays(interventionStart, -input.baselineDays, 'intervention-start')
+      } else {
+        throw new VaultCliError(
+          'invalid_payload',
+          '--baseline-days requires --baseline-start, --baseline-end, or --intervention-start so Murph can write canonical baseline dates.',
+        )
+      }
+    }
+  }
+
+  if (input.interventionDays !== undefined) {
+    if (input.interventionDays <= 0) {
+      throw new VaultCliError('invalid_option', '--intervention-days must be greater than zero.')
+    }
+
+    if (!interventionStart && !interventionEnd && baselineEnd) {
+      interventionStart = addLocalDays(baselineEnd, 1, 'baseline-end')
+    }
+
+    if (interventionStart) {
+      interventionEnd = mergeComputedDate(
+        interventionEnd,
+        addLocalDays(interventionStart, input.interventionDays - 1, 'intervention-start'),
+        'intervention-end',
+        'intervention-days',
+      )
+    } else if (interventionEnd) {
+      interventionStart = addLocalDays(
+        interventionEnd,
+        1 - input.interventionDays,
+        'intervention-end',
+      )
+    } else {
+      throw new VaultCliError(
+        'invalid_payload',
+        '--intervention-days requires --intervention-start, --intervention-end, or a baseline window so Murph can write canonical intervention dates.',
+      )
+    }
+  }
+
+  return compactObject({
+    baselineStart,
+    baselineEnd,
+    interventionStart,
+    interventionEnd,
+  })
+}
+
+function mergeComputedDate(
+  existing: string | undefined,
+  computed: string,
+  optionName: string,
+  sourceOptionName: string,
+) {
+  if (existing !== undefined && existing !== computed) {
+    throw new VaultCliError(
+      'invalid_payload',
+      `--${optionName} conflicts with --${sourceOptionName}; expected ${computed}.`,
+    )
+  }
+
+  return existing ?? computed
+}
+
+function normalizeLocalDateOption(value: string | undefined, optionName: string) {
+  if (value === undefined) {
+    return undefined
+  }
+
+  const parsed = localDateSchema.safeParse(value)
+  if (!parsed.success) {
+    throw new VaultCliError('invalid_option', `--${optionName} must use YYYY-MM-DD.`)
+  }
+
+  assertValidLocalDate(parsed.data, optionName)
+  return parsed.data
+}
+
+function assertValidLocalDate(value: string, optionName: string) {
+  const [yearText, monthText, dayText] = value.split('-')
+  const year = Number(yearText)
+  const month = Number(monthText)
+  const day = Number(dayText)
+  const date = new Date(Date.UTC(year, month - 1, day))
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    throw new VaultCliError('invalid_option', `--${optionName} must be a real calendar date.`)
+  }
+}
+
+function addLocalDays(value: string, days: number, optionName: string) {
+  assertValidLocalDate(value, optionName)
+  const [yearText, monthText, dayText] = value.split('-')
+  const date = new Date(Date.UTC(
+    Number(yearText),
+    Number(monthText) - 1,
+    Number(dayText) + days,
+  ))
+  return [
+    date.getUTCFullYear(),
+    String(date.getUTCMonth() + 1).padStart(2, '0'),
+    String(date.getUTCDate()).padStart(2, '0'),
+  ].join('-')
+}
+
+function normalizeHealthCommonsKeyOption(value: string, optionName: string) {
+  const normalized = normalizeRequiredTextOption(value, optionName)
+  const parsed = safeParseContract(healthCommonsKeySchema, normalized)
+
+  if (!parsed.success) {
+    throw new VaultCliError(
+      'invalid_option',
+      `--${optionName} must be a Health Commons key such as protocol:family/variant or biomarker:name.`,
+    )
+  }
+
+  return parsed.data
+}
+
+function normalizeProtocolKeyOption(value: string, optionName: string) {
+  const normalized = normalizeHealthCommonsKeyOption(value, optionName)
+
+  if (!normalized.startsWith('protocol_variant:')) {
+    throw new VaultCliError(
+      'invalid_option',
+      `--${optionName} must be a Health Commons protocol_variant key.`,
+    )
+  }
+
+  return normalized
+}
+
+function normalizeHealthCommonsKeyListOption(
+  values: readonly string[] | undefined,
+  optionName: string,
+) {
+  const normalized = normalizeTextListOption(values, optionName)
+  if (normalized === undefined) {
+    return undefined
+  }
+
+  return normalized.map((entry) => normalizeHealthCommonsKeyOption(entry, optionName))
+}
+
+function normalizeExpectedDirectionEntriesOption(
+  values: readonly string[] | undefined,
+  existing: ExperimentAnalysisPlanValue['expectedDirections'] | undefined,
+) {
+  const normalized = normalizeTextListOption(values, 'expected-direction')
+  if (normalized === undefined) {
+    return undefined
+  }
+
+  const next = new Map<string, z.infer<typeof experimentSignalDirectionSchema>>()
+  for (const entry of existing ?? []) {
+    next.set(entry.biomarkerKey, entry.direction)
+  }
+
+  for (const entry of normalized) {
+    const delimiterIndex = entry.lastIndexOf('=')
+    if (delimiterIndex <= 0 || delimiterIndex === entry.length - 1) {
+      throw new VaultCliError(
+        'invalid_option',
+        '--expected-direction must use biomarker:key=increase|decrease|stabilize.',
+      )
+    }
+
+    const biomarkerKey = normalizeHealthCommonsKeyOption(
+      entry.slice(0, delimiterIndex),
+      'expected-direction',
+    )
+    const direction = experimentSignalDirectionSchema.safeParse(
+      entry.slice(delimiterIndex + 1).trim(),
+    )
+    if (!direction.success) {
+      throw new VaultCliError(
+        'invalid_option',
+        '--expected-direction values must be increase, decrease, or stabilize.',
+      )
+    }
+
+    next.set(biomarkerKey, direction.data)
+  }
+
+  return experimentExpectedDirectionsSchema.parse(
+    [...next].map(([biomarkerKey, direction]) => ({ biomarkerKey, direction })),
+  )
+}
+
+function normalizeSha256RevisionOption(value: string, optionName: string) {
+  const normalized = normalizeRequiredTextOption(value, optionName)
+  if (!/^sha256:[a-f0-9]{64}$/u.test(normalized)) {
+    throw new VaultCliError(
+      'invalid_option',
+      `--${optionName} must use sha256:<64 lowercase hex>.`,
+    )
+  }
+
+  return normalized
 }

--- a/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
+++ b/packages/vault-usecases/src/usecases/experiment-journal-vault.ts
@@ -9,17 +9,13 @@ import {
   eventSourceSchema,
   experimentAnalysisPlanSchema,
   experimentAssistantSupportSchema,
-  experimentExpectedDirectionsSchema,
-  experimentPrimaryOutcomeSchema,
   effectiveProtocolSnapshotSchema,
   experimentOutcomeSchema,
   experimentFrontmatterSchema,
   experimentOnboardingCaptureSchema,
   commonsProtocolRefSchema,
-  experimentRunLoggingSchema,
   experimentRunPlanSchema,
   experimentRunScheduleIntentSchema,
-  healthCommonsKeySchema,
   jsonObjectSchema,
   protocolRefSchema,
   safeParseContract,
@@ -82,18 +78,15 @@ import {
   uniqueStrings,
 } from './vault-usecase-helpers.js'
 import {
-  normalizeExperimentMeasurementAnchorFlagOption,
-  normalizeExperimentPlannedMeasurementFlagOption,
-} from '../option-utils.js'
-import {
+  buildAnalysisPlanForOnboardingApply,
+  buildCommonsProtocolRefForOnboardingApply,
+  buildRunLoggingForOnboardingApply,
+  buildRunPlanDatePatch,
   buildExperimentAssistantSupportFromOptions,
   buildExperimentOnboardingCaptureFromOptions,
   normalizeRequiredTextOption,
-  normalizeStableIdListOption,
-  normalizeStableIdOption,
   normalizeTextListOption,
-  type ExperimentAssistantSupportOptions,
-  type ExperimentOnboardingCaptureOptions,
+  type ApplyExperimentOnboardingRecordInput,
 } from '../experiment-onboarding-options.js'
 import { upsertEventRecord } from './provider-event.js'
 import {
@@ -102,6 +95,8 @@ import {
   detachInterventionSessionFromExperiment,
 } from './intervention-experiment-link.js'
 import type { JsonObject } from '../health-cli-method-types.js'
+
+export type { ApplyExperimentOnboardingRecordInput } from '../experiment-onboarding-options.js'
 
 type EntityFamily = 'experiment' | 'journal'
 type JournalLinkKind = 'eventIds' | 'sampleStreams'
@@ -320,10 +315,8 @@ interface ExperimentJournalVaultCoreRuntime {
 
 const experimentStatusSchema = z.enum(EXPERIMENT_STATUSES)
 type ExperimentStatusValue = z.infer<typeof experimentStatusSchema>
-const experimentSignalDirectionSchema = z.enum(['increase', 'decrease', 'stabilize'])
 type ExperimentFrontmatterValue = z.infer<typeof experimentFrontmatterSchema>
 type CommonsProtocolRefValue = z.infer<typeof commonsProtocolRefSchema>
-type ExperimentRunLoggingValue = z.infer<typeof experimentRunLoggingSchema>
 type ExperimentRunPlanValue = z.infer<typeof experimentRunPlanSchema>
 type ExperimentAnalysisPlanValue = z.infer<typeof experimentAnalysisPlanSchema>
 const EXPERIMENT_OUTCOME_WRITE_MAX_ATTEMPTS = 3
@@ -380,52 +373,6 @@ const experimentSelectorPayloadSchema = z
       typeof value.slug === 'string',
     'Expected one of lookup, experimentId, or slug.',
   )
-
-export interface ApplyExperimentOnboardingRecordInput
-  extends ExperimentOnboardingCaptureOptions,
-    ExperimentAssistantSupportOptions {
-  vault: string
-  lookup: string
-  status?: ExperimentStatusValue
-  protocolKey?: string
-  pageRevisionId?: string
-  runSpecRevisionId?: string
-  testPlanId?: string
-  baselineStart?: string
-  baselineEnd?: string
-  baselineDays?: number
-  interventionStart?: string
-  interventionEnd?: string
-  interventionDays?: number
-  modality?: string
-  schedule?: ExperimentRunScheduleIntent
-  scheduleInputFile?: string
-  scheduleKind?: ExperimentRunScheduleIntent['kind']
-  scheduleCron?: string
-  scheduleLocalTime?: string
-  scheduleTimeZone?: string
-  dose?: string
-  sessionsPerWeek?: number
-  targetSessions?: number
-  minimumUsefulSessions?: number
-  sessionField?: readonly string[]
-  confounderField?: readonly string[]
-  stopCondition?: readonly string[]
-  primaryBiomarkerKey?: string
-  primaryOutcomeKey?: string
-  primaryOutcomeKind?: ExperimentPrimaryOutcome['kind']
-  primaryOutcomeLabel?: string
-  primaryOutcomeSessionField?: string
-  primaryOutcomeSourceMetricKey?: string
-  primaryOutcomeUnit?: string
-  comparisonStatistic?: ExperimentOutcomeStatistic
-  secondaryBiomarkerKey?: readonly string[]
-  desiredDirection?: z.infer<typeof experimentSignalDirectionSchema>
-  expectedDirection?: readonly string[]
-  analysisAnchor?: readonly string[]
-  plannedMeasurement?: readonly string[]
-  analysisNote?: readonly string[]
-}
 
 const privateProtocolPlanInputSchema = z
   .object({
@@ -3195,54 +3142,6 @@ function hasExperimentOnboardingApplyPatch(input: ApplyExperimentOnboardingRecor
   return false
 }
 
-function buildCommonsProtocolRefForOnboardingApply(
-  input: ApplyExperimentOnboardingRecordInput,
-  existing: ExperimentFrontmatterValue['commonsProtocolRef'],
-): CommonsProtocolRefValue | undefined {
-  const touched =
-    input.protocolKey !== undefined ||
-    input.pageRevisionId !== undefined ||
-    input.runSpecRevisionId !== undefined ||
-    input.testPlanId !== undefined
-
-  if (!touched) {
-    return undefined
-  }
-
-  const key =
-    input.protocolKey === undefined
-      ? existing?.key
-      : normalizeProtocolKeyOption(input.protocolKey, 'protocol-key')
-  const pageRevisionId =
-    input.pageRevisionId === undefined
-      ? existing?.pageRevisionId
-      : normalizeSha256RevisionOption(input.pageRevisionId, 'page-revision-id')
-  const runSpecRevisionId =
-    input.runSpecRevisionId === undefined
-      ? existing?.runSpecRevisionId
-      : normalizeSha256RevisionOption(input.runSpecRevisionId, 'run-spec-revision-id')
-  const testPlanId =
-    input.testPlanId === undefined
-      ? existing?.testPlanId
-      : normalizeStableIdOption(input.testPlanId, 'test-plan-id')
-
-  if (!key || !pageRevisionId || !runSpecRevisionId) {
-    throw new VaultCliError(
-      'invalid_payload',
-      'Applying a protocol reference requires --protocol-key, --page-revision-id, and --run-spec-revision-id unless the experiment already has them.',
-    )
-  }
-
-  return commonsProtocolRefSchema.parse(
-    compactObject({
-      key,
-      pageRevisionId,
-      runSpecRevisionId,
-      testPlanId,
-    }),
-  )
-}
-
 async function buildRunPlanForOnboardingApply(
   input: ApplyExperimentOnboardingRecordInput,
   existing: ExperimentFrontmatterValue['runPlan'],
@@ -3418,460 +3317,6 @@ function parseExperimentRunScheduleIntent(
   return parsed.data
 }
 
-function buildRunLoggingForOnboardingApply(
-  input: ApplyExperimentOnboardingRecordInput,
-  existing: ExperimentRunLoggingValue | undefined,
-): ExperimentRunLoggingValue | undefined {
-  const sessionFields = normalizeStableIdListOption(input.sessionField, 'session-field')
-  const confounderFields = normalizeStableIdListOption(
-    input.confounderField,
-    'confounder-field',
-  )
-
-  if (sessionFields === undefined && confounderFields === undefined) {
-    return undefined
-  }
-
-  const next = compactObject({
-    ...(existing ?? {}),
-    ...(sessionFields === undefined ? {} : { sessionFields }),
-    ...(confounderFields === undefined ? {} : { confounderFields }),
-  })
-
-  if (!Array.isArray(next.sessionFields) || next.sessionFields.length === 0) {
-    throw new VaultCliError(
-      'invalid_payload',
-      '--confounder-field requires --session-field unless the experiment already has runPlan.logging.sessionFields.',
-    )
-  }
-
-  return experimentRunLoggingSchema.parse(next)
-}
-
-function buildAnalysisPlanForOnboardingApply(
-  input: ApplyExperimentOnboardingRecordInput,
-  existing: ExperimentFrontmatterValue['analysisPlan'],
-): ExperimentAnalysisPlanValue | undefined {
-  if (
-    input.primaryOutcomeKey !== undefined &&
-    input.primaryBiomarkerKey !== undefined
-  ) {
-    throw new VaultCliError(
-      'invalid_option',
-      'experiment edit accepts either --primary-outcome-key or the legacy --primary-biomarker-key, not both.',
-    )
-  }
-  const patch: Partial<ExperimentAnalysisPlanValue> = {}
-  const normalizedPrimaryKey = input.primaryBiomarkerKey === undefined
-    ? undefined
-    : normalizeHealthCommonsKeyOption(
-        input.primaryBiomarkerKey,
-        'primary-biomarker-key',
-      )
-
-  if (normalizedPrimaryKey !== undefined && existing?.primaryOutcome === undefined) {
-    patch.primaryBiomarkerKey = normalizedPrimaryKey
-  }
-
-  const primaryOutcome = buildPrimaryOutcomeForOnboardingApply(
-    input,
-    existing?.primaryOutcome,
-    normalizedPrimaryKey ?? existing?.primaryBiomarkerKey,
-  )
-  if (primaryOutcome !== undefined) {
-    patch.primaryOutcome = primaryOutcome
-  }
-
-  const secondaryBiomarkerKeys = normalizeHealthCommonsKeyListOption(
-    input.secondaryBiomarkerKey,
-    'secondary-biomarker-key',
-  )
-  if (secondaryBiomarkerKeys !== undefined) {
-    patch.secondaryBiomarkerKeys = secondaryBiomarkerKeys
-  }
-
-  if (input.desiredDirection !== undefined) {
-    patch.desiredDirection = experimentSignalDirectionSchema.parse(input.desiredDirection)
-  }
-
-  const expectedDirections = normalizeExpectedDirectionEntriesOption(
-    input.expectedDirection,
-    existing?.expectedDirections,
-  )
-  if (expectedDirections !== undefined) {
-    patch.expectedDirections = expectedDirections
-  }
-
-  const measurementAnchors = normalizeExperimentMeasurementAnchorFlagOption(
-    input.analysisAnchor,
-    existing?.measurementAnchors,
-  )
-  if (measurementAnchors !== undefined) {
-    patch.measurementAnchors = measurementAnchors
-  }
-
-  const plannedMeasurements = normalizeExperimentPlannedMeasurementFlagOption(
-    input.plannedMeasurement,
-    existing?.plannedMeasurements,
-  )
-  if (plannedMeasurements !== undefined) {
-    patch.plannedMeasurements = plannedMeasurements
-  }
-
-  const notes = normalizeTextListOption(input.analysisNote, 'analysis-note')
-  if (notes !== undefined) {
-    patch.notes = notes
-  }
-
-  if (Object.keys(patch).length === 0) {
-    return undefined
-  }
-
-  const next = compactObject({
-    ...(existing ?? {}),
-    ...patch,
-  })
-  if (primaryOutcome !== undefined) {
-    delete next.primaryBiomarkerKey
-  }
-  return experimentAnalysisPlanSchema.parse(next)
-}
-
-function buildPrimaryOutcomeForOnboardingApply(
-  input: ApplyExperimentOnboardingRecordInput,
-  existing: ExperimentPrimaryOutcome | undefined,
-  legacyKey: string | undefined,
-): ExperimentPrimaryOutcome | undefined {
-  const touched =
-    input.primaryOutcomeKey !== undefined ||
-    (input.primaryBiomarkerKey !== undefined && existing !== undefined) ||
-    input.primaryOutcomeKind !== undefined ||
-    input.primaryOutcomeLabel !== undefined ||
-    input.comparisonStatistic !== undefined ||
-    input.primaryOutcomeSessionField !== undefined ||
-    input.primaryOutcomeSourceMetricKey !== undefined ||
-    input.primaryOutcomeUnit !== undefined
-  if (!touched) {
-    return undefined
-  }
-
-  const kind = input.primaryOutcomeKind ?? existing?.kind ?? 'metric'
-  const key =
-    input.primaryOutcomeKey === undefined
-      ? input.primaryBiomarkerKey === undefined
-        ? existing?.key ?? legacyKey
-        : normalizeHealthCommonsKeyOption(
-            input.primaryBiomarkerKey,
-            'primary-biomarker-key',
-          )
-      : normalizeHealthCommonsKeyOption(
-          input.primaryOutcomeKey,
-          'primary-outcome-key',
-        )
-  if (!key) {
-    throw new VaultCliError(
-      'invalid_option',
-      'A configured primary outcome requires --primary-outcome-key as its stable outcome key.',
-    )
-  }
-  const label =
-    input.primaryOutcomeLabel === undefined
-      ? existing?.label
-      : normalizeRequiredTextOption(
-          input.primaryOutcomeLabel,
-          'primary-outcome-label',
-        )
-  if (kind === 'structured_review') {
-    if (
-      input.comparisonStatistic !== undefined ||
-      input.primaryOutcomeSessionField !== undefined ||
-      input.primaryOutcomeSourceMetricKey !== undefined ||
-      input.primaryOutcomeUnit !== undefined
-    ) {
-      throw new VaultCliError(
-        'invalid_option',
-        'Comparison and metric-capture options are only valid for metric outcomes.',
-      )
-    }
-    return experimentPrimaryOutcomeSchema.parse(
-      compactObject({ kind, key, label }),
-    )
-  }
-
-  if (
-    input.primaryOutcomeSessionField !== undefined &&
-    input.primaryOutcomeSourceMetricKey !== undefined
-  ) {
-    throw new VaultCliError(
-      'invalid_option',
-      'A metric outcome cannot use both a session field and a derived source metric.',
-    )
-  }
-  if (
-    input.primaryOutcomeUnit !== undefined &&
-    input.primaryOutcomeSessionField === undefined
-  ) {
-    throw new VaultCliError(
-      'invalid_option',
-      '--primary-outcome-unit requires --primary-outcome-session-field.',
-    )
-  }
-  const existingStatistic = existing?.kind === 'metric' ? existing.statistic : undefined
-  const existingCapture = existing?.kind === 'metric' ? existing.capture : undefined
-  const capture = input.primaryOutcomeSessionField !== undefined
-    ? {
-        kind: 'session_field' as const,
-        fieldId: normalizeStableIdOption(
-          input.primaryOutcomeSessionField,
-          'primary-outcome-session-field',
-        ),
-        unit: input.primaryOutcomeUnit === undefined
-          ? undefined
-          : normalizeRequiredTextOption(
-              input.primaryOutcomeUnit,
-              'primary-outcome-unit',
-            ),
-      }
-    : input.primaryOutcomeSourceMetricKey !== undefined
-      ? {
-          kind: 'derived_metric' as const,
-          sourceMetricKey: normalizeRequiredTextOption(
-            input.primaryOutcomeSourceMetricKey,
-            'primary-outcome-source-metric-key',
-          ),
-        }
-      : existingCapture
-  return experimentPrimaryOutcomeSchema.parse(compactObject({
-    kind,
-    key,
-    label,
-    statistic: input.comparisonStatistic ?? existingStatistic,
-    capture,
-  }))
-}
-
-function buildRunPlanDatePatch(input: ApplyExperimentOnboardingRecordInput) {
-  let baselineStart = normalizeLocalDateOption(input.baselineStart, 'baseline-start')
-  let baselineEnd = normalizeLocalDateOption(input.baselineEnd, 'baseline-end')
-  let interventionStart = normalizeLocalDateOption(
-    input.interventionStart,
-    'intervention-start',
-  )
-  let interventionEnd = normalizeLocalDateOption(input.interventionEnd, 'intervention-end')
-
-  if (input.baselineDays !== undefined) {
-    if (input.baselineDays < 0) {
-      throw new VaultCliError('invalid_option', '--baseline-days must be zero or greater.')
-    }
-
-    if (input.baselineDays === 0) {
-      baselineStart = undefined
-      baselineEnd = undefined
-    } else {
-      if (baselineStart) {
-        baselineEnd = mergeComputedDate(
-          baselineEnd,
-          addLocalDays(baselineStart, input.baselineDays - 1, 'baseline-start'),
-          'baseline-end',
-          'baseline-days',
-        )
-      } else if (baselineEnd) {
-        baselineStart = addLocalDays(baselineEnd, 1 - input.baselineDays, 'baseline-end')
-      } else if (interventionStart) {
-        baselineEnd = addLocalDays(interventionStart, -1, 'intervention-start')
-        baselineStart = addLocalDays(interventionStart, -input.baselineDays, 'intervention-start')
-      } else {
-        throw new VaultCliError(
-          'invalid_payload',
-          '--baseline-days requires --baseline-start, --baseline-end, or --intervention-start so Murph can write canonical baseline dates.',
-        )
-      }
-    }
-  }
-
-  if (input.interventionDays !== undefined) {
-    if (input.interventionDays <= 0) {
-      throw new VaultCliError('invalid_option', '--intervention-days must be greater than zero.')
-    }
-
-    if (!interventionStart && !interventionEnd && baselineEnd) {
-      interventionStart = addLocalDays(baselineEnd, 1, 'baseline-end')
-    }
-
-    if (interventionStart) {
-      interventionEnd = mergeComputedDate(
-        interventionEnd,
-        addLocalDays(interventionStart, input.interventionDays - 1, 'intervention-start'),
-        'intervention-end',
-        'intervention-days',
-      )
-    } else if (interventionEnd) {
-      interventionStart = addLocalDays(
-        interventionEnd,
-        1 - input.interventionDays,
-        'intervention-end',
-      )
-    } else {
-      throw new VaultCliError(
-        'invalid_payload',
-        '--intervention-days requires --intervention-start, --intervention-end, or a baseline window so Murph can write canonical intervention dates.',
-      )
-    }
-  }
-
-  return compactObject({
-    baselineStart,
-    baselineEnd,
-    interventionStart,
-    interventionEnd,
-  })
-}
-
-function mergeComputedDate(
-  existing: string | undefined,
-  computed: string,
-  optionName: string,
-  sourceOptionName: string,
-) {
-  if (existing !== undefined && existing !== computed) {
-    throw new VaultCliError(
-      'invalid_payload',
-      `--${optionName} conflicts with --${sourceOptionName}; expected ${computed}.`,
-    )
-  }
-
-  return existing ?? computed
-}
-
-function normalizeLocalDateOption(value: string | undefined, optionName: string) {
-  if (value === undefined) {
-    return undefined
-  }
-
-  const parsed = localDateSchema.safeParse(value)
-  if (!parsed.success) {
-    throw new VaultCliError('invalid_option', `--${optionName} must use YYYY-MM-DD.`)
-  }
-
-  assertValidLocalDate(parsed.data, optionName)
-  return parsed.data
-}
-
-function assertValidLocalDate(value: string, optionName: string) {
-  const [yearText, monthText, dayText] = value.split('-')
-  const year = Number(yearText)
-  const month = Number(monthText)
-  const day = Number(dayText)
-  const date = new Date(Date.UTC(year, month - 1, day))
-
-  if (
-    date.getUTCFullYear() !== year ||
-    date.getUTCMonth() !== month - 1 ||
-    date.getUTCDate() !== day
-  ) {
-    throw new VaultCliError('invalid_option', `--${optionName} must be a real calendar date.`)
-  }
-}
-
-function addLocalDays(value: string, days: number, optionName: string) {
-  assertValidLocalDate(value, optionName)
-  const [yearText, monthText, dayText] = value.split('-')
-  const date = new Date(Date.UTC(
-    Number(yearText),
-    Number(monthText) - 1,
-    Number(dayText) + days,
-  ))
-  return [
-    date.getUTCFullYear(),
-    String(date.getUTCMonth() + 1).padStart(2, '0'),
-    String(date.getUTCDate()).padStart(2, '0'),
-  ].join('-')
-}
-
-function normalizeHealthCommonsKeyOption(value: string, optionName: string) {
-  const normalized = normalizeRequiredTextOption(value, optionName)
-  const parsed = safeParseContract(healthCommonsKeySchema, normalized)
-
-  if (!parsed.success) {
-    throw new VaultCliError(
-      'invalid_option',
-      `--${optionName} must be a Health Commons key such as protocol:family/variant or biomarker:name.`,
-    )
-  }
-
-  return parsed.data
-}
-
-function normalizeProtocolKeyOption(value: string, optionName: string) {
-  const normalized = normalizeHealthCommonsKeyOption(value, optionName)
-
-  if (!normalized.startsWith('protocol_variant:')) {
-    throw new VaultCliError(
-      'invalid_option',
-      `--${optionName} must be a Health Commons protocol_variant key.`,
-    )
-  }
-
-  return normalized
-}
-
-function normalizeHealthCommonsKeyListOption(
-  values: readonly string[] | undefined,
-  optionName: string,
-) {
-  const normalized = normalizeTextListOption(values, optionName)
-  if (normalized === undefined) {
-    return undefined
-  }
-
-  return normalized.map((entry) => normalizeHealthCommonsKeyOption(entry, optionName))
-}
-
-function normalizeExpectedDirectionEntriesOption(
-  values: readonly string[] | undefined,
-  existing: ExperimentAnalysisPlanValue['expectedDirections'] | undefined,
-) {
-  const normalized = normalizeTextListOption(values, 'expected-direction')
-  if (normalized === undefined) {
-    return undefined
-  }
-
-  const next = new Map<string, z.infer<typeof experimentSignalDirectionSchema>>()
-  for (const entry of existing ?? []) {
-    next.set(entry.biomarkerKey, entry.direction)
-  }
-
-  for (const entry of normalized) {
-    const delimiterIndex = entry.lastIndexOf('=')
-    if (delimiterIndex <= 0 || delimiterIndex === entry.length - 1) {
-      throw new VaultCliError(
-        'invalid_option',
-        '--expected-direction must use biomarker:key=increase|decrease|stabilize.',
-      )
-    }
-
-    const biomarkerKey = normalizeHealthCommonsKeyOption(
-      entry.slice(0, delimiterIndex),
-      'expected-direction',
-    )
-    const direction = experimentSignalDirectionSchema.safeParse(
-      entry.slice(delimiterIndex + 1).trim(),
-    )
-    if (!direction.success) {
-      throw new VaultCliError(
-        'invalid_option',
-        '--expected-direction values must be increase, decrease, or stabilize.',
-      )
-    }
-
-    next.set(biomarkerKey, direction.data)
-  }
-
-  return experimentExpectedDirectionsSchema.parse(
-    [...next].map(([biomarkerKey, direction]) => ({ biomarkerKey, direction })),
-  )
-}
-
 type HealthCommonsBiomarkerDirectionRuntime = {
   resolveGeneratedHealthCommonsBiomarkerDesiredDirection(
     biomarkerKey: string,
@@ -3894,18 +3339,6 @@ function isMissingHealthCommonsBiomarkerDirectionArtifactError(
     'code' in error &&
     error.code === 'ENOENT'
   )
-}
-
-function normalizeSha256RevisionOption(value: string, optionName: string) {
-  const normalized = normalizeRequiredTextOption(value, optionName)
-  if (!/^sha256:[a-f0-9]{64}$/u.test(normalized)) {
-    throw new VaultCliError(
-      'invalid_option',
-      `--${optionName} must use sha256:<64 lowercase hex>.`,
-    )
-  }
-
-  return normalized
 }
 
 function requireExperimentFrontmatter(entity: QueryCanonicalEntity) {

--- a/packages/vault-usecases/test/experiment-onboarding-schedule.test.ts
+++ b/packages/vault-usecases/test/experiment-onboarding-schedule.test.ts
@@ -419,6 +419,7 @@ test("applyExperimentOnboardingRecord rejects legacy string schedule payloads", 
 
 test("experiment onboarding writers do not preserve legacy string run-plan schedules", async () => {
   const sourceFiles = [
+    "packages/vault-usecases/src/experiment-onboarding-options.ts",
     "packages/vault-usecases/src/usecases/experiment-journal-vault.ts",
     "packages/vault-usecases/src/usecases/types.ts",
     "packages/cli/src/commands/experiment.ts",


### PR DESCRIPTION
## Why and outcome

Experiment edit compiled protocol references, run logging, analysis, and date options inside the large vault mutation usecase while related onboarding builders lived in a dedicated options owner. Move the pure builders and their validators into that existing owner so option changes can be reviewed independently of canonical write orchestration.

The original usecase input type remains available through a type reexport. Schedule-file reads, current frontmatter, canonical locks, write calls, field semantics, and failure ordering are preserved.

## Product UX

- Effort: Not applicable; internal module ownership change with identical option behavior.
- Result: Not applicable; no interface, permission, or user journey change.
- Walkthrough: Existing CLI edit integration checks cover canonical frontmatter, write ordering, and lifecycle effects.

## Evidence

- Direct: Babel AST comparison against `b80bd40f84d1b367c1810e2fe046e3089cc28aa4` proves all 14 moved top-level functions and 100 retained functions are identical, including the lock/read/update and asynchronous schedule orchestration. The reused compaction primitive has the same AST as the previous helper. Parent source review independently confirmed the move.
- Coverage: Focused onboarding tests, CLI edit integration, source typechecks, and workspace boundaries verify the existing callers. Required exact-head CI and final review are owned by the completion parent.
- `pnpm --dir packages/vault-usecases exec vitest run --config vitest.config.ts --no-coverage --maxWorkers=2 test/experiment-onboarding-schedule.test.ts`: 6 passed. Initial cold transform exceeded the unchanged 60-second test deadline; rerun passed without timeout/config changes.
- `pnpm --dir packages/cli exec vitest run --config vitest.config.ts --no-coverage --maxWorkers=2 test/cli-expansion-experiment-journal-vault-phase2.test.ts -t 'experiment edit maps public run options|experiment edit preserves canonical write order|experiment edit, checkpoint, and stop'`: 3 passed, 42 skipped. Prepared missing public protocol fixtures with `pnpm --dir packages/health-commons generate` in this worktree before the passing run.
- `pnpm --dir packages/cli typecheck`: passed.
- `pnpm --dir packages/vault-usecases typecheck`: passed.
- `pnpm verify:workspace-boundaries`, `bash scripts/check-agent-docs-drift.sh`, and `git diff --check`: passed.

## Non-obvious affected surfaces

The legacy string-schedule source guard now includes the options owner so moving the input declaration does not narrow its coverage. The original type export is preserved; package entrypoints and service signatures are unchanged.

## Architecture and reuse

- Existing systems reused: `experiment-onboarding-options.ts` owns the moved pure builders; existing text, stable-ID, list, and compaction primitives are reused. Measurement-anchor and planned-measurement parsing stays in `option-utils.ts`.
- New logic: No new validation, scheduling, business, or failure behavior; function syntax is preserved.
- New abstractions: No new module, state owner, callback, or package entrypoint; the original input interface moves with its builders and retains its prior export.
- Complexity intentionally avoided: No injected schedule loader or generalized option compiler; async reads and canonical orchestration remain together in the usecase.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base b80bd40f84d1b367c1810e2fe046e3089cc28aa4`; 16 exact moved function frames and zero unmoved debt increase.
- Hotspots: Moved `buildPrimaryOutcomeForOnboardingApply` (37) and `buildAnalysisPlanForOnboardingApply` (23) retain their validation branches. Unchanged usecase hotspots are the locked update callback (38), `logExperimentSessionRecord` (35), plan schema refinement (26), and `assertHealthCommonsProtocolSafetyAllowsActivation` (22).
- Agent judgment: Group the coherent pure option rules at their established owner. Further splitting would obscure related validation and failure precedence; transaction, schedule, safety, and replay code remain intact.

## Hot reply path impact

- Path status: Not applicable; this refactor preserves the existing experiment command execution path and adds no work before provider start or reply handoff.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved; date and logging validation still precede the existing schedule read under the canonical lock.
- Before/after proof: Exact AST comparison of retained orchestration and focused CLI write-order integration.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged for individual and group runtimes.
- Tool/schema/generated guidance: Unchanged; command schema and service field inventory are untouched.
- Other provider-visible input: Unchanged; only internal option-builder location changes.
- Measurement method: Not run; no provider-input surface changed for either runtime.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal module relocation preserves package exports, command inputs, persisted records, and all runtime protocols; no mixed-version rollout contract changes.

## Change-shape breakdown

Classification rule: Package implementation files are source, the source guard is tests, and the package README and completed implementation plan are docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 589 | 574 |
| Tests / fixtures | 1 | 0 |
| Docs | 56 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **646** | **574** |

## Changelog

- Changelog: not applicable
- Reason: Internal responsibility consolidation preserves all member-visible behavior.


## ReviewGPT

ReviewGPT first-reviewed head: 0c8d7ee765b0801baa0860add91d59557ec875a7
ReviewGPT context sensitivity: sensitive
Reason: Cross-owner experiment option compilation and canonical write boundary; validation and ordering remain unchanged.

## Final review evidence

- Parent candidate review: passed; no unresolved findings.
- ReviewGPT round 1: PASS on `0c8d7ee765b0801baa0860add91d59557ec875a7`, with no qualifying findings. The full-snapshot response inspected the changed ownership boundary, callers, and regression coverage.
- Acceptance: exact submitted turn, response hash, completion marker, and `gpt-6-pro` model metadata verified (Apollo; approximately 391.9 seconds from send to captured response). Round-1 baseline and empty remediation deltas verified.
- Response SHA-256: `389cf2b99b57c14150d59ef76eeb98c64fa32d9e21a96c59efebeee37d2fa282`.
- Integration: conflict-free against `006ce0768111cac657518a79f3074b81ce97b4db`; the seven cleanup PRs have no overlapping authored paths.
