### PR TITLE
fix: preserve development CLI arguments

### DIFF
--- a/scripts/evaluate-dev-cli
+++ b/scripts/evaluate-dev-cli
@@ -51,9 +51,7 @@ pnpm_args=(
   --config.registry=https://registry.npmjs.org/
   dlx
   "$package_spec"
+  "$@"
 )
-if [[ $# -gt 0 ]]; then
-  pnpm_args+=(-- "$@")
-fi
 
 exec pnpm "${pnpm_args[@]}"

--- a/scripts/evaluate-dev-cli.test.ts
+++ b/scripts/evaluate-dev-cli.test.ts
@@ -74,11 +74,26 @@ afterEach(() => {
 });
 
 describe("temporary development CLI evaluation", () => {
-  it("uses isolated scriptless public-registry dlx without touching workspace dependency files", () => {
+  it.each([
+    {
+      args: ["--", "inspect", "--format", "json"],
+      forwarded: ["inspect", "--format", "json"],
+    },
+    {
+      args: ["inspect", "--format", "json"],
+      forwarded: ["inspect", "--format", "json"],
+    },
+    { args: ["--", "--help"], forwarded: ["--help"] },
+    { args: [], forwarded: [] },
+    {
+      args: ["--", "inspect", "--", "two words", "", "$(exit 99)"],
+      forwarded: ["inspect", "--", "two words", "", "$(exit 99)"],
+    },
+  ])("forwards $args through scriptless registry dlx without changing dependencies", ({ args, forwarded }) => {
     const harness = createHarness();
     const result = spawnSync(
       "../../scripts/evaluate-dev-cli",
-      ["@fixture/tool@1.2.3", "--", "inspect", "--format", "json"],
+      ["@fixture/tool@1.2.3", ...args],
       {
         cwd: harness.appDir,
         encoding: "utf8",
@@ -93,10 +108,7 @@ describe("temporary development CLI evaluation", () => {
         "--config.registry=https://registry.npmjs.org/",
         "dlx",
         "@fixture/tool@1.2.3",
-        "--",
-        "inspect",
-        "--format",
-        "json",
+        ...forwarded,
         "",
       ].join("\n"),
     );


### PR DESCRIPTION
## Why and outcome

The development CLI evaluation helper inserted an extra `--` after the package specification. Pinned pnpm forwards that separator to the target CLI, so command flags could become positional input. Forward the requested arguments directly: `evaluate-dev-cli wrangler@4.93.0 -- deploy --help` now displays deployment help.

Frog autofix issue: #3238

## Product UX

- Effort: Not applicable — repository-local developer tooling.
- Result: Not applicable
- Walkthrough: CLI evaluation retains the caller's workspace and exact registry package.

## Evidence

- Direct: With pnpm 10.33.0 and Wrangler 4.93.0, the original helper exited 1 with an unknown-command diagnostic. The direct pnpm invocation and repaired helper exited 0 with deployment help. Root/app manifests and lockfile hashes stayed unchanged. The [pnpm 10 documentation](https://pnpm.io/10.x/cli/dlx) documents arguments following the package directly.
- Coverage: Four parameterized cases failed before the fix; all 11 tests pass with `pnpm exec vitest run --config scripts/vitest.config.ts scripts/evaluate-dev-cli.test.ts --no-coverage`. Cases cover optional wrapper separators, no arguments, flag-only input, literal downstream separators, spaces, empty strings, and shell metacharacters, alongside existing package-policy and caller-directory checks.
- Checks: `bash -n scripts/evaluate-dev-cli`, `git diff --check`, and focused strict TypeScript proof passed: `node scripts/run-typescript.mjs package --ignoreConfig --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --skipLibCheck --types node scripts/evaluate-dev-cli.test.ts`.
- Review: Independent parent review passed. Full ReviewGPT round 1 passed on `e2423b655597f53794b4c07a9bb673fcc333f854` with no qualifying findings; concrete GPT-6 Pro response metadata, exact turn and response hash, full snapshot manifest, and 185.676 seconds of response wait were verified. All four required GitHub checks passed on that exact head.

## Non-obvious affected surfaces

None. The exact-package admission, public registry, disabled dependency lifecycle scripts, working directory, and workspace dependency files retain their existing owners.

## Architecture and reuse

- Existing systems reused: The existing shell helper and its subprocess test harness.
- New logic: Arguments enter the existing pnpm array directly after the package specification.
- New abstractions: None; quoted shell argument expansion preserves boundaries.
- Complexity intentionally avoided: Removed the conditional separator insertion instead of adding argument parsing or another execution wrapper.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; shell changes and test-only TypeScript produce no eligible authored JavaScript/TypeScript source metrics.
- Hotspots: None in the changed source; the helper loses one conditional branch.
- Agent judgment: The direct quoted expansion is the smallest correction at the existing owner.

## Hot reply path impact

- Path status: Not applicable — this helper only runs during explicit development CLI evaluation.
- Database calls: None.
- Network/provider calls: No reply-path calls.
- Other awaited latency: None.
- Before/after proof: The changed files are repository tooling and its isolated test.

## Murph initial provider input impact

- Individual Murph: Not applicable — no provider-input surface changes.
- Group Murph: Not applicable — no provider-input surface changes.
- Measurement method: Not run — repository-local CLI tooling only.

## Deployment concerns

- Deployment: not applicable
- Reason: No deployed source, runtime configuration, dependency graph, or infrastructure changes.

## Change-shape breakdown

Classification rule: The shell helper is tooling; the Vitest file is tests. No binaries or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 18 | 6 |
| Docs | 0 | 0 |
| Config / tooling | 1 | 3 |
| Generated / other | 0 | 0 |
| **Total** | **19** | **9** |

## Changelog

- Changelog: not applicable
- Reason: Internal developer tooling repair with no member-visible product behavior.

ReviewGPT first-reviewed head: e2423b655597f53794b4c07a9bb673fcc333f854
ReviewGPT context sensitivity: routine
Classification reason: Narrow repository-local argument forwarding; existing registry, lifecycle-script, admission, and credential boundaries remain unchanged.
