### PR TITLE
perf: decode inline conversations during mailbox fetch

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-10-mailbox-fetch-decode.md
+++ b/agent-docs/exec-plans/active/2026-09-10-mailbox-fetch-decode.md
@@ -43,9 +43,11 @@ message setup with identical accepted assistant input; live latency awaits deplo
 - Runtime bridge tests import the same conversation with and without enrichment;
   enriched imports never call the decoder and preserve staged-input evidence.
 - 67 Cloudflare decode/encryption/bridge cases, 272 routing cases, 80 assistant
-  payload/import cases and 10 changelog SSR cases pass. The final composed check
-  has 14 cases. Cloudflare and assistant-runtime typechecks pass; final stable
-  formatting and cache-control edits are being rechecked before Ready.
+  payload/import cases and 10 changelog SSR cases pass. The composed check
+  also covers the maximum 100-row conversation batch and resolves crypto context
+  once. Cloudflare and assistant-runtime typechecks pass, including final stable
+  formatting and no-store response policy. Maximum-batch proof and its final
+  Cloudflare typecheck are the remaining candidate checks before Ready.
 - Complexity guard passes. The web-control handler drops from 47 to 46 by deriving
   five POST-only classifications from the already-validated route policy. Its
   broader dispatch ownership and two unrelated runtime hotspots remain unchanged.

--- a/agent-docs/exec-plans/active/2026-09-10-mailbox-fetch-decode.md
+++ b/agent-docs/exec-plans/active/2026-09-10-mailbox-fetch-decode.md
@@ -1,0 +1,57 @@
+# Decode inline conversation payloads during mailbox fetch
+
+## Outcome and protected boundary
+
+Remove the second container-to-Worker request for fresh inline conversation
+messages. Web retains encrypted mailbox ordering and access/usage gates; Worker
+retains ingress keys and write-fence validation; runtime retains payload identity,
+routing, skipped-item and import semantics. No plaintext is persisted or logged.
+
+## Evidence and smallest design
+
+The existing authenticated Worker proxy already receives ciphertext while
+forwarding mailbox fetch. It can decode eligible inline conversation items there
+using the existing decoder owner. Add an explicit request opt-in and an optional
+parsed wake on the response item; carry it to the existing importer. No cache,
+side map, second scheduler, new endpoint or key distribution is necessary.
+
+Only fresh inline conversation items are enriched. Large sidecar payloads keep
+the existing fetch/decode path: fetching all sidecars eagerly would add network
+work for items that runtime later skips and delay the first conversation item.
+Retired, consumed and system items retain their current lazy behavior. Decode
+failures retain the ordinary decoder path and its existing error semantics.
+
+## Rollout and proof
+
+Old containers omit the opt-in. Old Workers ignore it and return ciphertext;
+new containers retain the existing decoder for that case and for sidecars. No
+persisted shape changes or hard-cut deployment are required. Current/current
+inline imports should make one fewer HTTP request and write-fence RPC.
+
+Prove real Worker decryption and import composition, caller skew, user/fence
+mismatch, skipped/consumed/sidecar cases, crypto failure and cancellation. Run
+focused Cloudflare/shared-contract/assistant-runtime tests, affected typechecks,
+complexity review, then PR review and exact-head CI. Product UX Patch: shorter
+message setup with identical accepted assistant input; live latency awaits deploy.
+
+## Candidate evidence
+
+- Composed Worker/port tests prove real secure-box decryption with one container
+  fetch, one Web forwarding call and one write-fence check, and one crypto context
+  per batch. Old containers omit the opt-in; old Worker responses are accepted
+  by the existing port and decoder. Canonical Web parsing discards decodedWake.
+- Runtime bridge tests import the same conversation with and without enrichment;
+  enriched imports never call the decoder and preserve staged-input evidence.
+- 67 Cloudflare decode/encryption/bridge cases, 272 routing cases, 80 assistant
+  payload/import cases and 10 changelog SSR cases pass. The final composed check
+  has 14 cases. Cloudflare and assistant-runtime typechecks pass; final stable
+  formatting and cache-control edits are being rechecked before Ready.
+- Complexity guard passes. The web-control handler drops from 47 to 46 by deriving
+  five POST-only classifications from the already-validated route policy. Its
+  broader dispatch ownership and two unrelated runtime hotspots remain unchanged.
+- Public payload, assistant instruction/tool assembly, model choice and import
+  identity checks remain unchanged. Success is deterministic transport equality,
+  so no live-Codex behavioral journey or provider token measurement is applicable.
+- Parent candidate review found no new durable state, key disclosure, additional
+  success-path network call or changed usage/access authority. External review
+  and exact-head CI remain pending. No merge or deployment is included.

--- a/agent-docs/exec-plans/completed/2026-09-10-mailbox-fetch-decode.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-mailbox-fetch-decode.md
@@ -46,8 +46,8 @@ message setup with identical accepted assistant input; live latency awaits deplo
   payload/import cases and 10 changelog SSR cases pass. The composed check
   also covers the maximum 100-row conversation batch and resolves crypto context
   once. Cloudflare and assistant-runtime typechecks pass, including final stable
-  formatting and no-store response policy. Maximum-batch proof and its final
-  Cloudflare typecheck are the remaining candidate checks before Ready.
+  formatting and no-store response policy. The final 15-case composed batch
+  proof and final Cloudflare typecheck also pass.
 - Complexity guard passes. The web-control handler drops from 47 to 46 by deriving
   five POST-only classifications from the already-validated route policy. Its
   broader dispatch ownership and two unrelated runtime hotspots remain unchanged.
@@ -55,5 +55,23 @@ message setup with identical accepted assistant input; live latency awaits deplo
   identity checks remain unchanged. Success is deterministic transport equality,
   so no live-Codex behavioral journey or provider token measurement is applicable.
 - Parent candidate review found no new durable state, key disclosure, additional
-  success-path network call or changed usage/access authority. External review
-  and exact-head CI remain pending. No merge or deployment is included.
+  success-path network call or changed usage/access authority. No merge or
+  deployment is included. Final-head CI remains the PR completion gate.
+
+## Final review and handoff
+
+ReviewGPT round 1 passed on `526ddd0bfa678e34842f50a7b2a86149d9bd237d`
+with no qualifying bugs or material Complexity Collapse findings. The reviewer
+checked the full patch and snapshot through crypto, authority, import, batching
+and both rollout directions; tests were inspected rather than executed there.
+The parent ran the focused checks above. Persisted gpt-6-pro model metadata,
+response hash and captured response/user-turn identity agree. Managed browser
+response waiting exceeded the required 270 seconds. The final follow-up only
+closes this plan and records existing evidence; production source is unchanged.
+
+The two mailbox PRs merge cleanly with each other and with the earlier-wake PR.
+Current-base mergeability and all applicable final-head CI checks remain required
+at PR handoff. Production timing improvement remains unmeasured until deployment.
+Status: completed
+Updated: 2026-09-10
+Completed: 2026-09-10

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -92,6 +92,8 @@ The live ownership split is:
   for sidecars. Both directions of Worker/container skew are supported, with no
   Web deployment dependency or persisted schema change. After convergence,
   fresh inline messages omit the second request and its write-fence RPC.
+  Retire the opt-in once the supported Worker/runner rollback floor and all warm
+  callers consume decodedWake; the decoder remains for lazy sidecar/system work.
   The container must not receive ingress root keys, callback-signing private
   material, private JWKs, or a root-fetch capability for mailbox import.
 - `packages/assistant-runtime` restores the local runtime, imports mailbox

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -77,13 +77,22 @@ The live ownership split is:
   separation lets paused-member retention and an explicitly authorized
   Settings export restore encrypted workspace state without reopening ordinary
   assistant or model work.
-  During active mailbox import, the runner container calls a Worker-owned
-  mailbox-payload decode route over the invocation outbound proxy. That route
-  requires the runtime write fence, decrypts the mailbox payload with the
-  Worker-owned ingress crypto context, and returns only a parsed hosted wake or
-  a semantic blocked result. Legacy active-invocation RPC names remain only for
-  deployed-caller compatibility and must be deleted after 2026-05-25. The
-  container must not receive ingress root keys, callback-signing private
+  During active mailbox import, the container opts into Worker-side inline
+  conversation decryption on its existing mailbox fetch. The Worker validates
+  the current write fence, forwards the signed fetch to Web, and decrypts fresh
+  inline conversation items using one ingress context per batch. It returns an
+  ephemeral parsed `decodedWake` beside the original ciphertext. Only the
+  Cloudflare runtime port accepts that field; canonical Web mailbox parsing
+  discards it. Runtime keeps its existing identity, routing and import checks.
+  Consumed, system and sidecar items retain lazy processing. An unsuccessful
+  optional decode retains the original item so one bad payload cannot fail
+  unrelated lanes; ordinary import still owns that item's decode failure/retry.
+  Old containers omit the opt-in; old Workers return the original ciphertext,
+  and new containers keep the existing decode endpoint for that response and
+  for sidecars. Both directions of Worker/container skew are supported, with no
+  Web deployment dependency or persisted schema change. After convergence,
+  fresh inline messages omit the second request and its write-fence RPC.
+  The container must not receive ingress root keys, callback-signing private
   material, private JWKs, or a root-fetch capability for mailbox import.
 - `packages/assistant-runtime` restores the local runtime, imports mailbox
   rows, stages assistant input, runs assistant/device work, and checkpoints the

--- a/apps/cloudflare/src/runner-outbound/mailbox-payload-decode.ts
+++ b/apps/cloudflare/src/runner-outbound/mailbox-payload-decode.ts
@@ -1,5 +1,6 @@
 import {
   parseHostedExecutionWake,
+  parseHostedMailboxFetchResponse,
 } from "@murphai/hosted-execution/parsers";
 import type {
   HostedExecutionWake,
@@ -9,11 +10,11 @@ import { type readHostedExecutionEnvironment } from "../env.ts";
 import {
   createHostedMailboxEncryptionEnvironmentFromIngressRootResolver,
   decryptHostedMailboxPayloadCiphertext,
-  type HostedMailboxEncryptionEnvironment,
 } from "../hosted-mailbox-encryption.ts";
 import { json, jsonError, methodNotAllowed, readJsonObject, unauthorized } from "../json.ts";
 import {
   parseHostedMailboxPayloadDecodeRequest,
+  type HostedMailboxPayloadDecodeRequest,
 } from "../runtime-mailbox-payload-decode-contract.ts";
 import {
   requireRunnerRuntimeWriteFence,
@@ -65,32 +66,8 @@ export async function handleRunnerMailboxPayloadDecodeRequest(input: {
 
   let wake: HostedExecutionWake;
   try {
-    const cryptoContext = await resolveRunnerOutboundUserCryptoContext({
-      bucket: input.env.BUNDLES,
-      domain: "ingress",
-      env: input.env,
-      environment: input.environment,
-      userId: input.userId,
-    });
-    const environment = createHostedMailboxPayloadDecodeEncryptionEnvironment({
-      resolveKeyById: cryptoContext.resolveKeyById,
-    });
-    const decodedPayload = await decryptHostedMailboxPayloadCiphertext({
-      ciphertext: request.payloadCiphertext,
-      environment,
-      metadata: {
-        dedupeKey: request.itemRef.dedupeKey,
-        itemId: request.itemRef.id,
-        kind: request.itemRef.kind,
-        lane: request.itemRef.lane,
-        laneSeq: request.itemRef.laneSeq,
-        occurredAt: request.itemRef.occurredAt,
-        payloadSchema: request.payloadSchema,
-        payloadStorage: request.payloadSource === "inline" ? "inline" : "sidecar",
-        userId: request.itemRef.userId,
-      },
-    });
-    wake = parseHostedExecutionWake(decodedPayload);
+    const decode = await createRunnerMailboxPayloadDecoder(input);
+    wake = await decode(request);
   } catch {
     return jsonError("Mailbox payload decode failed.", 502);
   }
@@ -109,20 +86,85 @@ export async function handleRunnerMailboxPayloadDecodeRequest(input: {
   });
 }
 
-function createHostedMailboxPayloadDecodeEncryptionEnvironment(input: {
-  resolveKeyById(rootKeyId: string): Promise<Uint8Array | null>;
-}): HostedMailboxEncryptionEnvironment {
-  return createHostedMailboxEncryptionEnvironmentFromIngressRootResolver({
+async function createRunnerMailboxPayloadDecoder(input: {
+  env: RunnerOutboundEnvironmentSource;
+  environment: ReturnType<typeof readHostedExecutionEnvironment>;
+  userId: string;
+}): Promise<(payload: HostedMailboxPayloadDecodeRequest) => Promise<HostedExecutionWake>> {
+  const cryptoContext = await resolveRunnerOutboundUserCryptoContext({
+    bucket: input.env.BUNDLES,
+    domain: "ingress",
+    env: input.env,
+    environment: input.environment,
+    userId: input.userId,
+  });
+  const environment = createHostedMailboxEncryptionEnvironmentFromIngressRootResolver({
     async readIngressRoot(rootKeyId) {
-      const rootKey = await input.resolveKeyById(rootKeyId);
+      const rootKey = await cryptoContext.resolveKeyById(rootKeyId);
       if (!rootKey) {
         throw new Error("Hosted mailbox ingress root is not available.");
       }
-
-      return {
-        rootKey,
-        rootKeyId,
-      };
+      return { rootKey, rootKeyId };
     },
   });
+  return async (payload) => {
+    const decodedPayload = await decryptHostedMailboxPayloadCiphertext({
+      ciphertext: payload.payloadCiphertext,
+      environment,
+      metadata: {
+        dedupeKey: payload.itemRef.dedupeKey,
+        itemId: payload.itemRef.id,
+        kind: payload.itemRef.kind,
+        lane: payload.itemRef.lane,
+        laneSeq: payload.itemRef.laneSeq,
+        occurredAt: payload.itemRef.occurredAt,
+        payloadSchema: payload.payloadSchema,
+        payloadStorage: payload.payloadSource === "inline" ? "inline" : "sidecar",
+        userId: payload.itemRef.userId,
+      },
+    });
+    return parseHostedExecutionWake(decodedPayload);
+  };
+}
+
+/** The caller has already validated the current runtime write fence. */
+export async function decodeRunnerMailboxFetchResponse(input: {
+  env: RunnerOutboundEnvironmentSource;
+  environment: ReturnType<typeof readHostedExecutionEnvironment>;
+  response: Response;
+  userId: string;
+}): Promise<Response> {
+  const mailbox = parseHostedMailboxFetchResponse(await input.response.json());
+  if (mailbox.userId !== input.userId
+    || mailbox.items.some((item) => item.userId !== input.userId)) {
+    return unauthorized();
+  }
+  const consumed = mailbox.consumedSeqByLane?.find((cursor) => cursor.lane === "conversation");
+  let decode: Awaited<ReturnType<typeof createRunnerMailboxPayloadDecoder>> | undefined;
+  for (const item of mailbox.items) {
+    if (item.kind !== "conversation.message" || item.lane !== "conversation"
+      || item.consumedAt || !item.payloadInlineCiphertext || item.payloadRef
+      || (consumed && BigInt(item.laneSeq) <= BigInt(consumed.consumedSeq))) {
+      continue;
+    }
+    try {
+      decode ??= await createRunnerMailboxPayloadDecoder(input);
+      const wake = await decode({
+        itemRef: item,
+        payloadCiphertext: item.payloadInlineCiphertext,
+        payloadRequestId: null,
+        payloadSchema: item.payloadSchema,
+        payloadSource: "inline",
+      });
+      if (wake.userId === input.userId && wake.kind === "conversation.message") {
+        item.decodedWake = wake;
+      }
+    } catch {
+      // Keep lazy import's existing item-scoped failure/retry behavior. A bad
+      // payload must not make the whole fetch (including other lanes) fail.
+    }
+  }
+  const response = json(mailbox);
+  response.headers.set("cache-control", "no-store");
+  return response;
 }

--- a/apps/cloudflare/src/runner-outbound/web-control.ts
+++ b/apps/cloudflare/src/runner-outbound/web-control.ts
@@ -24,7 +24,6 @@ import {
   parseHostedVaultShareEffectDeadlineAtEpochMs,
 } from "@murphai/hosted-execution/vault-share";
 import {
-  HOSTED_RUNTIME_BROWSER_VAULT_REPLICA_PUBLISH_PATH,
   HOSTED_RUNTIME_USAGE_RECORD_PATH,
   HOSTED_RUNTIME_WORKSPACE_CHECKPOINT_PATH,
 } from "@murphai/hosted-execution/routes";
@@ -47,6 +46,7 @@ import {
 } from "./write-fence.ts";
 import {
   handleRunnerMailboxPayloadDecodeRequest,
+  decodeRunnerMailboxFetchResponse,
 } from "./mailbox-payload-decode.ts";
 import {
   HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_SNAPSHOT_PATH,
@@ -129,19 +129,12 @@ export async function handleRunnerWebControlRequest(input: {
     return notFound();
   }
 
-  const isCheckpointRequest = input.url.pathname === HOSTED_RUNTIME_WORKSPACE_CHECKPOINT_PATH
-    && input.request.method === "POST";
-  const isUsageRecordRequest = input.url.pathname === HOSTED_RUNTIME_USAGE_RECORD_PATH
-    && input.request.method === "POST";
-  const isBrowserVaultReplicaPublishRequest =
-    input.url.pathname === HOSTED_RUNTIME_BROWSER_VAULT_REPLICA_PUBLISH_PATH
-    && input.request.method === "POST";
-  const isDeviceSyncRuntimeSnapshotRequest =
-    input.url.pathname === HOSTED_EXECUTION_DEVICE_SYNC_RUNTIME_SNAPSHOT_PATH
-    && input.request.method === "POST";
-  const isVaultShareDeliveryRequest =
-    policy.operation === "vault_share_deliver"
-    && input.request.method === "POST";
+  // The allowlist above already proved each operation's HTTP method.
+  const isCheckpointRequest = policy.operation === "workspace_checkpoint";
+  const isUsageRecordRequest = policy.operation === "usage_recording";
+  const isBrowserVaultReplicaPublishRequest = policy.operation === "browser_vault_replica_publish";
+  const isDeviceSyncRuntimeSnapshotRequest = policy.operation === "device_sync_runtime_snapshot";
+  const isVaultShareDeliveryRequest = policy.operation === "vault_share_deliver";
   const vaultShareEffectDeadlineAtEpochMs = isVaultShareDeliveryRequest
     ? parseHostedVaultShareEffectDeadlineAtEpochMs(
       input.request.headers.get(HOSTED_VAULT_SHARE_EFFECT_DEADLINE_HEADER),
@@ -311,6 +304,11 @@ export async function handleRunnerWebControlRequest(input: {
     } catch {
       return jsonError("Hosted workspace checkpoint response was invalid.", 502);
     }
+  }
+
+  if (response.ok && policy.operation === "mailbox_fetch"
+    && body && JSON.parse(body).decodeInlinePayloads === true) {
+    return decodeRunnerMailboxFetchResponse({ ...input, response });
   }
 
   if (!isVaultShareDeliveryRequest) {

--- a/apps/cloudflare/src/runtime-platform/mailbox-port.ts
+++ b/apps/cloudflare/src/runtime-platform/mailbox-port.ts
@@ -1,6 +1,7 @@
 import type { HostedRuntimePlatform } from "@murphai/assistant-runtime/hosted-runtime-contracts";
 import {
   parseHostedMailboxFetchResponse,
+  parseHostedExecutionWake,
   parseHostedMailboxPayloadFetchResponse,
 } from "@murphai/hosted-execution/parsers";
 import {
@@ -24,7 +25,7 @@ export function createHostedWebMailboxPort(input: {
       let payload: unknown;
       try {
         payload = await fetchReplaySafeHostedWebControlPlaneJson({
-          body: request,
+          body: { ...request, decodeInlinePayloads: true },
           boundUserId: input.boundUserId,
           description: "Hosted mailbox fetch",
           fetchImpl: input.fetchImpl,
@@ -40,7 +41,19 @@ export function createHostedWebMailboxPort(input: {
         throw error;
       }
 
-      return parseHostedMailboxFetchResponse(payload);
+      const mailbox = parseHostedMailboxFetchResponse(payload);
+      // The ordinary parser proves these item records. Only the Worker port
+      // accepts this ephemeral enrichment; Web's canonical parser discards it.
+      const rawItems = (payload as { items: Array<Record<string, unknown>> }).items;
+      return {
+        ...mailbox,
+        items: mailbox.items.map((item, index) => ({
+          ...item,
+          ...(rawItems[index]?.decodedWake === undefined ? {} : {
+            decodedWake: parseHostedExecutionWake(rawItems[index]!.decodedWake),
+          }),
+        })),
+      };
     },
     async fetchPayload(
       request: Parameters<NonNullable<HostedRuntimePlatform["mailboxPort"]>["fetchPayload"]>[0],

--- a/apps/cloudflare/test/runner-mailbox-fetch-decode.test.ts
+++ b/apps/cloudflare/test/runner-mailbox-fetch-decode.test.ts
@@ -89,17 +89,19 @@ describe("Worker mailbox fetch/decode composition", () => {
     // Canonical Web parsing never accepts the ephemeral plaintext field.
     expect(parseHostedMailboxFetchResponse(fetched).items[0]).not.toHaveProperty("decodedWake");
   });
-  it("resolves ingress context once for a batch of inline items", async () => {
+  it.each([2, 100])("resolves ingress context once for %i inline items", async (count) => {
     const mailbox = await mailboxFixture();
-    const next = await mailboxFixture(2);
-    mailbox.items.push(next.items[0]!);
-    mailbox.maxSeqByLane[0]!.maxSeq = "2";
+    for (let index = 2; index <= count; index += 1) {
+      const next = await mailboxFixture(index);
+      mailbox.items.push(next.items[0]!);
+    }
+    mailbox.maxSeqByLane[0]!.maxSeq = String(count);
     mocks.forward.mockResolvedValue(Response.json(mailbox));
     const response = await handle(request());
     expect(response.headers.get("cache-control")).toBe("no-store");
-    expect(await response.json()).toMatchObject({ items: [
-      { decodedWake: wake }, { decodedWake: { ...wake, eventId: "synthetic-event-2" } },
-    ] });
+    expect(await response.json()).toMatchObject({ items: Array.from({ length: count }, (_, index) => ({
+      decodedWake: index === 0 ? wake : { ...wake, eventId: `synthetic-event-${index + 1}` },
+    })) });
     expect(mocks.crypto).toHaveBeenCalledTimes(1);
   });
   it("leaves old containers on the original fetch contract", async () => {

--- a/apps/cloudflare/test/runner-mailbox-fetch-decode.test.ts
+++ b/apps/cloudflare/test/runner-mailbox-fetch-decode.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildHostedExecutionLinqConversationMessageWake } from "@murphai/hosted-execution";
+import { buildHostedSecureBoxAad, sealHostedSecureBox, serializeHostedSecureBoxEnvelope } from "@murphai/runtime-state";
+import { buildHostedMailboxPayloadScope, buildHostedMailboxPayloadSecureBoxAad, HOSTED_MAILBOX_ITEM_PAYLOAD_SCHEMA } from "@murphai/hosted-execution/runtime-control";
+import { parseHostedMailboxFetchResponse } from "@murphai/hosted-execution/parsers";
+
+const mocks = vi.hoisted(() => ({ forward: vi.fn(), fence: vi.fn(), crypto: vi.fn() }));
+vi.mock("../src/web-control-plane.ts", async (original) => ({
+  ...await original<typeof import("../src/web-control-plane.ts")>(),
+  fetchHostedExecutionWebControlPlaneResponse: mocks.forward,
+}));
+vi.mock("../src/runner-outbound/write-fence.ts", async (original) => ({
+  ...await original<typeof import("../src/runner-outbound/write-fence.ts")>(),
+  requireRunnerRuntimeWriteFence: mocks.fence,
+}));
+vi.mock("../src/runner-outbound/shared.ts", async (original) => ({
+  ...await original<typeof import("../src/runner-outbound/shared.ts")>(),
+  resolveRunnerOutboundUserCryptoContext: mocks.crypto,
+}));
+import { HOSTED_RUNNER_WEB_CONTROL_ROUTES } from "../src/runner-outbound/shared-web-control-policy.ts";
+import { handleRunnerWebControlRequest } from "../src/runner-outbound/web-control.ts";
+import { RunnerRuntimeWriteFenceError } from "../src/runner-outbound/write-fence.ts";
+import { createHostedWebMailboxPort } from "../src/runtime-platform/mailbox-port.ts";
+import { createHostedExecutionTestEnv } from "./hosted-execution-fixtures.ts";
+import { readHostedExecutionEnvironment } from "../src/env.ts";
+
+const rootKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+const rootKeyId = "udrk:ingress:synthetic-fetch";
+const wake = buildHostedExecutionLinqConversationMessageWake({
+  eventId: "synthetic-event", occurredAt: "2026-09-10T00:00:00Z", userId: "synthetic-member",
+  phoneLookupKey: "synthetic-phone-lookup",
+  linqMessage: { chatId: "synthetic-chat", from: "+15550100000", isFromMe: false,
+    messageId: "synthetic-message", parts: [{ type: "text", value: "Hello" }] },
+});
+const requestBody = { requestId: "synthetic-fetch", limitPerLane: 10,
+  lanes: [{ lane: "conversation" as const, importedSeq: "0" }] };
+
+async function mailboxFixture(index = 1) {
+  const itemWake = index === 1 ? wake : { ...wake, eventId: `synthetic-event-${index}` };
+  const item = { createdAt: wake.occurredAt, updatedAt: wake.occurredAt,
+    dedupeKey: itemWake.eventId, id: `synthetic-item-${index}`, kind: "conversation.message" as const,
+    lane: "conversation" as const, laneSeq: String(index), occurredAt: wake.occurredAt,
+    payloadSchema: HOSTED_MAILBOX_ITEM_PAYLOAD_SCHEMA, payloadInlineCiphertext: "",
+    payloadRef: null as string | null, consumedAt: null as string | null, userId: wake.userId };
+  const metadata = { ...item, itemId: item.id, payloadStorage: "inline" as const };
+  const scope = buildHostedMailboxPayloadScope("inline");
+  item.payloadInlineCiphertext = serializeHostedSecureBoxEnvelope(await sealHostedSecureBox({
+    aad: buildHostedSecureBoxAad({ ...buildHostedMailboxPayloadSecureBoxAad(metadata),
+      domain: "ingress", lane: "mailbox-payload", scope, userId: wake.userId }),
+    domain: "ingress", lane: "mailbox-payload", scope, rootKey, rootKeyId,
+    plaintext: new TextEncoder().encode(JSON.stringify(itemWake)),
+  }));
+  return { assistantProvider: "openai", fetchedAt: wake.occurredAt, userId: wake.userId, items: [item],
+    maxSeqByLane: [{ lane: "conversation", maxSeq: "1" }],
+    consumedSeqByLane: [{ lane: "conversation", consumedSeq: "0" }] };
+}
+async function handle(request: Request) {
+  const env = {
+    ...createHostedExecutionTestEnv(),
+    BUNDLES: { get: async () => null, put: async () => undefined },
+    USER_RUNNER: { getByName: () => ({ validateRuntimeWriteFence: async () => true }) },
+  };
+  return handleRunnerWebControlRequest({ env, environment: readHostedExecutionEnvironment(createHostedExecutionTestEnv()),
+    request, url: new URL(request.url), userId: wake.userId });
+}
+function request(optIn = true) {
+  return new Request("http://web-control.worker/api/internal/hosted-mailbox/fetch", {
+    method: "POST", body: JSON.stringify({ ...requestBody, ...(optIn ? { decodeInlinePayloads: true } : {}) }),
+  });
+}
+describe("Worker mailbox fetch/decode composition", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.fence.mockResolvedValue({ attemptId: "synthetic-attempt", generation: "1", workspaceVersion: "1" });
+    mocks.crypto.mockResolvedValue({ resolveKeyById: async (id: string) => id === rootKeyId ? rootKey : null });
+  });
+  it("returns a parsed wake through one container request, one Web fetch and one fence check", async () => {
+    const mailbox = await mailboxFixture();
+    mocks.forward.mockImplementation(async () => Response.json(mailbox));
+    const fetchImpl = vi.fn<typeof fetch>(async (url, init) => handle(new Request(url, init)));
+    const port = createHostedWebMailboxPort({ boundUserId: wake.userId, fetchImpl,
+      timeoutMs: 1000, transport: { mode: "proxy" } });
+    const fetched = await port.fetch(requestBody);
+    expect(fetched.items[0]?.decodedWake).toEqual(wake);
+    expect(fetched.items[0]?.payloadInlineCiphertext).toBe(mailbox.items[0]!.payloadInlineCiphertext);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(mocks.forward).toHaveBeenCalledTimes(1);
+    expect(mocks.fence).toHaveBeenCalledTimes(1);
+    // Canonical Web parsing never accepts the ephemeral plaintext field.
+    expect(parseHostedMailboxFetchResponse(fetched).items[0]).not.toHaveProperty("decodedWake");
+  });
+  it("resolves ingress context once for a batch of inline items", async () => {
+    const mailbox = await mailboxFixture();
+    const next = await mailboxFixture(2);
+    mailbox.items.push(next.items[0]!);
+    mailbox.maxSeqByLane[0]!.maxSeq = "2";
+    mocks.forward.mockResolvedValue(Response.json(mailbox));
+    const response = await handle(request());
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toMatchObject({ items: [
+      { decodedWake: wake }, { decodedWake: { ...wake, eventId: "synthetic-event-2" } },
+    ] });
+    expect(mocks.crypto).toHaveBeenCalledTimes(1);
+  });
+  it("leaves old containers on the original fetch contract", async () => {
+    const mailbox = await mailboxFixture();
+    mocks.forward.mockResolvedValue(Response.json(mailbox));
+    expect(await (await handle(request(false))).json()).toEqual(mailbox);
+    expect(mocks.crypto).not.toHaveBeenCalled();
+  });
+  it.each(["consumed", "floor", "sidecar", "corrupt"])("preserves lazy import for %s items", async (kind) => {
+    const mailbox = await mailboxFixture();
+    if (kind === "consumed") mailbox.items[0]!.consumedAt = wake.occurredAt;
+    if (kind === "floor") mailbox.consumedSeqByLane[0]!.consumedSeq = "1";
+    if (kind === "sidecar") mailbox.items[0]!.payloadRef = "synthetic-sidecar";
+    if (kind === "corrupt") mailbox.items[0]!.payloadInlineCiphertext = "invalid-ciphertext";
+    mocks.forward.mockResolvedValue(Response.json(mailbox));
+    const response = await handle(request());
+    expect(response.status).toBe(200);
+    expect(await response.json()).not.toHaveProperty("items.0.decodedWake");
+    expect(mocks.crypto).toHaveBeenCalledTimes(kind === "corrupt" ? 1 : 0);
+  });
+  it.each([
+    HOSTED_RUNNER_WEB_CONTROL_ROUTES.workspaceCheckpoint,
+    HOSTED_RUNNER_WEB_CONTROL_ROUTES.usageRecording,
+    HOSTED_RUNNER_WEB_CONTROL_ROUTES.browserVaultReplicaPublish,
+    HOSTED_RUNNER_WEB_CONTROL_ROUTES.deviceSyncRuntimeSnapshot,
+    HOSTED_RUNNER_WEB_CONTROL_ROUTES.vaultShareDeliver,
+  ])("rejects GET for POST-only $operation before authority or forwarding", async (route) => {
+    expect((await handle(new Request(`http://web-control.worker${route.path}`, { method: "GET" }))).status).toBe(404);
+    expect(mocks.fence).not.toHaveBeenCalled();
+    expect(mocks.forward).not.toHaveBeenCalled();
+  });
+  it("rejects a stale write fence before Web or crypto work", async () => {
+    mocks.fence.mockRejectedValue(new RunnerRuntimeWriteFenceError());
+    expect((await handle(request())).status).toBe(401);
+    expect(mocks.forward).not.toHaveBeenCalled();
+    expect(mocks.crypto).not.toHaveBeenCalled();
+  });
+  it("rejects a wrong-user mailbox before decrypting", async () => {
+    const mailbox = await mailboxFixture();
+    mailbox.items[0]!.userId = "another-synthetic-member";
+    mocks.forward.mockResolvedValue(Response.json(mailbox));
+    expect((await handle(request())).status).toBe(401);
+    expect(mocks.crypto).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -8598,6 +8598,7 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     expect(request.method).toBe("POST");
     expect(request.headers.has("x-hosted-execution-runner-proxy-token")).toBe(false);
     await expect(request.json()).resolves.toEqual({
+      decodeInlinePayloads: true,
       lanes: [
         {
           importedSeq: "0",

--- a/apps/cloudflare/test/runtime-bridge-workspace.test.ts
+++ b/apps/cloudflare/test/runtime-bridge-workspace.test.ts
@@ -2407,7 +2407,7 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
     })).toThrow("Hosted mailbox payload decoder is required for this invocation.");
   });
 
-  it("imports conversation mailbox items with empty platform env when a decoder is provided", async () => {
+  it.each([false, true])("imports conversation mailbox items with empty platform env (decoded in fetch: %s)", async (decodedInFetch) => {
     const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-cloudflare-workspace-"));
     cleanupPaths.push(vaultRoot);
     await writeFile(path.join(vaultRoot, "vault.json"), "{}", "utf8");
@@ -2459,6 +2459,7 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
     await expect(options.importItem({
       item,
       payload: {
+        ...(decodedInFetch ? { decodedWake: wake } : {}),
         payloadCiphertext: "opaque-conversation-ciphertext",
         payloadSchema: HOSTED_MAILBOX_PAYLOAD_SCHEMA,
         requestId: "request_bridge_decoder_conversation",
@@ -2490,21 +2491,25 @@ describe("createHostedWorkspaceRuntimeBridgeJobOptions", () => {
         type: "assistant_input_staged",
       }),
     });
-    expect(decodeMailboxPayload.decode).toHaveBeenCalledWith({
-      itemRef: {
-        dedupeKey: item.dedupeKey,
-        id: item.id,
-        kind: item.kind,
-        lane: item.lane,
-        laneSeq: item.laneSeq,
-        occurredAt: item.occurredAt,
-        userId: item.userId,
-      },
-      payloadCiphertext: "opaque-conversation-ciphertext",
-      payloadRequestId: "request_bridge_decoder_conversation",
-      payloadSchema: HOSTED_MAILBOX_PAYLOAD_SCHEMA,
-      payloadSource: "inline",
-    });
+    if (decodedInFetch) {
+      expect(decodeMailboxPayload.decode).not.toHaveBeenCalled();
+    } else {
+      expect(decodeMailboxPayload.decode).toHaveBeenCalledWith({
+        itemRef: {
+          dedupeKey: item.dedupeKey,
+          id: item.id,
+          kind: item.kind,
+          lane: item.lane,
+          laneSeq: item.laneSeq,
+          occurredAt: item.occurredAt,
+          userId: item.userId,
+        },
+        payloadCiphertext: "opaque-conversation-ciphertext",
+        payloadRequestId: "request_bridge_decoder_conversation",
+        payloadSchema: HOSTED_MAILBOX_PAYLOAD_SCHEMA,
+        payloadSource: "inline",
+      });
+    }
   });
 
   it("captures server-owned return targets from decoded conversation wakes", async () => {

--- a/apps/web/changelog/entries/2026-09-10/message-fetch-without-decode-roundtrip.json
+++ b/apps/web/changelog/entries/2026-09-10/message-fetch-without-decode-roundtrip.json
@@ -12,6 +12,8 @@
       "messaging",
       "reliability"
     ],
-    "sourcePullRequests": []
+    "sourcePullRequests": [
+      3201
+    ]
   }
 }

--- a/apps/web/changelog/entries/2026-09-10/message-fetch-without-decode-roundtrip.json
+++ b/apps/web/changelog/entries/2026-09-10/message-fetch-without-decode-roundtrip.json
@@ -1,0 +1,17 @@
+{
+  "publishedOn": "2026-09-10",
+  "order": 120,
+  "item": {
+    "id": "message-fetch-without-decode-roundtrip",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "One fewer wait before message processing",
+    "summary": "Ordinary conversation messages skip an extra setup round trip before Murph processes them.",
+    "details": "Message encryption and current access checks stay in place. Large message payloads keep their existing loading path.",
+    "relevanceTags": [
+      "messaging",
+      "reliability"
+    ],
+    "sourcePullRequests": []
+  }
+}

--- a/packages/assistant-runtime/src/hosted-runtime/mailbox-payloads.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/mailbox-payloads.ts
@@ -25,6 +25,7 @@ export type HostedMailboxPayloadBlockedCode =
 
 export type HostedMailboxPayloadResolutionResult =
   | {
+      decodedWake?: HostedMailboxItem["decodedWake"];
       payloadCiphertext: string;
       payloadSchema: string;
       requestId: string | null;
@@ -59,6 +60,7 @@ export async function resolveHostedMailboxItemPayload(input: {
 
   if (hasInlinePayload) {
     return {
+      ...(input.item.decodedWake ? { decodedWake: input.item.decodedWake } : {}),
       payloadCiphertext: payloadInlineCiphertext,
       payloadSchema: input.item.payloadSchema,
       requestId: null,

--- a/packages/assistant-runtime/src/hosted-runtime/snapshot-bridge-mailbox.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/snapshot-bridge-mailbox.ts
@@ -107,13 +107,15 @@ export function createHostedWorkspaceBridgeMailboxImporter(input: {
       assistantTarget: context?.assistantTarget ?? null,
       decodePayload: {
         decode: async (decodeInput) => {
-          const decoded = await input.decodeMailboxPayload.decode({
-            itemRef: decodeInput.itemRef,
-            payloadCiphertext: decodeInput.payloadCiphertext,
-            payloadRequestId: decodeInput.payloadRequestId,
-            payloadSchema: decodeInput.payloadSchema,
-            payloadSource: decodeInput.payloadSource,
-          });
+          const decoded = item.payload.decodedWake
+            ? { status: "decoded" as const, wake: item.payload.decodedWake }
+            : await input.decodeMailboxPayload.decode({
+                itemRef: decodeInput.itemRef,
+                payloadCiphertext: decodeInput.payloadCiphertext,
+                payloadRequestId: decodeInput.payloadRequestId,
+                payloadSchema: decodeInput.payloadSchema,
+                payloadSource: decodeInput.payloadSource,
+              });
 
           if (decoded.status === "blocked") {
             return decoded;

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-payloads.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-payloads.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 
+import { buildHostedExecutionLinqConversationMessageWake } from "@murphai/hosted-execution";
+
 import { test } from "vitest";
 
 import type {
@@ -48,6 +50,22 @@ test("returns inline mailbox ciphertext without fetching a sidecar payload", asy
     source: "inline",
     status: "resolved",
   });
+});
+
+test("carries Worker-decoded inline wake to import without a payload fetch", async () => {
+  const wake = buildHostedExecutionLinqConversationMessageWake({
+    eventId: "synthetic-event", userId: TEST_USER_ID, occurredAt: TEST_NOW,
+    phoneLookupKey: "synthetic-lookup",
+    linqMessage: { chatId: "synthetic-chat", from: "+15550100000", isFromMe: false,
+      messageId: "synthetic-message", parts: [{ type: "text", value: "Hello" }] },
+  });
+  const { mailboxPort, payloadFetchRequests } = createMailboxPort({ fetchedAt: TEST_NOW, payload: null });
+  const result = await resolveHostedMailboxItemPayload({ mailboxPort, item: createMailboxItem({
+    decodedWake: wake, payloadInlineCiphertext: "synthetic-ciphertext", payloadRef: null,
+  }) });
+  assert.equal(result.status, "resolved");
+  if (result.status === "resolved") assert.deepEqual(result.decodedWake, wake);
+  assert.deepEqual(payloadFetchRequests, []);
 });
 
 test("fetches sidecar mailbox ciphertext with a generated request id and item id", async () => {

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -25,6 +25,7 @@ import type {
   HostedAssistantReasoningEffortOverride,
 } from "./assistant-model.ts";
 import type {
+  HostedExecutionWake,
   HostedExecutionAcceptedGroupMessageParticipant,
   HostedExecutionAssistantAskOrigin,
   HostedExecutionAssistantAskResult,
@@ -763,6 +764,8 @@ function requireHostedMailboxPayloadAadString(value: string, label: string): str
 }
 
 export interface HostedMailboxItem {
+  /** Ephemeral Worker decryption; never written to the canonical mailbox. */
+  decodedWake?: HostedExecutionWake;
   causalSeq?: string | null;
   consumedAt?: string | null;
   createdAt: string;


### PR DESCRIPTION
## Why and outcome

Fresh inline conversation messages crossed the container/Worker boundary twice:
once to fetch ciphertext and again to return it for decoding. The existing Worker
fetch now optionally returns the parsed wake alongside ciphertext. Runtime imports
that wake directly, removing the second HTTP request and write-fence RPC.

## Product UX

- Effort: Patch.
- Result: Ready.
- Walkthrough: Ordinary inline conversation messages reach the same input staging
  path with less setup. Identity, routing, consent/usage and reply behavior stay
  unchanged. Sidecars remain lazy so the first message does not wait for large or
  later-skipped payloads. Consumed and system items retain their current behavior.

## Evidence

- Direct: Real secure-box ciphertext passes through the production Worker handler
  and runtime mailbox port with one container request, one Web fetch and one
  write-fence check. Both two-item and maximum 100-item batches resolve ingress context once. The real
  workspace importer stages the same input with zero decode calls when enriched.
- Coverage: 67 Cloudflare bridge/encryption/decode cases; 272 Web-control routing
  cases; 80 assistant payload/import cases; 10 changelog SSR cases. The final
  15-case composed check also passes, including no-store response policy.
- Cloudflare and assistant-runtime typechecks pass. Final ReviewGPT round 1
  passed on `526ddd0bfa678e34842f50a7b2a86149d9bd237d` with no qualifying
  findings. Response hash, captured turn identity and gpt-6-pro metadata agree;
  browser response waiting exceeded 270 seconds. The reviewer inspected tests;
  the parent ran the checks above. Follow-ups close the plan and correct one
  stale platform-test assertion to expect the existing decode opt-in. The full
  209-case platform suite and Cloudflare typecheck pass after that one-line
  correction; production source is unchanged. The explanatory-docs and isolated
  proof exemptions apply. All 32 applicable CI checks pass on the final head.
- Current platform boundary: Cloudflare's official outbound-handler contract
  keeps trusted interception outside the container:
  https://developers.cloudflare.com/containers/guides/outbound-traffic/

## Non-obvious affected surfaces

Five POST-only request classifications now use the operation already validated
by the allowlist, removing redundant method/path checks. Focused GET-rejection,
checkpoint and full egress-interception tests preserve those boundaries.
Canonical Web parsing discards the ephemeral decodedWake field; Web never
persists or accepts it as mailbox authority.

## Architecture and reuse

- Existing systems reused: Authenticated Worker Web-control proxy, secure-box
  decoder, ingress context, mailbox port and workspace importer.
- New logic: Opt into inline conversation decoding during fetch and carry the
  parsed wake directly to the existing importer.
- New abstractions: Extracted existing decoder into a request-local closure so
  the old endpoint and fetch share one decoder and batches resolve context once.
- Complexity intentionally avoided: No new endpoint, service, key distribution,
  persisted record, decoded-payload cache, side map, queue or eager sidecar fetch.
  The existing decode path remains for real deployed callers and lazy payloads.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: Web-control handler 47 → 46; existing system importer 23 and runtime
  timing subdivision 25 are unchanged. Further unrelated splitting is unnecessary.
- Agent judgment: Existing owners cover the change. The opt-in and optional result
  support deployed old containers and old Worker responses without a new fallback
  implementation. Optional enrichment failure preserves the existing item's
  lazy decode error/retry semantics and cannot fail unrelated mailbox lanes.

## Hot reply path impact

- Path status: Touched.
- Database calls: None added. Web's existing access/usage/mailbox fetch is unchanged.
- Network/provider calls: Fresh inline conversation imports remove one container
  HTTP request and one Worker-to-UserRunner write-fence RPC per decoded item.
  One existing ingress context resolution is shared per eligible batch; no other
  network/provider call is added. Sidecar, system and consumed paths stay lazy.
- Other awaited latency: Existing decrypt/parse work moves into the fetch response,
  sequentially over the existing maximum of 100 conversation rows (128 KiB
  plaintext per inline item) and at most 100 system rows that are not decoded. There is no new timer or retry.
  The fetch retains its transport deadline and cancellation. On failed enrichment,
  ordinary import still owns decoding and may repeat that failed crypto attempt.
- Before/after proof: Direct composed call counts and both importer generations
  prove removal of the second request with identical wake and staged-input evidence.
  This is not a production typing-latency benchmark; decode time moves into fetch.

## Murph initial provider input impact

- Individual and group: Not applicable; the same parsed wake reaches unchanged
  instruction/message/tool assembly, provider selection and identity checks.
- Assembled instructions: Unchanged.
- Tool and guidance surface: Unchanged.
- Other provider-visible changes: None.
- Measurement method: Not run; success is deterministic transport equality and
  does not depend on model behavior. No live-Codex behavioral journey is needed.

## Deployment concerns

- Deployment: applicable
- Supported skew: Old containers omit the opt-in and receive the existing response.
  New containers accept old Worker ciphertext responses via the existing decoder.
  New Worker/new container uses the optional wake. Both keep sidecar decoding.
- Safe order: Normal Worker/container rollout; no Web dependency or hard cut.
- Rollback floor: Unchanged; no new persisted data or minimum runner version.
- Expected exposure: During rollout, older callers keep the existing latency;
  enriched inline imports gain the improvement as the new runner is selected.
- Reversibility: Either component can return to the previous wire behavior.
- Convergence proof: Old/new request and response cases plus real importer tests;
  ordinary managed smoke must report the deployed Worker and runner fingerprints.
- Post-deploy checks: Confirm fingerprints, inspect bounded fetch/decode errors,
  and compare warm-message fetch-to-staging latency. Keys remain Worker-only.

## Change-shape breakdown

Classification rule: Production TS is source, tests are fixtures, owner docs/plans
and release copy are docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 120 | 60 |
| Tests / fixtures | 189 | 16 |
| Docs | 114 | 7 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **423** | **83** |

## Changelog

- Changelog: updated
- Items: 2026-09-10 · message-fetch-without-decode-roundtrip

ReviewGPT context sensitivity: sensitive
Classification reason: Hosted encrypted transport, write-fence and Worker/container boundary.

ReviewGPT first-reviewed head: 526ddd0bfa678e34842f50a7b2a86149d9bd237d
