### PR TITLE
refactor: isolate hosted-local Cloudflare source snapshots

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-simplify-harness-snapshot.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-simplify-harness-snapshot.md
@@ -1,0 +1,85 @@
+# Isolate hosted-local Cloudflare source snapshot preparation
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+- Give hosted-local Cloudflare source copying and workspace materialization one
+  focused owner, with the existing stack remaining the lifecycle owner.
+
+## Success criteria
+
+- Preserve copied content, dependency traversal order, skip/error behavior,
+  per-dependency external symlinks, abort checks, and public stack entrypoints.
+- Prove the builder against a small synthetic filesystem and retain existing
+  stack, main, harness, and public package-resolution coverage.
+
+## Scope
+
+- In scope: snapshot builder extraction, shared path constant, focused tests.
+- Out of scope: startup lifecycle, credentials, runner preparation, dependency
+  policy, deployed runtime behavior, and the concurrent authentication PR.
+
+## Constraints
+
+- Reuse existing path constants and runtime abort checking; no reverse imports,
+  dependency changes, lifecycle wrappers, or runtime parameters solely for tests.
+- Base: b80bd40f84d1b367c1810e2fe046e3089cc28aa4. Separate task checkout.
+- Root owns final candidate review, Ready, ReviewGPT and exact-head CI.
+
+## Risks and mitigations
+
+1. Snapshot copying could accidentally alias mutable workspace artifacts.
+   Mitigation: preserve function bodies and verify real copies plus exact links.
+2. Dependency traversal or failure ordering could change during extraction.
+   Mitigation: retain traversal unchanged and test cycles, missing packages/dist,
+   ignored dependencies, cancellation, and invalid package manifests.
+3. Concurrent PR #3134 changes stack authentication integration.
+   Mitigation: its snapshot cluster and snapshot assertions are identical to the
+   base; preserve surrounding authentication and lifecycle code unchanged.
+
+## Tasks
+
+1. Move the complete snapshot closure into cloudflare-source-snapshot.ts and the
+   shared runner-bundle path into constants.ts; update the sole caller import.
+2. Add filesystem proof through mocked existing path ownership, retaining stack
+   integration tests and public exports.
+3. Run focused tests, prerequisite package builds, typecheck, complexity diff,
+   source-identity comparison, and privacy/diff review.
+4. Prepare complete PR evidence; close this plan with a scoped neutral-identity
+   commit, push, and open a draft for root completion ownership.
+
+## Decisions
+
+- Release-package helpers are not reused: their publication filtering, missing
+  dependency handling, and ordering differ from hosted-local materialization.
+- Source snapshot output stays temporary and stack-owned; no new persisted state,
+  product policy, deploy compatibility requirement, or member-facing changelog.
+
+## Verification
+
+- Frozen dependency installation in this checkout; no sibling build reuse.
+- Focused Vitest: snapshot, stack, main, harness, and package boundary tests with
+  at most two workers; package typecheck; pnpm complexity:diff against the base.
+- Exact moved source identity and unchanged stack lifecycle/call ordering.
+- Passed: pnpm install --frozen-lockfile --reporter append-only.
+- Passed: pnpm --filter '@murphai/hosted-local-harness^...'
+  --workspace-concurrency=1 run build (12 prerequisite packages).
+- Passed: MURPH_HOSTED_LOCAL_HARNESS_TEST_PACKAGE_BOUNDARY=1 pnpm --dir
+  packages/hosted-local-harness exec vitest run --config vitest.config.ts
+  --no-coverage --maxWorkers=2 --silent=true
+  test/dev-hosted-local/cloudflare-source-snapshot.test.ts
+  test/dev-hosted-local/stack.test.ts test/dev-hosted-local/main.test.ts
+  test/harness.test.ts test/package-boundary.test.ts (94 tests, five files).
+- Passed: pnpm --dir packages/hosted-local-harness typecheck.
+- Passed: pnpm complexity:diff --base b80bd40f84d1b367c1810e2fe046e3089cc28aa4.
+  The extracted module has maximum complexity 6 and no debt. Stack startup stays
+  at 139 with unchanged debt; its ordered lifecycle remains one owner.
+- Passed: byte comparison of the complete moved function cluster (apart from
+  its export keyword), private helper bodies, and stack startup/lifecycle body.
+- Frog list checked after frozen installation; no task-specific friction entry.
+- Broad runtime/acceptance proof, final review and exact-head CI belong to the
+  root completion owner. No live stack or deployed runtime was exercised locally.
+Completed: 2026-09-10

--- a/packages/hosted-local-harness/README.md
+++ b/packages/hosted-local-harness/README.md
@@ -44,6 +44,11 @@ setting the internal `MURPH_DEV_SKIP_RUNNER_BUNDLE=1` flag supply both an existi
 runner bundle and prepared workspace artifacts; the public `--no-bundle` E2E
 command owns the workspace preparation described above.
 
+`src/dev-hosted-local/cloudflare-source-snapshot.ts` owns the temporary Worker
+source copy and built workspace dependency materialization. `stack.ts` prepares
+the runner bundle first, then supplies the resulting snapshot paths to Wrangler;
+startup, readiness, and teardown remain with the stack.
+
 `doctor` reports Docker daemon and Buildx prerequisites separately. Isolated
 Docker configuration selects the first candidate plugin directory containing an
 executable `docker-buildx`, so an empty or unusable earlier directory cannot hide

--- a/packages/hosted-local-harness/src/dev-hosted-local/cloudflare-source-snapshot.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/cloudflare-source-snapshot.ts
@@ -1,0 +1,275 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { access, copyFile, cp, mkdir, rm, symlink } from "node:fs/promises";
+import path from "node:path";
+
+import { cloudflareDir, HOSTED_LOCAL_RUNNER_BUNDLE_ROOT, repoRoot } from "./constants.ts";
+import { throwIfAbortSignalAborted } from "./runtime.ts";
+
+const HOSTED_LOCAL_CLOUDFLARE_SOURCE_SNAPSHOT_DIR = "cloudflare-source";
+const HOSTED_LOCAL_WORKSPACE_PACKAGE_SCOPE = "@murphai/";
+
+type HostedLocalCloudflareSourceSnapshot = {
+  cloudflareAppDir: string;
+  workspaceRoot: string;
+};
+
+type HostedLocalWorkspacePackage = {
+  dependencies: readonly string[];
+  dir: string;
+  externalDependencies: readonly string[];
+  packageJsonPath: string;
+};
+
+export async function prepareHostedLocalCloudflareSourceSnapshot(input: {
+  abortSignal: AbortSignal | undefined;
+  tempDir: string;
+}): Promise<HostedLocalCloudflareSourceSnapshot> {
+  const workspaceRoot = path.join(
+    input.tempDir,
+    HOSTED_LOCAL_CLOUDFLARE_SOURCE_SNAPSHOT_DIR,
+  );
+  const cloudflareAppDir = path.join(workspaceRoot, "apps", "cloudflare");
+
+  await rm(workspaceRoot, { force: true, recursive: true });
+  await mkdir(cloudflareAppDir, { recursive: true });
+  throwIfAbortSignalAborted(input.abortSignal);
+
+  await copyFile(
+    path.join(repoRoot, "Dockerfile.cloudflare-hosted-runner"),
+    path.join(workspaceRoot, "Dockerfile.cloudflare-hosted-runner"),
+  );
+  await copyFile(
+    path.join(cloudflareDir, "package.json"),
+    path.join(cloudflareAppDir, "package.json"),
+  );
+  await copyFile(
+    path.join(cloudflareDir, ".dockerignore"),
+    path.join(cloudflareAppDir, ".dockerignore"),
+  );
+  await cp(
+    path.join(cloudflareDir, "src"),
+    path.join(cloudflareAppDir, "src"),
+    { recursive: true },
+  );
+  throwIfAbortSignalAborted(input.abortSignal);
+
+  await mkdir(path.join(cloudflareAppDir, ".deploy"), { recursive: true });
+  await cp(
+    HOSTED_LOCAL_RUNNER_BUNDLE_ROOT,
+    path.join(cloudflareAppDir, ".deploy", "runner-bundle"),
+    { recursive: true },
+  );
+  await symlinkIfPresent(
+    path.join(repoRoot, "node_modules"),
+    path.join(workspaceRoot, "node_modules"),
+  );
+  await materializeHostedLocalCloudflareWorkspacePackages({
+    abortSignal: input.abortSignal,
+    cloudflareAppDir,
+  });
+
+  return { cloudflareAppDir, workspaceRoot };
+}
+
+async function materializeHostedLocalCloudflareWorkspacePackages(input: {
+  abortSignal: AbortSignal | undefined;
+  cloudflareAppDir: string;
+}): Promise<void> {
+  const packagesByName = discoverHostedLocalWorkspacePackages();
+  const packageNames = resolveHostedLocalCloudflareWorkspacePackageNames(packagesByName);
+  const nodeModulesRoot = path.join(input.cloudflareAppDir, "node_modules");
+  const cloudflarePackageJson = readPackageJsonRecord(
+    path.join(cloudflareDir, "package.json"),
+  );
+
+  await rm(
+    path.join(nodeModulesRoot, HOSTED_LOCAL_WORKSPACE_PACKAGE_SCOPE.slice(0, -1)),
+    { force: true, recursive: true },
+  );
+
+  for (const packageName of packageNames) {
+    throwIfAbortSignalAborted(input.abortSignal);
+    const workspacePackage = packagesByName.get(packageName);
+    if (!workspacePackage) {
+      throw new Error(
+        `Hosted local Cloudflare snapshot could not find workspace package ${packageName}.`,
+      );
+    }
+
+    const packageTargetDir = path.join(nodeModulesRoot, ...packageName.split("/"));
+    const sourceDistDir = path.join(workspacePackage.dir, "dist");
+    if (!existsSync(sourceDistDir)) {
+      throw new Error(
+        `Hosted local Cloudflare snapshot requires ${packageName}/dist. Run the package build before starting pnpm dev.`,
+      );
+    }
+
+    await mkdir(packageTargetDir, { recursive: true });
+    await copyFile(
+      workspacePackage.packageJsonPath,
+      path.join(packageTargetDir, "package.json"),
+    );
+    await cp(sourceDistDir, path.join(packageTargetDir, "dist"), {
+      recursive: true,
+    });
+    await linkHostedLocalExternalDependencies({
+      dependencyNames: workspacePackage.externalDependencies,
+      sourceNodeModulesRoot: path.join(workspacePackage.dir, "node_modules"),
+      targetNodeModulesRoot: path.join(packageTargetDir, "node_modules"),
+    });
+  }
+
+  await linkHostedLocalExternalDependencies({
+    dependencyNames: readExternalDependencyNames(cloudflarePackageJson),
+    sourceNodeModulesRoot: path.join(cloudflareDir, "node_modules"),
+    targetNodeModulesRoot: nodeModulesRoot,
+  });
+}
+
+async function linkHostedLocalExternalDependencies(input: {
+  dependencyNames: readonly string[];
+  sourceNodeModulesRoot: string;
+  targetNodeModulesRoot: string;
+}): Promise<void> {
+  for (const dependencyName of input.dependencyNames) {
+    const dependencyParts = dependencyName.split("/");
+    const sourcePath = path.join(input.sourceNodeModulesRoot, ...dependencyParts);
+    const targetPath = path.join(input.targetNodeModulesRoot, ...dependencyParts);
+
+    await mkdir(path.dirname(targetPath), { recursive: true });
+    await symlinkIfPresent(sourcePath, targetPath);
+  }
+}
+
+function resolveHostedLocalCloudflareWorkspacePackageNames(
+  packagesByName: ReadonlyMap<string, HostedLocalWorkspacePackage>,
+): readonly string[] {
+  const cloudflarePackageJsonPath = path.join(cloudflareDir, "package.json");
+  const cloudflarePackageJson = readPackageJsonRecord(cloudflarePackageJsonPath);
+  const queue = readWorkspaceDependencyNames(cloudflarePackageJson);
+  const names: string[] = [];
+  const seen = new Set<string>();
+
+  for (let index = 0; index < queue.length; index += 1) {
+    const packageName = queue[index];
+    if (seen.has(packageName)) {
+      continue;
+    }
+
+    const workspacePackage = packagesByName.get(packageName);
+    if (!workspacePackage) {
+      throw new Error(
+        `Cloudflare depends on ${packageName}, but no matching workspace package was found.`,
+      );
+    }
+
+    seen.add(packageName);
+    names.push(packageName);
+    queue.push(...workspacePackage.dependencies);
+  }
+
+  return names;
+}
+
+function discoverHostedLocalWorkspacePackages(): ReadonlyMap<string, HostedLocalWorkspacePackage> {
+  const packagesRoot = path.join(repoRoot, "packages");
+  const packagesByName = new Map<string, HostedLocalWorkspacePackage>();
+
+  for (const entry of readdirSync(packagesRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const packageJsonPath = path.join(packagesRoot, entry.name, "package.json");
+    if (!existsSync(packageJsonPath)) {
+      continue;
+    }
+
+    const packageJson = readPackageJsonRecord(packageJsonPath);
+    const packageName = packageJson.name;
+    if (
+      typeof packageName !== "string"
+      || !packageName.startsWith(HOSTED_LOCAL_WORKSPACE_PACKAGE_SCOPE)
+    ) {
+      continue;
+    }
+
+    packagesByName.set(packageName, {
+      dependencies: readWorkspaceDependencyNames(packageJson),
+      dir: path.dirname(packageJsonPath),
+      externalDependencies: readExternalDependencyNames(packageJson),
+      packageJsonPath,
+    });
+  }
+
+  return packagesByName;
+}
+
+function readPackageJsonRecord(packageJsonPath: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  if (!isRecord(parsed)) {
+    throw new Error(`Invalid package.json at ${formatRepoPath(packageJsonPath)}.`);
+  }
+
+  return parsed;
+}
+
+function readWorkspaceDependencyNames(
+  packageJson: Record<string, unknown>,
+): string[] {
+  return readPackageDependencyNames(packageJson, "workspace");
+}
+
+function readExternalDependencyNames(
+  packageJson: Record<string, unknown>,
+): string[] {
+  return readPackageDependencyNames(packageJson, "external");
+}
+
+function readPackageDependencyNames(
+  packageJson: Record<string, unknown>,
+  kind: "external" | "workspace",
+): string[] {
+  const dependencies = isRecord(packageJson.dependencies)
+    ? packageJson.dependencies
+    : {};
+
+  return Object.entries(dependencies)
+    .filter(([name, version]) => {
+      if (typeof version !== "string") {
+        return false;
+      }
+
+      const workspaceDependency =
+        name.startsWith(HOSTED_LOCAL_WORKSPACE_PACKAGE_SCOPE)
+        && version.startsWith("workspace:");
+      return kind === "workspace" ? workspaceDependency : !workspaceDependency;
+    })
+    .map(([name]) => name);
+}
+
+async function symlinkIfPresent(sourcePath: string, targetPath: string): Promise<void> {
+  try {
+    await access(sourcePath);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return;
+    }
+
+    throw error;
+  }
+
+  await symlink(sourcePath, targetPath, "dir");
+}
+
+function formatRepoPath(filePath: string): string {
+  return path.relative(repoRoot, filePath).replaceAll(path.sep, "/");
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/hosted-local-harness/src/dev-hosted-local/constants.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/constants.ts
@@ -94,6 +94,13 @@ export const HOSTED_LOCAL_CLOUDFLARE_ACCOUNT_ID =
 export const webDir = path.join(repoRoot, "apps", "web");
 export const cloudflareDir = path.join(repoRoot, "apps", "cloudflare");
 export const cloudflareDevVarsPath = path.join(cloudflareDir, ".dev.vars");
+export const HOSTED_LOCAL_RUNNER_BUNDLE_ROOT = path.join(
+  repoRoot,
+  "apps",
+  "cloudflare",
+  ".deploy",
+  "runner-bundle",
+);
 export const vercelLinkCandidatePaths = [
   path.join(webDir, ".vercel", "project.json"),
   path.join(webDir, ".vercel", "repo.json"),

--- a/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
@@ -1,7 +1,7 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { constants, existsSync, readdirSync, readFileSync } from "node:fs";
-import { access, chmod, copyFile, cp, mkdir, mkdtemp, readFile, rename, rm, symlink, utimes, writeFile } from "node:fs/promises";
+import { constants, existsSync } from "node:fs";
+import { access, chmod, cp, mkdir, mkdtemp, readFile, rename, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -16,6 +16,7 @@ import {
   resolveHostedLocalCodexSubscriptionAuthEnvValue,
   shouldSeedHostedLocalCodexSubscriptionAuth,
 } from "./codex-subscription-auth.ts";
+import { prepareHostedLocalCloudflareSourceSnapshot } from "./cloudflare-source-snapshot.ts";
 import { resolveHostedLocalDevConfig } from "./config.ts";
 import {
   cloudflareDir,
@@ -25,6 +26,7 @@ import {
   DEFAULT_WORKER_PERSIST_DIR,
   DEFAULT_WORKER_PORT,
   HOSTED_LOCAL_WORKTREE_ROOT,
+  HOSTED_LOCAL_RUNNER_BUNDLE_ROOT,
   HOSTED_LOCAL_DEPLOY_SMOKE_USE_BUILD_ID_ENV,
   HOSTED_LOCAL_WORKTREE_SCOPE_ENV,
   HOSTED_RUNTIME_CODEX_CHATGPT_AUTH_JSON_ENV,
@@ -199,30 +201,8 @@ const HOSTED_LOCAL_OPENAI_FLEX_SERVICE_TIER = {
 } as const;
 const HOSTED_LOCAL_DEPLOY_SMOKE_MODEL_SLUG = "gpt-5.4-nano";
 const HOSTED_LOCAL_DEPLOY_SMOKE_TEMPLATE_MODEL_SLUG = "gpt-5.4-mini";
-const HOSTED_LOCAL_RUNNER_BUNDLE_ROOT = path.join(
-  repoRoot,
-  "apps",
-  "cloudflare",
-  ".deploy",
-  "runner-bundle",
-);
 const HOSTED_LOCAL_RUNNER_BUNDLE_MANIFEST_FILE =
   ".murph-runner-bundle-manifest.json";
-const HOSTED_LOCAL_CLOUDFLARE_SOURCE_SNAPSHOT_DIR = "cloudflare-source";
-const HOSTED_LOCAL_WORKSPACE_PACKAGE_SCOPE = "@murphai/";
-
-type HostedLocalCloudflareSourceSnapshot = {
-  cloudflareAppDir: string;
-  workspaceRoot: string;
-};
-
-type HostedLocalWorkspacePackage = {
-  dependencies: readonly string[];
-  dir: string;
-  externalDependencies: readonly string[];
-  packageJsonPath: string;
-};
-
 function registerHostedLocalStackLifecycle(input: {
   abortSignal?: AbortSignal;
   kill: (signal?: NodeJS.Signals) => void;
@@ -1867,248 +1847,6 @@ function usesHostedLocalIsolatedRunnerScope(env: NodeJS.ProcessEnv): boolean {
 function shouldUseIsolatedDockerConfig(env: NodeJS.ProcessEnv): boolean {
   return requiresHostedLocalE2eIsolation(env)
     && env[HOSTED_LOCAL_PRESERVE_DOCKER_CONFIG_ENV]?.trim() !== "1";
-}
-
-async function prepareHostedLocalCloudflareSourceSnapshot(input: {
-  abortSignal: AbortSignal | undefined;
-  tempDir: string;
-}): Promise<HostedLocalCloudflareSourceSnapshot> {
-  const workspaceRoot = path.join(
-    input.tempDir,
-    HOSTED_LOCAL_CLOUDFLARE_SOURCE_SNAPSHOT_DIR,
-  );
-  const cloudflareAppDir = path.join(workspaceRoot, "apps", "cloudflare");
-
-  await rm(workspaceRoot, { force: true, recursive: true });
-  await mkdir(cloudflareAppDir, { recursive: true });
-  throwIfAbortSignalAborted(input.abortSignal);
-
-  await copyFile(
-    path.join(repoRoot, "Dockerfile.cloudflare-hosted-runner"),
-    path.join(workspaceRoot, "Dockerfile.cloudflare-hosted-runner"),
-  );
-  await copyFile(
-    path.join(cloudflareDir, "package.json"),
-    path.join(cloudflareAppDir, "package.json"),
-  );
-  await copyFile(
-    path.join(cloudflareDir, ".dockerignore"),
-    path.join(cloudflareAppDir, ".dockerignore"),
-  );
-  await cp(
-    path.join(cloudflareDir, "src"),
-    path.join(cloudflareAppDir, "src"),
-    { recursive: true },
-  );
-  throwIfAbortSignalAborted(input.abortSignal);
-
-  await mkdir(path.join(cloudflareAppDir, ".deploy"), { recursive: true });
-  await cp(
-    HOSTED_LOCAL_RUNNER_BUNDLE_ROOT,
-    path.join(cloudflareAppDir, ".deploy", "runner-bundle"),
-    { recursive: true },
-  );
-  await symlinkIfPresent(
-    path.join(repoRoot, "node_modules"),
-    path.join(workspaceRoot, "node_modules"),
-  );
-  await materializeHostedLocalCloudflareWorkspacePackages({
-    abortSignal: input.abortSignal,
-    cloudflareAppDir,
-  });
-
-  return { cloudflareAppDir, workspaceRoot };
-}
-
-async function materializeHostedLocalCloudflareWorkspacePackages(input: {
-  abortSignal: AbortSignal | undefined;
-  cloudflareAppDir: string;
-}): Promise<void> {
-  const packagesByName = discoverHostedLocalWorkspacePackages();
-  const packageNames = resolveHostedLocalCloudflareWorkspacePackageNames(packagesByName);
-  const nodeModulesRoot = path.join(input.cloudflareAppDir, "node_modules");
-  const cloudflarePackageJson = readPackageJsonRecord(
-    path.join(cloudflareDir, "package.json"),
-  );
-
-  await rm(
-    path.join(nodeModulesRoot, HOSTED_LOCAL_WORKSPACE_PACKAGE_SCOPE.slice(0, -1)),
-    { force: true, recursive: true },
-  );
-
-  for (const packageName of packageNames) {
-    throwIfAbortSignalAborted(input.abortSignal);
-    const workspacePackage = packagesByName.get(packageName);
-    if (!workspacePackage) {
-      throw new Error(
-        `Hosted local Cloudflare snapshot could not find workspace package ${packageName}.`,
-      );
-    }
-
-    const packageTargetDir = path.join(nodeModulesRoot, ...packageName.split("/"));
-    const sourceDistDir = path.join(workspacePackage.dir, "dist");
-    if (!existsSync(sourceDistDir)) {
-      throw new Error(
-        `Hosted local Cloudflare snapshot requires ${packageName}/dist. Run the package build before starting pnpm dev.`,
-      );
-    }
-
-    await mkdir(packageTargetDir, { recursive: true });
-    await copyFile(
-      workspacePackage.packageJsonPath,
-      path.join(packageTargetDir, "package.json"),
-    );
-    await cp(sourceDistDir, path.join(packageTargetDir, "dist"), {
-      recursive: true,
-    });
-    await linkHostedLocalExternalDependencies({
-      dependencyNames: workspacePackage.externalDependencies,
-      sourceNodeModulesRoot: path.join(workspacePackage.dir, "node_modules"),
-      targetNodeModulesRoot: path.join(packageTargetDir, "node_modules"),
-    });
-  }
-
-  await linkHostedLocalExternalDependencies({
-    dependencyNames: readExternalDependencyNames(cloudflarePackageJson),
-    sourceNodeModulesRoot: path.join(cloudflareDir, "node_modules"),
-    targetNodeModulesRoot: nodeModulesRoot,
-  });
-}
-
-async function linkHostedLocalExternalDependencies(input: {
-  dependencyNames: readonly string[];
-  sourceNodeModulesRoot: string;
-  targetNodeModulesRoot: string;
-}): Promise<void> {
-  for (const dependencyName of input.dependencyNames) {
-    const dependencyParts = dependencyName.split("/");
-    const sourcePath = path.join(input.sourceNodeModulesRoot, ...dependencyParts);
-    const targetPath = path.join(input.targetNodeModulesRoot, ...dependencyParts);
-
-    await mkdir(path.dirname(targetPath), { recursive: true });
-    await symlinkIfPresent(sourcePath, targetPath);
-  }
-}
-
-function resolveHostedLocalCloudflareWorkspacePackageNames(
-  packagesByName: ReadonlyMap<string, HostedLocalWorkspacePackage>,
-): readonly string[] {
-  const cloudflarePackageJsonPath = path.join(cloudflareDir, "package.json");
-  const cloudflarePackageJson = readPackageJsonRecord(cloudflarePackageJsonPath);
-  const queue = readWorkspaceDependencyNames(cloudflarePackageJson);
-  const names: string[] = [];
-  const seen = new Set<string>();
-
-  for (let index = 0; index < queue.length; index += 1) {
-    const packageName = queue[index];
-    if (seen.has(packageName)) {
-      continue;
-    }
-
-    const workspacePackage = packagesByName.get(packageName);
-    if (!workspacePackage) {
-      throw new Error(
-        `Cloudflare depends on ${packageName}, but no matching workspace package was found.`,
-      );
-    }
-
-    seen.add(packageName);
-    names.push(packageName);
-    queue.push(...workspacePackage.dependencies);
-  }
-
-  return names;
-}
-
-function discoverHostedLocalWorkspacePackages(): ReadonlyMap<string, HostedLocalWorkspacePackage> {
-  const packagesRoot = path.join(repoRoot, "packages");
-  const packagesByName = new Map<string, HostedLocalWorkspacePackage>();
-
-  for (const entry of readdirSync(packagesRoot, { withFileTypes: true })) {
-    if (!entry.isDirectory()) {
-      continue;
-    }
-
-    const packageJsonPath = path.join(packagesRoot, entry.name, "package.json");
-    if (!existsSync(packageJsonPath)) {
-      continue;
-    }
-
-    const packageJson = readPackageJsonRecord(packageJsonPath);
-    const packageName = packageJson.name;
-    if (
-      typeof packageName !== "string"
-      || !packageName.startsWith(HOSTED_LOCAL_WORKSPACE_PACKAGE_SCOPE)
-    ) {
-      continue;
-    }
-
-    packagesByName.set(packageName, {
-      dependencies: readWorkspaceDependencyNames(packageJson),
-      dir: path.dirname(packageJsonPath),
-      externalDependencies: readExternalDependencyNames(packageJson),
-      packageJsonPath,
-    });
-  }
-
-  return packagesByName;
-}
-
-function readPackageJsonRecord(packageJsonPath: string): Record<string, unknown> {
-  const parsed: unknown = JSON.parse(readFileSync(packageJsonPath, "utf8"));
-  if (!isRecord(parsed)) {
-    throw new Error(`Invalid package.json at ${formatRepoPath(packageJsonPath)}.`);
-  }
-
-  return parsed;
-}
-
-function readWorkspaceDependencyNames(
-  packageJson: Record<string, unknown>,
-): string[] {
-  return readPackageDependencyNames(packageJson, "workspace");
-}
-
-function readExternalDependencyNames(
-  packageJson: Record<string, unknown>,
-): string[] {
-  return readPackageDependencyNames(packageJson, "external");
-}
-
-function readPackageDependencyNames(
-  packageJson: Record<string, unknown>,
-  kind: "external" | "workspace",
-): string[] {
-  const dependencies = isRecord(packageJson.dependencies)
-    ? packageJson.dependencies
-    : {};
-
-  return Object.entries(dependencies)
-    .filter(([name, version]) => {
-      if (typeof version !== "string") {
-        return false;
-      }
-
-      const workspaceDependency =
-        name.startsWith(HOSTED_LOCAL_WORKSPACE_PACKAGE_SCOPE)
-        && version.startsWith("workspace:");
-      return kind === "workspace" ? workspaceDependency : !workspaceDependency;
-    })
-    .map(([name]) => name);
-}
-
-async function symlinkIfPresent(sourcePath: string, targetPath: string): Promise<void> {
-  try {
-    await access(sourcePath);
-  } catch (error) {
-    if (isNodeError(error) && error.code === "ENOENT") {
-      return;
-    }
-
-    throw error;
-  }
-
-  await symlink(sourcePath, targetPath, "dir");
 }
 
 async function maybePersistHostedLocalLinqWebhookSecret(input: {

--- a/packages/hosted-local-harness/test/dev-hosted-local/cloudflare-source-snapshot.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/cloudflare-source-snapshot.test.ts
@@ -1,0 +1,193 @@
+import { cp, lstat, mkdir, mkdtemp, readFile, readlink, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fixture = vi.hoisted(() => ({ root: "" }));
+
+vi.mock("../../src/dev-hosted-local/constants.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/dev-hosted-local/constants.ts")>();
+  return {
+    ...actual,
+    get repoRoot() { return fixture.root; },
+    get cloudflareDir() { return path.join(fixture.root, "apps", "cloudflare"); },
+    get HOSTED_LOCAL_RUNNER_BUNDLE_ROOT() {
+      return path.join(fixture.root, "apps", "cloudflare", ".deploy", "runner-bundle");
+    },
+  };
+});
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return { ...actual, cp: vi.fn(actual.cp) };
+});
+
+async function writeFixtureFile(relativePath: string, text: string): Promise<void> {
+  const filePath = path.join(fixture.root, relativePath);
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, text);
+}
+
+async function writeWorkspacePackage(
+  slug: string,
+  dependencies: Record<string, unknown> = {},
+): Promise<void> {
+  await writeFixtureFile(`packages/${slug}/package.json`, JSON.stringify({
+    name: `@murphai/${slug}`,
+    dependencies,
+  }));
+  await writeFixtureFile(`packages/${slug}/dist/index.js`, `export const name = "${slug}";`);
+}
+
+async function prepareSnapshot(abortSignal?: AbortSignal) {
+  const { prepareHostedLocalCloudflareSourceSnapshot } = await import(
+    "../../src/dev-hosted-local/cloudflare-source-snapshot.ts"
+  );
+  return await prepareHostedLocalCloudflareSourceSnapshot({
+    abortSignal,
+    tempDir: path.join(fixture.root, "output"),
+  });
+}
+
+describe("hosted-local Cloudflare source snapshot", () => {
+  beforeEach(async () => {
+    const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    vi.mocked(cp).mockReset().mockImplementation(actual.cp);
+    fixture.root = await mkdtemp(path.join(os.tmpdir(), "murph-source-snapshot-"));
+    await writeFixtureFile("Dockerfile.cloudflare-hosted-runner", "FROM fixture-runner\n");
+    await writeFixtureFile("apps/cloudflare/.dockerignore", "node_modules\n");
+    await writeFixtureFile("apps/cloudflare/src/index.ts", "export const worker = true;\n");
+    await writeFixtureFile("apps/cloudflare/.deploy/runner-bundle/index.js", "runner bundle\n");
+    await writeFixtureFile("apps/cloudflare/package.json", JSON.stringify({
+      dependencies: { "@murphai/alpha": "workspace:*", "@murphai/beta": "workspace:*" },
+      devDependencies: { "@murphai/unused-dev": "workspace:*" },
+    }));
+    await writeWorkspacePackage("alpha", { "@murphai/shared": "workspace:*" });
+    await writeWorkspacePackage("beta", { "@murphai/shared": "workspace:*" });
+    await writeWorkspacePackage("shared", { "@murphai/alpha": "workspace:*" });
+  });
+
+  afterEach(async () => {
+    await rm(fixture.root, { force: true, recursive: true });
+  });
+
+  it("copies the dependency closure once in breadth-first order and isolates built artifacts", async () => {
+    await writeWorkspacePackage("unreferenced");
+    await writeFixtureFile("packages/not-workspace/package.json", '{"name":"external-package"}');
+    await mkdir(path.join(fixture.root, "packages", "without-manifest"));
+    await writeFixtureFile("packages/README.txt", "ignored file");
+    await writeFixtureFile("output/cloudflare-source/stale.txt", "stale snapshot");
+
+    const snapshot = await prepareSnapshot();
+    expect(snapshot).toEqual({
+      cloudflareAppDir: path.join(fixture.root, "output/cloudflare-source/apps/cloudflare"),
+      workspaceRoot: path.join(fixture.root, "output/cloudflare-source"),
+    });
+    const packagesRoot = path.join(snapshot.cloudflareAppDir, "node_modules", "@murphai");
+    expect(vi.mocked(cp).mock.calls
+      .map(([, destination]) => String(destination))
+      .filter((destination) => destination.endsWith(`${path.sep}dist`)))
+      .toEqual(["alpha", "beta", "shared"].map((slug) => path.join(packagesRoot, slug, "dist")));
+    expect(await readFile(path.join(snapshot.workspaceRoot, "Dockerfile.cloudflare-hosted-runner"), "utf8"))
+      .toBe("FROM fixture-runner\n");
+    expect(await readFile(path.join(snapshot.cloudflareAppDir, ".dockerignore"), "utf8"))
+      .toBe("node_modules\n");
+    expect(await readFile(path.join(snapshot.cloudflareAppDir, ".deploy/runner-bundle/index.js"), "utf8"))
+      .toBe("runner bundle\n");
+    expect(await readFile(path.join(packagesRoot, "alpha/package.json"), "utf8"))
+      .toBe(await readFile(path.join(fixture.root, "packages/alpha/package.json"), "utf8"));
+    await writeFixtureFile("packages/alpha/dist/index.js", "changed after snapshot");
+    await writeFixtureFile("apps/cloudflare/src/index.ts", "changed after snapshot");
+    expect(await readFile(path.join(packagesRoot, "alpha/dist/index.js"), "utf8"))
+      .toBe('export const name = "alpha";');
+    expect(await readFile(path.join(snapshot.cloudflareAppDir, "src/index.ts"), "utf8"))
+      .toBe("export const worker = true;\n");
+    await expect(lstat(path.join(snapshot.workspaceRoot, "stale.txt"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(lstat(path.join(packagesRoot, "unreferenced"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("links individual installed external dependencies without aliasing Cloudflare node_modules", async () => {
+    await writeWorkspacePackage("alpha", {
+      zod: "1.0.0",
+      "@vendor/tool": "1.0.0",
+      "@murphai/published": "1.0.0",
+      missing: "1.0.0",
+      invalid: 42,
+    });
+    await writeFixtureFile("apps/cloudflare/package.json", JSON.stringify({
+      dependencies: { "@murphai/alpha": "workspace:*", jose: "1.0.0" },
+    }));
+    for (const relativePath of [
+      "node_modules/root-only/index.js",
+      "packages/alpha/node_modules/zod/index.js",
+      "packages/alpha/node_modules/@vendor/tool/index.js",
+      "packages/alpha/node_modules/@murphai/published/index.js",
+      "apps/cloudflare/node_modules/jose/index.js",
+    ]) {
+      await writeFixtureFile(relativePath, "external fixture");
+    }
+
+    const snapshot = await prepareSnapshot();
+    const nodeModulesRoot = path.join(snapshot.cloudflareAppDir, "node_modules");
+    expect((await lstat(nodeModulesRoot)).isSymbolicLink()).toBe(false);
+    expect(await readlink(path.join(snapshot.workspaceRoot, "node_modules")))
+      .toBe(path.join(fixture.root, "node_modules"));
+    expect(await readlink(path.join(nodeModulesRoot, "jose")))
+      .toBe(path.join(fixture.root, "apps/cloudflare/node_modules/jose"));
+    for (const dependency of ["zod", "@vendor/tool", "@murphai/published"]) {
+      expect(await readlink(path.join(nodeModulesRoot, "@murphai/alpha/node_modules", dependency)))
+        .toBe(path.join(fixture.root, "packages/alpha/node_modules", dependency));
+    }
+    for (const dependency of ["missing", "invalid"]) {
+      await expect(lstat(path.join(nodeModulesRoot, "@murphai/alpha/node_modules", dependency)))
+        .rejects.toMatchObject({ code: "ENOENT" });
+    }
+  });
+
+  it("rejects a missing transitive workspace package before materializing packages", async () => {
+    await writeWorkspacePackage("shared", { "@murphai/missing": "workspace:*" });
+    await expect(prepareSnapshot()).rejects.toThrow(
+      "Cloudflare depends on @murphai/missing, but no matching workspace package was found.",
+    );
+    expect(vi.mocked(cp).mock.calls.some(([, destination]) => String(destination).endsWith(`${path.sep}dist`)))
+      .toBe(false);
+  });
+
+  it("rejects an unbuilt workspace package and leaves later packages untouched", async () => {
+    await rm(path.join(fixture.root, "packages/alpha/dist"), { recursive: true });
+    await expect(prepareSnapshot()).rejects.toThrow(
+      "Hosted local Cloudflare snapshot requires @murphai/alpha/dist. Run the package build before starting pnpm dev.",
+    );
+    await expect(lstat(path.join(fixture.root, "output/cloudflare-source/apps/cloudflare/node_modules/@murphai/beta")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects a non-object manifest with a repository-relative diagnostic", async () => {
+    await writeFixtureFile("packages/alpha/package.json", "[]");
+    await expect(prepareSnapshot()).rejects.toThrow("Invalid package.json at packages/alpha/package.json.");
+  });
+
+  it("stops an already-aborted build before copying source", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(prepareSnapshot(controller.signal)).rejects.toMatchObject({ name: "AbortError" });
+    expect(cp).not.toHaveBeenCalled();
+  });
+
+  it("checks cancellation between workspace packages", async () => {
+    const controller = new AbortController();
+    const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    vi.mocked(cp).mockImplementation(async (source, destination, options) => {
+      await actual.cp(source, destination, options);
+      if (String(source) === path.join(fixture.root, "packages/alpha/dist")) {
+        controller.abort();
+      }
+    });
+    await expect(prepareSnapshot(controller.signal)).rejects.toMatchObject({ name: "AbortError" });
+    const packagesRoot = path.join(fixture.root, "output/cloudflare-source/apps/cloudflare/node_modules/@murphai");
+    expect(await readFile(path.join(packagesRoot, "alpha/dist/index.js"), "utf8"))
+      .toBe('export const name = "alpha";');
+    await expect(lstat(path.join(packagesRoot, "beta"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});


### PR DESCRIPTION
## Why and outcome

Hosted-local stack startup also owned source copying, workspace dependency traversal, and built-package materialization. Move that complete filesystem responsibility into `cloudflare-source-snapshot.ts`, so isolation and dependency failures can be tested without configuring the full stack lifecycle.

Keep the snapshot algorithm and startup ordering unchanged. The shared runner-bundle path stays with existing path constants; the stack still prepares the bundle, passes snapshot paths to Wrangler, and owns readiness and teardown.

## Product UX

- Effort: Not applicable — internal hosted-local implementation extraction.
- Result: Not applicable.
- Walkthrough: Existing CLI and programmatic stack entrypoints retain the same behavior. No member-facing journey changes.

## Evidence

- Direct: Seven new tests use a real synthetic filesystem for breadth-first traversal with cycles, ignored packages/dependencies, independent source/dist copies, exact external dependency links, missing packages/dist, invalid manifests, and cancellation before copying and between packages.
- Coverage: All 94 tests in five focused files pass, including stack, main, harness, and public package resolution with `MURPH_HOSTED_LOCAL_HARNESS_TEST_PACKAGE_BOUNDARY=1`. Existing stack assertions continue to check snapshot paths and prohibit aliasing the entire Cloudflare `node_modules` directory.
- Source equivalence: The entire moved function cluster differs only by its exported entrypoint; the private helper bodies and stack startup/lifecycle body match the base byte-for-byte.
- Passed: `pnpm install --frozen-lockfile --reporter append-only`; own prerequisite closure with `pnpm --filter '@murphai/hosted-local-harness^...' --workspace-concurrency=1 run build`; `pnpm --dir packages/hosted-local-harness typecheck`.
- Focused command: `MURPH_HOSTED_LOCAL_HARNESS_TEST_PACKAGE_BOUNDARY=1 pnpm --dir packages/hosted-local-harness exec vitest run --config vitest.config.ts --no-coverage --maxWorkers=2 --silent=true test/dev-hosted-local/cloudflare-source-snapshot.test.ts test/dev-hosted-local/stack.test.ts test/dev-hosted-local/main.test.ts test/harness.test.ts test/package-boundary.test.ts`.
- Scope: Local deterministic proof only. Required exact-head CI and final ReviewGPT remain with the completion owner; no live stack or deployed runtime was exercised locally.

## Non-obvious affected surfaces

The existing advertised stack entrypoint is imported by CLI, main, and programmatic harness callers; all retain coverage, including real package resolution. Concurrent authentication retirement PR #3134 touches the same stack files, but its snapshot cluster and snapshot assertions match this base; authentication and lifecycle integration are unchanged here.

## Architecture and reuse

- Existing systems reused: Existing repository/Cloudflare path constants, the runtime abort checker, Node filesystem operations, and the stack's single startup callsite.
- New logic: None in production. Traversal ordering, missing/skip rules, copy operations, errors, and external symlink behavior are preserved.
- New abstractions: One concrete source-snapshot module owns the complete filesystem preparation cluster and its private types. No package manifest or existing public entrypoint changes.
- Complexity intentionally avoided: No generic dependency-graph framework, lifecycle wrapper, test-only runtime parameter, reverse import, new dependency, or alternate state owner. Publication helpers have different filtering and failure semantics and are not imported into the harness.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base b80bd40f84d1b367c1810e2fe046e3089cc28aa4`.
- Hotspots: `startHostedLocalDevStack` remains at 139, with unchanged debt 119. It owns coupled startup, cancellation, readiness, and teardown. The extracted module has maximum complexity 6 and zero debt; the guard recognizes 12 exact moved functions.
- Agent judgment: This extraction gives filesystem preparation a direct test boundary. Further splitting the shared stack lifecycle is not justified by this change.

## Hot reply path impact

- Path status: Not applicable — local harness source preparation precedes local Worker startup; production message processing is untouched.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: Existing local filesystem operations retain the same order and callsite.
- Before/after proof: Exact source identity plus preserved stack integration tests.

## Murph initial provider input impact

Not applicable to individual and group runtimes: no provider-input builder, prompt, tool/schema definition, model catalog, or generated guidance changes.

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal local harness extraction with unchanged stack contract and filesystem output. No deployed service, persisted schema, or cross-version protocol changes.

## Change-shape breakdown

Classification rule: Harness implementation is Source; its focused test is Tests / fixtures; README and completed execution plan are Docs. No generated output or binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 286 | 266 |
| Tests / fixtures | 193 | 0 |
| Docs | 90 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **569** | **266** |

## Changelog

- Changelog: not applicable
- Reason: Internal hosted-local source ownership and testability change; no member-visible behavior changes.

ReviewGPT first-reviewed head: cda76d6dd8c8726a487b93ce94a580d574502b35

ReviewGPT context sensitivity: sensitive

Classification reason: Extracts filesystem ownership from hosted-local startup; snapshot isolation and lifecycle composition require full-patch review.

## Final review evidence

- Parent candidate review: passed; no unresolved findings.
- ReviewGPT round 1: PASS on `cda76d6dd8c8726a487b93ce94a580d574502b35`, with no qualifying findings. The full-snapshot review checked the moved source, callers, public package boundary, filesystem isolation, dependency traversal, cancellation, and lifecycle composition.
- Acceptance: exact submitted turn, response hash, completion marker, `gpt-6-pro` model metadata, round-1 baseline, and empty remediation deltas verified (Apollo; approximately 450.3 seconds from send to captured response).
- Tooling retries: Phlebas failed model selection before send; Mountain returned after 246 seconds and was rejected below the repository minimum. Both are excluded from final proof; the accepted Apollo run used the same commit and round number.
- Response SHA-256: `cdd7e84be0a4f3d9d9912932ebdc607a6a7f661c0ca997a06bc3f99675193b72`.
- Integration: conflict-free against `006ce0768111cac657518a79f3074b81ce97b4db`; the seven cleanup PRs have no overlapping authored paths.
