### PR TITLE
Test native Wrangler namespace bootstrap behavior

### DIFF
--- a/.agents/friction-log/20260910203224-development-cli-evaluation/friction.md
+++ b/.agents/friction-log/20260910203224-development-cli-evaluation/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Development CLI evaluation forwards the argument separator to Wrangler'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The repository CLI evaluation helper should pass the requested command and flags to an exact registry CLI without changing the workspace dependency graph.
+
+## Current Behavior
+
+Evaluating Wrangler deployment help through the helper fails because the extra argument separator reaches Wrangler, which treats the command and help flag as positional arguments. Running the same pinned pnpm dlx invocation without that separator succeeds.
+
+## Possible Solution
+
+Check the pinned pnpm dlx argument forwarding contract and omit the separator before CLI arguments if it is forwarded literally.
+
+## Minimal Reproducible Example
+
+From apps/cloudflare, run ../../scripts/evaluate-dev-cli wrangler@4.93.0 -- deploy --help. Compare it with pnpm --config.ignore-scripts=true --config.registry=https://registry.npmjs.org/ dlx wrangler@4.93.0 deploy --help.
+
+## Context
+
+This blocks a read-only deployment CLI compatibility evaluation and requires reproducing the helper's policy-preserving command manually.

--- a/agent-docs/exec-plans/completed/2026-09-10-member-one-vcpu.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-member-one-vcpu.md
@@ -1,6 +1,6 @@
 # Member-specific one-vCPU container experiment
 
-Status: active
+Status: completed
 Created: 2026-09-10
 Updated: 2026-09-10
 
@@ -55,7 +55,7 @@ Updated: 2026-09-10
 2. Add fixed resource rendering and protected namespace/application provisioning.
 3. Map the selector and provisioning control in private Murph Cloud.
 4. Run focused proof, typechecks, complexity review, CI and ReviewGPT gates.
-5. Merge, deploy, verify account convergence and close this plan.
+5. Merge, deploy, verify native convergence and record account-allocation limits.
 
 ## Decisions
 
@@ -92,7 +92,48 @@ Updated: 2026-09-10
 - The forward fix permits an exact observed image reference only in the
   namespace-only preservation path. New release admission remains digest-only;
   native before/after receipts, resource checks and routing-off ordering remain.
-  Live convergence is pending the focused correction and its review/CI gates.
+- The correction merged as PR #3216 after 100 focused tests, Cloudflare
+  typecheck, complexity checks and all required exact-head CI passed. Final
+  ReviewGPT round 1 passed with verified Pro metadata and a 366-second response
+  capture, including 27 independently executed checks. The first tooling
+  attempt was invalid because its archive was absent; the exact captured thread
+  was inspected before the successful same-round full-snapshot retry.
+- The protected full retry passed all predeployment gates and stopped before
+  Worker mutation: pinned Wrangler 4.90.0 rejects the bootstrap no-rollout flag.
+  An actual-CLI synthetic probe proves that omitting the flag can reconcile an
+  existing application when native fields differ, despite matching image and
+  resources. Native Wrangler 4.93.0 provides the migration-only skip without
+  a deployment patch. The existing macOS compatibility correction is unrelated.
+- A separate main-branch upgrade shipped Wrangler 4.93.0 while the experiment's
+  dependency candidate was being verified. That candidate is superseded; the
+  outcome follow-up retains only the actual-CLI regression and task records.
+- Against the upgraded main branch, the frozen lockfile install, 36 actual-CLI,
+  bootstrap and deployment tests, and Cloudflare typecheck pass. The actual CLI
+  uploads the new namespace with selection off and makes no Container API call;
+  a plain deploy attempts a native application patch in the synthetic case.
+- Protected deployment completed successfully using the main-branch Wrangler
+  upgrade. All predeployment gates, deployment, final endpoint smoke and live
+  convergence verification passed. Native application admission checked the
+  exact 1-vCPU / 3-GiB / 6,000-MB specification. The final receipt reports the
+  dedicated application created at version 1 with capacity 1; ordinary serving
+  capacity remains 702 and retired applications remain at zero.
+- The protected selector metadata is unchanged, selection remains enabled, and
+  the one-time bootstrap control was cleared after namespace provisioning. A
+  later deployment had already begun; the existing-namespace branch skips
+  bootstrap before consulting that control, so the cleanup preserves its path.
+- Documentation drift, gardening and complexity checks pass. The outcome
+  follow-up changes isolated CLI proof and historical records only; it does not
+  require another final ReviewGPT production review.
+
+## Outcome and remaining measurement
+
+The smaller application and fresh-allocation eligibility are shipped. Existing
+warm sessions retain their exact target until normal retirement. The selected
+account's first smaller-container allocation has not been independently observed;
+that original success criterion remains an operational verification limit.
+Existing aggregate hot-reply and CLI timing provides the baseline, but no
+post-change timing or performance conclusion is claimed. Normal member traffic
+can supply the next allocation and the comparison data.
 
 - Focused allocation, slot lifecycle, namespace, configuration, staging and
   deployment tests; Cloudflare typecheck and complexity diff.
@@ -102,3 +143,4 @@ Updated: 2026-09-10
 - Prove first provisioning preserves serving resources, failed admission cannot
   enable routing, worker-only mode retains images, and later releases update the
   dedicated application. Verify actual 1/3/6000 resources after deployment.
+Completed: 2026-09-10

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -157,6 +157,7 @@ Generated-image retirement after hosted media expiry is owned by
 | `agent-docs/operations/device-sync-ingestion-invariants.md` | Device-sync push/pull ingestion invariants. | Device-sync ingestion contract | High | 2026-08-20 |
 | `agent-docs/PLANS.md` | Execution-plan lifecycle and storage rules. | Plan workflow | Medium | 2026-03-31 |
 | `agent-docs/exec-plans/completed/README.md` | Completed-plan archive interpretation. | Completed-plan archive interpretation | Medium | 2026-07-22 |
+| `agent-docs/exec-plans/completed/2026-09-10-member-one-vcpu.md` | Dedicated smaller-container deployment, native CLI bootstrap proof and pending natural-traffic measurement. | Historical implementation evidence | Low | 2026-09-10 |
 | `agent-docs/exec-plans/completed/2026-09-06-all-tool-failure-diagnostics-extension.md` | Separate PR #2985 telemetry extension record; original completed plan unchanged. | Historical implementation evidence | Low | 2026-09-06 |
 | `agent-docs/generated/README.md` | Meaning and expectations for generated doc artifacts. | Generated-doc conventions | Low | 2026-04-02 |
 | `agent-docs/exec-plans/completed/2026-09-09-bundled-cli-query-timing-owner.md` | Exact-leaf runner bundle correction and proof handoff; actual assembled validation and parent evidence pending. | Historical implementation evidence | Low | 2026-09-09 |

--- a/apps/cloudflare/test/small-runner-wrangler.test.ts
+++ b/apps/cloudflare/test/small-runner-wrangler.test.ts
@@ -1,0 +1,152 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type IncomingMessage } from "node:http";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { prepareSmallRunnerNamespaceBootstrap } from "../scripts/stage-runner-release.ts";
+
+const execute = promisify(execFile);
+const require = createRequire(import.meta.url);
+const account = "0".repeat(32);
+const versionId = "11111111-1111-4111-8111-111111111111";
+const classes = ["RunnerContainer", "SmallRunnerContainer"];
+const image = `registry.cloudflare.com/${account}/synthetic-runner:retained-release`;
+const native = {
+  id: "synthetic-application", name: "synthetic-worker-runnercontainer",
+  durable_objects: { namespace_id: "ns-RunnerContainer" }, scheduling_policy: "default",
+  configuration: { image, vcpu: 2, memory_mib: 6144, disk: { size_mb: 6000 },
+    observability: { logs: { enabled: true } }, wrangler_ssh: { enabled: false },
+    // A field outside the requested release identity can still trigger reconciliation.
+    authorized_keys: ["synthetic-public-key"],
+  },
+  max_instances: 10, constraints: { tiers: [1, 2] }, rollout_active_grace_period: 300,
+};
+
+async function bootstrapConfig(directory: string): Promise<string> {
+  const bindings = classes.map(class_name => ({ name: class_name.toUpperCase(), class_name }));
+  const vars = { HOSTED_EXECUTION_SMALL_RUNNER_ENABLED: "true",
+    HOSTED_EXECUTION_RUNNER_BUNDLE_FINGERPRINT: "a".repeat(64),
+    HOSTED_EXECUTION_RUNNER_SOURCE_FINGERPRINT: "b".repeat(64) };
+  const configPath = path.join(directory, "wrangler.json");
+  await writeFile(configPath, JSON.stringify({
+    name: "synthetic-worker", main: "worker.js", compatibility_date: "2026-01-01", account_id: account,
+    workers_dev: false, preview_urls: false, observability: { logs: { enabled: true } }, vars,
+    durable_objects: { bindings },
+    migrations: [{ tag: "v8", new_sqlite_classes: ["RunnerContainer"] },
+      { tag: "v9", new_sqlite_classes: ["SmallRunnerContainer"] }],
+    containers: classes.map(class_name => ({ class_name, image,
+      instance_type: { vcpu: 2, memory_mib: 6144, disk_mb: 6000 }, max_instances: 10,
+      rollout_active_grace_period: 300, rollout_step_percentage: [100], ssh: { enabled: false } })),
+  }));
+  const output = await prepareSmallRunnerNamespaceBootstrap({ allowed: true, configPath,
+    currentVersionId: versionId, listApplications: async () => [native],
+    currentVersion: { resources: { bindings: [
+      { type: "durable_object_namespace", ...bindings[0], namespace_id: "ns-RunnerContainer" },
+      ...Object.entries(vars).map(([name, text]) => ({ type: "plain_text", name, text })),
+    ] } },
+  });
+  if (!output) throw new Error("Synthetic bootstrap config was not produced");
+  return output;
+}
+
+async function readUploadMetadata(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  const form = await new Response(Buffer.concat(chunks), {
+    headers: { "content-type": String(request.headers["content-type"]) },
+  }).formData();
+  const metadata = form.get("metadata");
+  if (metadata === null) throw new Error("Worker upload omitted metadata");
+  return JSON.parse(typeof metadata === "string" ? metadata : await metadata.text());
+}
+
+async function runWranglerBootstrap(skipContainers: boolean) {
+  const directory = await mkdtemp(path.join(tmpdir(), "murph-bootstrap-cli-"));
+  const requests: string[] = [];
+  let metadata: unknown;
+  const server = createServer(async (request, response) => {
+    const route = new URL(request.url ?? "/", "http://localhost").pathname;
+    const method = request.method;
+    requests.push(`${method} ${route}`);
+    let result: unknown;
+    try {
+      if (method === "PUT" && route.endsWith("/workers/scripts/synthetic-worker")) {
+        metadata = await readUploadMetadata(request);
+        result = { deployment_id: versionId, startup_time_ms: 0 };
+      } else if (method === "GET" && route.endsWith("/workers/services/synthetic-worker")) {
+        result = { default_environment: { environment: "production",
+          script: { tag: "synthetic-tag", tags: [], last_deployed_from: "wrangler", migration_tag: "v8" } } };
+      } else if (method === "GET" && route.endsWith("/deployments")) {
+        result = { deployments: [{ id: "synthetic-deployment", versions: [{ version_id: versionId, percentage: 100 }] }] };
+      } else if (method === "GET" && route.endsWith("/workers/scripts")) {
+        result = [{ id: "synthetic-worker", migration_tag: "v8" }];
+      } else if (method === "GET" && route.endsWith("/settings")) {
+        result = { migration_tag: "v8", bindings: [] };
+      } else if (method === "GET" && route.endsWith(`/versions/${versionId}`)) {
+        result = { id: versionId, resources: { bindings: classes.map(class_name => ({
+          type: "durable_object_namespace", class_name, namespace_id: `ns-${class_name}`,
+        })) } };
+      } else if (method === "GET" && route.endsWith("/containers/applications")) {
+        result = [native];
+      } else if ((method === "GET" || method === "POST") && route.endsWith("/subdomain")) {
+        result = { enabled: false, previews_enabled: false };
+      } else {
+        throw new Error("Unexpected synthetic API operation");
+      }
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ success: true, errors: [], messages: [], result }));
+    } catch {
+      response.writeHead(500, { "content-type": "application/json" });
+      response.end(JSON.stringify({ success: false, errors: [{ code: 10000, message: "Unexpected synthetic API operation" }] }));
+    }
+  });
+  try {
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Synthetic API did not bind a TCP port");
+    const configPath = await bootstrapConfig(directory);
+    await writeFile(path.join(directory, "worker.js"),
+      "export class RunnerContainer {}\nexport class SmallRunnerContainer {}\nexport default { fetch() { return new Response('synthetic'); } };\n");
+    const packagePath = require.resolve("wrangler/package.json");
+    const { bin } = JSON.parse(await readFile(packagePath, "utf8"));
+    const command = execute(process.execPath, [path.resolve(path.dirname(packagePath), bin.wrangler),
+      "deploy", "--config", configPath, ...(skipContainers ? ["--containers-rollout=none"] : [])], {
+      cwd: directory, timeout: 30_000,
+      env: { PATH: process.env.PATH, CI: "true", XDG_CONFIG_HOME: path.join(directory, "config"),
+        CLOUDFLARE_ACCOUNT_ID: account, CLOUDFLARE_API_TOKEN: "synthetic-api-token",
+        CLOUDFLARE_API_BASE_URL: `http://127.0.0.1:${address.port}/client/v4`,
+        WRANGLER_SEND_METRICS: "false", WRANGLER_LOG_PATH: path.join(directory, "wrangler.log") },
+    });
+    const succeeded = await command.then(() => true, () => false);
+    return { succeeded, requests, metadata };
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>(resolve => server.close(() => resolve()));
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+describe("installed Wrangler namespace bootstrap", () => {
+  it("uploads the new namespace with selection off and never enters the container API", async () => {
+    const result = await runWranglerBootstrap(true);
+    expect(result.succeeded).toBe(true);
+    expect(result.metadata).toMatchObject({
+      containers: [{ class_name: "RunnerContainer" }],
+      migrations: { old_tag: "v8", new_tag: "v9", steps: [{ new_sqlite_classes: ["SmallRunnerContainer"] }] },
+      bindings: expect.arrayContaining([
+        { type: "durable_object_namespace", name: "SMALLRUNNERCONTAINER", class_name: "SmallRunnerContainer" },
+        { type: "plain_text", name: "HOSTED_EXECUTION_SMALL_RUNNER_ENABLED", text: "false" },
+      ]),
+    });
+    expect(result.requests.some(request => request.includes("/containers/"))).toBe(false);
+  });
+
+  it("shows why a normal deploy cannot promise to preserve every existing container setting", async () => {
+    const result = await runWranglerBootstrap(false);
+    expect(result.succeeded).toBe(false);
+    expect(result.requests).toContain(`PATCH /client/v4/accounts/${account}/containers/applications/synthetic-application`);
+  });
+});


### PR DESCRIPTION
## Why and outcome

Exercise the installed Wrangler binary against a synthetic Cloudflare API to prove that namespace bootstrap uploads the new binding and migration with selection disabled and makes no Container API call. The counterexample shows that a plain deploy can patch an existing application when native fields differ despite matching image and resources.

Record the successful smaller-container deployment from #3206 and #3216 and close its execution plan. Wrangler 4.93.0 is already on main; this follow-up changes proof and historical records only.

## Product UX

- Effort: Not applicable — isolated deployment tests and historical documentation.
- Result: Not applicable.
- Walkthrough: No product behavior changes. The deployment record distinguishes native provisioning from the still-unobserved first natural account allocation and latency comparison.

## Evidence

- Direct: The real installed Wrangler binary uploads bootstrap metadata and makes zero Container API calls with `--containers-rollout=none`; plain deployment attempts a PATCH in the same synthetic setup.
- Coverage: 36 tests pass across `small-runner-wrangler.test.ts`, `small-runner-deploy.test.ts` and `deploy-worker-version-cli.test.ts` using the Cloudflare Node Vitest workspace with coverage disabled.
- `pnpm --dir apps/cloudflare typecheck` and frozen-lockfile installation pass.
- `pnpm complexity:diff`, `pnpm docs:drift`, `pnpm docs:gardening` and diff whitespace checks pass.
- The protected deployment passed its predeployment gates, native admission, final endpoint smoke and live release convergence. No post-change latency claim is made.
- Required PR CI will verify this authored head. Final ReviewGPT is not applicable under the isolated proof/documentation exemption.

## Non-obvious affected surfaces

None. The CLI test supplies synthetic credentials, an isolated config directory and a loopback API; it does not inherit production credentials.

## Architecture and reuse

- Existing systems reused: The actual bootstrap renderer and installed Wrangler binary.
- New logic: Test-only API responses and upload assertions.
- New abstractions: None; helpers remain local to the single regression file.
- Complexity intentionally avoided: No dependency update, CLI patch or production deployment change.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`; no authored production JavaScript or TypeScript source changes.
- Hotspots: None in the production diff.
- Agent judgment: The narrow HTTP harness proves the external CLI boundary that dependency metadata alone cannot establish.

## Hot reply path impact

- Path status: Not applicable — tests and documentation only.
- Database calls: None.
- Network/provider calls: None on the runtime path.
- Other awaited latency: None on the runtime path.
- Before/after proof: The diff changes no production runtime code.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no prompts, tools, schemas, input builders or runtime files change. Complete provider-input measurement was not run because those surfaces are unchanged.

## Deployment concerns

- Deployment: not applicable
- Reason: The deployment is already shipped. This follow-up adds isolated CLI proof and records the outcome without changing deployment configuration or runtime behavior.

## Change-shape breakdown

Classification rule: The CLI regression is tests; the execution-plan move, index and Frog report are docs. The plan is counted as a rename. No binary files or generated output.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 152 | 0 |
| Docs | 70 | 3 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **222** | **3** |

## Changelog

- Changelog: not applicable
- Reason: Internal regression proof and historical task records only.
