### PR TITLE
Verify the merge base under narrowed fetch mappings

### DIFF
--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -147,10 +147,10 @@ Generated-image retirement after hosted media expiry is owned by
 | `agent-docs/operations/product-ux.md` | Product UX workflow. | Product UX workflow | High | 2026-08-31 |
 | `agent-docs/operations/live-provider-canaries.md` | Fresh native, Linq, Stripe and Garmin provider outcomes; GitHub dispatch, protected execution, exact receipts and cross-repository rollout. | Live provider proof | High | 2026-09-10 |
 | `agent-docs/operations/native-android-hosted-e2e.md` | Native Android verification operations. | Native Android verification operations | High | 2026-09-01 |
-| `agent-docs/operations/verification-and-runtime.md` | Verification ownership by delivery path, CI compiler memory and production-build proof, independent worktree build outputs, authorized base reconciliation with bounded conflict resolution, and Temporal integration build/process-shard proof. | Verification policy | High | 2026-09-10 |
+| `agent-docs/operations/verification-and-runtime.md` | Verification ownership by delivery path, CI compiler memory and production-build proof, independent worktree build outputs, verified remote-tracking base refresh, authorized base reconciliation with bounded conflict resolution, and Temporal integration build/process-shard proof. | Verification policy | High | 2026-09-11 |
 | `agent-docs/operations/database-transaction-starvation-audit.md` | Database critical-section reliability. | Database critical-section reliability | High | 2026-08-09 |
 | `agent-docs/operations/typescript-verification-performance.md` | Verification performance policy. | Verification performance policy | Medium | 2026-07-29 |
-| `agent-docs/operations/completion-workflow.md` | Completion workflow. | Completion workflow | High | 2026-09-02 |
+| `agent-docs/operations/completion-workflow.md` | Completion workflow and verified-base mergeability gate. | Completion workflow | High | 2026-09-11 |
 | `agent-docs/operations/imessage-deliverability.md` | Phone-number messaging policy. | Phone-number messaging policy | High | 2026-08-11 |
 | `agent-docs/operations/local-storage-lifecycle.md` | Local rebuildable-storage lifecycle and guarded partial-retirement recovery. | Local rebuildable-storage lifecycle | High | 2026-09-06 |
 | `agent-docs/operations/hosted-local-worktree-dev.md` | Local hosted runtime workflow, call-scoped cancellation, and exact-child startup/exit cleanup ownership. | Local hosted runtime workflow | Medium | 2026-09-05 |

--- a/agent-docs/operations/completion-workflow.md
+++ b/agent-docs/operations/completion-workflow.md
@@ -51,7 +51,8 @@ alone does not authorize a narrower product or another state owner.
    Include every public-safe Frog entry created or modified during the task in that same scoped commit.
    A behavior-changing final edit needs the applicable checks and next review;
    explanatory docs and isolated proof additions follow the review loop's exemptions.
-8. Fetch the current base and prove mergeability with
+8. Refresh and verify the remote-tracking base using the explicit-refspec
+   procedure in `verification-and-runtime.md`, then prove mergeability with
    `git merge-tree --write-tree HEAD origin/<base>`. Keep green required CI on
    the PR-authored head. Reconcile the base when the authorized merge path
    needs it, following the review loop's Base-Update-Only Exception.

--- a/agent-docs/operations/verification-and-runtime.md
+++ b/agent-docs/operations/verification-and-runtime.md
@@ -137,6 +137,16 @@ the loaded APT policy, one-shot Playwright status, Ubuntu caller inventory, and
 overall step-timeout contract; exact-head Actions then prove the wrapper on the
 GitHub-hosted Ubuntu runner.
 
+Before checking mergeability, refresh the remote-tracking base with an explicit
+destination refspec: `git fetch origin refs/heads/main:refs/remotes/origin/main`.
+Verify that `git rev-parse origin/main` matches the SHA returned by
+`git ls-remote origin refs/heads/main`; if the base advanced, refresh and check
+again. For another base branch, substitute its name in all three commands.
+A bare `git fetch origin main` can update only `FETCH_HEAD` when another task
+has narrowed the shared fetch mapping, leaving `origin/main` stale. Preserve
+the shared `remote.origin.fetch` configuration and use the verified base for
+the merge-tree proof.
+
 For readiness, the exact PR head is the commit that contains the PR-authored
 change; it does not need to be repeatedly merged with a moving base. Keep green
 required CI on that head and prove current-base mergeability with


### PR DESCRIPTION
## Why and outcome

A narrowed shared fetch mapping can leave `origin/main` stale after `git fetch origin main`, so merge preparation checks an outdated base. The verification guide now uses an explicit destination refspec and checks the tracking SHA against the remote; completion routes to that procedure.

Frog autofix issue: #3119

## Product UX

- Effort: Not applicable — internal repository merge preparation.
- Result: Not applicable
- Walkthrough: Maintainers refresh and verify the actual base before the existing merge-tree check, preserving shared fetch configuration.

## Evidence

- Direct: A disposable synthetic Git reproduction confirmed bare fetch retained the old tracking SHA while FETCH_HEAD advanced. The documented explicit refspec made the tracking SHA equal the remote SHA and preserved the narrow fetch mapping.
- Coverage: `pnpm docs:drift`, `pnpm docs:gardening` (zero issues), and `git diff --check` passed. Read back all three changed documents and checked the command sequence.
- Full ReviewGPT round 1: PASS with no findings on the exact first-reviewed head below. Concrete model, accepted turn, response hash and minimum capture duration verified. All four required Actions-owned checks passed on this exact head. Current-base merge-tree and final ownership/authority checks passed. Shared repository policy requires human merge.

## Non-obvious affected surfaces

The docs index describes the updated verification owner and completion gate.

## Architecture and reuse

- Existing systems reused: Git fetch, ls-remote, and merge-tree; the existing verification guide owns the procedure.
- New logic: None; documentation corrects how the existing base is refreshed and verified.
- New abstractions: None; no new script, lock, or state owner.
- Complexity intentionally avoided: Shared Git configuration is preserved and the completion guide links to one procedure.

## Complexity impact

- Guard: not applicable — only repository documentation changed; no authored JavaScript or TypeScript.
- Hotspots: No source functions changed.
- Agent judgment: One owner procedure and a routing reference are sufficient for this gap.

## Hot reply path impact

- Path status: Not applicable — repository merge preparation only.
- Database calls: None.
- Network/provider calls: None on the runtime reply path.
- Other awaited latency: None on the runtime reply path.
- Before/after proof: The synthetic Git check covers the changed developer command sequence.

## Murph initial provider input impact

- Individual Murph: Not applicable — no runtime prompts or tools changed.
- Group Murph: Not applicable — no runtime prompts or tools changed.
- Measurement method: Not run; these repository operations documents are not initial provider input.

## Deployment concerns

- Deployment: not applicable
- Reason: Documentation changes local repository merge preparation only.

## Change-shape breakdown

Classification rule: All three changed Markdown files are repository docs. No binary files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 0 | 0 |
| Docs | 14 | 3 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **14** | **3** |

## Changelog

- Changelog: not applicable
- Reason: Internal repository workflow correction with no member-visible behavior.

ReviewGPT first-reviewed head: 2ac6e5344ab1d0aa1b984f4eba48fd6fab038473
ReviewGPT context sensitivity: routine
Classification reason: Repository-only Git procedure documentation; runtime, deployment, and authorization boundaries are unchanged.
