### PR TITLE
fix(cloudflare): preserve native images during namespace bootstrap

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-10-member-one-vcpu.md
+++ b/agent-docs/exec-plans/active/2026-09-10-member-one-vcpu.md
@@ -69,15 +69,30 @@ Updated: 2026-09-10
   seven-test selector/namespace suite after adding unavailable-binding proof.
 - Passed: Cloudflare typecheck, complexity diff (no increased hotspot debt),
   and the real public/private environment forwarding contract (90 variables,
-  37 secrets). Full workspace/private verification and PR gates remain pending.
+  37 secrets).
 - Full workspace typecheck passed. Public final ReviewGPT round 1 passed on
   the initial candidate with verified Pro evidence and 366-second capture.
 - CI exposed missing local harness namespace parity and stale capacity
   expectations. The correction changes isolated local proof scaffolding only;
   142 focused tests, both affected typechecks and complexity diff passed.
-- Private exact-head CI verification passed. Local umbrella verification reached
-  four timeouts in unchanged Temporal deploy-controller tests; focused contract
-  coverage and private typecheck passed. Deployment and final CI remain pending.
+- Public PR #3206 and the matching private deployment change merged after their
+  required exact-head CI and routed reviews passed. Private preliminary review
+  found two coverage gaps; both were corrected in the existing contract test.
+- Private final ReviewGPT round 2 passed on the corrected candidate with verified
+  Pro evidence and a 489-second capture. The final local `pnpm verify` run passed,
+  including all deployment-controller and built-worker tests. An earlier local
+  run timed out in four unchanged deployment-controller tests.
+- Optional hosted integration repeated failures in unchanged foreground-priority,
+  reminder/device-sync and wearable-replay scenarios. The protected deployment
+  retains all of its predeployment gates.
+- The protected selector and first-provisioning controls are configured. All
+  protected predeployment gates passed. Namespace bootstrap stopped before any
+  Worker mutation because retained native image metadata failed the new-image
+  contract. A synthetic tagged-image regression reproduces the exact failure.
+- The forward fix permits an exact observed image reference only in the
+  namespace-only preservation path. New release admission remains digest-only;
+  native before/after receipts, resource checks and routing-off ordering remain.
+  Live convergence is pending the focused correction and its review/CI gates.
 
 - Focused allocation, slot lifecycle, namespace, configuration, staging and
   deployment tests; Cloudflare typecheck and complexity diff.

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -52,7 +52,9 @@ first protected full deployment. That deployment alone requires
 `CF_BOOTSTRAP_SMALL_RUNNER=true`: migration `v9` creates the SQLite namespace
 using a full Worker deploy with selection off and every existing application
 pinned to its live image, resources and capacity. Native before/after receipts
-must remain unchanged. This is the bounded namespace-bootstrap exception to
+must remain unchanged. Existing native image tags are preserved exactly in this
+namespace-only step; newly admitted release images still require immutable
+digests. This is the bounded namespace-bootstrap exception to
 the ordinary version-only release flow; no application image rollout belongs
 in that bootstrap. Missing live authority, a pending candidate or an active
 native rollout stops provisioning. Clear the bootstrap control after success.

--- a/apps/cloudflare/scripts/runner-release-application.ts
+++ b/apps/cloudflare/scripts/runner-release-application.ts
@@ -1,11 +1,12 @@
 import { createHash } from "node:crypto";
 import { isObjectRecord } from "./deploy-automation/shared.ts";
 
-/** The deployed renderer's explicit native configuration, shared by identity and admission. */
-export function runnerApplicationSpecification(container: Record<string, unknown>, logsEnabled: boolean) {
+/** New images require digests. Only a namespace-only bootstrap may preserve an
+ * exact image reference already observed on the native application. */
+export function runnerApplicationSpecification(container: Record<string, unknown>, logsEnabled: boolean, retainedImage?: string) {
   const image = container.image;
   const size = container.instance_type;
-  if (typeof image !== "string" || !/@sha256:[a-f0-9]{64}$/u.test(image)
+  if (typeof image !== "string" || (!/@sha256:[a-f0-9]{64}$/u.test(image) && image !== retainedImage)
     || !Number.isSafeInteger(container.max_instances) || Number(container.max_instances) < 0) throw invalid();
   const resources = typeof size === "string" ? { instance_type: size }
     : isObjectRecord(size) ? {

--- a/apps/cloudflare/scripts/stage-runner-release.ts
+++ b/apps/cloudflare/scripts/stage-runner-release.ts
@@ -63,7 +63,9 @@ export async function prepareSmallRunnerNamespaceBootstrap(input: {
       || live.durable_objects.namespace_id !== readNamespaceId(input.currentVersion, className)
       || live.active_rollout != null) throw invalid();
     const retained = retainNativeContainer(value, live);
-    if (!runnerApplicationMatches(live, runnerApplicationSpecification(retained, logsEnabled))) throw invalid();
+    if (!runnerApplicationMatches(live, runnerApplicationSpecification(
+      retained, logsEnabled, requiredString(live.configuration.image),
+    ))) throw invalid();
     containers.push(retained);
   }
   const output = path.join(path.dirname(input.configPath), `wrangler.bootstrap-small-${randomUUID()}.jsonc`);

--- a/apps/cloudflare/test/small-runner-deploy.test.ts
+++ b/apps/cloudflare/test/small-runner-deploy.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { prepareSmallRunnerNamespaceBootstrap, stageHostedRunnerRelease } from "../scripts/stage-runner-release.ts";
+import { runnerApplicationSpecification } from "../scripts/runner-release-application.ts";
 
 const oldImage = `registry.example.test/runner@sha256:${"a".repeat(64)}`;
 const newImage = `registry.example.test/runner@sha256:${"b".repeat(64)}`;
@@ -81,6 +82,24 @@ describe("small runner protected deployment", () => {
       currentVersionId: "worker-live", listApplications: listApplications() };
     await expect(prepareSmallRunnerNamespaceBootstrap(input)).rejects.toThrow("CF_BOOTSTRAP_SMALL_RUNNER=true");
     await expect(prepareSmallRunnerNamespaceBootstrap({ ...input, currentVersion: version(true) })).resolves.toBeNull();
+  });
+
+  it("preserves a native image tag during namespace-only provisioning without admitting tagged releases", async () => {
+    const image = "registry.example.test/runner:retained-release";
+    const output = await prepareSmallRunnerNamespaceBootstrap({ allowed: true, configPath,
+      currentVersion: version(false), currentVersionId: "worker-live",
+      listApplications: async name => (await listApplications()(name)).map(entry => ({ ...entry,
+        configuration: { ...entry.configuration, image } })),
+    });
+    const bootstrap = JSON.parse(await readFile(output!, "utf8"));
+    expect(bootstrap.containers.map((entry: { image: string }) => entry.image)).toEqual([image, image]);
+    expect(bootstrap.vars.HOSTED_EXECUTION_SMALL_RUNNER_ENABLED).toBe("false");
+    expect(() => runnerApplicationSpecification({ ...config.containers[0], image }, true))
+      .toThrow("outside the supported deployment contract");
+    expect(() => runnerApplicationSpecification({ ...config.containers[0], image }, true, `${image}-different`))
+      .toThrow("outside the supported deployment contract");
+    expect(() => runnerApplicationSpecification({ ...config.containers[0], image, max_instances: -1 }, true, image))
+      .toThrow("outside the supported deployment contract");
   });
 
   it("refuses provisioning during an incomplete image transition", async () => {


### PR DESCRIPTION
## Why and outcome

First-time small-runner namespace provisioning fails when an existing native application uses an image reference without an immutable digest. The namespace-only bootstrap must preserve that exact live reference while leaving container images and instances unchanged.

Permit the exact observed native image reference only in the bootstrap specification check. New release admission still requires an immutable digest. The existing resource, namespace, rollout-state and before/after receipt checks remain in place.

## Product UX

- Effort: Not applicable — protected deployment compatibility.
- Result: Required CI and final review passed; production retry remains pending.
- Walkthrough: Selection stays off during namespace creation. Existing native applications are preserved, and ordinary image admission remains strict.

## Evidence

- Direct: A synthetic tagged-native-image case reproduced the same bootstrap failure and now passes. The protected attempt stopped before Worker mutation after all predeployment gates passed.
- Coverage: 100 tests across five deployment, application, staging and receipt files passed. The regression also rejects tagged new releases, mismatched retained references and invalid capacity.
- Verification: Cloudflare typecheck, diff checks and complexity guard passed. Both changed source files remain below the complexity threshold.
- Parent review: The only third-argument caller is the namespace-only bootstrap and derives it directly from native provider metadata. It neither resolves nor changes that reference.

## Non-obvious affected surfaces

The application specification helper is shared with ordinary release admission. Its existing two-argument callers retain digest enforcement. The bootstrap still uses `--containers-rollout=none` and verifies native receipts before and after the Worker migration.

## Architecture and reuse

- Existing systems reused: Native application specification, bootstrap and receipt owners.
- New logic: Permit an exact retained native image reference at the bootstrap caller.
- New abstractions: None; one explicit optional reference on the existing validator.
- Complexity intentionally avoided: No registry lookup, image retagging, new deployment workflow or credential path.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`.
- Hotspots: None above 20; application specification maximum 18 to 19, staging unchanged at 19.
- Agent judgment: The bounded image exception preserves the existing validation and deployment ordering.

## Hot reply path impact

Not applicable: deployment tooling and regression coverage only; no runtime I/O or scheduling changes.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no provider input, prompt, tool or model changes.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing native image references are retained exactly during namespace provisioning.
- Safe order: Merge, then retry the existing protected full deployment with secret synchronization and the approved bootstrap control.
- Rollback floor: The small-namespace reader remains required once small targets exist. No rollback is part of this correction.
- Expected exposure: Namespace provisioning only; selected-account allocation is unchanged.
- Reversibility: Selection remains off until native admission and smoke succeed.
- Convergence proof: Existing before/after native receipts and live release observer.
- Post-deploy checks: Verify native resources and Worker convergence, clear bootstrap control, and observe natural selected-account allocation.

## Change-shape breakdown

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 7 | 4 |
| Tests / fixtures | 19 | 0 |
| Docs | 22 | 5 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **48** | **9** |

## Changelog

- Changelog: not applicable
- Reason: Internal provisioning correction for a privately selected infrastructure experiment.

ReviewGPT context sensitivity: sensitive
Classification reason: Production deployment, image identity and namespace migration.
ReviewGPT first-reviewed head: 60056a54ae5d930f09742f71865aeda9f39ece69

Final review: PASS on 60056a54ae5d with verified gpt-6-pro response metadata and a 366-second response capture. The first browser attempt was confirmed INVALID because the archive was absent; the same-round full-snapshot retry validated all five file blobs and independently ran 27 checks. Required exact-head CI and current-base mergeability passed.
