### PR TITLE
Unify Linq route authority parsing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,6 +17,12 @@ retaining provider content.
 `agent-docs/RELIABILITY.md` specifies the supported content, ordering, limits,
 and conservative behavior after an ambiguous retry.
 
+The existing `@murphai/hosted-execution/routes` contract owns parsing the
+complete Linq delivery route at Web, Worker, and runtime boundaries. It binds
+target, directness, and nullable sender/recipient coordinates together; consumers
+use the normalized route without re-parsing. Live route revalidation and the
+provider dispatch claim remain separate Web-owned checks.
+
 Exact-message replies and reactions share one accepted-message targeting
 primitive. The model sees only an existing `AssistantInputEvent.inputId` as a
 `Message ref` beside eligible accepted Linq iMessage input or Telegram input

--- a/agent-docs/exec-plans/completed/2026-09-10-linq-route-parsing.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-linq-route-parsing.md
@@ -1,0 +1,39 @@
+# Parse Linq route authority at one contract owner
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal and scope
+
+Remove duplicate Linq route parsers across Web, Worker, and runtime. Keep one pure parser in the existing hosted-execution routes contract and remove immediate runtime re-parsing of its normalized result. SMS and iMessage share this boundary.
+
+## Required behavior
+
+Preserve current live Web route authority before planning and provider entry, exact expected-route comparison, health policy, provider claim/idempotency, group isolation, route revocation, voice and reaction delivery. A canonical route binds target and directness together. Missing nullable fields, invalid phone coordinates, mismatched participant recipients, and group routes with a direct recipient fail closed.
+
+## Design
+
+Move existing runtime semantic checks into the common wire contract; replace the weaker Web/Worker copies. Keep each boundary's existing failure handling. The runtime port still validates alternate platform implementations. Require normalized route presence without running the same parser again.
+
+## Tasks and verification
+
+1. Trace all consumers; unify parsing and delete obsolete helpers.
+2. Test valid direct/group/participant routes and malformed payloads; replay Web engagement, Worker transport, runtime text/voice/reaction and scheduled authority suites.
+3. Typecheck affected owners, review full diff, complexity guard, final scoped commit, draft PR, exact-head CI and ReviewGPT.
+
+## Constraints
+
+No new dependencies, state, configuration, service, route, or authority lookup. No model prompt or permission change; model journey not applicable to this mechanical contract refactor. No production mutation. Existing valid protocol works with old/new Web, Worker, and runtime.
+
+## Verification
+
+- 25 shared route parser cases pass.
+- 215 Worker platform tests pass, including malformed/legacy route payloads and health metadata.
+- 285 runtime callback tests pass, including text/voice/reaction delivery, current-route checks, provider claims and malformed route fail-closed behavior.
+- 67 Web engagement tests pass, including malformed expected routes before DB access and preflight/provider route drift.
+- Hosted execution, assistant runtime, Worker, and Web typechecks pass.
+- Complexity guard passes: 122 net production source lines deleted; runtime complexity debt falls by five. Existing unrelated effect/transaction hotspots are unchanged.
+- Parent diff review: one parser preserves valid protocol and rejects malformed routes earlier; no new effect, latency, persisted state, provider input, or product flow.
+- Final candidate ready for exact-head CI and ReviewGPT on its PR; no merge or deploy requested.
+Completed: 2026-09-10

--- a/apps/cloudflare/src/runtime-platform/effects-port.ts
+++ b/apps/cloudflare/src/runtime-platform/effects-port.ts
@@ -9,6 +9,7 @@ import {
   parseHostedOperatorTaskControlResponse,
 } from "@murphai/hosted-execution";
 import {
+  parseHostedExecutionResolvedLinqDeliveryRoute,
   HOSTED_RUNTIME_LINQ_DELIVERY_BLOCK_CODES,
   HOSTED_RUNTIME_LINQ_DELIVERY_POSTURES,
 } from "@murphai/hosted-execution/routes";
@@ -510,63 +511,9 @@ function parseHostedRuntimeLinqRecentInboundEngagementResult(
     result.providerDispatchClaimed = response.providerDispatchClaimed;
   }
 
-  const resolvedRoute = response.resolvedRoute;
-  if (
-    !resolvedRoute ||
-    typeof resolvedRoute !== "object" ||
-    Array.isArray(resolvedRoute)
-  ) {
-    return result;
-  }
-
-  const record = resolvedRoute as Record<string, unknown>;
-  const target = readOptionalStringField(record, "target");
-  const targetKind = readOptionalStringField(record, "targetKind");
-  const conversationThreadId = readHostedRuntimeNullableStringField(
-    record,
-    "conversationThreadId",
-  );
-  const directRecipientPhoneNumber = readHostedRuntimeNullableStringField(
-    record,
-    "directRecipientPhoneNumber",
-  );
-  const fromPhoneNumber = readHostedRuntimeNullableStringField(
-    record,
-    "fromPhoneNumber",
-  );
-  if (
-    target
-    && (targetKind === "participant" || targetKind === "thread")
-    && conversationThreadId !== undefined
-    && directRecipientPhoneNumber !== undefined
-    && fromPhoneNumber !== undefined
-    && typeof record.threadIsDirect === "boolean"
-  ) {
-    result.resolvedRoute = {
-      conversationThreadId,
-      directRecipientPhoneNumber,
-      fromPhoneNumber,
-      target,
-      targetKind,
-      threadIsDirect: record.threadIsDirect,
-    };
-  }
+  const resolvedRoute = parseHostedExecutionResolvedLinqDeliveryRoute(response.resolvedRoute);
+  if (resolvedRoute) result.resolvedRoute = resolvedRoute;
   return result;
-}
-
-function readHostedRuntimeNullableStringField(
-  record: Record<string, unknown>,
-  field: string,
-): string | null | undefined {
-  const value = record[field];
-  if (value === null) {
-    return null;
-  }
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = value.trim();
-  return normalized.length > 0 ? normalized : undefined;
 }
 
 function readOptionalHostedEmailDeliverySummary(

--- a/apps/cloudflare/test/runner-platform.test.ts
+++ b/apps/cloudflare/test/runner-platform.test.ts
@@ -7480,10 +7480,11 @@ describe("buildHostedExecutionRuntimePlatform", () => {
     }
   });
 
-  it("does not synthesize a Linq route from legacy response fields", async () => {
+  it.each([undefined, { target: "chat_legacy", targetKind: "thread", threadIsDirect: true }, { conversationThreadId: null, directRecipientPhoneNumber: "+15550100001", fromPhoneNumber: null, target: "chat_group", targetKind: "thread", threadIsDirect: false }])("does not synthesize a Linq route from legacy or invalid response fields %#", async (resolvedRoute) => {
     const fetchMock = vi.fn(async () =>
       new Response(JSON.stringify({
         ok: true,
+        resolvedRoute,
         targetOverride: {
           conversationThreadId: "hid_legacy_chat",
           target: "chat_legacy",

--- a/apps/web/app/api/internal/hosted-runtime/linq-egress/engagement/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/linq-egress/engagement/route.ts
@@ -1,3 +1,4 @@
+import { parseHostedExecutionResolvedLinqDeliveryRoute } from "@murphai/hosted-execution/routes";
 import {
   requireHostedCloudflareCallbackRequest,
 } from "@/src/lib/hosted-execution/cloudflare-callback-auth";
@@ -277,57 +278,9 @@ function parseOptionalResolvedLinqDeliveryRoute(
   if (value === undefined || value === null) {
     return null;
   }
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throwResolvedLinqDeliveryRouteInvalid();
-  }
-  const record = value as Record<string, unknown>;
-  const target = readOptionalBodyString(record.target);
-  const targetKind = readOptionalBodyString(record.targetKind);
-  const conversationThreadId = readRequiredNullableBodyString(
-    record,
-    "conversationThreadId",
-  );
-  const directRecipientPhoneNumber = readRequiredNullableBodyString(
-    record,
-    "directRecipientPhoneNumber",
-  );
-  const fromPhoneNumber = readRequiredNullableBodyString(
-    record,
-    "fromPhoneNumber",
-  );
-  if (
-    !target
-    || (targetKind !== "participant" && targetKind !== "thread")
-    || conversationThreadId === undefined
-    || directRecipientPhoneNumber === undefined
-    || fromPhoneNumber === undefined
-    || typeof record.threadIsDirect !== "boolean"
-  ) {
-    throwResolvedLinqDeliveryRouteInvalid();
-  }
-  return {
-    conversationThreadId,
-    directRecipientPhoneNumber,
-    fromPhoneNumber,
-    target,
-    targetKind,
-    threadIsDirect: record.threadIsDirect,
-  };
-}
-
-function readRequiredNullableBodyString(
-  record: Record<string, unknown>,
-  field: string,
-): string | null | undefined {
-  if (!(field in record)) {
-    return undefined;
-  }
-  const value = record[field];
-  if (value === null) {
-    return null;
-  }
-  const normalized = readOptionalBodyString(value);
-  return normalized ?? undefined;
+  const route = parseHostedExecutionResolvedLinqDeliveryRoute(value);
+  if (!route) throwResolvedLinqDeliveryRouteInvalid();
+  return route;
 }
 
 function throwResolvedLinqDeliveryRouteInvalid(): never {

--- a/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-egress-engagement.test.ts
@@ -1634,6 +1634,20 @@ describe("hosted Linq egress authority", () => {
     expect(prisma.hostedLinqDelivery.createMany).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { conversationThreadId: null, directRecipientPhoneNumber: "+15550100001", fromPhoneNumber: null, target: "chat-group", targetKind: "thread", threadIsDirect: false },
+    { conversationThreadId: null, directRecipientPhoneNumber: "+15550100001", fromPhoneNumber: null, target: "+15550100003", targetKind: "participant", threadIsDirect: true },
+    { target: "chat-home", targetKind: "thread", threadIsDirect: true },
+  ])("rejects invalid expected routes before acquiring database authority %#", async (expectedResolvedRoute) => {
+    const response = await postHostedLinqEgressEngagement(new Request("https://internal.example.test/engagement", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ authorityCheckOnly: false, target: "chat-home", targetKind: "thread", expectedResolvedRoute }),
+    }));
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "HOSTED_LINQ_EGRESS_RESOLVED_ROUTE_INVALID" } });
+    expect(mocks.getPrisma).not.toHaveBeenCalled();
+  });
+
   it("checks route authority without claiming provider dispatch", async () => {
     const prisma = createPrismaStub({
       homeChatId: "chat-home",

--- a/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
+++ b/packages/assistant-runtime/src/hosted-runtime/callbacks.ts
@@ -1,3 +1,4 @@
+import { parseHostedExecutionResolvedLinqDeliveryRoute } from "@murphai/hosted-execution/routes";
 import { createHash } from "node:crypto";
 
 import type {
@@ -6263,7 +6264,7 @@ function normalizeHostedAssistantLinqEngagementResult(
   if (typeof result?.providerDispatchClaimed === "boolean") {
     normalized.providerDispatchClaimed = result.providerDispatchClaimed;
   }
-  const resolvedRoute = normalizeHostedAssistantLinqResolvedRoute(
+  const resolvedRoute = parseHostedExecutionResolvedLinqDeliveryRoute(
     result?.resolvedRoute,
   );
   if (resolvedRoute) {
@@ -6275,9 +6276,7 @@ function normalizeHostedAssistantLinqEngagementResult(
 function requireHostedAssistantLinqResolvedRoute(
   result: HostedRuntimeLinqRecentInboundEngagementResult,
 ): HostedExecutionResolvedLinqDeliveryRoute {
-  const resolvedRoute = normalizeHostedAssistantLinqResolvedRoute(
-    result.resolvedRoute,
-  );
+  const resolvedRoute = result.resolvedRoute;
   if (!resolvedRoute) {
     throw new VaultCliError(
       "ASSISTANT_LINQ_RESOLVED_ROUTE_PROTOCOL_UNAVAILABLE",
@@ -6286,71 +6285,6 @@ function requireHostedAssistantLinqResolvedRoute(
     );
   }
   return resolvedRoute;
-}
-
-function normalizeHostedAssistantLinqResolvedRoute(
-  value: HostedExecutionResolvedLinqDeliveryRoute | null | undefined,
-): HostedExecutionResolvedLinqDeliveryRoute | null {
-  if (!value || typeof value !== "object") {
-    return null;
-  }
-  const target = value.target?.trim() ?? "";
-  const conversationThreadId = normalizeHostedLinqRouteNullableText(
-    value.conversationThreadId,
-  );
-  const directRecipientPhoneNumber = normalizeHostedLinqDirectRecipient(
-    value.directRecipientPhoneNumber,
-  );
-  const fromPhoneNumber = normalizeHostedLinqDirectRecipient(
-    value.fromPhoneNumber,
-  );
-  if (
-    !target
-    || !("conversationThreadId" in value)
-    || !("directRecipientPhoneNumber" in value)
-    || !("fromPhoneNumber" in value)
-    || (value.targetKind !== "participant" && value.targetKind !== "thread")
-    || typeof value.threadIsDirect !== "boolean"
-    || (
-      value.conversationThreadId !== null
-      && conversationThreadId === null
-    )
-    || (
-      value.directRecipientPhoneNumber !== null
-      && directRecipientPhoneNumber === null
-    )
-    || (value.fromPhoneNumber !== null && fromPhoneNumber === null)
-    || (
-      value.targetKind === "participant"
-      && (
-        value.threadIsDirect !== true
-        || directRecipientPhoneNumber === null
-        || directRecipientPhoneNumber !== target
-      )
-    )
-    || (
-      value.targetKind === "thread"
-      && value.threadIsDirect === false
-      && directRecipientPhoneNumber !== null
-    )
-  ) {
-    return null;
-  }
-  return {
-    conversationThreadId,
-    directRecipientPhoneNumber,
-    fromPhoneNumber,
-    target,
-    targetKind: value.targetKind,
-    threadIsDirect: value.threadIsDirect,
-  };
-}
-
-function normalizeHostedLinqRouteNullableText(
-  value: string | null | undefined,
-): string | null {
-  const normalized = value?.trim() ?? "";
-  return normalized.length > 0 ? normalized : null;
 }
 
 function normalizeHostedAssistantLinqTargetKind(

--- a/packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
+++ b/packages/assistant-runtime/test/hosted-runtime-callbacks.test.ts
@@ -11946,8 +11946,12 @@ describe("hosted runtime callbacks", () => {
     expect(mocks.sendLinqMessage).not.toHaveBeenCalled();
   });
 
-  it("fails closed before capability or provider access when Web lacks the canonical-route protocol", async () => {
-    const assertRecentInbound = vi.fn(async () => ({}));
+  it.each([undefined, {
+    conversationThreadId: null, directRecipientPhoneNumber: "+15550100001",
+    fromPhoneNumber: null, target: "chat_group", targetKind: "thread" as const,
+    threadIsDirect: false,
+  }])("fails closed before capability or provider access for missing or contradictory route %#", async (resolvedRoute) => {
+    const assertRecentInbound = vi.fn(async () => resolvedRoute ? { resolvedRoute } : {});
     const persistAppCardTextFallback = vi.fn(async () => undefined);
     const providerFetch = vi.fn<typeof fetch>();
     const recordDeliveryOutcome = vi.fn(async () => undefined);

--- a/packages/hosted-execution/src/routes.ts
+++ b/packages/hosted-execution/src/routes.ts
@@ -1,3 +1,5 @@
+import type { HostedExecutionResolvedLinqDeliveryRoute } from "./contracts.ts";
+
 export const HOSTED_RUNTIME_MAILBOX_FETCH_PATH = "/api/internal/hosted-mailbox/fetch";
 export const HOSTED_RUNTIME_MAILBOX_PAYLOAD_FETCH_PATH =
   "/api/internal/hosted-mailbox/payload/fetch";
@@ -189,3 +191,45 @@ export const HOSTED_DEVICE_SYNC_RECOVERY_SWEEP_PATH =
   "/api/internal/device-sync/recovery-sweep";
 export const HOSTED_DEVICE_SYNC_RECOVERY_SWEEP_CALLBACK_USER_ID =
   "hosted-device-sync-reconciler";
+
+/** Parses the complete Web-owned route; target and audience must agree. */
+export function parseHostedExecutionResolvedLinqDeliveryRoute(
+  value: unknown,
+): HostedExecutionResolvedLinqDeliveryRoute | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const target = readLinqRouteText(record.target);
+  const conversationThreadId = readLinqRouteText(record.conversationThreadId);
+  const directRecipientPhoneNumber = readLinqRouteText(record.directRecipientPhoneNumber);
+  const fromPhoneNumber = readLinqRouteText(record.fromPhoneNumber);
+  if (
+    !target
+    || (record.targetKind !== "participant" && record.targetKind !== "thread")
+    || typeof record.threadIsDirect !== "boolean"
+    || conversationThreadId === undefined
+    || directRecipientPhoneNumber === undefined
+    || fromPhoneNumber === undefined
+  ) return null;
+  if (
+    (directRecipientPhoneNumber !== null && !directRecipientPhoneNumber.startsWith("+"))
+    || (fromPhoneNumber !== null && !fromPhoneNumber.startsWith("+"))
+  ) return null;
+  if (
+    record.targetKind === "participant"
+    && (!record.threadIsDirect || directRecipientPhoneNumber !== target)
+  ) return null;
+  if (!record.threadIsDirect && directRecipientPhoneNumber !== null) return null;
+  return {
+    conversationThreadId,
+    directRecipientPhoneNumber,
+    fromPhoneNumber,
+    target,
+    targetKind: record.targetKind,
+    threadIsDirect: record.threadIsDirect,
+  };
+}
+
+function readLinqRouteText(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  return typeof value === "string" ? value.trim() || undefined : undefined;
+}

--- a/packages/hosted-execution/test/hosted-execution.test.ts
+++ b/packages/hosted-execution/test/hosted-execution.test.ts
@@ -1043,6 +1043,7 @@ describe("hosted execution coverage gaps", () => {
       "HOSTED_RUNTIME_WORKSPACE_PATH",
       "buildHostedRuntimeOwnerReleaseSearch",
       "isHostedRuntimeVaultShareDeliverContinuation",
+      "parseHostedExecutionResolvedLinqDeliveryRoute",
       "parseHostedRuntimeOwnerReleaseSearch",
     ]);
     expect(routeModule.HOSTED_RUNTIME_MAILBOX_PAYLOAD_FETCH_PATH).toBe(

--- a/packages/hosted-execution/test/linq-route.test.ts
+++ b/packages/hosted-execution/test/linq-route.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { parseHostedExecutionResolvedLinqDeliveryRoute } from "../src/routes.ts";
+
+const direct = {
+  conversationThreadId: "opaque-thread",
+  directRecipientPhoneNumber: "+15550100001",
+  fromPhoneNumber: "+15550100002",
+  target: "chat-current",
+  targetKind: "thread",
+  threadIsDirect: true,
+};
+
+describe("canonical Linq delivery route parser", () => {
+  it.each([
+    direct,
+    { ...direct, targetKind: "participant", target: direct.directRecipientPhoneNumber },
+    { ...direct, threadIsDirect: false, directRecipientPhoneNumber: null },
+    { ...direct, conversationThreadId: null, fromPhoneNumber: null, directRecipientPhoneNumber: null },
+  ])("preserves a complete authorized route %#", (route) => {
+    expect(parseHostedExecutionResolvedLinqDeliveryRoute(route)).toEqual(route);
+  });
+
+  it("normalizes route coordinates without changing their audience", () => {
+    expect(parseHostedExecutionResolvedLinqDeliveryRoute({
+      ...direct, target: " chat-current ", fromPhoneNumber: " +15550100002 ",
+    })).toEqual(direct);
+  });
+
+  it.each([
+    null, undefined, [], "route", {},
+    { ...direct, target: " " },
+    { ...direct, target: 123 },
+    { ...direct, targetKind: "explicit" },
+    { ...direct, threadIsDirect: "true" },
+    { ...direct, conversationThreadId: undefined },
+    { ...direct, conversationThreadId: " " },
+    { ...direct, directRecipientPhoneNumber: undefined },
+    { ...direct, directRecipientPhoneNumber: "member@example.test" },
+    { ...direct, fromPhoneNumber: undefined },
+    { ...direct, fromPhoneNumber: 123 },
+    { ...direct, fromPhoneNumber: "15550100002" },
+    { ...direct, targetKind: "participant" },
+    { ...direct, targetKind: "participant", target: direct.directRecipientPhoneNumber, threadIsDirect: false },
+    { ...direct, targetKind: "participant", target: direct.directRecipientPhoneNumber, directRecipientPhoneNumber: null },
+    { ...direct, threadIsDirect: false },
+  ])("rejects incomplete or contradictory route %#", (route) => {
+    expect(parseHostedExecutionResolvedLinqDeliveryRoute(route)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why and outcome

Linq route authority was parsed differently in Web, Worker, and runtime, then parsed again immediately before use. Move the existing runtime invariants into one pure parser in the existing hosted-execution routes contract and delete the duplicate implementations. This removes 122 net production source lines.

The live Web authority checks before planning and sending, current-route comparison, group isolation, health policy, and provider dispatch claim remain in place. SMS and iMessage keep their existing delivery behavior; malformed routes fail closed at each boundary.

## Product UX

- Effort: Not applicable — mechanical route-contract consolidation; no legitimate messaging flow or assistant behavior changes.
- Result: Ready.
- Walkthrough: Direct, group, and participant routes; text, card, voice, and reaction paths; missing protocol, group/recipient contradictions, route drift, revoked authority and provider claim outcomes.

## Evidence

- Direct: 592 focused tests passed: shared route parser 25, Worker platform 215, runtime callbacks 285, Web engagement 67.
- Commands: `pnpm --filter @murphai/hosted-execution test test/linq-route.test.ts`; `pnpm --filter @murphai/assistant-runtime test test/hosted-runtime-callbacks.test.ts`; `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/runner-platform.test.ts`; `pnpm --dir apps/web test:prepared -- hosted-onboarding-linq-egress-engagement.test.ts`.
- Typechecks: hosted-execution, assistant-runtime, Cloudflare Worker and Web passed.
- Coverage: The shared parser exercises complete/malformed wire records; actual Web/Worker/runtime consumers prove fail-closed dispatch, current target binding, unchanged two-phase authority and health/claim handling. No production sends.
- [ReviewGPT round 1](https://chatgpt.com/c/6aa36022-1418-83ea-8c6e-611b0e769377): PASS at `832b014819c6c8796315791e6e0576a2186afd89`; captured GPT-6 Pro and response hash verified, 371 seconds, no accepted findings. The subsequent change only adds the already-reviewed parser to the public-export test expectation; 35 focused contract tests and hosted-execution typecheck pass, with no production delta. Final exact-head required CI passed, including Release checks (ubuntu), both CLI host platforms and the hosted billing boundary.

## Non-obvious affected surfaces

Alternate runtime effects-port implementations still pass through runtime validation. Voice and reaction paths consume the already-normalized route. Scheduled route resolution receives the same canonical result through the Worker parser. Existing callback and platform suites cover these callers.

## Architecture and reuse

- Existing systems reused: hosted-execution route contract, Web route authority, signed effects port, runtime delivery owner.
- New logic: None for valid routes; existing runtime semantic checks now also reject malformed wire routes at Web and Worker entry.
- New abstractions: One exported pure parser replaces three implementations at the existing public contract boundary; no new type, service, or package.
- Complexity intentionally avoided: No audience service, extra lookup, cache, configuration, persistent state, fallback route, dependency, or schema migration.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; runtime debt decreases by five; other changed-file debt unchanged. Shared parser is 20.
- Hotspots: Existing Web transaction 30; runtime send closure 73, Telegram provider authority 47, drain 37, prepared delivery 35, effect collection 33, outcome ambiguity 32, vault-file approval 28, voice closure 26, outcome builder 25, email send 24, dispatch preflight/progress dependency factory/file preload/payload builder 21 each. Their independent effect, transaction and failure branches are unchanged.
- Agent judgment: Deleted duplicate route validation and redundant re-parsing. Further decomposition of unrelated delivery owners is outside this bounded refactor.

## Hot reply path impact

- Path status: Touched — synchronous validation only.
- Database calls: None added or moved; current authority and dispatch transaction owners unchanged.
- Network/provider calls: None added or moved; existing preflight and send-time checks retain their distinct roles.
- Other awaited latency: None added or moved. Existing timeouts, retries and recovery unchanged.
- Before/after proof: Callback and Web suites retain preflight/provider assertion ordering, route drift refusal and provider claim behavior; one immediate repeated parse is deleted. No latency benchmark claimed.

## Murph initial provider input impact

Not applicable for either individual or group runtime: no prompt, tool/schema, generated guidance, model request, or conversation classification changes. Only the existing transient route result validation is consolidated. No token measurement claimed.

## Deployment concerns

- Deployment: applicable
- Supported skew: The six-field route protocol is unchanged. Old/new Web, Worker and runtime accept the same valid production route records. Required nullable fields and participant/group invariants retain runtime semantics.
- Safe order: Any order; each upgraded boundary uses the same parser, with existing missing-protocol handling.
- Rollback floor: Existing protocol; no migration, state, or writer cutover.
- Expected exposure: Invalid protocol payloads may be rejected earlier during a mixed rollout; legitimate direct/group/participant routes are unchanged.
- Reversibility: Source revert; no data repair.
- Convergence proof: Existing Web route fixtures, shared valid-route matrix, Worker transport and runtime callback tests exercise the unchanged producer shapes. No new/old shape distinction exists.
- Post-deploy checks: Existing Linq delivery canaries and bounded route-protocol/claim error rates; verify direct/group sends and current-route revocation remain correct.

## Change-shape breakdown

Classification rule: production TypeScript is source, test paths are tests, Markdown is docs. No binaries or generated output.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 54 | 176 |
| Tests / fixtures | 72 | 3 |
| Docs | 45 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **171** | **179** |

## Changelog

- Changelog: not applicable
- Reason: Internal parser consolidation; valid messaging behavior is unchanged.

ReviewGPT first-reviewed head: 832b014819c6c8796315791e6e0576a2186afd89
ReviewGPT context sensitivity: sensitive
Classification reason: Cross-owner hosted delivery authority and external-effect boundary.
