### PR TITLE
Preserve colored hosted-local port collision recovery

### DIFF
--- a/.agents/friction-log/20260911010303-colored-child-diagnostics/friction.md
+++ b/.agents/friction-log/20260911010303-colored-child-diagnostics/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Colored child diagnostics hide hosted-local port collisions'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Hosted-local startup should classify a child process address-in-use error regardless of terminal styling, preserve the stable retry marker, and use its existing bounded retry with fresh port reservations.
+
+## Current Behavior
+
+The classifier applies a leading word-boundary regular expression directly to buffered child output. A bold ANSI sequence immediately before Address leaves an ASCII m adjacent to that word, so the expression misses the error. When later output pushes the original message beyond the short diagnostic tail, the outer startup owner cannot recover its classification.
+
+## Minimal Reproducible Example
+
+Pass a child stderr buffer containing the JavaScript string "\u001b[1mAddress already in use (0.0.0.0:43001).\u001b[0m\n" followed by 4,000 filler characters through the existing child-exit readiness path. The plain-text equivalent receives the stable address-in-use marker; the styled equivalent does not.
+
+## Possible Solution
+
+Use Node's stripVTControlCharacters only before the existing child-output collision expressions. Preserve diagnostic redaction, retention, owned cleanup, and the current maximum of three startup attempts.
+
+## Context
+
+This is reproducible repository harness friction that can stop hosted E2E before any business assertion executes. The defect concerns error classification; it does not identify the original competing port owner.

--- a/agent-docs/exec-plans/completed/2026-09-11-hosted-local-colored-port-collision.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-hosted-local-colored-port-collision.md
@@ -1,0 +1,66 @@
+# Preserve colored hosted-local port-collision recovery
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal
+
+- Preserve hosted-local startup's existing bounded port-collision recovery when
+  a child process styles its diagnostic with terminal control sequences.
+
+## Success criteria
+
+- A colored child address-in-use error survives verbose output as the existing
+  plain retry marker; ordinary startup failures still fail without retry.
+- The outer startup owner keeps three attempts, fresh reservations, and owned cleanup.
+- Focused harness/helper tests, relevant typechecks, complexity, and docs checks pass.
+
+## Scope
+
+- In scope: child diagnostic classification and focused regression evidence.
+- Out of scope: port allocation, timeouts, retry policy, production behavior,
+  provider requests, diagnostic retention/redaction, and workflow dispatches.
+
+## Constraints
+
+- Use Node's existing stripVTControlCharacters utility only for classification.
+- The parent owns candidate review, PR admission, final review, and shipping.
+
+## Risks and mitigations
+
+1. Terminal styling can hide an existing collision token at a regex word boundary.
+   Strip controls before the existing expressions; test each supported token.
+2. A recovery fix could accidentally widen retries or obscure unrelated failures.
+   Preserve the current classifier, attempt cap, cancellation, and cleanup owners.
+
+## Tasks
+
+1. Done: reproduced the styled-output defect in the existing child-exit readiness test.
+2. Done: normalized only classifier input; added real child-buffer and outer retry proof.
+3. Done: focused verification and scope/privacy inspection. Parent reviewed all
+   seven scoped files and approved the candidate without blockers.
+4. Approved for plan-wrapper closure, scoped commit, and draft PR handoff.
+
+## Decisions
+
+- The current child buffer retains ANSI, while its word-boundary expressions
+  miss a bold prefix immediately before Address. The original port contender
+  is not established; no checkpoint-ordering business assertion was reached.
+- No new state, dependency, retry loop, production branch, or runtime protocol.
+- Internal harness correction: no member-visible changelog entry required.
+
+## Verification
+
+- Before source correction, the focused child-exit regression failed for all
+  three styled forms while the unstyled address case passed.
+- `pnpm --dir packages/hosted-local-harness test test/dev-hosted-local/stack.test.ts test/dev-hosted-local/runtime.test.ts`: 103 passed.
+- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.test.ts`: 23 passed.
+- `pnpm --dir packages/hosted-local-harness typecheck`: passed.
+- `pnpm --dir apps/web prisma:generate`, then `pnpm --dir apps/cloudflare typecheck`: passed.
+- `pnpm complexity:diff`: passed; existing source debt and maximum unchanged.
+- `pnpm docs:drift`, `pnpm docs:gardening`, and `git diff --check`: passed.
+- Required exact-head CI and protected scenario proof remain parent-owned.
+- Local evidence proves classification and retry handoff. It does not identify
+  the original port contender or prove the checkpoint-ordering business journey.
+Completed: 2026-09-11

--- a/apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.test.ts
+++ b/apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.test.ts
@@ -312,10 +312,14 @@ it("keeps Wrangler inspector traffic out of streamed hosted E2E logs", async () 
   }
 });
 
-it("retries startup with fresh port reservations after an address-in-use race", async () => {
+it.each([
+  "Address already in use (0.0.0.0:4300).",
+  "cloudflare dev process exited before the hosted local stack became healthy. "
+    + "Address already in use was reported by the exited process.",
+])("retries startup with fresh port reservations after an address-in-use race (%s)", async (message) => {
   const harness = createScenarioHarness();
   mocks.startHostedLocalDevHarness
-    .mockRejectedValueOnce(new Error("Address already in use (0.0.0.0:4300)."))
+    .mockRejectedValueOnce(new Error(message))
     .mockResolvedValueOnce(harness);
 
   const scenario = await startScenario();
@@ -326,6 +330,23 @@ it("retries startup with fresh port reservations after an address-in-use race", 
     expect(mocks.startHostedLocalOidcFixture).toHaveBeenCalledTimes(2);
   } finally {
     await scenario.stop();
+  }
+});
+
+it("stops after three attempts when the child keeps reporting a port collision", async () => {
+  const error = new Error(
+    "cloudflare dev process exited before the hosted local stack became healthy. "
+    + "Address already in use was reported by the exited process.",
+  );
+  mocks.startHostedLocalDevHarness.mockRejectedValue(error);
+
+  await expect(startScenario()).rejects.toBe(error);
+  expect(mocks.startHostedLocalDevHarness).toHaveBeenCalledTimes(3);
+  expect(mocks.reserveLocalTcpPort).toHaveBeenCalledTimes(6);
+  expect(mocks.reserveLocalTemporalTcpPort).toHaveBeenCalledTimes(3);
+  for (const result of mocks.startHostedLocalOidcFixture.mock.results) {
+    const fixture = await result.value;
+    expect(fixture.stop).toHaveBeenCalledOnce();
   }
 });
 

--- a/packages/hosted-local-harness/README.md
+++ b/packages/hosted-local-harness/README.md
@@ -194,6 +194,12 @@ identifiers, payload-like env values, and sensitive command args are redacted.
 
 ## Design rules
 
+On a child exit before readiness, port-collision classification strips terminal
+controls from the retained child output before producing the existing plain
+address-in-use marker. Diagnostic redaction and retention stay unchanged. The
+full-stack scenario helper consumes that marker through its existing three-attempt
+startup limit, with fresh port reservations and owned cleanup for each attempt.
+
 1. Root `pnpm hosted-local ...` is the canonical developer and CI entrypoint.
 2. `apps/*/package.json` may expose broad aliases, but not one-off hosted-local
    scenario scripts.

--- a/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
+++ b/packages/hosted-local-harness/src/dev-hosted-local/stack.ts
@@ -5,6 +5,7 @@ import { access, chmod, cp, mkdir, mkdtemp, readFile, rename, rm, symlink, utime
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { stripVTControlCharacters } from "node:util";
 
 import {
   removeHostedLocalWebAuthorityFromProcessEnvironment,
@@ -2817,11 +2818,12 @@ function appendStartupDiagnostics(
 }
 
 function childReportedPortBindCollision(child: BufferedNamedChildProcess): boolean {
-  return [child.stdoutText(), child.stderrText()].some((output) =>
-    /\bEADDRINUSE\b/u.test(output)
-    || /\baddress already in use\b/ui.test(output)
-    || /\bport \d+ is already in use\b/ui.test(output)
-  );
+  return [child.stdoutText(), child.stderrText()].some((output) => {
+    const plainOutput = stripVTControlCharacters(output);
+    return /\bEADDRINUSE\b/u.test(plainOutput)
+      || /\baddress already in use\b/ui.test(plainOutput)
+      || /\bport \d+ is already in use\b/ui.test(plainOutput);
+  });
 }
 
 function combineChildOutput(input: readonly BufferedNamedChildProcess[] | readonly string[]): string {

--- a/packages/hosted-local-harness/test/dev-hosted-local/runtime.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/runtime.test.ts
@@ -405,13 +405,16 @@ describe("redactHostedLocalDiagnosticText", () => {
 });
 
 describe("spawnChildProcess diagnostics", () => {
-  it("retains bounded full text separately from the diagnostic tail", async () => {
+  it.each([
+    "Address already in use.",
+    "\u001b[1mAddress already in use.\u001b[0m",
+  ])("retains bounded full text separately from the diagnostic tail (%j)", async (message) => {
     const child = spawnChildProcess(
       "cloudflare",
       process.execPath,
       [
         "-e",
-        "process.stderr.write('Address already in use.\\n' + 'x'.repeat(4000))",
+        `process.stderr.write(${JSON.stringify(message)} + '\\n' + 'x'.repeat(4000))`,
       ],
       process.env,
       { pipeOutput: false },
@@ -429,7 +432,7 @@ describe("spawnChildProcess diagnostics", () => {
     });
 
     expect(child.stderrTail()).not.toContain("Address already in use");
-    expect(child.stderrText()).toContain("Address already in use");
+    expect(child.stderrText()).toContain(message);
   });
 
   it("tails captured child output before running expensive diagnostic redaction", async () => {

--- a/packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts
+++ b/packages/hosted-local-harness/test/dev-hosted-local/stack.test.ts
@@ -3749,14 +3749,17 @@ describe("hosted local dev stack", () => {
     );
   });
 
-  it("preserves an exited child's port-bind classification past verbose sibling output", async () => {
+  it.each([
+    { channel: "stderr", message: "Address already in use (0.0.0.0:43001).", name: "plain address" },
+    { channel: "stderr", message: "\u001b[1mAddress already in use (0.0.0.0:43001).\u001b[0m", name: "bold address" },
+    { channel: "stdout", message: "\u001b[31mEADDRINUSE\u001b[0m", name: "colored code" },
+    { channel: "stderr", message: "\u001b[1mPort 43001 is already in use.\u001b[0m", name: "bold port" },
+  ])("preserves $name port-bind classification on $channel past verbose sibling output", async ({ channel, message }) => {
     const cloudflareChild = createBufferedChild({
       exitCode: 1,
       name: "cloudflare",
       pid: 503,
-      stderrText:
-        "Address already in use (0.0.0.0:43001).\n"
-        + "x".repeat(4_000),
+      [channel === "stderr" ? "stderrText" : "stdoutText"]: message + "\n" + "x".repeat(4_000),
     });
     spawnChildProcess
       .mockReturnValueOnce(cloudflareChild)
@@ -3777,7 +3780,11 @@ describe("hosted local dev stack", () => {
       env: process.env,
     });
 
-    await expect(stack.ready).rejects.toThrow("Address already in use");
+    await expect(stack.ready).rejects.toThrow(
+      "cloudflare dev process exited before the hosted local stack became healthy. "
+      + "Address already in use was reported by the exited process.",
+    );
+    expect(terminateChildProcessAndWait).toHaveBeenCalledTimes(2);
   });
 
   it("skips Vercel link and env pull when the caller already provides a Vercel OIDC token", async () => {


### PR DESCRIPTION
## Why and outcome

A styled child-process port error can lose its retry classification: the ANSI bold prefix immediately before `Address already in use` ends in `m`, so the existing leading word-boundary expression does not match. Verbose output can then push that diagnostic beyond the final tail, leaving startup with only a generic child-exit error.

Normalize terminal controls only when classifying retained child output. The existing plain collision marker now reaches the full-stack helper's bounded retry. Diagnostic retention/redaction, fresh port reservations, cleanup ownership, and the three-attempt cap are unchanged.

## Product UX

- Effort: Not applicable — internal local/CI harness correction.
- Result: Not applicable.
- Walkthrough: No member-facing behavior, provider request, checkpoint assertion, or production configuration changes.

## Evidence

- ReviewGPT: [Round 1](https://chatgpt.com/c/6aa38d86-63f8-83ea-a8fa-618d5a799434) passed exact head `f2c170936857d67398707f00b0e0d357c5dab8d8`. Parent verified the full sensitive snapshot, all seven changed blobs, committed turn identity, requested/actual `gpt-6-pro`, and 305.611-second minimum-wait evidence. Response SHA-256: `4ed51e65851fe79a92e8e1d6ac210d1e8ab39aa7b3dcfa2a4cb3e85fb02498e7`. The reviewer reproduced the classifier distinction with isolated exact-source checks and inspected cleanup/retry preservation; it did not rerun the full Vitest suites or protected scenario.
- Direct: On the unchanged source, the plain address case passed and all three styled cases failed at the real stack-readiness error boundary. After the fix, Address, EADDRINUSE, and Port N errors produce the existing marker through stdout/stderr and verbose sibling output.
- Coverage: The real Node child-process test proves ANSI bytes remain in the retained buffer while the short tail omits the collision. Existing dependency-isolated stack tests prove marker propagation and child cleanup; helper tests prove fresh reservations, successful retry handoff, the three-attempt cap, cancellation, unrelated failures, and fixture cleanup.
- `pnpm --dir packages/hosted-local-harness test test/dev-hosted-local/stack.test.ts test/dev-hosted-local/runtime.test.ts`: 103 passed.
- `pnpm exec vitest run --config apps/cloudflare/vitest.node.workspace.ts --no-coverage apps/cloudflare/test/helpers/hosted-local-full-stack-scenario.test.ts`: 23 passed.
- `pnpm --dir packages/hosted-local-harness typecheck`: passed.
- `pnpm --dir apps/web prisma:generate`, then `pnpm --dir apps/cloudflare typecheck`: passed.
- `pnpm complexity:diff`, `pnpm docs:drift`, `pnpm docs:gardening`, and `git diff --check`: passed.
- Parent reviewed all seven scoped files and approved the candidate without blockers. Required exact-head CI and protected checkpoint-ordering proof remain pending. The original port contender is unknown; these local tests prove classification and handoff, not provider or business outcomes.

## Non-obvious affected surfaces

The full-stack helper consumes the stable plain marker rather than the styled child diagnostic. Its tests cover the handoff without changing helper implementation or retry policy.

## Architecture and reuse

- Existing systems reused: Node `stripVTControlCharacters`, retained child buffers, stack readiness marker, and existing full-stack retry/cleanup owners.
- New logic: Normalize classifier input before the same three collision expressions.
- New abstractions: None; existing owners already carry the required failure and recovery information.
- Complexity intentionally avoided: No retry loop, timeout, port-allocation machinery, shared regex abstraction, dependency, state, or production branch added.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff`; source debt 119 → 119 and maximum 139 → 139.
- Hotspots: Existing `startHostedLocalDevStack` remains 139 and is unchanged; classification remains in its existing helper.
- Agent judgment: The native normalization call is the smallest correction. Refactoring the broader startup owner would add unrelated scope.

## Hot reply path impact

- Path status: Not applicable — only local/CI process startup failure classification changes.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved.
- Before/after proof: The focused regression reproduces the missing startup marker before the correction and passes afterward; production reply execution is unchanged.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no prompts, tools, schemas, generated guidance, provider payloads, or runtime environment projections change. No provider-input measurement was run.

ReviewGPT first-reviewed head: f2c170936857d67398707f00b0e0d357c5dab8d8
ReviewGPT context sensitivity: sensitive
Classification reason: Startup failure classification controls the existing retry and cleanup handoff between the harness and full-stack helper.

## Deployment concerns

- Deployment: not applicable
- Reason: Local/CI harness code and tests only; no deployed Worker/Web protocol, persisted state, migration, credential, or runtime artifact changes. The protected scenario must still execute its business assertions.

## Change-shape breakdown

Classification rule: Harness implementation is source; executable test files are tests; README, completed plan, and synthetic Frog report are docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 7 | 5 |
| Tests / fixtures | 41 | 10 |
| Docs | 96 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **144** | **15** |

## Changelog

- Changelog: not applicable
- Reason: Internal local/CI startup recovery correction with no member-visible product change.
