### PR TITLE
fix: restore Messages workout saves for installed iOS clients

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-11-imessage-workout-null-fields.md
+++ b/agent-docs/exec-plans/active/2026-09-11-imessage-workout-null-fields.md
@@ -1,0 +1,32 @@
+# Restore Messages workout submission compatibility
+
+Status: active
+Created: 2026-09-11
+
+## Outcome and protected contract
+
+Outcome: Existing Messages clients can submit a workout with unfinished sets.
+Reaches: Authenticated workout apply and snapshot requests with sparse presentation.
+Proof: A synthetic request produced by the native Swift draft and encoder fails before the fix; route admission must normalize it to the unchanged shared contract.
+
+## Design
+
+The Messages Web ingress owns compatibility with installed native clients. Restore only absent nullable presentation fields before existing strict request validation. Preserve credential checks, access and consent gates, timestamps, mutation preconditions, unknown-field rejection, mailbox identity, and canonical runtime schemas. No new persistence, dependency, model call, or runner rollout is needed. A Web rollback restores the prior rejection but leaves normalized persisted requests readable.
+
+## Work
+
+- Add synthetic native-wire regression coverage for apply, snapshot, retry equivalence, and malformed input rejection.
+- Normalize sparse presentation at the existing Messages validation boundary.
+- Document the boundary and add a member-facing changelog fragment.
+- Run focused tests, Web typecheck, native-wire proof, parent review, and applicable final review/CI.
+
+## Evidence
+
+- Native-wire apply and snapshot regressions failed before implementation and pass afterward.
+- Four focused API/mailbox suites: 46 tests passed.
+- Changed API/service and changelog rendering suites: 50 tests passed.
+- Web typecheck passed after narrowing the validated exercises array at its guarded access.
+- Parent walkthrough: sparse apply and snapshot requests normalize into the unchanged shared schema; malformed completed results and missing mutation preconditions fail closed; omitted/null retries admit identical envelopes. Patch UX Ready at this changed admission boundary.
+- Complexity guard passed with zero hotspots. No awaited operation or provider input changed.
+- Remaining completion: PR provenance, final review, exact-head CI. Production deployment and a member retry remain separate outcome proof.
+- Private production evidence stays outside repository artifacts.

--- a/agent-docs/exec-plans/completed/2026-09-11-imessage-workout-null-fields.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-imessage-workout-null-fields.md
@@ -1,6 +1,6 @@
 # Restore Messages workout submission compatibility
 
-Status: active
+Status: completed
 Created: 2026-09-11
 
 ## Outcome and protected contract
@@ -28,5 +28,7 @@ The Messages Web ingress owns compatibility with installed native clients. Resto
 - Web typecheck passed after narrowing the validated exercises array at its guarded access.
 - Parent walkthrough: sparse apply and snapshot requests normalize into the unchanged shared schema; malformed completed results and missing mutation preconditions fail closed; omitted/null retries admit identical envelopes. Patch UX Ready at this changed admission boundary.
 - Complexity guard passed with zero hotspots. No awaited operation or provider input changed.
-- Remaining completion: PR provenance, final review, exact-head CI. Production deployment and a member retry remain separate outcome proof.
+- Implementation is complete in PR #3286. Final review and exact-head CI are tracked on that PR by the original task owner. Production deployment and a member retry remain separate outcome proof.
 - Private production evidence stays outside repository artifacts.
+Updated: 2026-09-11
+Completed: 2026-09-11

--- a/agent-docs/product-specs/imessage-workout-tracking.md
+++ b/agent-docs/product-specs/imessage-workout-tracking.md
@@ -546,6 +546,18 @@ forward fix. Focused proof must pin the exact V6 TypeScript/Swift fixture,
 exercise-reorder continuity, incompatible-unit rejection, planned defaults as
 incomplete until explicit completion, and preference-only/mixed action outcomes.
 
+## Installed Messages client request compatibility
+
+The Messages Web ingress accepts Swift-omitted nullable presentation fields on
+`workout.live.apply` and `workout.live.snapshot`: `subtitle`, `footer`, and each
+set's `target` and `actual`. It normalizes absence to explicit `null` before the
+existing strict member-action validation and mailbox admission. Completed sets
+still require an actual result; mutation preconditions, authority fields,
+unknown-field rejection, and bounds keep their existing validation. This is
+only an ingress compatibility rule. Canonical and persisted action schemas stay
+unchanged, so normalized requests remain readable by existing runners and
+omitted/null-equivalent retries retain the same admitted payload.
+
 ## V4/V6 live refresh
 
 Live refresh preserves the permanent card-reader contract: no new workout-card

--- a/apps/web/changelog/entries/2026-09-11/imessage-workout-save-recovery.json
+++ b/apps/web/changelog/entries/2026-09-11/imessage-workout-save-recovery.json
@@ -12,6 +12,8 @@
       "workouts",
       "imessage"
     ],
-    "sourcePullRequests": []
+    "sourcePullRequests": [
+      3286
+    ]
   }
 }

--- a/apps/web/changelog/entries/2026-09-11/imessage-workout-save-recovery.json
+++ b/apps/web/changelog/entries/2026-09-11/imessage-workout-save-recovery.json
@@ -1,0 +1,17 @@
+{
+  "publishedOn": "2026-09-11",
+  "order": 100,
+  "item": {
+    "id": "imessage-workout-save-recovery",
+    "kind": "improvement",
+    "priority": 3,
+    "title": "Save workout sets in Messages",
+    "summary": "Workout cards can save completed sets while other sets are still unfinished.",
+    "details": "This fixes a submission error in existing iPhone app versions without requiring an app update.",
+    "relevanceTags": [
+      "workouts",
+      "imessage"
+    ],
+    "sourcePullRequests": []
+  }
+}

--- a/apps/web/src/lib/imessage-mini-app/service.ts
+++ b/apps/web/src/lib/imessage-mini-app/service.ts
@@ -21,7 +21,7 @@ import {
   assertHostedHistoricalLaunchConsentGranted,
   assertHostedLaunchRequiredConsentGranted,
 } from "../legal/consent";
-import { sha256Hex, toIsoTimestamp } from "../primitives";
+import { isRecord, sha256Hex, toIsoTimestamp } from "../primitives";
 
 export const IMESSAGE_MINI_APP_BEARER_TOKEN_PREFIX = "hbds_imessage_";
 export const IMESSAGE_MINI_APP_RENEWAL_BEARER_TOKEN_PREFIX = "hbds_imessage_renew_";
@@ -471,7 +471,10 @@ export function validateIMessageMiniAppMemberAction(
   body: Record<string, unknown>,
   now = new Date(),
 ): MemberActionRequestV1 {
-  const parsed = memberActionRequestV1Schema.safeParse(body);
+  const parsed = memberActionRequestV1Schema.safeParse({
+    ...body,
+    action: normalizeNativeWorkoutPresentation(body.action),
+  });
   if (!parsed.success) {
     throw miniAppRequestInvalid("Member action request is invalid.");
   }
@@ -485,6 +488,44 @@ export function validateIMessageMiniAppMemberAction(
   }
 
   return parsed.data;
+}
+
+// Swift's synthesized Encodable omits nil presentation fields. Normalize only
+// this installed-client wire shape; persisted actions still use the strict schema.
+function normalizeNativeWorkoutPresentation(action: unknown): unknown {
+  if (
+    !isRecord(action)
+    || (action.kind !== "workout.live.apply" && action.kind !== "workout.live.snapshot")
+    || !isRecord(action.presentation)
+    || !isRecord(action.presentation.workout)
+    || !Array.isArray(action.presentation.workout.exercises)
+  ) {
+    return action;
+  }
+
+  const presentation = action.presentation;
+  const workout = action.presentation.workout;
+  const exercises = action.presentation.workout.exercises.map((exercise: unknown) => {
+    if (!isRecord(exercise) || !Array.isArray(exercise.sets)) {
+      return exercise;
+    }
+    return {
+      ...exercise,
+      sets: exercise.sets.map((set: unknown) => isRecord(set)
+        ? { ...set, target: set.target ?? null, actual: set.actual ?? null }
+        : set),
+    };
+  });
+
+  return {
+    ...action,
+    presentation: {
+      ...presentation,
+      subtitle: presentation.subtitle ?? null,
+      footer: presentation.footer ?? null,
+      workout: { ...workout, exercises },
+    },
+  };
 }
 
 function rejectUnknownFields(

--- a/apps/web/test/fixtures/imessage-workout-native-request.json
+++ b/apps/web/test/fixtures/imessage-workout-native-request.json
@@ -1,0 +1,61 @@
+{
+  "action": {
+    "presentation": {
+      "title": "Synthetic workout",
+      "workout": {
+        "exercises": [
+          {
+            "name": "Cable Row",
+            "sets": [
+              {
+                "status": "completed",
+                "actual": "80 lb \u00d7 10"
+              },
+              {
+                "status": "pending"
+              }
+            ]
+          }
+        ],
+        "version": 1,
+        "state": "active"
+      }
+    },
+    "expectedWorkout": {
+      "actionBinding": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "exercises": [
+        {
+          "name": "Cable Row",
+          "sets": [
+            {
+              "logged": false
+            },
+            {
+              "logged": false
+            }
+          ]
+        }
+      ]
+    },
+    "kind": "workout.live.apply",
+    "mutations": [
+      {
+        "result": {
+          "reps": 10,
+          "weight": 80,
+          "kind": "weight_reps",
+          "weightUnit": "lb"
+        },
+        "kind": "set.put",
+        "setPosition": 1,
+        "exercisePosition": 1,
+        "exerciseName": "Cable Row",
+        "expectedResult": null
+      }
+    ],
+    "version": 1
+  },
+  "schemaVersion": 1,
+  "actionId": "11111111-1111-4111-8111-111111111111",
+  "requestedAt": "2026-08-12T15:00:00.000Z"
+}

--- a/apps/web/test/imessage-mini-app-routes.test.ts
+++ b/apps/web/test/imessage-mini-app-routes.test.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import nativeWorkoutRequest from "./fixtures/imessage-workout-native-request.json";
+
 import { hostedOnboardingError } from "../src/lib/hosted-onboarding/errors";
 import { isRecord } from "../src/lib/primitives";
 import { createBearerRequest } from "./route-test-helpers";
@@ -556,6 +558,71 @@ describe("iMessage mini-app routes", () => {
       duplicate: false,
       schemaVersion: 1,
     });
+  });
+
+  it("admits the native Swift payload and canonicalizes omitted/null retries identically", async () => {
+    const body = { ...nativeWorkoutRequest, requestedAt: new Date().toISOString() };
+    const first = await memberActionRoute.POST(jsonRequest(
+      "https://example.test/api/device-sync/companion/imessage-mini-app/member-actions",
+      MESSAGES_TOKEN,
+      "POST",
+      body,
+    ));
+    expect(first.status).toBe(202);
+    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).toHaveBeenCalledTimes(1);
+    const admitted = mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx.mock.calls[0]?.[0].envelope;
+    expect(admitted.request).toMatchObject({
+      actionId: body.actionId,
+      requestedAt: body.requestedAt,
+      action: {
+        mutations: body.action.mutations,
+        presentation: {
+          subtitle: null,
+          footer: null,
+          workout: { exercises: [{ sets: [
+            { status: "completed", actual: "80 lb × 10", target: null },
+            { status: "pending", actual: null, target: null },
+          ] }] },
+        },
+      },
+    });
+    const retry = await memberActionRoute.POST(jsonRequest(
+      "https://example.test/api/device-sync/companion/imessage-mini-app/member-actions",
+      MESSAGES_TOKEN,
+      "POST",
+      admitted.request,
+    ));
+    expect(retry.status).toBe(202);
+    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx.mock.calls[1]?.[0].envelope)
+      .toEqual(admitted);
+    expect(mocks.assertActiveHostedMemberAccessAllowed).toHaveBeenCalledTimes(2);
+    expect(mocks.assertHostedHistoricalLaunchConsentGranted).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects an incomplete completed result before mailbox preparation", async () => {
+    const response = await memberActionRoute.POST(jsonRequest(
+      "https://example.test/api/device-sync/companion/imessage-mini-app/member-actions",
+      MESSAGES_TOKEN,
+      "POST",
+      {
+        ...nativeWorkoutRequest,
+        requestedAt: new Date().toISOString(),
+        action: {
+          ...nativeWorkoutRequest.action,
+          presentation: {
+            ...nativeWorkoutRequest.action.presentation,
+            workout: {
+              ...nativeWorkoutRequest.action.presentation.workout,
+              exercises: [{ name: "Cable Row", sets: [{ status: "completed" }] }],
+            },
+          },
+        },
+      },
+    ));
+    expect(response.status).toBe(400);
+    expect(mocks.runWithPreparedHostedMailboxItemAppendCrypto).not.toHaveBeenCalled();
+    expect(mocks.appendHostedMailboxEnvelopeWithPreparedCryptoTx).not.toHaveBeenCalled();
+    expect(mocks.signalHostedMailboxAppendRuntime).not.toHaveBeenCalled();
   });
 
   it("admits a workout snapshot read and returns its typed card result", async () => {

--- a/apps/web/test/imessage-mini-app-service.test.ts
+++ b/apps/web/test/imessage-mini-app-service.test.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 
 import { describe, expect, it, vi } from "vitest";
+import { memberActionRequestV1Schema } from "@murphai/contracts";
+
+import nativeWorkoutRequest from "./fixtures/imessage-workout-native-request.json";
 
 import { HostedAgentSessionService } from "../src/lib/hosted-agent-sessions";
 import {
@@ -199,6 +202,91 @@ describe("iMessage mini-app service", () => {
       httpStatus: 401,
     });
     expect(store.authenticateAgentSessionByTokenHash).not.toHaveBeenCalled();
+  });
+
+  it("normalizes the sparse presentation emitted by the native Swift workout encoder", () => {
+    // Synthetic output from WorkoutEntryDraft and MessagesMiniAppAPIClient.makeEncoder.
+    const request = structuredClone(nativeWorkoutRequest);
+    const before = structuredClone(request);
+    const now = new Date(request.requestedAt);
+    expect(memberActionRequestV1Schema.safeParse(request).success).toBe(false);
+
+    const normalized = validateIMessageMiniAppMemberAction(request, now);
+
+    expect(normalized.action).toMatchObject({
+      presentation: {
+        subtitle: null,
+        footer: null,
+        workout: {
+          exercises: [{
+            sets: [
+              { status: "completed", actual: "80 lb × 10", target: null },
+              { status: "pending", actual: null, target: null },
+            ],
+          }],
+        },
+      },
+    });
+    expect(memberActionRequestV1Schema.safeParse(normalized).success).toBe(true);
+    expect(validateIMessageMiniAppMemberAction(normalized, now)).toEqual(normalized);
+    expect(request).toEqual(before);
+  });
+
+  it("normalizes the same native presentation for live snapshot reads", () => {
+    const request = {
+      ...nativeWorkoutRequest,
+      action: {
+        kind: "workout.live.snapshot",
+        version: 1,
+        workoutBinding: nativeWorkoutRequest.action.expectedWorkout.actionBinding,
+        presentation: nativeWorkoutRequest.action.presentation,
+      },
+    };
+    const normalized = validateIMessageMiniAppMemberAction(request, new Date(request.requestedAt));
+    expect(normalized.action).toMatchObject({
+      kind: "workout.live.snapshot",
+      presentation: { subtitle: null, footer: null },
+    });
+    expect(memberActionRequestV1Schema.safeParse(normalized).success).toBe(true);
+  });
+
+  it.each([
+    { ...nativeWorkoutRequest.action.presentation, subtitle: 7 },
+    { ...nativeWorkoutRequest.action.presentation, memberId: "untrusted-member" },
+    { ...nativeWorkoutRequest.action.presentation, workout: null },
+    { ...nativeWorkoutRequest.action.presentation, workout: { exercises: "invalid" } },
+    {
+      ...nativeWorkoutRequest.action.presentation,
+      workout: {
+        ...nativeWorkoutRequest.action.presentation.workout,
+        exercises: [{ name: "Cable Row", sets: [{ status: "completed" }] }],
+      },
+    },
+    {
+      ...nativeWorkoutRequest.action.presentation,
+      workout: {
+        ...nativeWorkoutRequest.action.presentation.workout,
+        exercises: [{ name: "Cable Row", sets: [{ status: "pending", actual: "10 reps" }] }],
+      },
+    },
+  ])("keeps malformed native presentation fail-closed: %#", (presentation) => {
+    expect(() => validateIMessageMiniAppMemberAction({
+      ...nativeWorkoutRequest,
+      action: { ...nativeWorkoutRequest.action, presentation },
+    }, new Date(nativeWorkoutRequest.requestedAt))).toThrowError(/request is invalid/iu);
+  });
+
+  it("does not fill missing mutation preconditions or accept unknown authority fields", () => {
+    const now = new Date(nativeWorkoutRequest.requestedAt);
+    const mutations = nativeWorkoutRequest.action.mutations.map(({ expectedResult: _expected, ...mutation }) => mutation);
+    expect(() => validateIMessageMiniAppMemberAction({
+      ...nativeWorkoutRequest,
+      action: { ...nativeWorkoutRequest.action, mutations },
+    }, now)).toThrowError(/request is invalid/iu);
+    expect(() => validateIMessageMiniAppMemberAction({
+      ...nativeWorkoutRequest,
+      action: { ...nativeWorkoutRequest.action, memberId: "untrusted-member" },
+    }, now)).toThrowError(/request is invalid/iu);
   });
 
   it("validates closed, versioned enrollment and member-action envelopes", () => {


### PR DESCRIPTION
## Why and outcome

Existing Messages clients omit nullable presentation fields when encoding a workout request. The strict Web validator rejected the whole submission, including completed sets, whenever presentation fields were absent. Normalize only those missing fields at Messages ingress so installed clients can save without an app update.

## Product UX

- Effort: Patch
- Result: Ready
- Walkthrough: Synthetic native-wire apply and live-snapshot requests now pass admission. Unfinished sets remain unfinished, completed results are preserved, and malformed input still fails before mailbox preparation. Omitted/null retries produce identical admitted requests. Device rendering and terminal save handling are unchanged; physical-device retry remains post-deploy proof.

## Evidence

- Direct: Captured synthetic output from the real Swift `WorkoutEntryDraft` and `MessagesMiniAppAPIClient.makeEncoder`; apply and snapshot tests failed before the fix and pass afterward. The route test exercises real parsing and wake construction through the mailbox boundary.
- Focused API/mailbox tests: 46 passed across `imessage-mini-app-service`, `imessage-mini-app-routes`, `member-action-mailbox-boundary`, and `member-action-outcome-route`.
- Changed API/service plus changelog-page suites: 50 passed.
- Web typecheck: `pnpm --dir apps/web typecheck:prepared` passed after the full typecheck prepared generated prerequisites.
- Coverage: malformed presentation, missing mutation preconditions, authentication, access/consent, strict persisted-schema validation, input immutability, and equivalent retry envelopes.
- Final review: ReviewGPT PASS on `dccce83b62f7a9ef5c60723e888b437a7630e613`; response hash and actual `gpt-6-pro` model metadata verified. Independent helper execution covered 64 omitted/null equivalence cases and 30 supplied-value preservation cases.
- CI: All 36 final-head checks passed, including every required check. Merged as `e62b1e19b36619e08fb270930021d2a925698f2b`. All five hosted production scenarios and final attestation passed on `77d953863f487588be93b0ee27756ac7ffacb62c`: [private proof](https://github.com/cobuildwithus/murph-cloud/actions/runs/34666585237) and [public admission](https://github.com/cobuildwithus/murph/actions/runs/34665620956). With explicit incident-specific approval, promoted Vercel deployment `dpl_CD2dR8wEuGQFEqAmMAdi2bjeccqg` after its GitHub-backed check remained stale despite successful admission. On 2026-09-12, verified `www.withmurph.ai` resolves to that deployment, its immutable source is `77d953863f487588be93b0ee27756ac7ffacb62c`, and it is promoted with domains assigned. Git ancestry confirms the workout fix is included. Post-deploy smoke: homepage HTTP 200 and unauthenticated member-action POST HTTP 401. These checks prove deployment and the auth boundary; an ordinary authenticated member retry remains unobserved. Repository-wide deployment policy was not changed.

## Non-obvious affected surfaces

Live snapshot reads use the same native presentation and receive the same normalization; focused coverage includes that action variant. Shared contracts, canonical writes, outcome polling, and runners retain their current format and behavior.

## Architecture and reuse

- Existing systems reused: Messages credential validation, strict member-action schema, encrypted mailbox admission, existing runtime wake and outcome owners.
- New logic: One ingress helper restores missing `subtitle`, `footer`, set `target`, and set `actual` to null for the two supported workout action kinds.
- New abstractions: None beyond this local compatibility helper; all validation and authority stays with the existing owners.
- Complexity intentionally avoided: No client-version registry, new wire version, permissive persisted schema, queue, state store, or runner rollout.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; source maximum complexity 6 to 9, debt remains zero.
- Hotspots: The changed source has no functions above the threshold of 20.
- Agent judgment: The bounded object projection preserves unknown fields for strict rejection and avoids duplicating the shared validation schema.

## Hot reply path impact

No conversation/assistant path change. The existing 24 KiB request bound limits synchronous normalization. No database, provider, network, or awaited operation was added or reordered.

## Murph initial provider input impact

- Individual and group: No provider-visible input changes; the deterministic member-action route invokes no model.
- Measurement method: Not run because no provider-input surface changed.

## Design proof

- Design page: https://www.withmurph.ai/screenshots/ops#changelog-archive
- Evidence: Content-only changelog copy checked through the production archive renderer in `changelog-page.test.tsx`, following the changelog README exception.
- Coverage: No component, layout, visual, or interaction changes.

## Deployment concerns

- Deployment: applicable
- Supported skew: Installed sparse clients and clients sending explicit nulls converge to the existing strict request format. Current runners accept normalized requests without changes.
- Safe order: Deploy Web only; no native or runner release dependency.
- Rollback floor: No new persisted shape or migration; preceding Web and runners can read admitted requests.
- Expected exposure: Sparse requests can still fail on the old Web deployment until traffic converges.
- Reversibility: Reverting Web restores the prior admission failure without making stored requests unreadable.
- Convergence proof: Route tests show normalized requests satisfy the unchanged shared schema and omitted/null variants admit identical envelopes.
- Post-deploy checks: Confirm the Web deployment SHA, inspect bounded Messages request-error aggregates, and confirm an ordinary member retry reaches admission and its terminal outcome.

## Change-shape breakdown

Classification rule: Production TypeScript is source; test modules and synthetic JSON are tests/fixtures; Markdown is docs; authored changelog JSON is content/other. No binary files or generated output are included.

- Source: +43 / -2
- Tests/fixtures: +216 / -0
- Docs: +46 / -0
- Config/tooling: +0 / -0
- Generated/other: +19 / -0 (authored changelog content; no generated files)
- Total: +324 / -2

## Changelog

- Changelog: updated
- Items: 2026-09-11 · imessage-workout-save-recovery

ReviewGPT first-reviewed head: dccce83b62f7a9ef5c60723e888b437a7630e613
ReviewGPT context sensitivity: sensitive
Classification reason: Authenticated public API request compatibility for a health-data editor.
