### PR TITLE
fix(test): support focused input events in shared renderer

### DIFF
--- a/apps/web/test/render-client-component.test.tsx
+++ b/apps/web/test/render-client-component.test.tsx
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+
+import { act, useState } from "react";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { renderClientComponent } from "./render-client-component";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it("dispatches Enter and value changes for a focused controlled input", async () => {
+  const onEnter = vi.fn();
+  const onChange = vi.fn();
+  const onFocus = vi.fn();
+  const onBlur = vi.fn();
+  function Input() {
+    const [value, setValue] = useState("before");
+    return <input
+      type="text"
+      value={value}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onChange={(event) => {
+        onChange(event.currentTarget.value);
+        setValue(event.currentTarget.value);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") onEnter(event.currentTarget.value);
+      }}
+    />;
+  }
+  const rendered = await renderClientComponent(<Input />, { requireButton: false });
+  const input = rendered.container.querySelector("input");
+  assert.ok(input);
+  const detach = vi.spyOn(input, "removeEventListener");
+  try {
+    await act(async () => {
+      input.dispatchEvent(new rendered.window.Event("focusin", { bubbles: true }));
+    });
+    expect(onFocus).toHaveBeenCalledOnce();
+
+    // Use the native setter so React observes a user edit instead of a tracked
+    // programmatic assignment. LinkeDOM requires the legacy property event.
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      rendered.window.HTMLInputElement.prototype, "value",
+    )?.set;
+    assert.ok(valueSetter);
+    await act(async () => {
+      valueSetter.call(input, "after");
+      const event = new rendered.window.Event("propertychange");
+      Object.defineProperty(event, "propertyName", { value: "value" });
+      input.dispatchEvent(event);
+    });
+    expect(onChange).toHaveBeenCalledExactlyOnceWith("after");
+    expect(input.value).toBe("after");
+
+    await act(async () => {
+      const event = new rendered.window.Event("keydown", { bubbles: true });
+      Object.defineProperty(event, "key", { value: "Enter" });
+      input.dispatchEvent(event);
+      input.dispatchEvent(new rendered.window.Event("focusout", { bubbles: true }));
+    });
+    expect(onEnter).toHaveBeenCalledExactlyOnceWith("after");
+    expect(onBlur).toHaveBeenCalledOnce();
+    expect(detach).toHaveBeenCalledWith("propertychange", expect.any(Function));
+  } finally {
+    await rendered.cleanup();
+  }
+  expect(rendered.container.childNodes).toHaveLength(0);
+});
+
+it("moves legacy input observation to the next focused control", async () => {
+  const changed = vi.fn();
+  const rendered = await renderClientComponent(
+    <><input type="text" onChange={changed} /><input type="text" onChange={changed} /></>,
+    { requireButton: false },
+  );
+  const [first, second] = rendered.container.querySelectorAll("input");
+  assert.ok(first && second);
+  const detachFirst = vi.spyOn(first, "removeEventListener");
+  const detachSecond = vi.spyOn(second, "removeEventListener");
+  try {
+    await act(async () => {
+      first.dispatchEvent(new rendered.window.Event("focusin", { bubbles: true }));
+      second.dispatchEvent(new rendered.window.Event("focusin", { bubbles: true }));
+    });
+    expect(detachFirst).toHaveBeenCalledWith("propertychange", expect.any(Function));
+    await act(async () => {
+      second.dispatchEvent(new rendered.window.Event("focusout", { bubbles: true }));
+    });
+    expect(detachSecond).toHaveBeenCalledWith("propertychange", expect.any(Function));
+    expect(changed).not.toHaveBeenCalled();
+  } finally {
+    await rendered.cleanup();
+  }
+});

--- a/apps/web/test/render-client-component.tsx
+++ b/apps/web/test/render-client-component.tsx
@@ -255,6 +255,24 @@ function installGlobals(
   window: Window & typeof globalThis,
   document: Document,
 ) {
+  // React uses its legacy input-event fallback because LinkeDOM does not
+  // advertise native input-event support. Preserve listener registration and
+  // removal so focused controls still exercise React's real change handling.
+  Object.defineProperties(window.HTMLElement.prototype, {
+    attachEvent: {
+      configurable: true,
+      value(this: HTMLElement, eventName: string, listener: EventListener) {
+        this.addEventListener(eventName.replace(/^on/u, ""), listener);
+      },
+    },
+    detachEvent: {
+      configurable: true,
+      value(this: HTMLElement, eventName: string, listener: EventListener) {
+        this.removeEventListener(eventName.replace(/^on/u, ""), listener);
+      },
+    },
+  });
+
   class ResizeObserverMock {
     observe() {}
     unobserve() {}


### PR DESCRIPTION
## Why and outcome

Focused input tests using the shared LinkeDOM renderer fail when React selects its legacy input-event fallback and cannot attach its value listener. The renderer now supplies the same native listener adapters already used by the hero tests, so focus, controlled value changes, and Enter reach React's real handlers.

Frog autofix issue: #3121

## Product UX

- Effort: Not applicable; internal test renderer only.
- Result: Ready.
- Walkthrough: Synthetic controlled-input keyboard/change/focus proof; no product behavior changed.

## Evidence

- Before correction: both new focused regressions fail at missing `attachEvent` or `detachEvent` in React.
- `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/render-client-component.test.tsx apps/web/test/goal-client-privacy.test.tsx apps/web/test/hero-clocks-in.test.tsx` — 26 tests passed.
- `pnpm --dir apps/web exec eslint test/render-client-component.tsx test/render-client-component.test.tsx` — passed.
- `pnpm health-commons:generate` followed by `pnpm --dir apps/web typecheck:prepared` — passed. The fresh checkout initially lacked the generated catalog.
- `git diff --check` — passed.
- Direct proof covers focus callbacks, a controlled value change, Enter receiving the changed value, listener removal on blur/focus transfer, and DOM cleanup after unmount. It does not claim focused-unmount listener cleanup.
- Required exact-head CI: all four configured required checks passed. The complete release workflow passed with 24 successful jobs; its Markdown-only path was intentionally skipped.
- ReviewGPT round 1: PASS with no findings on `7e0bf0725a02ff04c5e4be0922bbfda3db289eda`. Full-snapshot metadata, exact turn binding, and `gpt-6-pro` response hash verified; capture wait 245.680 seconds exceeds the 180-second gate. Response SHA-256: `cb648cab96dd215ca7fe5c77af16349e2454e4a60c1d4a2ed68d4f6f6055b12b`.

## Non-obvious affected surfaces

All consumers of the shared test renderer receive the adapters. Existing goal and hero test suites pass. No production files change.

## Architecture and reuse

- Existing systems reused: Shared LinkeDOM renderer, React event handling, and the existing hero test's native listener adapters.
- New logic: Translate legacy event names to native registration/removal in test setup.
- New abstractions: None; the existing renderer installs both hooks.
- Complexity intentionally avoided: No component-specific patches, production retries, browser framework, dependency changes, or fake change-event implementation.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; the guard excludes test paths and reports no authored production JavaScript/TypeScript to analyze.
- Hotspots: No analyzed changed functions exceed 20; the two adapters are straight native listener calls.
- Agent judgment: The 18-line correction is confined to the existing test setup owner; further machinery is not justified.

## Hot reply path impact

Not applicable. Only test renderer and regression tests change; no database, network, provider, or runtime work changes.

## Murph initial provider input impact

Not applicable for individual or group Murph. No provider instructions, tools, schemas, generated guidance, or request assembly change.

ReviewGPT first-reviewed head: 7e0bf0725a02ff04c5e4be0922bbfda3db289eda
ReviewGPT context sensitivity: routine
Classification reason: Isolated synthetic test infrastructure; no runtime, external, dependency, or deployment boundary changes.

## Deployment concerns

- Deployment: not applicable
- Reason: Test-only files do not change deployed code or configuration.

## Change-shape breakdown

Classification: Both files are test infrastructure or regression tests. No binaries or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 116 | 0 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **116** | **0** |

## Changelog

- Changelog: not applicable
- Reason: Internal test reliability only; no member-visible change.
