### PR TITLE
refactor(query): share browser replica JSON values

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-simplify-replica-json.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-simplify-replica-json.md
@@ -1,0 +1,76 @@
+# Share browser replica JSON value copying
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+- Give browser replica construction and experiment projection one internal owner
+  for their existing JSON admission and detached-copy behavior.
+
+## Success criteria
+
+- Remove the two duplicate functions from both consumers without changing
+  accepted values, output bytes, field allowlists, or nullable-record behavior.
+- Pass focused value/copy tests, composed replica privacy and experiment tests,
+  browser entry checks, query typecheck, and the complexity guard.
+
+## Scope
+
+- In scope: query browser-replica build/experiments, internal json-values module,
+  focused tests, and this plan.
+- Out of scope: views/shared/barrels owned by PR #3167, public exports,
+  cooperative serialization, stricter input validation, and model calculations.
+
+## Constraints
+
+- Keep builder allowlists and the experiment nullable-record wrapper in place.
+  Preserve existing JSON.stringify handling of non-finite numbers, sparse arrays,
+  object prototypes, and unsupported nested values.
+- Use the assigned isolated worktree from pinned main b80bd40f. Open a draft;
+  the parent owns Ready, final ReviewGPT, exact-head CI, and merge decisions.
+
+## Risks and mitigations
+
+1. A generic JSON cleanup could change admission or expose extra replica fields.
+   Mitigation: move the builder functions unchanged, retain its allowlists, and
+   prove rejection and detached-copy semantics through existing callers.
+2. Importing the cooperative serializer would couple browser consumers to yielding.
+   Mitigation: use a dependency-free internal value module; leave json.ts intact.
+
+## Tasks
+
+1. Confirmed exports, callers, policy equivalence, test ownership, and PR overlap.
+2. Moved the builder functions unchanged and replaced both imports.
+3. Added focused admission, serialization, allowlist, and detached-copy proof.
+4. Passed focused tests, query typecheck, complexity, and full diff/privacy review.
+5. Delivery: scoped completion commit and draft PR; parent owns final gates.
+
+## Decisions
+
+- The existing cooperative json.ts has a different asynchronous responsibility.
+  The new module contains only the two real shared functions; no new policy,
+  adapter, public surface, persisted state, or deploy ordering is introduced.
+- The pinned implementations matched in 27 synthetic value cases before editing.
+- No changelog: internal consolidation preserves member-visible behavior.
+
+## Verification
+
+- PASS: pnpm --dir packages/query exec vitest run --config vitest.config.ts
+  --no-coverage --maxWorkers=2 test/browser-replica-json-values.test.ts
+  test/browser-vault-replica.test.ts test/browser-vault-experiment-results.test.ts
+  test/browser-entry-boundary.test.ts test/browser-entry-surface.test.ts
+  (130 tests across 5 files).
+- PASS: pnpm --dir packages/query typecheck.
+- PASS: pnpm complexity:diff --base b80bd40f84d1b367c1810e2fe046e3089cc28aa4.
+  Three source files; two exact moves; zero debt or maximum regressions.
+- Existing experiment hotspots inspected: buildProgressResult (73),
+  buildRunContext (48), classifyCoverageStatus (24), persisted metric mapping (21).
+  They retain their experiment policy responsibility and are unchanged.
+- PASS: git diff --check; no public surface or PR #3167 file changes.
+- Existing privacy fields remain excluded, invalid nested values remain rejected,
+  and source, replica, and result copies retain independent nested objects.
+- Frozen dependency install and scripts/frog list succeeded; no new repository
+  friction entry was needed. Broad CI and final ReviewGPT remain parent-owned.
+Completed: 2026-09-10

--- a/packages/query/src/browser-replica/build.ts
+++ b/packages/query/src/browser-replica/build.ts
@@ -57,6 +57,7 @@ import { projectBrowserTrainingSession } from "./training.ts";
 import { buildBrowserVaultExperimentRunCards } from "./experiment-run-cards.ts";
 import { createBrowserVaultProjectionQueryClient } from "./query.ts";
 import { stringifyJsonCooperatively } from "./json.ts";
+import { cloneJson, isBrowserSafeJson } from "./json-values.ts";
 
 export async function createBrowserVaultReplica(
   input: CreateBrowserVaultReplicaInput,
@@ -720,27 +721,6 @@ function previewText(value: string | null, limit: number): string | null {
 
 function uniqueStrings(values: readonly (string | null | undefined)[]): string[] {
   return [...new Set(values.filter((value): value is string => typeof value === "string" && value.length > 0))];
-}
-
-function cloneJson(value: unknown): unknown {
-  return JSON.parse(JSON.stringify(value));
-}
-
-function isBrowserSafeJson(value: unknown): boolean {
-  if (value === null) {
-    return true;
-  }
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-    return true;
-  }
-  if (Array.isArray(value)) {
-    return value.every(isBrowserSafeJson);
-  }
-  if (typeof value === "object") {
-    return Object.values(value as Record<string, unknown>).every(isBrowserSafeJson);
-  }
-
-  return false;
 }
 
 function subtractDaysFromIsoDate(value: string, days: number): string {

--- a/packages/query/src/browser-replica/experiments.ts
+++ b/packages/query/src/browser-replica/experiments.ts
@@ -48,6 +48,7 @@ import type {
   BrowserVaultSummaryConfidence,
 } from "./shared.ts";
 import { browserMetricRowToSeriesPoint } from "./metric-points.ts";
+import { cloneJson, isBrowserSafeJson } from "./json-values.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -2897,27 +2898,6 @@ function cloneRecord(record: JsonRecord): JsonRecord {
   }
 
   return output;
-}
-
-function cloneJson(value: unknown): unknown {
-  return JSON.parse(JSON.stringify(value));
-}
-
-function isBrowserSafeJson(value: unknown): boolean {
-  if (value === null) {
-    return true;
-  }
-
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-    return true;
-  }
-
-  if (Array.isArray(value)) {
-    return value.every(isBrowserSafeJson);
-  }
-
-  const record = readRecord(value);
-  return record ? Object.values(record).every(isBrowserSafeJson) : false;
 }
 
 function uniqueStrings(values: readonly (string | null | undefined)[]): string[] {

--- a/packages/query/src/browser-replica/json-values.ts
+++ b/packages/query/src/browser-replica/json-values.ts
@@ -1,0 +1,20 @@
+export function cloneJson(value: unknown): unknown {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function isBrowserSafeJson(value: unknown): boolean {
+  if (value === null) {
+    return true;
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.every(isBrowserSafeJson);
+  }
+  if (typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).every(isBrowserSafeJson);
+  }
+
+  return false;
+}

--- a/packages/query/test/browser-replica-json-values.test.ts
+++ b/packages/query/test/browser-replica-json-values.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+
+import { test } from "vitest";
+
+import { createBrowserVaultReplica } from "../src/browser-replica/build.ts";
+import { selectBrowserVaultExperimentResults } from "../src/browser-replica/experiments.ts";
+import { cloneJson, isBrowserSafeJson } from "../src/browser-replica/json-values.ts";
+import { createBrowserVaultQueryClient } from "../src/browser-replica/query.ts";
+import { createVaultReadModel } from "../src/read-model.ts";
+
+test("browser JSON admission rejects an entire value containing unsupported nested data", () => {
+  for (const value of [undefined, () => "ignored", Symbol("synthetic"), 1n]) {
+    assert.equal(isBrowserSafeJson(value), false);
+    assert.equal(isBrowserSafeJson({ nested: [value] }), false);
+    assert.equal(isBrowserSafeJson([null, { nested: value }]), false);
+  }
+
+  assert.equal(isBrowserSafeJson({ nested: [null, false, 0, ""] }), true);
+  assert.equal(isBrowserSafeJson({ toJSON: () => ({}) }), false);
+});
+
+test("browser JSON copies preserve existing serialization of numbers, holes, and object prototypes", () => {
+  const value = {
+    date: new Date("2026-04-20T12:00:00.000Z"),
+    empty: { array: [], object: {} },
+    nonfinite: [NaN, Infinity, -Infinity],
+    sparse: new Array(2),
+  };
+
+  assert.equal(isBrowserSafeJson(value), true);
+  assert.deepEqual(cloneJson(value), {
+    date: "2026-04-20T12:00:00.000Z",
+    empty: { array: [], object: {} },
+    nonfinite: [null, null, null],
+    sparse: [null, null],
+  });
+
+  const inherited = Object.create({ unsupported: undefined });
+  assert.equal(isBrowserSafeJson(inherited), true);
+  assert.deepEqual(cloneJson(inherited), {});
+});
+
+test("replica and experiment projections retain allowlists and detach nested protocol values", async () => {
+  const protocolRef = { protocolId: "protocol:synthetic", nested: ["original"] };
+  const attributes = {
+    effectiveProtocolSnapshot: { invalid: undefined },
+    protocolRef,
+    rawProvenance: { payload: "excluded" },
+    status: "active",
+  };
+  const replica = await createBrowserVaultReplica({
+    generatedAt: "2026-04-20T12:00:00.000Z",
+    metricPoints: [],
+    sourceBundleHash: "a".repeat(64),
+    vault: createVaultReadModel({
+      entities: [{
+        attributes,
+        body: null,
+        date: "2026-04-20",
+        entityId: "exp_json_copy",
+        experimentSlug: "json-copy",
+        family: "experiment",
+        frontmatter: null,
+        kind: "experiment_entry",
+        links: [],
+        lookupIds: ["exp_json_copy"],
+        occurredAt: "2026-04-20T00:00:00.000Z",
+        path: "bank/experiments/json-copy.md",
+        primaryLookupId: "exp_json_copy",
+        recordClass: "bank",
+        relatedIds: [],
+        status: "active",
+        stream: null,
+        tags: [],
+        title: "Synthetic protocol",
+      }],
+      metadata: null,
+      vaultRoot: "browser://synthetic",
+    }),
+  });
+  const projected = replica.entities.find((entity) => entity.id === "exp_json_copy");
+  assert.ok(projected);
+  assert.deepEqual(projected.attributes, { protocolRef, status: "active" });
+  assert.equal(Object.hasOwn(projected.attributes, "rawProvenance"), false);
+  assert.equal(Object.hasOwn(projected.attributes, "effectiveProtocolSnapshot"), false);
+
+  protocolRef.nested.push("source changed");
+  assert.deepEqual(projected.attributes.protocolRef, {
+    protocolId: "protocol:synthetic",
+    nested: ["original"],
+  });
+
+  const client = createBrowserVaultQueryClient(replica);
+  const result = selectBrowserVaultExperimentResults(client, "exp_json_copy", {
+    asOf: "2026-04-20T12:00:00.000Z",
+  });
+  assert.ok(result);
+  assert.equal(result.experiment.effectiveProtocolSnapshot, null);
+  assert.equal(result.experiment.commonsProtocolRef, null);
+  const resultRef = result.experiment.protocolRef;
+  assert.ok(resultRef);
+  assert.ok(Array.isArray(resultRef.nested));
+  resultRef.nested.push("result changed");
+  assert.deepEqual(projected.attributes.protocolRef, {
+    protocolId: "protocol:synthetic",
+    nested: ["original"],
+  });
+  assert.deepEqual(protocolRef.nested, ["original", "source changed"]);
+});


### PR DESCRIPTION
## Why and outcome

Browser replica construction and experiment results independently maintained identical recursive JSON admission and detached-copy functions. Both now import the original builder functions from one internal module, so future value-handling changes have one owner.

Field allowlists, nullable-record handling, serialized values, and public entrypoints retain their existing behavior.

## Product UX

- Effort: Not applicable — internal consolidation with no member-visible behavior change.
- Result: Not applicable.
- Walkthrough: The composed test builds a replica, reads experiment results, and verifies that nested protocol values remain isolated between the canonical source, replica, and returned result.

## Evidence

- Direct: Exact comparison confirms both shared function bodies match their original builder implementations.
- Coverage: 130 tests passed across five files, including three new admission/serialization/copy tests and existing replica privacy, experiment result, and browser entry tests.
- PASS: `pnpm --dir packages/query exec vitest run --config vitest.config.ts --no-coverage --maxWorkers=2 test/browser-replica-json-values.test.ts test/browser-vault-replica.test.ts test/browser-vault-experiment-results.test.ts test/browser-entry-boundary.test.ts test/browser-entry-surface.test.ts`.
- PASS: `pnpm --dir packages/query typecheck`.
- PASS: `pnpm complexity:diff --base b80bd40f84d1b367c1810e2fe046e3089cc28aa4`.
- PASS: `git diff --check` and scoped privacy review.
- Final ReviewGPT and required exact-head CI are pending parent admission.

## Non-obvious affected surfaces

The builder's event-kind field allowlists still exclude raw provenance, bodies, links, and unrelated attributes. Existing composed replica tests prove those exclusions. The new module has no dependencies, preserving browser entry safety. PR #3167-owned views, shared types, barrels, and tests are untouched.

## Architecture and reuse

- Existing systems reused: The builder's original JSON.stringify/parse copying and recursive value-admission functions; existing projection allowlists and experiment record wrappers.
- New logic: None; accepted/rejected values and JSON serialization behavior are preserved.
- New abstractions: One internal `browser-replica/json-values.ts` module replaces two implementations of the same stateless responsibility.
- Complexity intentionally avoided: No public export, dependency, generalized codec, normalization policy, or new state. Cooperative asynchronous serialization remains with its existing owner.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff --base b80bd40f84d1b367c1810e2fe046e3089cc28aa4`; three source files, two exact function moves, no debt or maximum regressions.
- Hotspots: Unchanged experiment functions: `buildProgressResult` 73, `buildRunContext` 48, `classifyCoverageStatus` 24, and the persisted-outcome metric mapping callback 21. Their experiment-policy behavior was inspected and remains outside the shared value-copy responsibility.
- Agent judgment: Consolidating the proven duplicate removes one policy owner. Further experiment-policy extraction is not justified by this change.

## Hot reply path impact

- Path status: Not applicable — internal synchronous value handling in browser replica projection; no accepted-message or reply-delivery orchestration changes.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved.
- Before/after proof: Original function bodies preserved; composed projection and experiment tests pass.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — neither individual nor group provider-input assembly is changed.

ReviewGPT first-reviewed head: 9220cce24b9b1e88423f3cca3ac1f0d8a6042b25
ReviewGPT context sensitivity: sensitive
Classification reason: The shared admission function participates in browser replica value projection; its privacy-adjacent semantics are preserved.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal function consolidation changes no wire format, persisted schema, runtime configuration, or independent deployment ordering.

## Change-shape breakdown

Classification rule: Production TypeScript is source, the focused test is tests, and the completed execution plan is docs. No binaries or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 22 | 42 |
| Tests / fixtures | 109 | 0 |
| Docs | 76 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **207** | **42** |

## Changelog

- Changelog: not applicable
- Reason: Internal consolidation preserves browser replica and experiment behavior.

## Final review evidence

- Parent candidate review: passed; no unresolved findings.
- ReviewGPT round 1: PASS on `9220cce24b9b1e88423f3cca3ac1f0d8a6042b25`, with no qualifying findings. The full-snapshot review checked allowlists, nullable records, copy isolation, browser imports, and 129 in-memory base/head differential cases.
- Acceptance: exact submitted turn, response hash, completion marker, `gpt-6-pro` model metadata, round-1 baseline, and empty remediation deltas verified (Apollo; approximately 384.2 seconds from send to captured response).
- Response SHA-256: `b57e1e9e67ec2c88bf0b8805632c8b8489275c6cd86cbcd5dec8645348c1b010`.
- Integration: conflict-free against `006ce0768111cac657518a79f3074b81ce97b4db`; the seven cleanup PRs have no overlapping authored paths.
