### PR TITLE
fix(web): reject omitted database test filters

### DIFF
--- a/apps/web/scripts/run-hosted-web-vitest.mts
+++ b/apps/web/scripts/run-hosted-web-vitest.mts
@@ -70,7 +70,11 @@ export function buildHostedWebVitestArgs(
     : [...callerArgs];
   // Vitest's parser prints help/version output itself; leave those invocations
   // to the child, which will not execute any tests.
-  const informational = normalizedCallerArgs.some((arg) =>
+  const delimiter = normalizedCallerArgs.indexOf("--");
+  const optionArgs = delimiter === -1
+    ? normalizedCallerArgs
+    : normalizedCallerArgs.slice(0, delimiter);
+  const informational = optionArgs.some((arg) =>
     ["--help", "-h", "--version", "-v"].includes(arg)
   );
   const databaseFile = !informational

--- a/apps/web/scripts/run-hosted-web-vitest.mts
+++ b/apps/web/scripts/run-hosted-web-vitest.mts
@@ -3,6 +3,8 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { parseCLI } from "vitest/node";
+
 import { hostedWebVitestProjectSpecs } from "../vitest-project-specs.mjs";
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -66,6 +68,23 @@ export function buildHostedWebVitestArgs(
   const normalizedCallerArgs = callerArgs[0] === "--"
     ? callerArgs.slice(1)
     : [...callerArgs];
+  // Vitest's parser prints help/version output itself; leave those invocations
+  // to the child, which will not execute any tests.
+  const informational = normalizedCallerArgs.some((arg) =>
+    ["--help", "-h", "--version", "-v"].includes(arg)
+  );
+  const databaseFile = !informational
+    ? parseCLI(["vitest", "run", ...normalizedCallerArgs]).filter
+      .find((fileArg) => /\.db\.test\.ts$/u.test(fileArg))
+    : undefined;
+  if (databaseFile) {
+    throw new Error(
+      `${JSON.stringify(path.basename(databaseFile))} is excluded from the hosted Web workspace. `
+      + "Run database tests separately from the repository root with "
+      + "pnpm exec vitest run --config apps/web/vitest.config.ts --no-coverage <database-test-file> "
+      + "and the test's documented local database configuration.",
+    );
+  }
   const args = [
     "run",
     "--config",

--- a/apps/web/test/run-hosted-web-vitest.test.ts
+++ b/apps/web/test/run-hosted-web-vitest.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   buildHostedWebVitestArgs,
@@ -118,6 +118,49 @@ describe("hosted Web Vitest entrypoint", () => {
       webTestFile,
     ]);
   });
+
+  it.each([
+    ["action-approvals.db.test.ts"],
+    ["test/action-approvals.db.test.ts"],
+    ["apps/web/test/action-approvals.db.test.ts"],
+    [path.join(repoRoot, "apps/web/test/action-approvals.db.test.ts")],
+    [webTestFile, "test/action-approvals.db.test.ts"],
+    ["test/action-approvals.db.test.ts", webTestFile],
+    ["--", webTestFile, "test/action-approvals.db.test.ts"],
+    ["--passWithNoTests", "test/action-approvals.db.test.ts"],
+    ["-t", "renders", "test/action-approvals.db.test.ts"],
+    ["--project", "hosted-web-store-config", "test/action-approvals.db.test.ts"],
+  ])("rejects excluded database file requests: %j", (...callerArgs) => {
+    expect(() => buildHostedWebVitestArgs(callerArgs, repoRoot)).toThrow(
+      /action-approvals\.db\.test\.ts.*pnpm exec vitest run --config apps\/web\/vitest\.config\.ts --no-coverage/u,
+    );
+  });
+
+  it.each([
+    ["--exclude", "action-approvals.db.test.ts"],
+    ["-t", "action-approvals.db.test.ts"],
+    ["--testNamePattern=action-approvals.db.test.ts"],
+    ["--outputFile", "action-approvals.db.test.ts"],
+  ])("preserves database-shaped option values: %j", (...optionArgs) => {
+    const callerArgs = [webTestFile, ...optionArgs];
+    expect(buildHostedWebVitestArgs(callerArgs, repoRoot).slice(-callerArgs.length))
+      .toEqual(callerArgs);
+  });
+
+  it.each(["--help", "-h", "--version", "-v"])(
+    "leaves %s output to the Vitest child without rejecting unused filters",
+    (flag) => {
+      const output = vi.spyOn(console, "log").mockImplementation(() => {});
+      try {
+        const callerArgs = [flag, "action-approvals.db.test.ts"];
+        expect(buildHostedWebVitestArgs(callerArgs, repoRoot).slice(-2))
+          .toEqual(callerArgs);
+        expect(output).not.toHaveBeenCalled();
+      } finally {
+        output.mockRestore();
+      }
+    },
+  );
 
   it("forwards native shard selection without narrowing the workspace", () => {
     expect(

--- a/apps/web/test/run-hosted-web-vitest.test.ts
+++ b/apps/web/test/run-hosted-web-vitest.test.ts
@@ -128,6 +128,8 @@ describe("hosted Web Vitest entrypoint", () => {
     ["test/action-approvals.db.test.ts", webTestFile],
     ["--", webTestFile, "test/action-approvals.db.test.ts"],
     ["--passWithNoTests", "test/action-approvals.db.test.ts"],
+    [webTestFile, "test/action-approvals.db.test.ts", "--", "--help"],
+    [webTestFile, "test/action-approvals.db.test.ts", "--", "--version"],
     ["-t", "renders", "test/action-approvals.db.test.ts"],
     ["--project", "hosted-web-store-config", "test/action-approvals.db.test.ts"],
   ])("rejects excluded database file requests: %j", (...callerArgs) => {


### PR DESCRIPTION
## Why and outcome

The hosted Web test wrapper can report success after silently omitting an explicitly requested database test from a mixed file request. It now rejects positional `*.db.test.ts` filters before starting Vitest, names the excluded file, and points to the dedicated database configuration.

Frog autofix issue: #3137

## Product UX

- Effort: Not applicable; internal test tooling only.
- Result: Ready.
- Walkthrough: Explicit database files fail with actionable guidance. Regular test selection and option values remain supported. Help and version invocations remain informational.

## Evidence

- Focused wrapper regression: 32 tests passed. Before the fix, all 10 new database-file rejection cases failed while the other 16 cases passed; four informational-output cases and two literal-delimiter regressions were then added and passed. The delimiter regressions also failed before their correction.
- Actual mixed-file `pnpm --dir apps/web test:prepared test/action-approval-decision-route.test.ts test/action-approvals.db.test.ts` invocation: exit 1, excluded file and dedicated configuration identified, no Vitest run started.
- Web typecheck, scoped Web ESLint, complexity guard and `git diff --check`: passed.
- Coverage: relative/absolute file paths, either mixed-file order, leading separator, explicit project, boolean and named options, database-shaped option values, and help/version output.
- No database connection or database test execution was needed to prove this command-selection boundary. All four required Actions-owned exact-head checks and the current Temporal compatibility status passed. Final current-base merge-tree and ownership checks passed.
- Full ReviewGPT round 1: PASS, no findings, on the exact first-reviewed head below. Concrete model, accepted turn, response hash and capture duration verified.

## Non-obvious affected surfaces

Vitest's public `parseCLI` owns option-versus-positional interpretation. Informational flags bypass this validation because that parser prints help/version itself and those commands do not execute tests.

## Architecture and reuse

- Existing systems reused: The current hosted Web wrapper, pinned Vitest public parser and dedicated database configuration.
- New logic: Reject positional database files that the wrapper's workspace excludes before spawning the test runner.
- New abstractions: None; validation stays in the existing argument builder.
- Complexity intentionally avoided: No copied CLI option table, dependency, database orchestration or test-project reclassification.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: None above 20 in the changed source file.
- Agent judgment: The existing parser keeps validation small and preserves option ownership; further extraction would add an unnecessary owner.

## Hot reply path impact

Not applicable. Only development test selection changes; no conversation or provider path is involved.

## Murph initial provider input impact

Not applicable for both individual and group Murph runtimes. No prompt, tool, generated guidance or provider-request assembly changes.

ReviewGPT context sensitivity: routine
Reason: Narrow repository-local test tooling with no deployed behavior or database access change.
ReviewGPT first-reviewed head: a06afde77b49cf68ec74732e63cc16cba3f119e4

## Deployment concerns

- Deployment: not applicable
- Reason: Test runner and regression coverage only; no deployed artifact behavior changes.

## Change-shape breakdown

Classification uses the authored base-to-head diff: the wrapper is tooling and its regression file is tests. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 46 | 1 |
| Docs | 0 | 0 |
| Config / tooling | 23 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **69** | **1** |

## Changelog

- Changelog: not applicable
- Reason: Internal developer verification tooling only; no member-visible behavior changes.
