### PR TITLE
Use authorized routes for hosted email audience

### DIFF
--- a/agent-docs/SECURITY.md
+++ b/agent-docs/SECURITY.md
@@ -804,7 +804,7 @@ Last verified: 2026-08-31
   when `Content-Length` is absent or underreported. Logs may include only a
   normalized error code/type and booleans/counts, never callback state/code,
   tokens, patient ids, URLs, or provider response bodies.
-- Hosted email ingress and delivery credentials must remain platform-managed, must not write raw authorization material to vault/runtime artifacts, and must limit assistant auto-reply to positively classified direct threads or signed hosted group routes that resolve to a current grantor; indeterminate or malformed hosted routes must fail closed. A signed group route is routing authority, not SMTP sender authentication, and must never authorize any assistant-style mutation, whether personal or room-owned.
+- Hosted email ingress and delivery credentials must remain platform-managed, must not write raw authorization material to vault/runtime artifacts, and must limit assistant auto-reply to positively classified direct threads or signed hosted group routes that resolve to a current grantor; indeterminate or malformed hosted routes must fail closed. Hosted ingress derives directness from the authorized personal or group route, never the number of SMTP header recipients; import preserves the supplied route fact and leaves missing legacy metadata unknown. This audience fact does not authenticate the sender or grant mutation authority. A signed group route is routing authority, not SMTP sender authentication, and must never authorize any assistant-style mutation, whether personal or room-owned.
 - The companion legal-consent route is shared by the iOS and Android apps. It
   records the generic server-owned `native-companion` audit source because
   member authentication does not attest the client platform; a request's

--- a/agent-docs/exec-plans/active/2026-09-10-email-audience-authority.md
+++ b/agent-docs/exec-plans/active/2026-09-10-email-audience-authority.md
@@ -1,0 +1,35 @@
+# Use authorized hosted email routes for audience scope
+
+Status: active
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal and scope
+
+Personal hosted email replies use the authorized member route for private audience scope even when incoming headers contain additional recipients. Signed group routes remain group-scoped. Remove hosted header inference; retain the local email connector classifier and existing current verified-recipient egress checks.
+
+## Cause and design
+
+Worker ingress counts To/Cc/Bcc recipients after Web has already authorized a personal or group route. A personal alias with Cc becomes non-direct and cannot auto-reply. Runtime import repeats that guess when metadata is missing. Derive the existing boolean at ingress; import the explicit fact, preserving unknown for legacy missing metadata and forcing signed group targets non-direct. Routing authority never authenticates the sender or grants mutation permission.
+
+## Success criteria and product journeys
+
+- Personal signed alias with extra To/Cc/Bcc is private; sender-style authority stays false.
+- Signed group alias stays non-direct, redacted, and grant-gated.
+- Missing/null scope stays unknown; legacy false stays false; no header inference.
+- Direct egress still sends only to current verified owner, clears Cc, and fails closed when verification disappears.
+- Focused real-Codex email reply queues one useful response with no additional effects.
+
+## Tasks
+
+1. Add deterministic regressions and remove hosted-only inference.
+2. Replay focused ingress/import/egress and real-Codex journeys; update security owner and changelog.
+3. Inspect full diff, typecheck, complexity guard, scoped final commit, draft PR, exact-head CI and ReviewGPT.
+
+## Constraints
+
+No new state, RPC, dependency, audience abstraction, or migration. Do not change saved cron route recovery or generic IMAP inference. No production sends or data access. Both new/old ingress and runtime combinations use the existing optional boolean contract.
+
+## Verification
+
+Pending implementation and focused proof.

--- a/agent-docs/exec-plans/completed/2026-09-10-email-audience-authority.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-email-audience-authority.md
@@ -1,6 +1,6 @@
 # Use authorized hosted email routes for audience scope
 
-Status: active
+Status: completed
 Created: 2026-09-10
 Updated: 2026-09-10
 
@@ -32,4 +32,12 @@ No new state, RPC, dependency, audience abstraction, or migration. Do not change
 
 ## Verification
 
-Pending implementation and focused proof.
+- Three To/Cc/Bcc regression cases failed before the fix and pass afterward; 31 Worker ingress tests pass.
+- 14 focused email import tests and 20 focused callback tests pass, including explicit/missing facts, group override/redaction, verified-owner-only recipient replacement and revoked verification.
+- Real Codex gpt-5.6-terra, local subscription: personal email containing Cc yields one queued direct reply, zero dynamic/command actions; response reviewed Ready. Initial fixture lacked the required delivery idempotency key; fixed the synthetic request and reran successfully on the same subscription.
+- Assistant engine, runtime and Worker typechecks pass; 10 changelog page tests pass.
+- Complexity guard passes; 48 net production source lines deleted, ingress debt decreases by one.
+- Parent review confirms authorized route and sender identity remain distinct; no new lookup, state, migration or prompt builder.
+- Product UX Ready: current personal alias replies work with extra headers, group scope remains isolated, missing legacy metadata fails closed and direct send recipient still revalidates.
+- PR #3233 contains the completed candidate; exact-head CI and ReviewGPT follow Ready. No merge or deploy requested.
+Completed: 2026-09-10

--- a/apps/cloudflare/src/hosted-email/worker-ingress.ts
+++ b/apps/cloudflare/src/hosted-email/worker-ingress.ts
@@ -20,9 +20,6 @@ import {
   buildParsedEmailThreadTarget,
   resolveParsedEmailThreadKey,
 } from "@murphai/inboxd/connectors/email/normalize-parsed";
-import {
-  inferDirectEmailThreadFromParticipants,
-} from "@murphai/inboxd/connectors/email/directness";
 
 import { readHostedExecutionEnvironment } from "../env.ts";
 import type {
@@ -260,16 +257,6 @@ export async function handleHostedEmailIngress(
         groupId: route.groupId,
         providerThreadKey,
       });
-  const threadIsDirect = isGroupRoute
-    ? false
-    : inferDirectEmailThreadFromParticipants({
-        accountAddress: route.identityId,
-        bcc: parsedMessage.bcc,
-        cc: parsedMessage.cc,
-        from: parsedMessage.from,
-        selfAddresses: [route.routeAddress],
-        to: parsedMessage.to,
-      });
   const promptProjection = buildHostedEmailPromptProjection({
     message: parsedMessage,
     redactedForGroup: isGroupRoute,
@@ -303,7 +290,7 @@ export async function handleHostedEmailIngress(
               HOSTED_EMAIL_PROMPT_SELF_ADDRESS_MAX_CHARS,
             ),
           }),
-      threadIsDirect,
+      threadIsDirect: !isGroupRoute,
       threadKey: normalizeHostedEmailPromptMetadataScalar(
         threadKey,
         HOSTED_EMAIL_PROMPT_THREAD_KEY_MAX_CHARS,

--- a/apps/cloudflare/test/hosted-email-worker-ingress.test.ts
+++ b/apps/cloudflare/test/hosted-email-worker-ingress.test.ts
@@ -792,7 +792,7 @@ describe("hosted email worker ingress", () => {
     expect(listHostedEmailMessageKeys(bucket)).toEqual([]);
   });
 
-  it("keeps signed member email body addresses unredacted while classifying extra recipients as non-direct", async () => {
+  it.each(["To", "Cc", "Bcc"])("keeps personal alias email private with an extra %s recipient", async (header) => {
     const bucket = new MemoryEncryptedR2Bucket();
     mocks.fetchHostedExecutionWebControlPlaneResponse
       .mockResolvedValueOnce(await createTestReplyAliasRegistrationResponse())
@@ -819,10 +819,10 @@ describe("hosted email worker ingress", () => {
       from: "owner@example.com",
       raw: buildRawEmail({
         body: "Please compare this note from teammate@example.test and keep From: Owner <owner@example.com> intact.",
-        extraHeaders: ["Cc: Teammate <teammate@example.test>"],
+        extraHeaders: header === "To" ? [] : [`${header}: Teammate <teammate@example.test>`],
         from: "Owner <owner@example.com>",
         subject: "Question from owner@example.com",
-        to: replyAliasAddress,
+        to: header === "To" ? `${replyAliasAddress}, teammate@example.test` : replyAliasAddress,
       }),
       to: replyAliasAddress,
     }, createWorkerEnv(bucket));
@@ -832,7 +832,8 @@ describe("hosted email worker ingress", () => {
     expect(appendInput?.body?.subject).toBe("Question from owner@example.com");
     expect(appendInput?.body?.textPreview).toContain("teammate@example.test");
     expect(appendInput?.body?.textPreview).toContain("owner@example.com");
-    expect(appendInput?.body?.threadIsDirect).toBe(false);
+    expect(appendInput?.body?.threadIsDirect).toBe(true);
+    expect(appendInput?.body?.assistantStyleSettingsAuthorized).toBe(false);
   });
 
   it("preserves long hosted email thread targets without truncation", async () => {

--- a/apps/web/changelog/entries/2026-09-10/personal-email-copied-recipients.json
+++ b/apps/web/changelog/entries/2026-09-10/personal-email-copied-recipients.json
@@ -1,0 +1,19 @@
+{
+  "publishedOn": "2026-09-10",
+  "order": 100,
+  "item": {
+    "id": "personal-email-copied-recipients",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Reliable personal email replies with copied recipients",
+    "summary": "Copying someone on a message to your personal Murph reply address no longer prevents Murph from answering you.",
+    "details": "Murph sends its reply only to your current verified email address. Group email conversations keep their existing sharing rules.",
+    "relevanceTags": [
+      "messaging",
+      "reliability"
+    ],
+    "sourcePullRequests": [
+      3233
+    ]
+  }
+}

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -16166,6 +16166,53 @@ describeRealCodex('real Codex legacy weekly digest prompt compatibility e2e', ()
   )
 })
 
+describeRealCodex('real Codex personal email audience e2e', () => {
+  it('answers a personal email with copied recipients in one queued private reply', async () => {
+    const config = await resolveRealCodexE2eConfig()
+    const workingDirectory = await mkdtemp(path.join(tmpdir(), 'murph-email-audience-e2e-'))
+    const permissionHome = await materializeRealCodexHostedPermissionHome(config)
+    try {
+      await initializeVault({ timezone: 'America/New_York', vaultRoot: workingDirectory })
+      const modelTarget = createAssistantModelTarget({
+        approvalPolicy: 'never', codexCommand: normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND),
+        codexHome: permissionHome.codexHome, model: config.model, modelProvider: config.modelProvider,
+        provider: 'codex-cli', reasoningEffort: 'low', sandbox: 'workspace-write',
+      })
+      if (!modelTarget) throw new Error('Expected real Codex target.')
+      const events: unknown[] = []
+      const result = await sendAssistantNotificationLocal({
+        actorId: null, bindingDeliveryTarget: 'member@example.test', channel: 'email',
+        deliveryDispatchMode: 'queue-only', deliveryTarget: 'member@example.test',
+        deliveryIdempotencyKey: 'synthetic-personal-email-reply',
+        executionContext: { hosted: { defaultTarget: modelTarget, memberId: 'synthetic-member', userEnvKeys: [] } },
+        identityId: 'synthetic-email-identity',
+        instructions: [
+          'Answer this email with one short practical suggestion, without asking a question or taking any other action.',
+          'Sender summary - Member <member@example.test>',
+          'Cc summary - teammate@example.test',
+          'Email body preview - I have two minutes between meetings. Suggest one easy stretch break I can do at my desk.',
+        ].join('\n'),
+        threadId: 'synthetic-personal-email', threadIsDirect: true,
+        onTraceEvent: (event) => events.push(event.rawEvent),
+        turnEnvironment: { currentWorkingDirectory: workingDirectory, env: config.env },
+        turnTrigger: 'manual-deliver', vault: workingDirectory, workingDirectory,
+      })
+      expect(result.decision.kind).toBe('send_message')
+      expect(result.deliveryOutcome?.kind).toBe('queued')
+      expect(readCapabilityRoutingActions(events)).toEqual([])
+      const intents = await listAssistantOutboxIntents(workingDirectory)
+      expect(intents).toHaveLength(1)
+      expect(intents[0]).toMatchObject({ channel: 'email', threadIsDirect: true, explicitTarget: 'member@example.test', status: 'pending' })
+      const reply = result.response ?? ''
+      process.stdout.write(`[real-codex personal email audience] ${JSON.stringify({ reply, intents: intents.length })}\n`)
+      expect(reply).toMatch(/stretch|shoulder|neck|roll|stand/iu)
+      expect(reply).not.toMatch(/\?|teammate@|verif|audience|permission|sent|scheduled/iu)
+    } finally {
+      await removeRealCodexTemporaryPaths([workingDirectory, ...permissionHome.temporaryPaths, ...config.temporaryPaths])
+    }
+  }, 360_000)
+})
+
 describeRealCodex('real Codex direct email signup welcome e2e', () => {
   it('delivers the exact activation welcome through the production notification turn', async () => {
     const config = await resolveRealCodexE2eConfig()

--- a/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/mailbox-conversation-import.ts
@@ -55,9 +55,6 @@ import type {
   AssistantModelTarget,
 } from "@murphai/operator-config/assistant-cli-contracts";
 import { createIntegratedInboxServices } from "@murphai/inbox-services";
-import {
-  inferDirectEmailThreadFromParticipants,
-} from "@murphai/inboxd/connectors/email/directness";
 
 import type {
   HostedMailboxConversationImportTiming,
@@ -1658,45 +1655,13 @@ function createHostedConversationAssistantInputConversation(
         identifierBlind,
         threadIdentity,
       ),
-      threadIsDirect: resolveHostedEmailConversationDirectness({
-        message: wake.message,
-        threadTarget: emailThreadTarget,
-      }),
+      threadIsDirect: emailThreadTarget?.targetKind === "group"
+        ? false
+        : wake.message.threadIsDirect ?? null,
     };
   }
 
   return null;
-}
-
-function resolveHostedEmailConversationDirectness(input: {
-  message: HostedExecutionEmailConversationMessagePayload;
-  threadTarget: ReturnType<typeof parseHostedEmailThreadTarget>;
-}): boolean | null {
-  const { message, threadTarget } = input;
-  if (threadTarget?.targetKind === "group") {
-    return false;
-  }
-
-  if (typeof message.threadIsDirect === "boolean") {
-    return message.threadIsDirect;
-  }
-  if (message.threadIsDirect === null) {
-    return null;
-  }
-
-  const from = message.from?.trim() ?? "";
-  const selfAddress = message.selfAddress?.trim() ?? "";
-  if (!from || !selfAddress || !Array.isArray(message.to) || !Array.isArray(message.cc)) {
-    return null;
-  }
-
-  return inferDirectEmailThreadFromParticipants({
-    accountAddress: message.identityId,
-    cc: message.cc,
-    from,
-    selfAddresses: [selfAddress],
-    to: message.to,
-  });
 }
 
 function createHostedConversationAssistantInputReplyTarget(

--- a/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-mailbox-conversation-import.test.ts
@@ -4099,7 +4099,7 @@ describe("hosted mailbox conversation import adapter", () => {
     );
   });
 
-  test("keeps email conversation metadata hashed while replyTarget uses private thread authority", async () => {
+  test.each([true, false, null, undefined] as const)("preserves explicit email audience %s without guessing from headers", async (threadIsDirect) => {
     const parentRoot = await mkdtemp(path.join(tmpdir(), "murph-hosted-input-email-"));
     tempRoots.push(parentRoot);
     const vaultRoot = path.join(parentRoot, "vault");
@@ -4112,7 +4112,10 @@ describe("hosted mailbox conversation import adapter", () => {
         rawMessageKey: "raw_email_thread_authority",
         selfAddress: "assistant@example.test",
         threadKey: "email_thread_root_synthetic",
-        threadIsDirect: true,
+        threadIsDirect,
+        from: "sender@example.test",
+        to: ["assistant@example.test"],
+        cc: [],
         threadTarget: serializeHostedEmailThreadTarget({
           lastMessageId: "email_message_synthetic_001",
           references: ["email_thread_root_synthetic"],
@@ -4149,7 +4152,7 @@ describe("hosted mailbox conversation import adapter", () => {
     assert.equal(listed.events.length, 1);
     const event = listed.events[0]!;
     assert.equal(event.conversation?.source, "email");
-    assert.equal(event.conversation?.threadIsDirect, true);
+    assert.equal(event.conversation?.threadIsDirect, threadIsDirect ?? null);
     assert.match(event.conversation?.accountId ?? "", HASHED_IDENTIFIER_PATTERN);
     assert.match(event.conversation?.threadId ?? "", HASHED_IDENTIFIER_PATTERN);
     const replyTarget = event.replyTarget;
@@ -4159,7 +4162,7 @@ describe("hosted mailbox conversation import adapter", () => {
     assert.ok(replyTarget.threadId?.startsWith("hostedmail:"));
     assert.equal(JSON.stringify(event).includes("raw_email_thread_authority"), false);
     assert.equal(JSON.stringify(event).includes("hosted_email_identity_synthetic"), false);
-    assert.equal(JSON.stringify(event).includes("assistant@example.test"), false);
+    assert.equal(JSON.stringify(event.conversation).includes("assistant@example.test"), false);
   });
 
   test("decodes conversation.message through the injected seam and imports it through the local inbox path", async () => {
@@ -5034,6 +5037,7 @@ describe("hosted mailbox conversation import adapter", () => {
         subject: "Question about sauna",
         textPreview:
           "Can you compare my sauna notes from this week and include teammate@example.test? From: Sender <sender@example.test>",
+        threadIsDirect: true,
         threadTarget: "hostedmail:opaque-thread-target",
         to: ["assistant@example.test"],
       },
@@ -5082,7 +5086,7 @@ describe("hosted mailbox conversation import adapter", () => {
     });
     assert.equal(JSON.stringify(event).includes("labs.pdf"), true);
     assert.equal(event.replyTarget?.threadId, "hostedmail:opaque-thread-target");
-    assert.equal(event.conversation?.threadIsDirect, false);
+    assert.equal(event.conversation?.threadIsDirect, true);
   });
 
   test("renders group-routed hosted email input without resurfacing address fields", async () => {
@@ -5116,6 +5120,7 @@ describe("hosted mailbox conversation import adapter", () => {
           "> Reply-To: member-two@example.test",
           "> Inline note from inline-address@example.test should be hidden.",
         ].join("\n"),
+        threadIsDirect: true,
         threadTarget: groupThreadTarget,
         to: ["assistant+g2-secret@mail.example.test", "Member Three <member-three@example.test>"],
       },


### PR DESCRIPTION
## Why and outcome

An extra To, Cc, or Bcc recipient made a personal signed email alias look like a group thread and suppressed its reply. Derive hosted audience scope from the already-authorized personal/group route and delete the runtime's second header-based guess.

Personal replies still resolve only the owner's current verified inbox immediately before sending. Group grant checks, redaction, and sender mutation permissions remain unchanged. Missing legacy audience metadata stays unknown.

## Product UX

- Effort: Patch — restore personal email replies with copied recipients.
- Result: Ready.
- Walkthrough: Personal alias with extra To/Cc/Bcc; signed group alias; unknown legacy metadata; verified recipient removed before delivery. Generic local email classification and saved email cron-route repair are excluded.

## Evidence

75 deterministic tests and one focused real-Codex journey passed.

- Direct: 31 Worker ingress tests passed, including three regressions that failed before the change; 14 focused email mailbox-import tests passed; 20 focused runtime callback tests passed.
- Coverage: Private/group admission, sender mutation authority, group redaction, missing audience facts, owner-only verified egress and revocation.
- Live: `pnpm test:assistant:live -- --test "answers a personal email with copied recipients in one queued private reply"` passed with gpt-5.6-terra via local subscription; one private queued reply, no dynamic/command actions. Synthetic response reviewed Ready.
- Typechecks: assistant engine, assistant runtime and Cloudflare Worker passed. `pnpm --dir apps/web test -- changelog-page.test.tsx`: 10 passed.
- [ReviewGPT round 1](https://chatgpt.com/c/6aa3604a-1278-83ea-ba01-9f2b9febc496): PASS on the exact candidate; captured GPT-6 Pro and response hash verified, 313 seconds, no accepted findings. Final exact-head required CI passed, including Release checks (ubuntu), both CLI host platforms and the hosted billing boundary.

## Non-obvious affected surfaces

Local IMAP classification remains unchanged. Existing direct email egress replaces the full To/Cc audience with the current verified member inbox.

## Architecture and reuse

- Existing systems reused: Web-authorized hosted email routes, existing wake directness field, runtime input journal and verified-recipient egress callback.
- New logic: Derive private/group directly from the authorized route.
- New abstractions: None; delete the hosted header-inference helper and its imports.
- Complexity intentionally avoided: No audience service, migration, state, dependency, callback, or compatibility inference.

## Complexity impact

- Guard: pass — pnpm complexity:diff; source debt decreases by one.
- Hotspots: Existing ingress handler 22; mailbox importer 49, input stager 33, source-metadata builder 26. The changed scope logic is now a boolean assignment and one group override; remaining branches own independent admission/projection work.
- Agent judgment: Further unrelated importer decomposition would add scope without improving this fix.

## Hot reply path impact

- Path status: Touched — remove synchronous header classification.
- Database calls: None added or moved.
- Network/provider calls: None added or moved; current verified-recipient lookup remains at egress.
- Other awaited latency: None added or moved; timeout/retry behavior unchanged.
- Before/after proof: Worker accepts one wake per ingress; runtime/provider regression assertions retain recipient resolution and fail-closed verification behavior.

## Murph initial provider input impact

Not applicable to prompt/tool/request construction for either individual or group runtime: no builder or schema changes. Previously suppressed personal Cc messages now enter the existing direct-email policy; there was no provider request for that failing path to compare. Existing direct and group fixtures retain their prompt construction.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing optional boolean wake shape is unchanged. Old/new runtimes read the new explicit flag; new runtime accepts old explicit true/false/null/missing flags and forces group targets non-direct.
- Safe order: Either order; Worker deployment restores personal Cc ingress classification.
- Rollback floor: Existing protocol; no migration or new durable shape.
- Expected exposure: Older in-flight personal Cc wakes can remain suppressed; later accepted wakes use current classification.
- Reversibility: Source revert restores prior behavior.
- Convergence proof: Deterministic import matrix covers explicit true/false/null/missing plus signed group override.
- Post-deploy checks: Verify a synthetic personal reply with Cc reaches only its current verified owner and a signed group reply retains group scope.

## Change-shape breakdown

Classification rule: production TypeScript is source; test paths are tests; Markdown and public release-note JSON are docs. No binaries or generated output.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 4 | 52 |
| Tests / fixtures | 62 | 9 |
| Docs | 63 | 1 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **129** | **62** |

## Changelog

- Changelog: updated
- Items: 2026-09-10 · personal-email-copied-recipients


ReviewGPT first-reviewed head: 69a96cc22915750756e6bc629f2999a5b646a4da
ReviewGPT context sensitivity: sensitive
Classification reason: Hosted email audience and cross-owner delivery privacy.
