### PR TITLE
Preserve Garmin canary credentials through recipient-sealed migration

### DIFF
--- a/.github/workflows/junction-wearable-secret-migration-check.yml
+++ b/.github/workflows/junction-wearable-secret-migration-check.yml
@@ -1,0 +1,32 @@
+name: Garmin Secret Migration Proof
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/junction-wearable-secret-migration*.yml'
+      - 'scripts/junction-wearable-secret-migration*.py'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/junction-wearable-secret-migration*.yml'
+      - 'scripts/junction-wearable-secret-migration*.py'
+
+permissions:
+  contents: read
+
+jobs:
+  synthetic-proof:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Install signed distribution proof dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends python3-nacl=1.5.0-4build1 python3-yaml mypy python3-typeshed
+      - name: Prove real recipient encryption and workflow authority
+        run: |
+          /usr/bin/python3 scripts/junction-wearable-secret-migration.test.py
+          /usr/bin/python3 -m mypy --strict --follow-imports=silent scripts/junction-wearable-secret-migration.py

--- a/.github/workflows/junction-wearable-secret-migration.yml
+++ b/.github/workflows/junction-wearable-secret-migration.yml
@@ -1,0 +1,91 @@
+name: One-time Garmin Secret Migration
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: live-junction-wearable-canary
+  cancel-in-progress: false
+
+jobs:
+  admit:
+    if: >-
+      ${{ github.repository == 'cobuildwithus/murph'
+          && github.event_name == 'workflow_dispatch'
+          && github.ref == 'refs/heads/main'
+          && github.ref_protected
+          && github.run_attempt == 1 }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    steps:
+      - name: Admit current protected main before Environment attachment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_SHA" = "$(gh api repos/cobuildwithus/murph/git/ref/heads/main --jq .object.sha)"
+
+  seal:
+    needs: admit
+    if: >-
+      ${{ github.repository == 'cobuildwithus/murph'
+          && github.event_name == 'workflow_dispatch'
+          && github.ref == 'refs/heads/main'
+          && github.ref_protected
+          && github.run_attempt == 1 }}
+    environment: junction-wearable-canary
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out admitted main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Install signed distribution cryptography without credentials
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends python3-nacl=1.5.0-4build1 python3-yaml
+          /usr/bin/python3 scripts/junction-wearable-secret-migration.test.py
+
+      - name: Revalidate main immediately before sealing
+        id: revalidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$GITHUB_SHA" = "$(gh api repos/cobuildwithus/murph/git/ref/heads/main --jq .object.sha)"
+          echo "sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Seal exactly five existing sandbox credentials
+        id: seal_capsule
+        env:
+          MIGRATION_ADMITTED_SHA: ${{ steps.revalidate.outputs.sha }}
+          JUNCTION_API_KEY: ${{ secrets.JUNCTION_API_KEY }}
+          JUNCTION_CLIENT_USER_ID_SECRET: ${{ secrets.JUNCTION_CLIENT_USER_ID_SECRET }}
+          KERNEL_API_KEY: ${{ secrets.KERNEL_API_KEY }}
+          GARMIN_CANARY_EMAIL: ${{ secrets.GARMIN_CANARY_EMAIL }}
+          GARMIN_CANARY_PASSWORD: ${{ secrets.GARMIN_CANARY_PASSWORD }}
+        run: /usr/bin/python3 scripts/junction-wearable-secret-migration.py
+
+      - name: Upload only the recipient-encrypted migration capsule
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: garmin-secret-migration-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/junction-wearable-secret-migration/capsule.json
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Remove owned runner ciphertext
+        if: ${{ always() && steps.seal_capsule.outcome == 'success' }}
+        run: |
+          rm -f -- "$RUNNER_TEMP/junction-wearable-secret-migration/capsule.json"
+          if [[ -d "$RUNNER_TEMP/junction-wearable-secret-migration" ]]; then
+            rmdir -- "$RUNNER_TEMP/junction-wearable-secret-migration"
+          fi

--- a/agent-docs/SECURITY.md
+++ b/agent-docs/SECURITY.md
@@ -1477,6 +1477,23 @@ locally readable.
   browser transport.
   Because a newly added workflow is not yet a protected trust root, its first
   credentialed proof occurs only after that exact workflow lands on `main`.
+- The one-time Garmin secret migration is a narrow exception for transferring
+  the existing five sandbox Environment credentials to the private executor.
+  Its separate manual workflow admits current protected main before attaching
+  the source Environment, rechecks main immediately before sealing, and gives
+  credentials only to the standard PyNaCl SealedBox step. The recipient repo,
+  Environment, public key, key id, and five names are reviewed source constants;
+  no dispatch input may choose them. No cross-repository credential enters the
+  source runner. Plaintext, plaintext fingerprints, exception payloads, and
+  ciphertext must not enter logs. Only one bounded recipient-encrypted capsule
+  may enter its one-day artifact; the authorized operator validates exact
+  successful-run provenance and imports ciphertext through GitHub's existing
+  Environment-secret API. The artifact is sensitive transient transport, never
+  a secret store or reusable canary output. Delete it after confirmed import,
+  remove the migration workflow/script/proof, and retire the old source
+  credentials after private canary acceptance. Ordinary canary artifact
+  restrictions remain unchanged. The operator procedure and fixed limits live
+  in [verification and runtime](operations/verification-and-runtime.md#one-time-garmin-credential-migration).
 - Native iOS and Android public controllers are protected-main production
   canaries only. They run on staggered six-hour schedules and admit no PR or
   deployment-status event. Manual recovery must name `refs/heads/main` at the

--- a/agent-docs/exec-plans/completed/2026-09-10-garmin-secret-migration.md
+++ b/agent-docs/exec-plans/completed/2026-09-10-garmin-secret-migration.md
@@ -1,0 +1,62 @@
+# Preserve Garmin canary secrets during private executor migration
+
+Status: completed
+Created: 2026-09-10
+Updated: 2026-09-10
+
+## Goal
+
+Preserve the five existing dedicated Garmin canary credentials, especially its
+stable Junction identity key, when provisioning the private executor. Plaintext
+must remain inside the protected source GitHub job.
+
+## Success criteria
+
+- Only current protected main can seal the fixed five source Environment values.
+- The recipient Environment and its public encryption key are reviewed constants.
+- Real sealed-box tests prove exact UTF-8 preservation, recipient confidentiality,
+  ciphertext integrity, strict admission, bounded output, and content-free errors.
+- Operator import and cleanup remain separate from this code-only task.
+
+## Scope
+
+- In scope: disposable source workflow, credential-free PR proof, standard PyNaCl
+  sealing script, synthetic tests, narrow security exception and operator procedure.
+- Out of scope: provider calls, secret value retrieval, imports, workflow dispatch,
+  deployment, account changes, new tokens, or ordinary canary artifact policy.
+
+## Risks and mitigations
+
+- Recipient substitution: pin recipient key and destination in reviewed code;
+  accept no workflow inputs or CLI arguments.
+- Credential disclosure: scope secrets to the seal step, validate before output,
+  use standard SealedBox, emit only a bounded recipient-encrypted capsule.
+- Identity drift: preserve all value bytes and prohibit identity-key regeneration.
+- Wrong artifact or partial import: require exact successful run provenance and
+  fixed schema; operator confirms every write before provider execution.
+- Temporary state surviving migration: one-day ciphertext retention, immediate
+  operator artifact deletion, and removal of workflow/script/proof after import.
+
+## Tasks
+
+1. Confirm the private Environment public key without reading secret values.
+2. Implement fixed-recipient sealing and admitted manual workflow.
+3. Prove cryptography, workflow authority, privacy, and type correctness.
+4. Document scoped migration and hand off a draft PR for parent review/execution.
+
+## Decisions
+
+- Reuse Ubuntu signed PyNaCl and GitHub's documented sealed-box format; introduce
+  no application crypto owner or repository dependency.
+- Export a single short-lived ciphertext artifact; no ciphertext in logs and no
+  cross-repository credential on the source runner.
+- Internal provisioning change only; no product UX or changelog change.
+
+## Verification
+
+- Focused proof: 14 synthetic tests passed using real PyNaCl 1.5.0.
+- Strict mypy source typecheck passed; actionlint passed for both workflows.
+- Scoped privacy and diff checks passed; docs drift and gardening passed with zero issues.
+- Parent owns ReviewGPT, exact-head CI, dispatch, ciphertext import, and cleanup.
+  No real secrets were read or transferred during implementation.
+Completed: 2026-09-10

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -146,7 +146,7 @@ Generated-image retirement after hosted media expiry is owned by
 | `agent-docs/operations/agent-workflow-routing.md` | Task scope, authority, checkout, commits, and instruction ownership. | Agent workflow routing | High | 2026-09-04 |
 | `agent-docs/operations/product-ux.md` | Product UX workflow. | Product UX workflow | High | 2026-08-31 |
 | `agent-docs/operations/native-android-hosted-e2e.md` | Native Android verification operations. | Native Android verification operations | High | 2026-09-01 |
-| `agent-docs/operations/verification-and-runtime.md` | Verification ownership by delivery path, CI compiler memory and production-build proof, independent worktree build outputs, authorized base reconciliation with bounded conflict resolution, and Temporal integration build/process-shard proof. | Verification policy | High | 2026-09-05 |
+| `agent-docs/operations/verification-and-runtime.md` | Verification ownership by delivery path, CI compiler memory and production-build proof, independent worktree build outputs, authorized base reconciliation with bounded conflict resolution, and Temporal integration build/process-shard proof, and the one-time recipient-encrypted Garmin credential migration. | Verification policy | High | 2026-09-10 |
 | `agent-docs/operations/database-transaction-starvation-audit.md` | Database critical-section reliability. | Database critical-section reliability | High | 2026-08-09 |
 | `agent-docs/operations/typescript-verification-performance.md` | Verification performance policy. | Verification performance policy | Medium | 2026-07-29 |
 | `agent-docs/operations/completion-workflow.md` | Completion workflow. | Completion workflow | High | 2026-09-02 |

--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -1143,3 +1143,105 @@ it is not permission to send unrelated messages, deploy, or change the webhook.
 - `Dockerfile.cloudflare-hosted-runner-base` is the checked-in scaffold for the stable native Cloudflare container base image. It installs the common Linux parser dependencies, creates the non-login runner user, and sets the default parser/runtime environment; hosted transcription has no in-image model and routes through the Worker-owned Workers AI binding. `Dockerfile.cloudflare-hosted-runner` is the small app-layer scaffold that starts from that base image, filters the native bundled Codex catalog to exactly `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, adds OpenAI Flex support, forces mixed `tool_mode: code_mode`, and validates both properties for every entry. Mixed mode preserves the code executor while exposing native `tool_search`; dynamic-tool `deferLoading` remains the owner of which broad schemas stay out of the initial model-visible surface. The image then copies the prebuilt `apps/cloudflare/.deploy/runner-bundle/` artifact into `/app` and promotes the pinned native Codex binary plus adjacent sandbox resources into a compact final layer for lazy image loading; the production deploy smoke uses the same catalog for one real `gpt-5.6-terra` turn. The image starts the private `apps/cloudflare/src/container-entrypoint.ts` bridge inside the container, serves `GET /health` plus `POST /internal/workspace-invocation` on that internal bridge only, and delegates bounded hosted workspace invocation directly to `packages/assistant-runtime`. The entrypoint keeps admission, fencing, health, and fatal reporting in a small static boot kernel, starts one cached heavy-runtime hydration after listen, and overlaps that hydration with the accepted invocation's one-shot workspace restore preparation. The prepared restore remains bound to the exact request and warm vault root and is consumed by the existing runtime owner before mailbox/provider work. The default execution path runs one hosted job at a time in-process, builds runtime config from explicit supervisor env plus worker-supplied runtime fields, and uses per-user warm workspace roots plus invocation-local writable cache/temp roots. The present expectation is Node `>=24.14.1`, the preassembled runner bundle plus its materialized production dependencies, writable temp storage for restore/snapshot work, `PORT`, optional `HOSTED_EXECUTION_RUNNER_COMMIT_TIMEOUT_MS`, and shared worker/container allowlist extension vars for encrypted per-user env overrides when additional key names must be permitted.
 - The current runner scaffold now ships as a preassembled deploy bundle copied into the native image rather than rebuilding the workspace from repo source inside Docker. `apps/cloudflare/DEPLOY.md` is the durable guide for the current staged manual deploy path.
 - Before adding a runtime target, document entrypoints, environment assumptions, and operational guardrails here.
+
+
+## One-time Garmin credential migration
+
+The temporary `junction-wearable-secret-migration.yml` workflow transfers the
+existing public `junction-wearable-canary` Environment's five credentials to
+`cobuildwithus/murph-cloud` / `junction-wearable-canary`. This preserves the stable
+Junction client-user identity key. It never reads provider data, calls providers,
+changes accounts, or writes GitHub secrets. An authorized operator owns dispatch,
+import, and cleanup; a passing synthetic proof is not a completed migration.
+
+Before dispatch, the operator must confirm all five names exist specifically in
+the source Environment, rather than relying on repository/organization fallback:
+`JUNCTION_API_KEY`, `JUNCTION_CLIENT_USER_ID_SECRET`, `KERNEL_API_KEY`,
+`GARMIN_CANARY_EMAIL`, and `GARMIN_CANARY_PASSWORD`. Confirm the target Environment
+exists, admits only protected main, and has the expected empty five-secret scope.
+Drain any old public provider run naturally and keep the old executor inactive
+before starting the private provider journey. Matching concurrency names across
+repositories alone do not serialize the two executors.
+
+Fetch only the target Environment's public key through
+`GET /repos/cobuildwithus/murph-cloud/environments/junction-wearable-canary/secrets/public-key`
+and compare both `key` and `key_id` with the reviewed constants in
+`scripts/junction-wearable-secret-migration.py`. A mismatch requires a reviewed
+source update. The workflow accepts no dispatch inputs or recipient override.
+Dispatch it only after its exact code is reviewed and merged to current protected
+main; it rejects re-runs and moved main before exposing values to the sealer.
+
+The credential-free preparation uses signed Ubuntu Noble `python3-nacl` and runs
+synthetic tests. Only the sealing step receives credentials. Each value must be
+nonempty and at most 4,096 UTF-8 bytes; Junction authority must have the US sandbox
+prefix. Values are encrypted exactly, including whitespace and Unicode, without
+normalization or plaintext fingerprints. Standard PyNaCl SealedBox produces the
+format GitHub's Environment-secret API expects. No private-repository token,
+new crypto key owner, or application dependency is introduced.
+
+The sole uploaded artifact is `garmin-secret-migration-<run-id>-1`, retained for
+one day. It contains only `capsule.json`, at most 32,768 uncompressed bytes. The
+schema has exactly `contractVersion`, `source`, `recipient`, and `secrets`:
+
+- `contractVersion` is `1`.
+- `source` has fixed public `repository`, exact `sha`, decimal-string `runId`, and
+  numeric `runAttempt: 1`.
+- `recipient` has fixed private `repository`, `environment`, `keyId`, and
+  base64 `publicKey` matching the reviewed constants and target API.
+- `secrets` maps exactly the five allowlisted names to base64 sealed ciphertext.
+  Every decoded ciphertext is longer than the 48-byte sealed-box overhead and
+  at most 4,144 bytes. There are no plaintext values or hashes.
+
+For import, the operator must:
+
+1. Read the exact public workflow run from GitHub and verify workflow path,
+   `workflow_dispatch`, expected main SHA, first attempt, completed status, and
+   successful conclusion. Download only that run's one expected artifact. Do not
+   print its content or copy it into a checkout, issue, plan, or PR.
+2. Bound the archive to 65,536 bytes; reject extra entries, wrong names, or an
+   uncompressed `capsule.json` larger than 32,768 bytes. Read that single entry
+   without extracting arbitrary archive paths. Parse it strictly against the
+   schema above and match source metadata to the GitHub run. Sealed boxes do not
+   authenticate senders or bind secret names, so trusted run provenance and the
+   exact name-to-ciphertext mapping are required.
+3. Re-fetch the target public key and require the original key and key id. For
+   each fixed name, submit only `{encrypted_value: ciphertext, key_id: keyId}`
+   using `PUT /repos/cobuildwithus/murph-cloud/environments/junction-wearable-canary/secrets/<name>`.
+   Use the operator's existing GitHub authorization, with JSON passed through
+   stdin or an owned temporary ciphertext file; never print bodies or token
+   values. No provider plaintext reaches the local machine.
+4. Require a successful API response for every write and verify the five target
+   Environment names. If import partially succeeds, keep provider execution
+   disabled and replay the same ciphertext mappings while the recipient key is
+   unchanged. Never generate a replacement client-user identity key. A changed
+   recipient key requires a new reviewed seal run.
+5. Delete the exact artifact through GitHub and remove owned local ciphertext
+   immediately after import. Disable and remove the migration workflow, script,
+   synthetic proof workflow, and tests after the five imports are confirmed.
+   Keep the old executor inactive; retire its source secrets only after the
+   private canonical-data canary succeeds. Ordinary provider canaries still
+   upload no artifacts.
+
+Public-repository readers may access the encrypted artifact; confidentiality
+relies on the pinned GitHub recipient key, not artifact access controls. The
+capsule is temporary credential transport, never a durable secret store. No
+ciphertext, provider pages, health data, identities, screenshots, traces, or
+plaintext fingerprints belong in logs.
+
+Focused proof uses actual ephemeral recipient keys and real encryption, including
+exact byte preservation, tamper/wrong-key rejection, missing/oversized/production
+inputs, admission failures, file permissions, and workflow credential partition:
+
+```bash
+uv run --no-project --with pynacl==1.5.0 --with pyyaml==6.0.2 \
+  python scripts/junction-wearable-secret-migration.test.py
+uv run --no-project --with pynacl==1.5.0 --with mypy==1.15.0 \
+  python -m mypy --strict --follow-imports=silent scripts/junction-wearable-secret-migration.py
+actionlint .github/workflows/junction-wearable-secret-migration.yml \
+  .github/workflows/junction-wearable-secret-migration-check.yml
+```
+
+The separate path-scoped `Garmin Secret Migration Proof` workflow runs synthetic
+proof and strict typechecking with signed Ubuntu packages and no Environment or
+provider credentials. API contracts: [GitHub secret encryption](https://docs.github.com/en/rest/guides/encrypting-secrets-for-the-rest-api)
+and [Environment secrets](https://docs.github.com/en/rest/actions/secrets#create-or-update-an-environment-secret).

--- a/scripts/junction-wearable-secret-migration.py
+++ b/scripts/junction-wearable-secret-migration.py
@@ -1,0 +1,127 @@
+"""One-time GitHub-hosted transfer to the reviewed Garmin Environment key.
+
+Remove with the migration workflow after the operator imports all five secrets.
+This program never calls a provider or imports secrets into GitHub.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Mapping
+
+from nacl import public
+
+
+SOURCE_REPOSITORY = "cobuildwithus/murph"
+WORKFLOW_PATH = ".github/workflows/junction-wearable-secret-migration.yml"
+RECIPIENT_REPOSITORY = "cobuildwithus/murph-cloud"
+RECIPIENT_ENVIRONMENT = "junction-wearable-canary"
+# Public encryption material from this exact recipient Environment API. A new
+# recipient or key requires a reviewed source change, never a dispatch input.
+RECIPIENT_KEY_ID = "3380204578043523366"
+RECIPIENT_PUBLIC_KEY = "FdUkJMi0G3LaTRFYMLo80OodxSf3zKvFTHJx3Si4qns="
+SECRET_NAMES = (
+    "JUNCTION_API_KEY",
+    "JUNCTION_CLIENT_USER_ID_SECRET",
+    "KERNEL_API_KEY",
+    "GARMIN_CANARY_EMAIL",
+    "GARMIN_CANARY_PASSWORD",
+)
+MAX_SECRET_BYTES = 4096
+MAX_CAPSULE_BYTES = 32768
+CAPSULE_DIRECTORY = "junction-wearable-secret-migration"
+CAPSULE_FILENAME = "capsule.json"
+
+
+def validate_admission(environment: Mapping[str, str]) -> None:
+    expected = {
+        "GITHUB_REPOSITORY": SOURCE_REPOSITORY,
+        "GITHUB_REF": "refs/heads/main",
+        "GITHUB_REF_PROTECTED": "true",
+        "GITHUB_EVENT_NAME": "workflow_dispatch",
+        "GITHUB_RUN_ATTEMPT": "1",
+        "GITHUB_WORKFLOW_REF": f"{SOURCE_REPOSITORY}/{WORKFLOW_PATH}@refs/heads/main",
+    }
+    if any(environment.get(name) != value for name, value in expected.items()):
+        raise ValueError("Migration admission failed.")
+    sha = environment.get("GITHUB_SHA", "")
+    if not re.fullmatch(r"[0-9a-f]{40}", sha):
+        raise ValueError("Migration revision failed validation.")
+    if environment.get("MIGRATION_ADMITTED_SHA") != sha:
+        raise ValueError("Migration revision is not current main.")
+    if not re.fullmatch(r"[1-9][0-9]{0,19}", environment.get("GITHUB_RUN_ID", "")):
+        raise ValueError("Migration run failed validation.")
+
+
+def build_capsule(environment: Mapping[str, str]) -> bytes:
+    validate_admission(environment)
+    # Validate every value before encrypting or creating any output. Do not trim,
+    # normalize, fingerprint, or serialize plaintext, especially the identity key.
+    values = {name: environment.get(name, "").encode("utf-8") for name in SECRET_NAMES}
+    if any(not value or len(value) > MAX_SECRET_BYTES for value in values.values()):
+        raise ValueError("Migration requires five bounded nonempty values.")
+    if not values["JUNCTION_API_KEY"].startswith(b"sk_us_"):
+        raise ValueError("Migration requires Junction sandbox US authority.")
+    recipient_key = base64.b64decode(RECIPIENT_PUBLIC_KEY, validate=True)
+    if len(recipient_key) != public.PublicKey.SIZE:
+        raise ValueError("Migration recipient key failed validation.")
+    sealed_box = public.SealedBox(public.PublicKey(recipient_key))
+    capsule = {
+        "contractVersion": 1,
+        "source": {
+            "repository": SOURCE_REPOSITORY,
+            "sha": environment["GITHUB_SHA"],
+            "runId": environment["GITHUB_RUN_ID"],
+            "runAttempt": 1,
+        },
+        "recipient": {
+            "repository": RECIPIENT_REPOSITORY,
+            "environment": RECIPIENT_ENVIRONMENT,
+            "keyId": RECIPIENT_KEY_ID,
+            "publicKey": RECIPIENT_PUBLIC_KEY,
+        },
+        "secrets": {
+            name: base64.b64encode(sealed_box.encrypt(value)).decode("ascii")
+            for name, value in values.items()
+        },
+    }
+    encoded = (json.dumps(capsule, separators=(",", ":")) + "\n").encode("ascii")
+    if len(encoded) > MAX_CAPSULE_BYTES:
+        raise ValueError("Migration capsule exceeded its size bound.")
+    return encoded
+
+
+def main() -> int:
+    try:
+        environment = dict(os.environ)
+        for name in SECRET_NAMES:
+            os.environ.pop(name, None)
+        capsule = build_capsule(environment)
+        output_directory = Path(environment["RUNNER_TEMP"]) / CAPSULE_DIRECTORY
+        # A stale directory or file fails closed; never overwrite another run.
+        output_directory.mkdir(mode=0o700)
+        descriptor = os.open(
+            output_directory / CAPSULE_FILENAME,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        with os.fdopen(descriptor, "wb") as output:
+            output.write(capsule)
+    except Exception:
+        # Exception details can contain credential bytes, so emit no cause/trace.
+        print("Garmin secret migration failed.", file=sys.stderr)
+        return 1
+    print("Sealed five Garmin canary credentials for the pinned recipient.")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 1:
+        print("Garmin secret migration accepts no arguments.", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(main())

--- a/scripts/junction-wearable-secret-migration.test.py
+++ b/scripts/junction-wearable-secret-migration.test.py
@@ -1,0 +1,268 @@
+"""Synthetic proof only: real sealed boxes, disposable keys, no provider calls."""
+
+import base64
+from contextlib import redirect_stderr, redirect_stdout
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from nacl import exceptions, public
+import yaml
+
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.dont_write_bytecode = True
+SPEC = importlib.util.spec_from_file_location(
+    "garmin_migration", ROOT / "scripts/junction-wearable-secret-migration.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+migration = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(migration)
+
+
+def synthetic_environment():
+    return {
+        "GITHUB_REPOSITORY": "cobuildwithus/murph",
+        "GITHUB_REF": "refs/heads/main",
+        "GITHUB_REF_PROTECTED": "true",
+        "GITHUB_EVENT_NAME": "workflow_dispatch",
+        "GITHUB_RUN_ATTEMPT": "1",
+        "GITHUB_WORKFLOW_REF": (
+            "cobuildwithus/murph/.github/workflows/"
+            "junction-wearable-secret-migration.yml@refs/heads/main"
+        ),
+        "GITHUB_SHA": "a" * 40,
+        "MIGRATION_ADMITTED_SHA": "a" * 40,
+        "GITHUB_RUN_ID": "12345",
+        "JUNCTION_API_KEY": "sk_us_synthetic-only",
+        "JUNCTION_CLIENT_USER_ID_SECRET": " stable synthetic identity\n",
+        "KERNEL_API_KEY": "synthetic-browser-authority",
+        "GARMIN_CANARY_EMAIL": "garmin@example.test",
+        "GARMIN_CANARY_PASSWORD": "  synthetic-π-password\nwith $ and ` bytes  ",
+        "UNRELATED_SECRET": "must-never-be-exported",
+    }
+
+
+class SealedMigrationProof(unittest.TestCase):
+    def setUp(self):
+        self.environment = synthetic_environment()
+        self.recipient = public.PrivateKey.generate()
+        self.public_key = base64.b64encode(bytes(self.recipient.public_key)).decode("ascii")
+
+    def capsule(self, environment=None):
+        # Replace only the public recipient with a disposable test key. Encryption,
+        # metadata admission, value validation, and serialization remain real.
+        with patch.object(migration, "RECIPIENT_PUBLIC_KEY", self.public_key):
+            return migration.build_capsule(environment or self.environment)
+
+    def test_real_recipient_decrypts_every_original_utf8_byte(self):
+        encoded = self.capsule()
+        capsule = json.loads(encoded)
+        self.assertEqual(set(capsule), {"contractVersion", "source", "recipient", "secrets"})
+        self.assertEqual(capsule["contractVersion"], 1)
+        self.assertEqual(capsule["source"], {
+            "repository": "cobuildwithus/murph", "sha": "a" * 40,
+            "runId": "12345", "runAttempt": 1,
+        })
+        self.assertEqual(capsule["recipient"], {
+            "repository": "cobuildwithus/murph-cloud",
+            "environment": "junction-wearable-canary",
+            "keyId": migration.RECIPIENT_KEY_ID,
+            "publicKey": self.public_key,
+        })
+        self.assertEqual(set(capsule["secrets"]), set(migration.SECRET_NAMES))
+        for name, ciphertext in capsule["secrets"].items():
+            plaintext = public.SealedBox(self.recipient).decrypt(base64.b64decode(ciphertext, validate=True))
+            self.assertEqual(plaintext, self.environment[name].encode("utf-8"))
+            self.assertNotIn(self.environment[name].encode("utf-8"), encoded)
+        self.assertNotIn(b"must-never-be-exported", encoded)
+
+    def test_wrong_recipient_and_modified_ciphertext_fail(self):
+        capsule = json.loads(self.capsule())
+        ciphertext = base64.b64decode(capsule["secrets"]["GARMIN_CANARY_PASSWORD"])
+        with self.assertRaises(exceptions.CryptoError):
+            public.SealedBox(public.PrivateKey.generate()).decrypt(ciphertext)
+        damaged = bytearray(ciphertext)
+        damaged[-1] ^= 1
+        with self.assertRaises(exceptions.CryptoError):
+            public.SealedBox(self.recipient).decrypt(bytes(damaged))
+
+    def test_environment_cannot_replace_the_reviewed_recipient(self):
+        environment = {
+            **self.environment,
+            "RECIPIENT_PUBLIC_KEY": self.public_key,
+            "RECIPIENT_KEY_ID": "attacker-selected",
+            "RECIPIENT_REPOSITORY": "untrusted/repository",
+        }
+        capsule = json.loads(migration.build_capsule(environment))
+        self.assertEqual(capsule["recipient"]["publicKey"], migration.RECIPIENT_PUBLIC_KEY)
+        self.assertEqual(capsule["recipient"]["keyId"], migration.RECIPIENT_KEY_ID)
+        self.assertEqual(capsule["recipient"]["repository"], "cobuildwithus/murph-cloud")
+        with self.assertRaises(exceptions.CryptoError):
+            public.SealedBox(self.recipient).decrypt(
+                base64.b64decode(capsule["secrets"]["JUNCTION_CLIENT_USER_ID_SECRET"])
+            )
+
+    def test_repeated_sealing_does_not_publish_a_stable_plaintext_fingerprint(self):
+        first = json.loads(self.capsule())["secrets"]
+        second = json.loads(self.capsule())["secrets"]
+        self.assertTrue(all(first[name] != second[name] for name in migration.SECRET_NAMES))
+
+    def test_rejects_each_missing_empty_and_oversized_secret(self):
+        for name in migration.SECRET_NAMES:
+            for value in [None, "", "x" * (migration.MAX_SECRET_BYTES + 1)]:
+                with self.subTest(name=name, value_kind=type(value).__name__):
+                    environment = dict(self.environment)
+                    if value is None:
+                        del environment[name]
+                    else:
+                        environment[name] = value
+                    with self.assertRaises(ValueError):
+                        self.capsule(environment)
+
+    def test_rejects_production_and_wrong_region_before_export(self):
+        for key in ["pk_us_synthetic", "pk_eu_synthetic", "sk_eu_synthetic", "not-a-key"]:
+            with self.subTest(prefix=key.split("_")[0]):
+                with self.assertRaises(ValueError):
+                    self.capsule({**self.environment, "JUNCTION_API_KEY": key})
+
+    def test_rejects_every_changed_admission_field(self):
+        changes = {
+            "GITHUB_REPOSITORY": "untrusted/repository",
+            "GITHUB_REF": "refs/heads/feature",
+            "GITHUB_REF_PROTECTED": "false",
+            "GITHUB_EVENT_NAME": "pull_request",
+            "GITHUB_RUN_ATTEMPT": "2",
+            "GITHUB_WORKFLOW_REF": "untrusted-workflow@refs/heads/main",
+            "GITHUB_SHA": "invalid",
+            "MIGRATION_ADMITTED_SHA": "b" * 40,
+            "GITHUB_RUN_ID": "0",
+        }
+        for name, value in changes.items():
+            with self.subTest(name=name):
+                with self.assertRaises(ValueError):
+                    self.capsule({**self.environment, name: value})
+
+    def test_maximum_values_fit_capsule_bound(self):
+        environment = {**self.environment, **{
+            name: "x" * migration.MAX_SECRET_BYTES for name in migration.SECRET_NAMES
+        }}
+        environment["JUNCTION_API_KEY"] = "sk_us_" + "x" * (migration.MAX_SECRET_BYTES - 6)
+        self.assertLessEqual(len(self.capsule(environment)), migration.MAX_CAPSULE_BYTES)
+
+    def test_entrypoint_writes_private_file_and_refuses_stale_output(self):
+        with tempfile.TemporaryDirectory(prefix="garmin-migration-proof-") as temporary:
+            environment = {**self.environment, "RUNNER_TEMP": temporary}
+            output, errors = io.StringIO(), io.StringIO()
+            with patch.dict(os.environ, environment, clear=True), redirect_stdout(output), redirect_stderr(errors):
+                self.assertEqual(migration.main(), 0)
+                self.assertTrue(all(name not in os.environ for name in migration.SECRET_NAMES))
+            capsule_path = Path(temporary) / migration.CAPSULE_DIRECTORY / migration.CAPSULE_FILENAME
+            original = capsule_path.read_bytes()
+            self.assertEqual(stat.S_IMODE(capsule_path.stat().st_mode), 0o600)
+            self.assertEqual(stat.S_IMODE(capsule_path.parent.stat().st_mode), 0o700)
+            self.assertEqual(json.loads(original)["recipient"]["publicKey"], migration.RECIPIENT_PUBLIC_KEY)
+            with patch.dict(os.environ, environment, clear=True), redirect_stdout(output), redirect_stderr(errors):
+                self.assertEqual(migration.main(), 1)
+            self.assertEqual(capsule_path.read_bytes(), original)
+            self.assertEqual(output.getvalue(), "Sealed five Garmin canary credentials for the pinned recipient.\n")
+            self.assertEqual(errors.getvalue(), "Garmin secret migration failed.\n")
+            for name in migration.SECRET_NAMES:
+                self.assertNotIn(environment[name], output.getvalue() + errors.getvalue())
+
+    def test_failed_validation_writes_nothing_and_logs_no_exception_payload(self):
+        with tempfile.TemporaryDirectory(prefix="garmin-migration-proof-") as temporary:
+            environment = {**self.environment, "RUNNER_TEMP": temporary, "GARMIN_CANARY_PASSWORD": ""}
+            output, errors = io.StringIO(), io.StringIO()
+            with patch.dict(os.environ, environment, clear=True), redirect_stdout(output), redirect_stderr(errors):
+                self.assertEqual(migration.main(), 1)
+            self.assertEqual(list(Path(temporary).iterdir()), [])
+            self.assertEqual(output.getvalue(), "")
+            self.assertEqual(errors.getvalue(), "Garmin secret migration failed.\n")
+
+
+class WorkflowAuthorityProof(unittest.TestCase):
+    def setUp(self):
+        self.workflow = yaml.load(
+            (ROOT / migration.WORKFLOW_PATH).read_text(), Loader=yaml.BaseLoader
+        )
+
+    def test_only_manual_admitted_main_can_attach_source_environment(self):
+        self.assertEqual(set(self.workflow["on"]), {"workflow_dispatch"})
+        self.assertEqual(self.workflow["on"]["workflow_dispatch"], "")
+        self.assertEqual(self.workflow["permissions"], {"contents": "read"})
+        self.assertEqual(self.workflow["concurrency"], {
+            "group": "live-junction-wearable-canary", "cancel-in-progress": "false",
+        })
+        admit = self.workflow["jobs"]["admit"]
+        self.assertNotIn("environment", admit)
+        self.assertEqual(admit["steps"][0]["env"], {"GH_TOKEN": "${{ github.token }}"})
+        for condition in [
+            "github.repository == 'cobuildwithus/murph'",
+            "github.event_name == 'workflow_dispatch'",
+            "github.ref == 'refs/heads/main'", "github.ref_protected", "github.run_attempt == 1",
+        ]:
+            self.assertIn(condition, admit["if"])
+        self.assertIn("git/ref/heads/main", admit["steps"][0]["run"])
+        seal = self.workflow["jobs"]["seal"]
+        self.assertEqual(seal["needs"], "admit")
+        self.assertEqual(seal["if"], admit["if"])
+        self.assertEqual(seal["environment"], "junction-wearable-canary")
+
+    def test_credentials_reach_only_the_sealer_after_install_and_main_revalidation(self):
+        steps = self.workflow["jobs"]["seal"]["steps"]
+        self.assertEqual(set(self.workflow["jobs"]), {"admit", "seal"})
+        self.assertNotIn("env", self.workflow)
+        for job in self.workflow["jobs"].values():
+            self.assertNotIn("env", job)
+        secret_steps = [
+            (index, step) for index, step in enumerate(steps)
+            if "secrets." in json.dumps(step)
+        ]
+        self.assertEqual(len(secret_steps), 1)
+        index, sealer = secret_steps[0]
+        self.assertEqual(set(sealer["env"]), {*migration.SECRET_NAMES, "MIGRATION_ADMITTED_SHA"})
+        for name in migration.SECRET_NAMES:
+            self.assertEqual(sealer["env"][name], "${{ secrets." + name + " }}")
+        self.assertEqual(sealer["run"], "/usr/bin/python3 scripts/junction-wearable-secret-migration.py")
+        prior = json.dumps(steps[:index])
+        self.assertIn("python3-nacl=1.5.0-4build1", prior)
+        self.assertIn("junction-wearable-secret-migration.test.py", prior)
+        self.assertIn("git/ref/heads/main", steps[index - 1]["run"])
+        checkout = steps[0]
+        self.assertEqual(checkout["with"]["ref"], "${{ github.sha }}")
+        self.assertEqual(checkout["with"]["persist-credentials"], "false")
+
+    def test_pr_proof_never_attaches_an_environment_or_receives_credentials(self):
+        proof = yaml.load(
+            (ROOT / ".github/workflows/junction-wearable-secret-migration-check.yml").read_text(),
+            Loader=yaml.BaseLoader,
+        )
+        self.assertEqual(proof["permissions"], {"contents": "read"})
+        self.assertNotIn("secrets.", json.dumps(proof))
+        for job in proof["jobs"].values():
+            self.assertNotIn("environment", job)
+
+    def test_only_exact_ciphertext_file_can_be_uploaded_then_owned_cleanup_runs(self):
+        steps = self.workflow["jobs"]["seal"]["steps"]
+        uploads = [step for step in steps if "actions/upload-artifact@" in step.get("uses", "")]
+        self.assertEqual(len(uploads), 1)
+        self.assertEqual(uploads[0]["with"], {
+            "name": "garmin-secret-migration-${{ github.run_id }}-${{ github.run_attempt }}",
+            "path": "${{ runner.temp }}/junction-wearable-secret-migration/capsule.json",
+            "if-no-files-found": "error", "retention-days": "1",
+        })
+        cleanup = steps[-1]
+        self.assertIn("steps.seal_capsule.outcome == 'success'", cleanup["if"])
+        self.assertIn('rm -f -- "$RUNNER_TEMP/junction-wearable-secret-migration/capsule.json"', cleanup["run"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why and outcome

The private Garmin executor needs the five credentials already stored in the public canary Environment. Regenerating its Junction client-user secret would remap existing provider identities. This one-time workflow preserves every credential byte by sealing it inside the protected source job to the reviewed private Environment public key.

Only a bounded recipient-encrypted capsule leaves the job. An authorized operator imports its ciphertext through GitHub's existing secret API; the public runner receives no cross-repository credential. Recipient, destination, and five secret names are fixed in reviewed code. The ordinary provider canary still uploads no artifacts.

## Product UX

- Effort: Not applicable — internal credential provisioning only.
- Result: Not applicable — no member-facing flow changes.
- Walkthrough: Operator reviews and lands the source workflow, imports exact-run ciphertext, removes migration transport, and verifies the private canary. Real execution remains pending.

## Evidence

- Direct: 14 synthetic tests passed using actual PyNaCl 1.5.0 sealed boxes and disposable recipient keys. They prove exact UTF-8/whitespace preservation, tamper and wrong-recipient rejection, fixed-recipient admission, five-value validation, private output permissions, metadata-only errors, and workflow credential partition.
- Coverage: Strict mypy source typecheck passed; actionlint passed both workflows; docs drift and gardening passed with zero issues; scoped privacy and whitespace checks passed. The path-scoped proof workflow repeats synthetic tests and strict typechecking using signed Ubuntu packages, without an Environment or provider credentials.
- Commands: `uv run --no-project --with pynacl==1.5.0 --with pyyaml==6.0.2 python scripts/junction-wearable-secret-migration.test.py`; `uv run --no-project --with pynacl==1.5.0 --with mypy==1.15.0 python -m mypy --strict --follow-imports=silent scripts/junction-wearable-secret-migration.py`; `actionlint .github/workflows/junction-wearable-secret-migration.yml .github/workflows/junction-wearable-secret-migration-check.yml`; `pnpm docs:drift`; `pnpm docs:gardening`.
- External boundary: Retrieved only the target Environment public encryption key/key id. No secret values read, provider calls made, migration dispatched, or secrets imported. Parent owns exact-head CI, ReviewGPT, execution, and cleanup.

## Non-obvious affected surfaces

Source Environment precedence and stable Junction identity ownership: the operator confirms the five names exist specifically at Environment scope before dispatch. During cutover, the old public executor stays inactive until the private canonical-data proof succeeds.

## Architecture and reuse

- Existing systems reused: GitHub protected Environments, standard PyNaCl SealedBox, signed Ubuntu packages, existing pinned checkout/upload actions, and GitHub's Environment-secret API.
- New logic: Current-main admission, fixed-recipient sealing, bounded capsule serialization, and a documented operator import/removal procedure.
- New abstractions: None shared with product code; the disposable script and proof workflows have an explicit post-import removal condition.
- Complexity intentionally avoided: No cross-repository token, secret store, custom cryptography, application dependency, provider call, or automatic secret importer.

## Complexity impact

- Guard: Not applicable — no authored JavaScript or TypeScript changed.
- Hotspots: None in the JS/TS complexity scope; the Python sealer has 127 lines and passes strict typechecking.
- Agent judgment: Standard sealed boxes and one fixed mapping keep the transfer explicit; additional secret-management machinery is unnecessary.

## Hot reply path impact

- Path status: Not applicable — isolated operator workflow only.
- Database calls: None.
- Network/provider calls: None on the reply path.
- Other awaited latency: None on the reply path.
- Before/after proof: No product runtime files changed.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed for either runtime.

## Risks

The temporary public artifact is confidential only because it is sealed to GitHub's pinned recipient key. Sealed boxes do not authenticate the sender or bind secret names; the operator must validate exact successful workflow/run provenance and the complete fixed mapping. Capsule size is at most 32,768 bytes; archive intake is bounded to 65,536 bytes. Recipient-key movement fails closed and requires a reviewed reseal. No plaintext fingerprints or ciphertext are logged.

ReviewGPT context sensitivity: sensitive
Classification reason: one-time transfer of provider credentials across protected GitHub Environments.

## Deployment concerns

- Deployment: applicable
- Supported skew: Both Environments may briefly retain the same credentials; only one provider executor may run.
- Safe order: Review and merge the fixed-recipient workflow; verify source names and target key/protection; seal and import all five values; delete ciphertext and disable/remove migration code; run the private canonical-data canary; retire old source secrets.
- Rollback floor: Preserve the existing stable Junction identity secret and keep provider execution disabled during partial import.
- Expected exposure: One recipient-encrypted artifact with one-day retention, deleted immediately after import; no plaintext outside the source GitHub job.
- Reversibility: The same ciphertext mappings can be replayed while the recipient key is unchanged. This workflow makes no provider/account mutations.
- Convergence proof: Successful API response for every imported name, five target Environment names, and a successful private canonical-data receipt.
- Post-deploy checks: Parent performs admitted main dispatch/import/cleanup and the private canary; none has been performed in this PR.

## Change-shape breakdown

Classification rule: Python sealer as source, Python unittest as tests, Markdown as docs, YAML workflows as config/tooling. No binary files or generated content.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 127 | 0 |
| Tests / fixtures | 268 | 0 |
| Docs | 182 | 1 |
| Config / tooling | 123 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **700** | **1** |

## Changelog

- Changelog: not applicable
- Reason: Internal one-time canary credential provisioning; no member-visible product behavior changes.

ReviewGPT first-reviewed head: 404a2928ce4cf36d3ecdf4994cfff73538881658

Final review: [ReviewGPT round 1 PASS](https://chatgpt.com/c/6aa36cff-3658-83ea-be06-fc23363894ab), no findings. Exact head `404a2928ce4cf36d3ecdf4994cfff73538881658`, concrete `gpt-6-pro`, 306 seconds, all eight guarded snapshot blobs verified, response hash and committed-turn identity validated. All four required CI checks passed on this exact head, as did the separate real-crypto synthetic proof workflow. Parent fetched current main and proved clean mergeability. No transfer has run.
