### PR TITLE
Preserve explicit cron route audience evidence

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-frog-3239-cron-audience.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-frog-3239-cron-audience.md
@@ -1,0 +1,39 @@
+# Preserve explicit cron route audience evidence
+
+## Outcome and invariant
+
+Patch: resolving and saving an explicit complete cron route preserves its supplied direct or group audience evidence. Evidence must never transfer to a route changed by saved defaults. Unknown audience stays unknown; hosted live authority and notification admission remain unchanged.
+
+## Owner and cause
+
+`assistant-engine` cron target resolution omits `threadIsDirect`; `operator-config` self-delivery defaults also rebuilds both result branches without it. Existing canonical automation and runtime stores already support this field. Extend the existing lookup type and preserve explicit booleans only for unchanged normalized nonempty routes. Reuse public workspace entrypoints. Do not change saved-target schema, delivery selection, continuity, prompts, or provider authority.
+
+## Product UX
+
+Outcome: a direct reminder retarget remains eligible for its existing private notification journey; a group route remains explicitly non-direct.
+Reaches: no-default and exact-saved-route resolution; changed or incomplete fallback routes retain unknown audience.
+Proof: deterministic defaults/canonical-write readback plus one focused production-composed real-Codex reminder notification with one queued synthetic effect and truthful reply.
+
+## Steps
+
+- [x] Prove both omission boundaries with focused failing regressions.
+- [x] Preserve evidence at existing callers and defaults owner with exact normalized route equality.
+- [x] Run focused regression, type, complexity and live journey proof; review final diff and UX with parent.
+- [x] Parent reviewed the final source and scoped live-fixture design; implementation is ready for its scoped plan-closing commit.
+
+PR completion remains tracked by the owning lane: draft creation, actual changelog PR provenance, final Ready admission, full exact-head ReviewGPT and required CI; human merge only.
+
+## State, deployment and completion
+
+No new state or wire shape. Existing optional boolean readers accept old and new writes. Rolling readers retain their existing live authority checks. Old writers may still lose evidence until upgraded, and rollback restores the defect without a schema incompatibility. No new network, database, retry, or foreground await. This runtime/privacy PR requires human merge; leave issue open until separately approved landing.
+
+## Evidence
+
+Frog issue #3239 is the existing exact-hash authority. Fresh live main was b0141ce79ae2f6a3d8cf83266b60e57b1e8a9425; only merged sync PR claims its binding. Sanctioned isolated checkout and frozen install succeeded; Frog list succeeded after install.
+
+Focused regressions first failed for explicit true and false at both owners. Final defaults suite: 10 passed. Canonical retarget regression: 2 passed; all 227 existing runtime tests passed. The continuity assertion reads its runtime owner because a keyed route deliberately does not expose an old session pin. Operator-config, Assistant Engine and Web typechecks passed. Complexity passed with no hotspots and unchanged maximum 15 in the defaults file. Changelog archive rendering: 10 passed.
+
+The focused real-Codex journey `queues one private reminder after explicit defaults preserve its audience` passed on gpt-5.6-terra using local subscription auth. It uses the public defaults helper with an explicit synthetic home, canonical validation/upsert/readback, production cron instruction composition, and the production notification path. Exactly one provider request queued exactly one direct Telegram outbox intent; the single existing automation remained. Parent separately reviewed the deterministic actual set-target caller proof. No global environment mutation, external delivery, or production data was used. Reply review: Ready, concise truthful reminder, no extra follow-up or question. Final review and CI remain separate PR gates.
+Status: completed
+Updated: 2026-09-11
+Completed: 2026-09-11

--- a/apps/web/changelog/entries/2026-09-11/private-reminder-targets.json
+++ b/apps/web/changelog/entries/2026-09-11/private-reminder-targets.json
@@ -1,0 +1,17 @@
+{
+  "publishedOn": "2026-09-11",
+  "order": 100,
+  "item": {
+    "id": "private-reminder-targets",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "More reliable private reminders",
+    "summary": "Reminders keep their private conversation setting when their destination is explicitly updated.",
+    "details": "An update to the same destination preserves whether the conversation is private or shared. Saved defaults cannot transfer that setting to a different destination.",
+    "relevanceTags": [
+      "reminders",
+      "reliability"
+    ],
+    "sourcePullRequests": []
+  }
+}

--- a/apps/web/changelog/entries/2026-09-11/private-reminder-targets.json
+++ b/apps/web/changelog/entries/2026-09-11/private-reminder-targets.json
@@ -12,6 +12,8 @@
       "reminders",
       "reliability"
     ],
-    "sourcePullRequests": []
+    "sourcePullRequests": [
+      3267
+    ]
   }
 }

--- a/packages/assistant-engine/src/assistant/cron/targets.ts
+++ b/packages/assistant-engine/src/assistant/cron/targets.ts
@@ -30,6 +30,7 @@ export async function resolveAssistantCronTargetDefaults<
       identityId: input.identityId,
       participantId: input.participantId,
       threadId: input.threadId,
+      threadIsDirect: input.threadIsDirect,
       deliveryTarget: input.deliveryTarget,
     },
     {

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -1,3 +1,5 @@
+import { applyAssistantSelfDeliveryTargetDefaults } from '@murphai/operator-config/operator-config'
+import { buildCanonicalAutomationRoute, resolveAssistantCronNotificationDeliveryRoute, validateAssistantCronDeliveryTarget } from '../src/assistant/cron/targets.ts'
 import { importClinicalFhirSnapshot } from '@murphai/vault-usecases/clinical-records'
 import { parsePersonalPatternNotificationLedger } from '../src/assistant/personal-patterns-eligibility.js'
 import { resolveAssistantStatePaths } from '../src/assistant/store/paths.js'
@@ -38804,4 +38806,91 @@ describeRealCodex('real Codex downloaded hospital documents e2e', () => {
       await removeRealCodexTemporaryPaths(config.temporaryPaths)
     }
   }, 720_000)
+})
+
+
+describeRealCodex('real Codex explicit cron audience preservation e2e', () => {
+  it('queues one private reminder after explicit defaults preserve its audience', async () => {
+    const config = await resolveRealCodexE2eConfig()
+    const workingDirectory = await mkdtemp(path.join(tmpdir(), 'murph-cron-audience-e2e-'))
+    const operatorHome = await mkdtemp(path.join(tmpdir(), 'murph-cron-audience-operator-'))
+    try {
+      await initializeVault({ vaultRoot: workingDirectory, timezone: 'UTC' })
+      const occurrenceAt = '2026-09-10T16:00:00.000Z'
+      const reminderInput = {
+        continuityPolicy: 'fresh',
+        instructions: 'Send a short, friendly reminder that it is time for the requested afternoon stretch break. Do not add a follow-up, ask a question, or claim the stretch happened.',
+        now: new Date('2026-09-10T15:00:00.000Z'),
+        route: { channel: 'telegram', identityId: null, participantId: null,
+          threadId: 'synthetic-prior-thread', deliveryTarget: null, threadIsDirect: true },
+        schedule: { kind: 'at', at: occurrenceAt },
+        slug: 'synthetic-stretch-break', status: 'active', tags: [],
+        title: 'Synthetic afternoon stretch break', vaultRoot: workingDirectory,
+      } satisfies Parameters<typeof upsertAutomation>[0]
+      const created = await upsertAutomation(reminderInput)
+      // The canonical caller's exact forwarding is proved deterministically.
+      // Exercise the real public defaults owner here with a scoped fixture home.
+      const resolved = await applyAssistantSelfDeliveryTargetDefaults({
+        channel: 'telegram', threadId: 'synthetic-private-thread', threadIsDirect: true,
+      }, { allowSingleSavedTargetFallback: true }, operatorHome)
+      const canonicalRoute = buildCanonicalAutomationRoute(validateAssistantCronDeliveryTarget(resolved))
+      expect(canonicalRoute.threadIsDirect).toBe(true)
+      await upsertAutomation({
+        ...reminderInput, automationId: created.record.automationId, route: canonicalRoute,
+      })
+      const source = findCanonicalAssistantCronRecordInList(
+        await listCanonicalAssistantCronRecords(workingDirectory), created.record.automationId)
+      if (!source || source.kind !== 'automation') throw new Error('Expected canonical reminder.')
+      expect(source.route).toMatchObject({
+        channel: 'telegram', threadId: 'synthetic-private-thread', threadIsDirect: true,
+      })
+      const runtimeState = createAssistantCronCanonicalRuntimeRecord({
+        jobId: resolveCanonicalAssistantCronJobId(source), now: occurrenceAt,
+      })
+      const job = projectCanonicalAssistantCronJob({ source, runtimeState })
+      const instructions = buildAssistantCronExecutionInstructions({
+        job, kind: 'canonical', runtimeState, source,
+      }, { automationId: null, contextReferences: [] })
+      const route = resolveAssistantCronNotificationDeliveryRoute(job.target)
+      expect(route.bindingDelivery).toEqual({ kind: 'thread', target: 'synthetic-private-thread' })
+      expect(route.threadIsDirect).toBe(true)
+      const modelTarget = createAssistantModelTarget({
+        approvalPolicy: 'never', codexCommand: normalizeEnvString(process.env.MURPH_REAL_CODEX_COMMAND),
+        codexHome: config.codexHome, model: config.model, modelProvider: config.modelProvider,
+        provider: 'codex-cli', reasoningEffort: 'low', sandbox: 'workspace-write',
+      })
+      if (!modelTarget) throw new Error('Expected real Codex reminder model.')
+      let providerRequests = 0
+      const result = await sendAssistantNotificationLocal({
+        actorId: job.target.participantId,
+        onProviderRequestStarted: () => { providerRequests += 1 },
+        bindingDeliveryTarget: route.bindingDelivery?.target, channel: job.target.channel,
+        deliveryTarget: route.deliveryTarget, identityId: job.target.identityId,
+        threadId: job.target.threadId, threadIsDirect: route.threadIsDirect,
+        deliveryDispatchMode: 'queue-only', deliveryDedupeToken: 'synthetic-cron-audience-occurrence',
+        deliveryIdempotencyKey: 'synthetic-cron-audience-occurrence',
+        executionContext: { hosted: { defaultTarget: modelTarget, memberId: 'synthetic-member', userEnvKeys: [] } },
+        instructions, scheduledAutomationScheduleKind: 'at',
+        scheduledInvocationAuthority: { automationId: created.record.automationId, occurrenceAt },
+        outboxAutomationAuthority: { automationId: created.record.automationId, expectedUpdatedAt: source.updatedAt },
+        turnEnvironment: { currentWorkingDirectory: workingDirectory, env: config.env },
+        turnTrigger: 'automation-cron', vault: workingDirectory, workingDirectory,
+      })
+      process.stdout.write(`[cron-audience-preservation-e2e] ${JSON.stringify({
+        decision: result.decision.kind, delivery: result.deliveryOutcome?.kind, providerRequests, reply: result.response,
+      })}\n`)
+      expect(providerRequests).toBe(1)
+      expect(result.decision.kind).toBe('send_message')
+      expect(result.deliveryOutcome?.kind).toBe('queued')
+      expect(result.response).toMatch(/stretch/iu)
+      expect(result.response).not.toMatch(/completed|already stretched|scheduled another|follow.up|cron|outbox|unverified/iu)
+      expect(result.response).not.toContain('?')
+      const intents = await listAssistantOutboxIntents(workingDirectory)
+      expect(intents).toHaveLength(1)
+      expect(intents[0]).toMatchObject({ channel: 'telegram', threadId: 'synthetic-private-thread', threadIsDirect: true })
+      expect((await listAutomations({ vaultRoot: workingDirectory })).items).toHaveLength(1)
+    } finally {
+      await removeRealCodexTemporaryPaths([workingDirectory, operatorHome, ...config.temporaryPaths])
+    }
+  }, 360_000)
 })

--- a/packages/assistant-engine/test/assistant-cron-runtime.test.ts
+++ b/packages/assistant-engine/test/assistant-cron-runtime.test.ts
@@ -3669,6 +3669,26 @@ describe('assistant cron runtime orchestration', () => {
     expect(updated.job.target.sessionId).toBeNull()
   })
 
+  it.each([true, false])('preserves explicit canonical target audience %s and session continuity', async (threadIsDirect) => {
+    const { vaultRoot } = await createRuntimeContext('assistant-cron-target-audience-')
+    const canonicalJob = await createCanonicalJob(vaultRoot, 'audience-reminder')
+    await updateCanonicalRuntimeState(vaultRoot, canonicalJob.jobId, (record) => ({
+      ...record, alias: 'synthetic-alias', sessionId: 'synthetic-session',
+    }))
+    const result = await setAssistantCronJobTarget({
+      channel: 'telegram', threadId: 'synthetic-thread', threadIsDirect,
+      sessionId: 'ignored-replacement-session', job: canonicalJob.jobId, vault: vaultRoot,
+    })
+    expect(result.job.target.threadIsDirect).toBe(threadIsDirect)
+    expect(result.job.target.sessionId).toBeNull()
+    const runtimeStore = await readAssistantCronCanonicalRuntimeStore(resolveAssistantStatePaths(vaultRoot))
+    expect(runtimeStore.jobs.find((record) => record.jobId === canonicalJob.jobId)?.sessionId).toBe('synthetic-session')
+    expect(result.job.target.alias).toBe('synthetic-alias')
+    expect(findCanonicalAutomation(vaultRoot, canonicalJob.jobId)?.route).toMatchObject({
+      channel: 'telegram', threadId: 'synthetic-thread', threadIsDirect,
+    })
+  })
+
   it('updates canonical targets and clears preserved continuity when requested', async () => {
     const { vaultRoot } = await createRuntimeContext(
       'assistant-cron-runtime-canonical-target-',

--- a/packages/operator-config/src/operator-config/self-delivery-targets.ts
+++ b/packages/operator-config/src/operator-config/self-delivery-targets.ts
@@ -11,6 +11,7 @@ export interface AssistantSelfDeliveryTargetLookupInput {
   identityId?: string | null
   participantId?: string | null
   threadId?: string | null
+  threadIsDirect?: boolean | null
 }
 
 export type AssistantSelfDeliveryTargetMap = Record<
@@ -164,34 +165,46 @@ export async function applyAssistantSelfDeliveryTargetDefaults(
       ? await resolveSingleAssistantSelfDeliveryTarget(dependencies, homeDirectory)
       : null
 
-  if (!savedTarget) {
-    return {
-      channel: normalizedChannel,
-      identityId: dependencies.normalizeString(input.identityId),
-      participantId: dependencies.normalizeString(input.participantId),
-      threadId: dependencies.normalizeString(input.threadId),
-      deliveryTarget: dependencies.normalizeString(input.deliveryTarget),
-    }
+  const explicit = {
+    channel: normalizedChannel,
+    identityId: dependencies.normalizeString(input.identityId),
+    participantId: dependencies.normalizeString(input.participantId),
+    threadId: dependencies.normalizeString(input.threadId),
+    deliveryTarget: dependencies.normalizeString(input.deliveryTarget),
   }
+  const resolved = savedTarget
+    ? {
+        channel: explicit.channel ?? savedTarget.channel,
+        identityId: explicit.identityId ?? savedTarget.identityId ?? null,
+        participantId: explicit.participantId ?? savedTarget.participantId ?? null,
+        threadId: explicit.threadId ?? savedTarget.threadId ?? null,
+        deliveryTarget: explicit.deliveryTarget ?? savedTarget.deliveryTarget ?? null,
+      }
+    : explicit
+  return preserveExplicitAssistantTargetAudience(input.threadIsDirect, explicit, resolved)
+}
+
+function preserveExplicitAssistantTargetAudience(
+  threadIsDirect: boolean | null | undefined,
+  explicit: AssistantSelfDeliveryTargetLookupInput,
+  resolved: AssistantSelfDeliveryTargetLookupInput,
+): AssistantSelfDeliveryTargetLookupInput {
+  // Audience evidence belongs to the supplied route, never a locator or
+  // destination introduced by saved defaults.
+  const preservesExplicitRoute =
+    explicit.channel !== null &&
+    Boolean(explicit.deliveryTarget || explicit.threadId || explicit.participantId) &&
+    explicit.channel === resolved.channel &&
+    explicit.identityId === resolved.identityId &&
+    explicit.participantId === resolved.participantId &&
+    explicit.threadId === resolved.threadId &&
+    explicit.deliveryTarget === resolved.deliveryTarget
 
   return {
-    channel: normalizedChannel ?? savedTarget.channel,
-    identityId:
-      dependencies.normalizeString(input.identityId) ??
-      savedTarget.identityId ??
-      null,
-    participantId:
-      dependencies.normalizeString(input.participantId) ??
-      savedTarget.participantId ??
-      null,
-    threadId:
-      dependencies.normalizeString(input.threadId) ??
-      savedTarget.threadId ??
-      null,
-    deliveryTarget:
-      dependencies.normalizeString(input.deliveryTarget) ??
-      savedTarget.deliveryTarget ??
-      null,
+    ...resolved,
+    ...(preservesExplicitRoute && typeof threadIsDirect === 'boolean'
+      ? { threadIsDirect }
+      : {}),
   }
 }
 

--- a/packages/operator-config/test/operator-config-seam.test.ts
+++ b/packages/operator-config/test/operator-config-seam.test.ts
@@ -648,3 +648,30 @@ test('assistant self delivery targets treat iMessage as the linq route alias', a
     },
   )
 })
+
+
+for (const threadIsDirect of [true, false]) {
+  test(`self-target defaults preserve explicit audience ${threadIsDirect} only on unchanged routes`, async () => {
+    const homeDirectory = await createTempHome('operator-config-route-audience-')
+    const route = {
+      channel: 'telegram',
+      identityId: 'synthetic-identity',
+      participantId: 'synthetic-participant',
+      threadId: 'synthetic-thread',
+      deliveryTarget: 'synthetic-target',
+    }
+    const resolve = (input: Parameters<typeof applyAssistantSelfDeliveryTargetDefaults>[0]) =>
+      applyAssistantSelfDeliveryTargetDefaults(input, { allowSingleSavedTargetFallback: true }, homeDirectory)
+
+    assert.equal((await resolve({ channel: ' Telegram ', threadId: ' synthetic-thread ', threadIsDirect })).threadIsDirect, threadIsDirect)
+    assert.equal((await resolve({ channel: 'telegram', threadIsDirect })).threadIsDirect, undefined)
+    await saveAssistantSelfDeliveryTarget({ ...route, deliverySource: null }, homeDirectory)
+    assert.deepEqual(await resolve({ ...route, threadIsDirect }), { ...route, threadIsDirect })
+    for (const field of ['channel', 'identityId', 'participantId', 'threadId', 'deliveryTarget'] as const) {
+      assert.equal((await resolve({ ...route, [field]: ' ', threadIsDirect })).threadIsDirect, undefined, `defaulted ${field} must not inherit audience`)
+    }
+    assert.equal((await resolve({ threadIsDirect })).threadIsDirect, undefined)
+    assert.equal((await resolve(route)).threadIsDirect, undefined)
+    assert.equal((await resolve({ ...route, threadIsDirect: null })).threadIsDirect, undefined)
+  })
+}


### PR DESCRIPTION
## Why and outcome

Explicit cron target updates lost `threadIsDirect` in both the cron caller and the operator defaults helper. A complete direct Telegram route could consequently become unverified before its reminder ran.

Preserve explicit true and false only when the final normalized channel, identity, participant, thread and delivery target exactly match the supplied nonempty route. Defaults that introduce any route field continue to carry no audience evidence.

Frog autofix issue: #3239

## Product UX

- Effort: Patch restoring existing reminder delivery behavior.
- Result: Ready; parent reviewed the source, proof and synthetic reply.
- Walkthrough: Direct and group values survive unchanged explicit routes, including exact saved defaults. Missing audience, incomplete routes, single-target channel fallback and any introduced locator remain unknown. The scoped real-model direct reminder produces one concise cue with no false completion, question or new follow-up.

## Evidence

- Direct: `pnpm test:assistant:live -- --test "queues one private reminder after explicit defaults preserve its audience"` passed with `gpt-5.6-terra`, local subscription auth. The real public defaults helper uses an explicit synthetic home, then canonical validation/upsert/readback and production cron instructions/notification preparation. Exactly one provider request queued exactly one direct Telegram outbox intent; the single existing automation remained. UX verdict: Ready. No external delivery or production data was used.
- Coverage: The actual `setAssistantCronJobTarget` caller is proved separately by deterministic canonical-write and continuity readback; the live fixture does not mutate process-wide configuration. Both boolean cases failed at both omission boundaries before the repair. Final operator-config seam suite: 10 passed; canonical-target regressions: 2 passed; all 227 existing cron runtime tests passed.
- Commands: `pnpm --dir packages/operator-config exec vitest run --config vitest.config.ts --no-coverage test/operator-config-seam.test.ts`; `pnpm --dir packages/assistant-engine exec vitest run --config vitest.config.ts --no-coverage test/assistant-cron-runtime.test.ts` plus focused rerun after correcting the continuity assertion to its runtime owner; both package typechecks passed.
- Changelog: `pnpm --dir apps/web test -- changelog-page.test.tsx` passed 10 tests; Web typecheck passed. `git diff --check` passed. Package paths are outside the app-only ESLint configuration, so its ignored-file output is not counted as lint evidence.
- Completion: Full ReviewGPT round 1 passed on `046dc58f336fcf44ec3420f6296331f8f2fb43a6` with no findings. Exact-turn and response-hash evidence confirms `gpt-6-pro`; capture took 365.617 seconds, and the owned target was closed. All four required exact-head checks passed, along with the full Host Support workflow and Temporal compatibility. Human merge is required for this runtime/privacy change.

## Non-obvious affected surfaces

The shared defaults helper also serves assistant CLI delivery and managed-automation fallback. Those callers do not supply audience booleans; their resolved route shape remains unchanged. Canonical continuity remains owned by existing runtime state; a keyed route intentionally does not expose an old session pin. Tests read that owner rather than substituting a new session.

## Architecture and reuse

- Existing systems reused: Public operator-config defaults, canonical cron target validation, canonical automation writes, ordinary notification planning and outbox authority.
- New logic: Preserve a supplied boolean only for an unchanged normalized nonempty route.
- New abstractions: One local audience-preservation helper keeps comparison separate from the existing defaults lookup. No public service or state owner is introduced.
- Complexity intentionally avoided: No saved-target schema migration, route resolver replacement, inference of audience, provider bypass, new retry, or test-only production injection.

## Complexity impact

- Guard: Pass, `pnpm complexity:diff`.
- Hotspots: None above 20 in changed production files. Defaults file maximum remains 15; cron targets maximum remains 14.
- Agent judgment: Normalize explicit fields once and keep one local comparison. Further generalization would broaden the patch without improving route ownership.

## Hot reply path impact

- Path status: Existing cron target configuration only; no foreground execution stage is added or moved.
- Database calls: None added.
- Network/provider calls: None added by the repair.
- Other awaited latency: None added; the same existing defaults read remains.
- Before/after proof: Exact source comparison and deterministic route tests. The focused notification journey observes one provider request and one queued effect after configuration.

## Murph initial provider input impact

Not applicable to input-size measurement: no production instructions, tools, schemas, history or generated provider guidance change for either individual or group runtimes. This repairs route audience preservation before the existing planner; the broken direct case previously failed audience admission rather than constructing a baseline provider request. No zero-token delta is claimed.

## Design proof

- Design page: [Existing changelog archive](https://www.withmurph.ai/screenshots/ops#changelog-archive).
- Evidence: Content-only JSON copy reviewed directly; the production archive rendering test loads all authored fragments.
- Coverage: New text through the unchanged archive component. No renderer, layout, responsive or interaction change; the documented content-only route applies.

ReviewGPT first-reviewed head: 046dc58f336fcf44ec3420f6296331f8f2fb43a6
ReviewGPT context sensitivity: sensitive
Classification reason: Audience evidence crosses operator defaults, canonical cron routing and notification privacy boundaries.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing canonical route codecs already read optional true/false and absent audience evidence. This changes no persisted shape or wire protocol.
- Safe order: Deploy the assistant runtime bundle containing both current owners normally; there is no Web/Worker schema ordering dependency.
- Rollback floor: Existing codecs remain compatible. Old writers can again omit the field and reproduce the prior unverified-route failure.
- Expected exposure: Only explicit target-default updates on affected runtime versions change; existing routes are not bulk rewritten.
- Reversibility: Code rollback remains structurally compatible; it restores the prior omission.
- Convergence proof: Deterministic tests retain absent legacy evidence and both existing boolean shapes without migration; no mixed-version protocol is introduced.
- Post-deploy checks: Inspect bounded notification outcomes for newly updated explicit routes; existing live route/egress authority checks remain unchanged.

## Change-shape breakdown

Classification rule: Production TypeScript is source; test files are tests; the closed plan and release-note copy are docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 39 | 25 |
| Tests / fixtures | 136 | 0 |
| Docs | 58 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **233** | **25** |

## Changelog

- Changelog: updated
- Items: 2026-09-11 · private-reminder-targets
