### PR TITLE
Fix empty wakes replaying background completion checkpoints

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-10-runtime-wake-disposal.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-runtime-wake-disposal.md
@@ -1,0 +1,29 @@
+# Preserve consumed wakes during disposal
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal and scope
+
+Complete PR #3207 and its authorized production release after correcting the concrete CI failure. Keep the previous completed local plan immutable. Reuse the checkpoint wake listener and foreground handoff; add no state owner or retry mechanism.
+
+## Cause and correction
+
+The first candidate added a post-wait disposal guard. A wake can resolve the wait before dispose begins, but resume its continuation afterward. Discarding that already-consumed notification prevents the durable-effect caller from re-notifying foreground work before a follow-up snapshot.
+
+The existing test `durable follow-up checkpoints yield to foreground-pending idle conflicts` failed both in CI and in an isolated local run on the first candidate. Removing the post-wait discard restores the original unconditional caller contract. Disposal still cancels a pending wait; notifications already received remain available to `takeNotification()`.
+
+## Product UX and verification
+
+- Result: Ready for release review. Real foreground input retains priority over a follow-up checkpoint; empty scheduler nudges still allow the final independent-completion snapshot to finish.
+- `pnpm --filter @murphai/assistant-runtime test hosted-runtime-workspace-entrypoint-checkpoint-races.test.ts hosted-runtime-background-wake-convergence.test.ts hosted-runtime-workspace-entrypoint-system-preemption.test.ts --maxWorkers=1`: all 51 tests passed, including the exact previously failing CI scenario.
+- `pnpm --filter @murphai/assistant-runtime typecheck`: passed.
+- `pnpm complexity:diff`: passed; existing hotspot debt and maximum remain unchanged.
+- Parent review: no extra network, provider, persistence, or auth change in this correction; existing cancellation and notification ownership are restored. Original local proof and compatible persisted schemas still apply.
+- Changelog: internal bookkeeping correction; no additional public entry.
+
+## Release gates
+
+The first ReviewGPT round passed, but its candidate is superseded by this CI correction. Push the corrected head, rerun sensitive full-snapshot ReviewGPT and required CI, merge only after both pass, then use the protected Cloudflare deployment workflow and verify the deployed version and native rollout receipt. Do not infer deployment success from upload alone.
+Completed: 2026-09-10

--- a/agent-docs/exec-plans/completed/2026-09-10-runtime-wake-loop.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-runtime-wake-loop.md
@@ -1,0 +1,70 @@
+# Stop repeated background runtime wakes
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+Stop empty background invocation loops by making completion state and wake projection converge across checkpoints and restores.
+
+## Success criteria
+
+- A synthetic regression fails on the unchanged implementation and passes after the correction.
+- Repeated restores complete retained work or preserve its real future retry; they do not manufacture immediately due work.
+- Foreground input still preempts background work, and interrupted work remains recoverable.
+- Focused runtime tests, relevant typecheck, complexity review, and scoped commit complete.
+
+## Scope and owners
+
+The independent system-work completion checkpoint and existing foreground mailbox prefetch own the correction. Reuse their existing state and ports. No new scheduler, persistent store, production mutation, or provider request is authorized by this plan.
+
+## Product UX
+
+Outcome: restore reliable background progress without repeated empty processing.
+Reaches: device imports, background completion recovery, and foreground conversations that interrupt them.
+Proof: synthetic repeated-invocation tests with actual snapshot restore and existing foreground/retry regression suites.
+
+## Investigation and implementation
+
+1. Reproduce the failure through the composed runtime entrypoint before changing production source.
+2. Identify the first inconsistent transition and correct its existing owner with the smallest maintainable change.
+3. Prove ordinary completion, repeated background wakes, genuine foreground interruption, future retry, and restore convergence.
+4. Review privacy, authority, deployment compatibility, and complexity; complete checks and commit.
+
+## Risks and mitigations
+
+- Dropped work: assert retained obligations survive interrupted snapshots and subsequent restore.
+- Delayed foreground replies: preserve real conversation preemption and run focused priority coverage.
+- Premature retries: assert the canonical future retry remains unchanged.
+- Version skew: retain existing persisted schemas and callback contracts.
+
+## Evidence
+
+All fixtures and evidence below are synthetic.
+
+- On unchanged base `e0b43e207c2f`, three runtime invocations each completed the device work locally but lost the completion snapshot to a default-owner nudge with no conversation input. The durable handled watermark remained `0` instead of `1`, with an immediately due wake; the test counted three interrupted completion snapshots and four accepted checkpoints.
+- The correction checks the bounded conversation mailbox only when a wake interrupts the final independent-completion snapshot. Empty responses keep the snapshot running and re-arm the wake listener. A real conversation batch is retained for the existing foreground handoff.
+- Recording and external acknowledgement remain immediately interruptible. The existing acknowledgement-interruption regression caught an overbroad first correction; the final implementation limits validation to the snapshot after recording finishes.
+- The new regression passes across three real snapshot round-trips, advances handled-through to `1`, clears both returned and durable wakes, and fetches the device snapshot once. A second scenario first supplies an empty nudge, then a real conversation; it proves the listener re-arms, cancels the snapshot, and reaches the foreground phase.
+
+## Verification and review
+
+- `pnpm --filter @murphai/assistant-runtime test hosted-runtime-workspace-entrypoint-system-preemption.test.ts hosted-runtime-workspace-entrypoint-system-mailbox.test.ts hosted-runtime-concurrent-device-import.integration.test.ts --maxWorkers=1`: 74 tests in the mailbox/concurrent-import suites passed; the acknowledgement-cancellation test exposed the first correction's scope issue.
+- After narrowing the correction, `pnpm --filter @murphai/assistant-runtime test hosted-runtime-workspace-entrypoint-system-preemption.test.ts --maxWorkers=1`: all 29 tests passed.
+- `pnpm --dir packages/assistant-runtime exec vitest --watch --config vitest.config.ts --no-coverage test/hosted-runtime-background-wake-convergence.test.ts`: both new regressions passed on the final source. The session-owned watcher was exited after verification.
+- `pnpm --filter @murphai/assistant-runtime typecheck`: passed.
+- `pnpm complexity:diff`: passed; existing source complexity debt and maximum are unchanged. Parent review found no justified broader extraction of the large existing runtime owner.
+- `git diff --check`: passed. Parent review checked cancellation, retained work, real foreground handoff, retry ownership, bounded reads, unchanged auth boundaries, and privacy.
+- Product UX: Ready for local review. Existing foreground delivery and retained-retry journeys passed. The new foreground test intentionally stops at phase entry; the concurrent-import suite covers synthetic delivery through the provider seam. No model instructions or tool choices changed, so a real-Codex prompt journey does not apply.
+- Changelog: not applicable. This is internal operational bookkeeping that avoids redundant requests after background work has already completed; no interface or new member capability is introduced.
+- Frog: existing entries reviewed; no new repository-actionable tooling defect was introduced or worked around.
+
+## Call, deployment, and completion boundaries
+
+The normal foreground path gains no reads. During the final background-completion snapshot, each coalesced wake can cause one sequential bounded conversation-prefix fetch using the existing mailbox budget, transport timeout/retry policy, and runtime/shutdown cancellation signal. A confirmed batch is reused for handoff; empty checks do not create another immediately due assistant wake. No provider or database mutation is added by classification.
+
+Persisted mailbox state, snapshots, callbacks, and wake schemas are unchanged. Old snapshots restore through the same owner; new completion snapshots remain readable by old code. Runtime rollout is sufficient, with no Web migration or ordering dependency. Reverting code is schema-compatible but can restore the loop.
+
+The authorized local fix and parent review are complete. No branch push, PR, external ReviewGPT, CI, or production deployment was performed. Those remain release-stage checks; after deployment, compare bounded empty-import/checkpoint/request rates and confirm foreground delivery plus handled-through advancement on the deployed runtime version. Local reproduction proves this defect and its correction, not that every production request in the observed increase shares this cause.
+Completed: 2026-09-10

--- a/packages/assistant-runtime/README.md
+++ b/packages/assistant-runtime/README.md
@@ -7,6 +7,7 @@ This package exists so hosted runtimes such as `apps/cloudflare` do not need to 
 Current responsibilities:
 
 - run bounded hosted workspace invocations for assistant, inbox, and device-sync work behind an explicit runtime context object
+- preserve independent system-work completion snapshots across empty runtime nudges; check the existing conversation mailbox before interrupting and reuse that fetched batch for a real foreground handoff
 - publish a device-sync completion record's retained provider cadence and
   checkpoint mailbox removal inside the same runtime admission after the exact
   completion record is durable, without another provider-free completion wake

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -3420,8 +3420,29 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
           }
         }
         if (shouldYieldSystemMailboxWork()) return;
+        let recordingComplete = false;
         const interruption = createHostedRuntimeCheckpointWakeInterruption({
           enabled: true, runtimeWakeSignal: options.runtimeWakeSignal ?? null,
+          // A scheduler nudge can arrive with an empty conversation mailbox.
+          // Only real foreground input may discard this completion snapshot.
+          async shouldInterrupt() {
+            if (!recordingComplete) return true;
+            if (assistantExecutionBlocked) return false;
+            const prefetch = await createHostedForegroundMailboxPrefetch({
+              lanes: HOSTED_INITIAL_CONVERSATION_MAILBOX_IMPORT_LANES,
+              limitPerLane: mailboxBudget.fetchLimitPerLane,
+              requestId: `${requestId}:independent-completion-foreground-check`,
+              runnerInput: baseRunnerInput,
+              signal: backgroundWorkSignal,
+            });
+            if (!(await prefetch.response).items.some((item) => item.lane === "conversation")) {
+              return false;
+            }
+            systemMailboxForegroundWakePrefetch = prefetch;
+            foregroundWakeObserved = true;
+            defaultOwnerWakeObserved = true;
+            return true;
+          },
         });
         const recordSignal = interruption.signal
           ? AbortSignal.any([backgroundWorkSignal, interruption.signal])
@@ -3439,6 +3460,7 @@ async function runHostedWorkspaceRuntimeJobInProcessImpl(
               completion?.nextWakeReason ?? null,
             ));
           }
+          recordingComplete = true;
           await checkpointSystemMailboxMode(
             "system_mailbox.checkpoint.independent_completion", [], interruption.signal,
           );
@@ -8334,6 +8356,7 @@ interface HostedRuntimeCheckpointWakeInterruption {
 function createHostedRuntimeCheckpointWakeInterruption(input: {
   enabled: boolean;
   runtimeWakeSignal: RuntimeWakeSignal | null;
+  shouldInterrupt?(notification: RuntimeWakeNotification): Promise<boolean>;
 }): HostedRuntimeCheckpointWakeInterruption {
   if (!input.enabled || !input.runtimeWakeSignal) {
     return {
@@ -8346,21 +8369,27 @@ function createHostedRuntimeCheckpointWakeInterruption(input: {
   const checkpointAbortController = new AbortController();
   const waitAbortController = new AbortController();
   let notification: RuntimeWakeNotification | null = null;
-  const waitCompletion = input.runtimeWakeSignal.wait(waitAbortController.signal).then(
-    (nextNotification) => {
-      notification = nextNotification;
-      checkpointAbortController.abort(
-        new HostedRuntimeCheckpointInterruptedByWakeError({
-          notification: nextNotification,
-        }),
-      );
-    },
-    (error: unknown) => {
+  const runtimeWakeSignal = input.runtimeWakeSignal;
+  const waitCompletion = (async () => {
+    try {
+      while (!waitAbortController.signal.aborted) {
+        const nextNotification = await runtimeWakeSignal.wait(waitAbortController.signal);
+        if (input.shouldInterrupt && !await input.shouldInterrupt(nextNotification)) continue;
+        if (waitAbortController.signal.aborted) return;
+        notification = nextNotification;
+        checkpointAbortController.abort(
+          new HostedRuntimeCheckpointInterruptedByWakeError({
+            notification: nextNotification,
+          }),
+        );
+        return;
+      }
+    } catch (error) {
       if (!waitAbortController.signal.aborted) {
         checkpointAbortController.abort(error);
       }
-    },
-  );
+    }
+  })();
 
   return {
     async dispose() {

--- a/packages/assistant-runtime/src/hosted-runtime.ts
+++ b/packages/assistant-runtime/src/hosted-runtime.ts
@@ -8375,7 +8375,8 @@ function createHostedRuntimeCheckpointWakeInterruption(input: {
       while (!waitAbortController.signal.aborted) {
         const nextNotification = await runtimeWakeSignal.wait(waitAbortController.signal);
         if (input.shouldInterrupt && !await input.shouldInterrupt(nextNotification)) continue;
-        if (waitAbortController.signal.aborted) return;
+        // A consumed wake still belongs to the caller if disposal has begun.
+        // Preserve it for takeNotification() and the foreground handoff.
         notification = nextNotification;
         checkpointAbortController.abort(
           new HostedRuntimeCheckpointInterruptedByWakeError({

--- a/packages/assistant-runtime/test/hosted-runtime-background-wake-convergence.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-background-wake-convergence.test.ts
@@ -1,0 +1,154 @@
+import {
+  TEST_NOW,
+  createEmptyDeviceSyncPort,
+  createDeferred,
+  withRealTimeout,
+  createDeviceSyncResolvedConfig,
+  createMailboxItem,
+  createMailboxPort,
+  createPlatform,
+  createVaultSnapshotBundle,
+  createWorkspacePort,
+  createWorkspaceRuntimeJobInput,
+  createWorkspaceState,
+  enqueueDeviceSyncSystemMailboxItemForTest,
+  removeTempRoot,
+  runHostedWorkspaceRuntimeJobInProcess,
+  writeMailboxImportStateFile,
+} from "./hosted-runtime-workspace-entrypoint.harness.ts";
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import { setImmediate } from "node:timers/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test, vi } from "vitest";
+import { initializeVault } from "@murphai/core";
+import type { HostedWorkspaceCheckpointRequest } from "@murphai/hosted-execution/runtime-control";
+import { createEmptyHostedMailboxImportState } from "../src/hosted-runtime/mailbox-state.ts";
+import { readHostedSystemMailboxState } from "../src/hosted-runtime/system-mailbox-state.ts";
+import { createCoalescingRuntimeWakeSignal } from "../src/hosted-runtime/runtime-wake.ts";
+
+test.each(["empty", "conversation after empty"] as const)("independent completion converges with %s wakes", async (scenario) => {
+  const vaultRoot = await mkdtemp(path.join(tmpdir(), "murph-background-wake-convergence-"));
+  const checkpointRequests: HostedWorkspaceCheckpointRequest[] = [];
+  const events: string[] = [];
+  const artifactBytesByHash = new Map<string, Uint8Array>();
+  const deviceSyncPort = createEmptyDeviceSyncPort();
+  const runtimeWakeSignal = createCoalescingRuntimeWakeSignal();
+  const deviceItem = createMailboxItem({
+    id: "mailbox_item_background_wake_convergence",
+    dedupeKey: "device-sync.wake:background-convergence",
+    kind: "device-sync.wake", lane: "system", laneSeq: "1",
+  });
+  const conversationItem = createMailboxItem({ id: "mailbox_item_completion_foreground", lane: "conversation", laneSeq: "1" });
+  const mailboxItems: ReturnType<typeof createMailboxItem>[] = [];
+  const foregroundReached = new Error("Synthetic foreground phase reached.");
+  const emptyWakeChecked = createDeferred<void>();
+  let wakeChecks = 0;
+  let injectedWakes = 0;
+  let snapshotOrdinal = 0;
+  let interruptedCompletions = 0;
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(new Date(TEST_NOW));
+  try {
+    await initializeVault({ createdAt: TEST_NOW, vaultRoot });
+    await enqueueDeviceSyncSystemMailboxItemForTest({ item: deviceItem, vaultRoot });
+    const importState = createEmptyHostedMailboxImportState();
+    importState.watermarks.system = "1";
+    await writeMailboxImportStateFile(vaultRoot, importState);
+    const initial = await createVaultSnapshotBundle({
+      key: "users/bundles/member-synthetic/background-convergence-initial.bundle.json", vaultRoot,
+    });
+    artifactBytesByHash.set(initial.hash, initial.bytes);
+    let workspace = createWorkspaceState({ snapshotRef: initial.snapshotRef, version: "0" });
+    const baseWorkspacePort = createWorkspacePort({ checkpointRequests, events, workspace });
+    const baseMailboxPort = createMailboxPort({ events, items: mailboxItems });
+    for (let invocation = 0; invocation < 3; invocation += 1) {
+      const run = runHostedWorkspaceRuntimeJobInProcess(createWorkspaceRuntimeJobInput({
+        request: {
+          attemptId: `attempt_background_convergence_${invocation}`,
+          processingMode: "system_mailbox", workspaceVersion: workspace.version,
+        },
+        resolvedConfig: createDeviceSyncResolvedConfig(),
+      }), {
+        vaultRoot, runtimeWakeSignal,
+        async createCheckpointSnapshot(_input, context) {
+          const state = await readHostedSystemMailboxState(vaultRoot);
+          if (state.pending.length === 0) {
+            injectedWakes += 1;
+            runtimeWakeSignal.notify({ requestedProcessingMode: "default" });
+            if (scenario === "conversation after empty") {
+              await withRealTimeout(emptyWakeChecked.promise, 2_000, () => "Empty wake was not checked.");
+              await setImmediate();
+              mailboxItems.push(conversationItem);
+              runtimeWakeSignal.notify({ requestedProcessingMode: "default" });
+              assert.ok(context?.signal);
+              await withRealTimeout(new Promise<void>((resolve) => {
+                if (context.signal?.aborted) resolve();
+                else context.signal?.addEventListener("abort", () => resolve(), { once: true });
+              }), 2_000, () => "Conversation input did not interrupt the snapshot.");
+            } else {
+              await setImmediate();
+            }
+            if (context?.signal?.aborted) interruptedCompletions += 1;
+            context?.signal?.throwIfAborted();
+          }
+          const snapshot = await createVaultSnapshotBundle({
+            key: `users/bundles/member-synthetic/background-convergence-${++snapshotOrdinal}.bundle.json`, vaultRoot,
+          });
+          artifactBytesByHash.set(snapshot.hash, snapshot.bytes);
+          return { snapshotRef: snapshot.snapshotRef };
+        },
+        async importItem() { throw new Error("The initial mailbox was already imported."); },
+        async runAssistantPhase() {
+          assert.equal(scenario, "conversation after empty");
+          assert.equal(interruptedCompletions, 1);
+          throw foregroundReached;
+        },
+        platform: createPlatform({ artifactBytesByHash, deviceSyncPort,
+          mailboxPort: {
+            ...baseMailboxPort,
+            async fetch(request) {
+              const response = await baseMailboxPort.fetch(request);
+              if (request.requestId.includes(":independent-completion-foreground-check")) {
+                wakeChecks += 1;
+                if (response.items.length === 0) emptyWakeChecked.resolve();
+              }
+              return response;
+            },
+          },
+          workspacePort: {
+            ...baseWorkspacePort,
+            async read() { return { fetchedAt: TEST_NOW, workspace }; },
+            async checkpoint(request) {
+              const response = await baseWorkspacePort.checkpoint(request);
+              workspace = response.workspace;
+              return response;
+            },
+          },
+        }),
+      });
+      if (scenario === "conversation after empty") {
+        await assert.rejects(run, (error) => error === foregroundReached);
+        assert.equal(interruptedCompletions, 1);
+        assert.equal(wakeChecks, 2);
+        assert.equal(workspace.redactedStatus?.hostedMailboxSystemHandledThroughSeq, "0");
+        return;
+      }
+      const result = await run;
+      assert.equal(result.nextWakeAt, null);
+      assert.notEqual(result.immediateRecheckRequested, true);
+    }
+    assert.ok(snapshotOrdinal > 0);
+    assert.ok(injectedWakes > 0);
+    assert.equal(interruptedCompletions, 0);
+    assert.equal(wakeChecks, injectedWakes);
+    assert.equal(workspace.redactedStatus?.hostedMailboxSystemHandledThroughSeq, "1",
+      JSON.stringify({ interruptedCompletions, checkpointCount: checkpointRequests.length, nextWakeAt: workspace.nextWakeAt }));
+    assert.equal(workspace.nextWakeAt, null);
+    assert.equal(deviceSyncPort.fetchSnapshotCalls, 1);
+  } finally {
+    vi.useRealTimers();
+    await removeTempRoot(vaultRoot);
+  }
+});


### PR DESCRIPTION
## Why and outcome

A scheduler nudge with no conversation input can interrupt the final independent-work completion snapshot. The next invocation restores unfinished bookkeeping and immediately repeats. Preserve that snapshot across empty nudges, while retaining immediate acknowledgement cancellation and handoff for actual conversation input.

## Product UX

- Effort: Patch to internal background completion bookkeeping.
- Result: Ready.
- Walkthrough: Repeated snapshot restores converge after completed device work. Empty nudges keep the final snapshot running; a later real message interrupts and enters the foreground phase. Existing device retry, acknowledgement cancellation, and synthetic foreground delivery journeys pass.

## Evidence

- Direct: On unchanged base, three invocations each lost the completion snapshot and retained handled-through `0` with an immediately due wake. The new regression advances handled-through to `1`, clears returned and durable wakes, and fetches the device snapshot once across three real snapshot round-trips.
- Coverage: Two new entrypoint regressions, 20 checkpoint-race tests, 29 system-preemption tests, and 74 system-mailbox/concurrent-device-import tests passed across focused runs. The new real-message scenario checks phase entry; the existing concurrent-import suite exercises synthetic provider delivery.
- Commands: `pnpm --filter @murphai/assistant-runtime test hosted-runtime-workspace-entrypoint-system-preemption.test.ts hosted-runtime-workspace-entrypoint-system-mailbox.test.ts hosted-runtime-concurrent-device-import.integration.test.ts --maxWorkers=1`; after narrowing acknowledgement handling, the 29-test preemption suite passed on rerun. The two new tests passed via the package Vitest configuration.
- `pnpm --filter @murphai/assistant-runtime typecheck`: pass.
- `pnpm complexity:diff` and `git diff --check`: pass.
- ReviewGPT round 1: PASS on `80846fac80f402a845bfc263266454149822bf15`, verified `gpt-6-pro` model and exact response/turn identity, approximately 366 seconds from response-wait start to capture. Full snapshot reviewed; no qualifying bugs or material complexity findings. The reviewer exercised seven isolated wake-helper checks; package regressions and typecheck are the local evidence above. Parent review accepted the complete substantive result; zero unresolved findings.
- The first candidate failed one additional CI checkpoint-race test. It reproduced locally: a disposal guard discarded an already-consumed wake before the durable-effect caller could forward it. The corrected head `d3ef00bbe99918eb1c95cc1217a5284495c281f0` removes that guard and retains the original notification ownership. All 51 checkpoint-race, system-preemption, and new convergence tests pass; typecheck and complexity guard pass.
- ReviewGPT round 2: PASS on `d3ef00bbe99918eb1c95cc1217a5284495c281f0`, verified `gpt-6-pro` model and matching response hash/committed-turn identity, approximately 486 seconds from response-wait start to capture. Full snapshot and all five interruption-helper callers reviewed. The reviewer independently reproduced the disposal regression and passed 15 isolated source-extracted checks; it did not independently rerun package tests. Parent review accepted the substantive result; zero unresolved findings. This supersedes round 1.
- Required CI: all four required contexts passed on the corrected head, including the full release aggregate, both host platforms, and hosted Stripe billing. All package suites, Web tests/build, typecheck, and Cloudflare verification passed. All reproduction data is synthetic; production rollout is not part of the local proof.

## Non-obvious affected surfaces

The generic checkpoint wake listener gains an optional asynchronous interruption predicate and continues waiting after ignored nudges. Existing callers retain unconditional interruption and retain already-consumed notifications across disposal; the predicate is used only by independent-work completion. The acknowledgement-interruption and foreground regression suites cover those boundaries.

## Architecture and reuse

- Existing systems reused: Runtime checkpoint owner, coalesced wake signal, bounded conversation-prefix fetch, and foreground-prefetched batch handoff.
- New logic: Once completion recording finishes, verify conversation input before aborting its final snapshot; keep listening after empty wakes.
- New abstractions: An optional predicate on the existing interruption helper; no new owner or durable state.
- Complexity intentionally avoided: No scheduler, queue, retry counter, schema, migration, rate limiter, or provider integration.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; debt 547 to 547 and maximum 252 to 252.
- Hotspots: The existing runtime entrypoint (252), system-mode owner (38), and return owner (24) retain their complexity; the helper and new predicate remain below 20. All 22 reported existing hotspots were reviewed for changed behavior.
- Agent judgment: The correction stays at the existing cancellation boundary; a broader extraction would add unrelated scope without simplifying the fix.

## Hot reply path impact

- Path status: Background-to-foreground handoff is touched; ordinary foreground execution gains no calls.
- Database calls: No direct database operation is added.
- Network/provider calls: During the final background completion snapshot, at most one sequential bounded conversation-prefix fetch per coalesced wake, using the existing mailbox budget and transport timeout/retry policy. The confirmed batch is reused for handoff. No model/provider call is added.
- Other awaited latency: Existing mailbox-state read plus the prefix response before snapshot interruption; runtime/shutdown cancellation is propagated. The previous handoff fetched the prefix after interruption. Empty wakes now complete rather than return another immediate wake.
- Before/after proof: The regression proves no immediate reschedule after empty wakes and exactly two checks for an empty wake followed by real conversation input. Existing synthetic foreground delivery tests pass; no production latency claim is made.

## Murph initial provider input impact

Not applicable for individual or group runtimes: no prompts, instructions, tool schemas, generated guidance, conversation history, or provider-visible input assembly changed. No token comparison was run.

ReviewGPT first-reviewed head: 80846fac80f402a845bfc263266454149822bf15
ReviewGPT context sensitivity: sensitive
Classification reason: Hosted runtime cancellation, completion persistence, and foreground ordering.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing snapshot, mailbox, callback, and wake schemas are unchanged; old and new runtimes read the same records.
- Safe order: Deploy the merged runtime through the protected Cloudflare release workflow. No Web migration or coordinated reader/writer rollout is needed.
- Rollback floor: Schema-compatible with the pre-change runtime; reverting would restore the faulty interruption behavior.
- Expected exposure: Old containers can continue looping until the new runtime rollout reaches them.
- Reversibility: Code-only change with no data rewrite; any production rollback requires separate explicit authorization.
- Convergence proof: Local snapshot round-trips pass. Verify the deployment receipt and running runtime commit after rollout.
- Post-deploy checks: Compare bounded empty-import/checkpoint/request rates, confirm handled-through advancement, and verify foreground delivery on the new runtime version.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source; regression TypeScript is tests; package README and completed local execution plan are docs. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 42 | 12 |
| Tests / fixtures | 154 | 0 |
| Docs | 100 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **296** | **12** |

## Changelog

- Changelog: not applicable
- Reason: Internal operational bookkeeping avoids redundant control-plane requests after background work has already completed; no interface or new member capability is introduced.
