### PR TITLE
fix(web): silence known Web Crypto experimental notices

### DIFF
--- a/apps/web/src/lib/process-warnings.ts
+++ b/apps/web/src/lib/process-warnings.ts
@@ -34,8 +34,17 @@ type ProcessEmitWarningRestArgs = Parameters<typeof process.emitWarning> extends
 const PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE =
   "Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0. Use async/await or an external async flow control mechanism instead.";
 
-const PG_WARNING_FILTER_FLAG = Symbol.for(
-  "murph.pgConcurrentQueryDeprecationWarningFilterInstalled",
+// Node 24 emits both notices even for a capability probe via
+// crypto.subtle.constructor.supports("importKey", "ML-DSA-44"). They report
+// API stability, not a failed crypto operation. Match only these exact notices
+// so other experimental algorithms and actual crypto failures remain visible.
+const WEB_CRYPTO_EXPERIMENTAL_MESSAGES = new Set([
+  "The supports Web Crypto API method is an experimental feature and might change at any time",
+  "The ML-DSA-44 Web Crypto API algorithm is an experimental feature and might change at any time",
+]);
+
+const HOSTED_WARNING_FILTER_FLAG = Symbol.for(
+  "murph.hostedWebNoiseWarningFilterInstalled",
 );
 
 type ProcessWithWarningFilterFlag = NodeJS.Process & {
@@ -46,7 +55,7 @@ export function installHostedWebWarningFilters(): void {
   installSqliteExperimentalWarningFilterWithOptions({
     matchMode: "includes",
   });
-  installPgConcurrentQueryDeprecationWarningFilter();
+  installHostedWebNoiseWarningFilter();
 }
 
 export function isHostedWebNoiseWarning(
@@ -56,7 +65,9 @@ export function isHostedWebNoiseWarning(
   return (
     isSqliteExperimentalWarning(warning, args, {
       matchMode: "includes",
-    }) || isPgConcurrentQueryDeprecationWarning(warning, args)
+    }) ||
+    isPgConcurrentQueryDeprecationWarning(warning, args) ||
+    isWebCryptoExperimentalWarning(warning, args)
   );
 }
 
@@ -72,18 +83,32 @@ export function isPgConcurrentQueryDeprecationWarning(
   );
 }
 
-function installPgConcurrentQueryDeprecationWarningFilter(): void {
+function isWebCryptoExperimentalWarning(
+  warning: string | Error,
+  args: readonly unknown[],
+): boolean {
+  const message = typeof warning === "string" ? warning : warning.message;
+  return (
+    readWarningType(warning, args) === "ExperimentalWarning" &&
+    WEB_CRYPTO_EXPERIMENTAL_MESSAGES.has(message)
+  );
+}
+
+function installHostedWebNoiseWarningFilter(): void {
   const processWithFlag = process as ProcessWithWarningFilterFlag;
 
-  if (processWithFlag[PG_WARNING_FILTER_FLAG] === true) {
+  if (processWithFlag[HOSTED_WARNING_FILTER_FLAG] === true) {
     return;
   }
 
-  processWithFlag[PG_WARNING_FILTER_FLAG] = true;
+  processWithFlag[HOSTED_WARNING_FILTER_FLAG] = true;
   const originalEmitWarning = process.emitWarning.bind(process);
 
   process.emitWarning = ((warning: string | Error, ...args: unknown[]) => {
-    if (isPgConcurrentQueryDeprecationWarning(warning, args)) {
+    if (
+      isPgConcurrentQueryDeprecationWarning(warning, args) ||
+      isWebCryptoExperimentalWarning(warning, args)
+    ) {
       return;
     }
 

--- a/apps/web/test/process-warnings.test.ts
+++ b/apps/web/test/process-warnings.test.ts
@@ -7,21 +7,21 @@ const SQLITE_WARNING_FILTER_FLAG = Symbol.for("murph.sqliteExperimentalWarningFi
 const SQLITE_WARNING_FILTER_INCLUDES_FLAG = Symbol.for(
   "murph.sqliteExperimentalWarningFilterInstalled.includes",
 );
-const PG_WARNING_FILTER_FLAG = Symbol.for(
-  "murph.pgConcurrentQueryDeprecationWarningFilterInstalled",
+const HOSTED_WARNING_FILTER_FLAG = Symbol.for(
+  "murph.hostedWebNoiseWarningFilterInstalled",
 );
 const PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE =
   "Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0. Use async/await or an external async flow control mechanism instead.";
 type ProcessWithWarningFilterFlags = NodeJS.Process & {
   [SQLITE_WARNING_FILTER_FLAG]?: boolean;
   [SQLITE_WARNING_FILTER_INCLUDES_FLAG]?: boolean;
-  [PG_WARNING_FILTER_FLAG]?: boolean;
+  [HOSTED_WARNING_FILTER_FLAG]?: boolean;
 };
 
 function deleteWarningFilterFlags(): void {
   delete (process as ProcessWithWarningFilterFlags)[SQLITE_WARNING_FILTER_FLAG];
   delete (process as ProcessWithWarningFilterFlags)[SQLITE_WARNING_FILTER_INCLUDES_FLAG];
-  delete (process as ProcessWithWarningFilterFlags)[PG_WARNING_FILTER_FLAG];
+  delete (process as ProcessWithWarningFilterFlags)[HOSTED_WARNING_FILTER_FLAG];
 }
 
 describe("hosted web warning filters", () => {
@@ -172,6 +172,48 @@ describe("hosted web warning filters", () => {
     expect(
       isPgConcurrentQueryDeprecationWarning(PG_CONCURRENT_QUERY_DEPRECATION_MESSAGE, []),
     ).toBe(false);
+  });
+
+  it.each([
+    "The supports Web Crypto API method is an experimental feature and might change at any time",
+    "The ML-DSA-44 Web Crypto API algorithm is an experimental feature and might change at any time",
+  ])("suppresses only the exact crypto experimental notice: %s", async (message) => {
+    const forwardedWarnings: unknown[][] = [];
+    process.emitWarning = ((warning: string | Error, ...args: unknown[]) => {
+      forwardedWarnings.push([warning, ...args]);
+    }) as typeof process.emitWarning;
+
+    const { installHostedWebWarningFilters, isHostedWebNoiseWarning } = await import(
+      "@/src/lib/process-warnings"
+    );
+    installHostedWebWarningFilters();
+
+    process.emitWarning(message, "ExperimentalWarning");
+    process.emitWarning(message, { type: "ExperimentalWarning" });
+    process.emitWarning(Object.assign(new Error(message), { name: "ExperimentalWarning" }));
+
+    const cryptoFailure = Object.assign(new Error("Signature verification failed"), {
+      name: "OperationError",
+    });
+    const differentAlgorithm = message.replace("ML-DSA-44", "ML-DSA-65").replace(
+      "supports Web Crypto API method",
+      "different Web Crypto API method",
+    );
+    process.emitWarning(message, "Warning");
+    process.emitWarning(message);
+    process.emitWarning(`${message} (extra context)`, "ExperimentalWarning");
+    process.emitWarning(differentAlgorithm, "ExperimentalWarning");
+    process.emitWarning(cryptoFailure);
+
+    expect(forwardedWarnings).toEqual([
+      [message, "Warning"],
+      [message],
+      [`${message} (extra context)`, "ExperimentalWarning"],
+      [differentAlgorithm, "ExperimentalWarning"],
+      [cryptoFailure],
+    ]);
+    expect(isHostedWebNoiseWarning(message, ["ExperimentalWarning"])).toBe(true);
+    expect(isHostedWebNoiseWarning(cryptoFailure, [])).toBe(false);
   });
 
   it("is idempotent", async () => {


### PR DESCRIPTION
## Why and outcome

SimpleWebAuthn 14.0.1 probes `SubtleCrypto.supports("verify", "ML-DSA-44")` during startup, which emits two Node experimental-API notices. Vercel surfaces these stderr notices as error entries. Extend the existing hosted Web warning filter to suppress only those two exact experimental notices, preserving unrelated warnings and crypto failure diagnostics.

## Product UX

- Effort: Not applicable — internal log-noise reduction only.
- Result: Not applicable.
- Walkthrough: Member authentication and passkey behavior are unchanged.

## Evidence

- Direct: On Node 24.14.1, the real crypto capability probe emits both notices before filtering; after installation it still returns supported, emits neither notice, and forwards a synthetic unrelated warning.
- Coverage: Seven focused warning tests pass, covering exact messages, string/options/Error argument forms, other algorithms, wrong warning types, additional context, ordinary warnings, crypto failure diagnostics, existing SQLite/pg filters, and idempotence.
- Passed on the PR head: `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/process-warnings.test.ts`; `pnpm --dir apps/web typecheck`; focused ESLint; `pnpm complexity:diff`; `git diff --check`.
- Local verification and all required CI checks pass on `efdb11fe0208154c7956be5e8983d326de507b4b`: [release checks](https://github.com/cobuildwithus/murph/actions/runs/34620793243), [hosted billing boundary](https://github.com/cobuildwithus/murph/actions/runs/34620793279), and both CLI host platforms. Current-base mergeability is confirmed.
- Browser visibility: direct synthetic verification confirms unsupported-operation diagnostics still forward and `console.warn`/`console.error` are unchanged. The filter runs only in Node; browser code and existing telemetry remain unchanged. Browser-only passkey failures have no explicit server-reporting path in the enrollment hook; adding that reporting is separate from this noise-filter change.
- Parent review: scoped diff, privacy, forwarding behavior, startup wiring, and complexity inspected. Final ReviewGPT is not applicable: this changes only an existing log-noise predicate, with no auth decisions, state, protocols, or trust-boundary behavior changed.

## Non-obvious affected surfaces

The process-wide Web filter also installs through Prisma initialization. Existing SQLite and pg warning behavior and repeated installation remain covered by the focused tests.

## Architecture and reuse

- Existing systems reused: Hosted Web process-warning filter and instrumentation registration.
- New logic: Exact message plus ExperimentalWarning type matching for two Node notices.
- New abstractions: No new subsystem; one private predicate extends the existing filter.
- Complexity intentionally avoided: No dependency patches, global warning disable switch, crypto changes, or new logging infrastructure.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: None above 20; maximum changed-file complexity remains 7.
- Agent judgment: A bounded exact-message predicate is sufficient; further abstraction is unnecessary.

## Hot reply path impact

- Path status: Not applicable — only synchronous process-warning classification changes.
- Database calls: None.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Diff adds no I/O, awaits, retries, or provider work.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no prompts, tools, schemas, history assembly, or provider-visible inputs change.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: No deployment protocol, schema, or cross-plane compatibility change. The filter takes effect through the ordinary Web deployment. After deployment, verify the two notices disappear while unrelated warnings remain visible.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source; the Vitest file is tests. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 33 | 8 |
| Tests / fixtures | 46 | 4 |
| Docs | 0 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **79** | **12** |

## Changelog

- Changelog: not applicable
- Reason: Internal operational log-noise reduction; no member-visible product behavior changes.

