### PR TITLE
Recover safely from transient database disconnects

### DIFF
--- a/agent-docs/exec-plans/active/2026-09-11-database-disconnect-retry.md
+++ b/agent-docs/exec-plans/active/2026-09-11-database-disconnect-retry.md
@@ -1,0 +1,58 @@
+# Recover safely from transient database disconnects
+
+Status: active
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal and scope
+
+Extend the existing Web database retry owner to recover from a transient closed
+connection without replaying a possible write. No new retry layer, pool,
+configuration, dependencies, schema, or durable state.
+
+## Product UX
+
+- Outcome: eligible reads and transaction setup recover from one brief disconnect.
+- Reaches: Web reads and hosted background work using the shared Prisma owner.
+- Proof: real local PostgreSQL disconnects, successful readback, and no replay
+  after callback entry or a potentially committed write.
+
+## Safety decisions
+
+- Match the driver's exact untyped disconnect message in the existing bounded
+  classifier; log only the existing allowlisted metadata.
+- Reuse the two-attempt limit, jitter, and local-pressure suppression.
+- Allow closed-connection replay only for explicit model read operations outside
+  transactions and interactive setup before callback entry.
+- Exclude raw SQL, model writes, batch transactions, and reads inside transaction
+  scope. Carry that scope through the existing transaction wrapper.
+
+## Tasks
+
+1. Add failing regression cases for recovery and replay boundaries.
+2. Extend the existing classifier and retry policies; update the owning contract.
+3. Run focused unit and real PostgreSQL proof, Web typecheck, and complexity review.
+4. Review the final diff, record results, close the plan, and make a scoped commit.
+
+## Verification
+
+- Before implementation, 19 new cases failed on missing disconnect recovery or
+  classification; the existing suite passed.
+- Focused candidate proof: 89 Prisma owner tests, 11 real PostgreSQL tests,
+  and 10 changelog page tests passed (110 total).
+- The real adapter/pool recovered startup and established-socket reads, ran an
+  interactive callback once after a startup disconnect, and preserved failed
+  transaction scope and mixed-batch atomicity. Independent readback proved an
+  acknowledged-by-storage write was not replayed after its response was lost.
+- Web typecheck and focused ESLint passed. A test-only Promise API mismatch was
+  corrected using the repository's existing deferred-promise pattern.
+- Complexity guard passed: classifier maximum 34 to 24 and debt 14 to 4.
+  The remaining bounded traversal belongs in this owner; another extraction
+  would not reduce concepts or improve the current change.
+- Product UX: Ready for the bounded recovery promise. No presentation or
+  provider-input changes. Public changelog describes recovery without private
+  incident details. Production behavior still requires deployment.
+- Parent review: no new pool, dependency, configuration, retry layer, or durable
+  state; one async transaction scope preserves the public Prisma boundary.
+  Existing operation timing, backpressure, retry delay, and attempt bounds remain.
+- PR review and CI: pending.

--- a/agent-docs/exec-plans/completed/2026-09-11-database-disconnect-retry.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-database-disconnect-retry.md
@@ -1,6 +1,6 @@
 # Recover safely from transient database disconnects
 
-Status: active
+Status: completed
 Created: 2026-09-11
 Updated: 2026-09-11
 
@@ -55,4 +55,6 @@ configuration, dependencies, schema, or durable state.
 - Parent review: no new pool, dependency, configuration, retry layer, or durable
   state; one async transaction scope preserves the public Prisma boundary.
   Existing operation timing, backpressure, retry delay, and attempt bounds remain.
-- PR review and CI: pending.
+- Implementation is committed in PR #3295. Final PR review and exact-head CI
+  remain separate completion gates; no production deployment was performed.
+Completed: 2026-09-11

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1741,18 +1741,25 @@ and database pressure. Connection failure logs expose only fixed
 operation/source labels, retry attempt and disposition, the configured pool
 limit, and numeric pre-attempt and post-failure pool counts.
 
-That module permits one jittered retry only for ambiguous transient failures
-that prove the database did no work. A `pool_checkout_timeout` means the
-statement never reached Postgres. A `connection_establishment_timeout` means
-the driver failed while opening the physical connection. A
-`transaction_start_timeout` is Prisma's
-`P2028` raised before it invokes the transaction callback. When the local pool
-is already full or has waiters, either failure is returned immediately as
-backpressure instead of re-entering the same queue. `P2028` also covers
-transactions that opened and later expired; the wrapper tracks callback entry
-and never replays a transaction that may have run. Failures that may have
-reached Postgres, such as closed connections, TLS faults, or an unreachable
-host, are reported and rethrown untouched.
+That module permits one jittered retry when replay cannot duplicate an effect.
+A `pool_checkout_timeout` means the statement never reached Postgres. A
+`connection_establishment_timeout` means the driver failed while opening the
+physical connection. A `transaction_start_timeout` is Prisma's `P2028` raised
+before it invokes the transaction callback. Closed connections, including pg's
+plain `Connection terminated unexpectedly` error, also permit one retry for
+standalone model reads or interactive transaction setup before callback entry.
+The model-read allowlist excludes raw SQL, which may have effects even through a
+query API. The existing public transaction wrapper carries an async scope so
+reads inside interactive or batch transactions do not independently retry a
+closed connection or escape their transaction's failure boundary. Batch
+transactions and potentially dispatched writes do not replay disconnects.
+
+When the local pool is already full or has waiters, failures return immediately
+as backpressure instead of re-entering the same queue. The wrapper tracks
+callback entry and never replays an interactive transaction that may have run,
+including a failure during commit. TLS faults, unreachable hosts, and unrelated
+errors remain terminal. Diagnostics use the existing bounded error traversal
+and fixed category labels without recording error messages or connection fields.
 
 Pool pressure is reported before it becomes a failure. `Hosted web database pool
 pressure.` logs the same total, idle, and waiting counts when the pool is full

--- a/apps/web/changelog/entries/2026-09-11/brief-connection-interruptions.json
+++ b/apps/web/changelog/entries/2026-09-11/brief-connection-interruptions.json
@@ -11,6 +11,8 @@
     "relevanceTags": [
       "reliability"
     ],
-    "sourcePullRequests": []
+    "sourcePullRequests": [
+      3295
+    ]
   }
 }

--- a/apps/web/changelog/entries/2026-09-11/brief-connection-interruptions.json
+++ b/apps/web/changelog/entries/2026-09-11/brief-connection-interruptions.json
@@ -1,0 +1,16 @@
+{
+  "publishedOn": "2026-09-11",
+  "order": 100,
+  "item": {
+    "id": "brief-connection-interruptions",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Fewer errors from brief connection interruptions",
+    "summary": "Murph can recover from more brief connection interruptions while loading information or preparing to save background progress.",
+    "details": "Recovery is limited to work that is safe to repeat. An uncertain save is not automatically repeated.",
+    "relevanceTags": [
+      "reliability"
+    ],
+    "sourcePullRequests": []
+  }
+}

--- a/apps/web/src/lib/prisma.ts
+++ b/apps/web/src/lib/prisma.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient, type Prisma } from "@prisma/client";
 import { attachDatabasePool } from "@vercel/functions";
@@ -30,6 +32,21 @@ const DATABASE_RETRY_MIN_DELAY_MS = 50;
 const DATABASE_RETRY_MAX_DELAY_MS = 250;
 const POOL_PRESSURE_SAMPLE_INTERVAL_MS = 10_000;
 const SLOW_TRANSACTION_MS = 5_000;
+
+// A read in a batch or interactive transaction must keep that transaction's
+// snapshot and failure boundary. The public transaction wrapper owns the scope;
+// no Prisma-private request metadata is needed.
+const databaseTransactionScope = new AsyncLocalStorage<boolean>();
+const REPLAYABLE_MODEL_READS = new Set([
+  "findUnique",
+  "findUniqueOrThrow",
+  "findFirst",
+  "findFirstOrThrow",
+  "findMany",
+  "count",
+  "aggregate",
+  "groupBy",
+]);
 
 export type PrismaInteractiveTransactionOperation =
   | "account_deletion.database_delete"
@@ -122,6 +139,19 @@ const DATABASE_POOL_FAILURE_BY_SQLSTATE = new Map<
 >([
   ["53300", "connection_limit"],
 ]);
+
+// pg sometimes emits plain Errors without a code. Keep message-only fallbacks
+// together; a closed socket alone does not prove whether SQL ran.
+const DATABASE_POOL_FAILURE_BY_MESSAGE: readonly [RegExp, DatabasePoolFailureCategory][] = [
+  [/^Connection terminated unexpectedly$/, "connection_closed"],
+  [/timeout exceeded when trying to connect/, "pool_checkout_timeout"],
+  // P2028 covers every transaction-API fault; only this message means setup.
+  [/Unable to start a transaction in the given time/, "transaction_start_timeout"],
+  [/Connection terminated due to connection timeout/, "connection_establishment_timeout"],
+  [/remaining connection slots are reserved/, "connection_limit"],
+  [/too many connections for role/, "connection_limit"],
+  [/sorry, too many clients already/, "connection_limit"],
+];
 
 const PGBOUNCER_MAX_CLIENT_CONN_SQLSTATE = "08P01";
 const PGBOUNCER_MAX_CLIENT_CONN_MESSAGE =
@@ -252,17 +282,25 @@ export function createPrismaClient(input: CreatePrismaClientInput): PrismaClient
             Date.now() - startedAtMs,
           );
         };
-        // A checkout timeout means the statement never reached Postgres, so the
-        // operation can be replayed without duplicating an effect.
+        // Checkout/establishment timeouts precede SQL dispatch. A disconnect
+        // can follow dispatch, so only standalone model reads can replay it.
+        // Raw SQL can have effects even when exposed as a query.
+        const retryableCategories: DatabasePoolFailureCategory[] = [
+          "pool_checkout_timeout",
+          "connection_establishment_timeout",
+        ];
+        if (
+          model && REPLAYABLE_MODEL_READS.has(operation)
+          && !databaseTransactionScope.getStore()
+        ) {
+          retryableCategories.push("connection_closed");
+        }
         return runWithDatabaseRetry(
           pool,
           poolMax,
           {
             operation: model ? `${model}.${operation}` : operation,
-            retryableCategories: [
-              "pool_checkout_timeout",
-              "connection_establishment_timeout",
-            ],
+            retryableCategories,
             source: "operation",
           },
           () => query(args),
@@ -284,9 +322,9 @@ export function createPrismaClient(input: CreatePrismaClientInput): PrismaClient
 }
 
 /**
- * Retries one ambiguous connection-establishment failure when the caller proves
- * the operation never began. Local pool saturation is already backpressure, so
- * it is reported and returned immediately instead of rejoining the same queue.
+ * Retries once when the caller proves replay is safe: no effect began, or the
+ * operation is a standalone model read. Local pool saturation is already
+ * backpressure, so it returns immediately instead of rejoining the same queue.
  */
 async function runWithDatabaseRetry<T>(
   pool: PgPool,
@@ -398,7 +436,10 @@ function withTransactionStartRetry(
                 ],
                 source: "transaction",
               },
-              () => Reflect.apply(value, target, args) as Promise<unknown>,
+              () => databaseTransactionScope.run(
+                true,
+                () => Reflect.apply(value, target, args) as Promise<unknown>,
+              ),
             );
           } finally {
             reportSlowDatabaseBatchTransaction(
@@ -416,6 +457,7 @@ function withTransactionStartRetry(
           {
             operation: "transaction.interactive",
             retryableCategories: [
+              "connection_closed",
               "transaction_start_timeout",
               "pool_checkout_timeout",
               "connection_establishment_timeout",
@@ -454,11 +496,10 @@ function withTransactionStartRetry(
             const transactionArgs = [wrappedCallback, ...args.slice(1)];
 
             try {
-              return await Reflect.apply(
-                value,
-                target,
-                transactionArgs,
-              ) as unknown;
+              return await databaseTransactionScope.run(
+                true,
+                () => Reflect.apply(value, target, transactionArgs) as Promise<unknown>,
+              );
             } finally {
               if (!callbackStarted) {
                 reportSlowDatabaseTransactionAcquisition(
@@ -602,25 +643,11 @@ function resolveDatabasePoolFailureCategory(
     ) {
       return "connection_limit";
     }
-    if (message?.includes("timeout exceeded when trying to connect")) {
-      return "pool_checkout_timeout";
-    }
-    // Prisma reports every transaction-API fault as P2028, so only the message
-    // separates "never started" from a transaction that ran and then expired.
-    if (message?.includes("Unable to start a transaction in the given time")) {
-      return "transaction_start_timeout";
-    }
-    if (message?.includes("Connection terminated due to connection timeout")) {
-      return "connection_establishment_timeout";
-    }
-    // Postgres words a SQLSTATE 53300 rejection differently depending on which
-    // limit refused the connection, and some wrappers keep only the message.
-    if (
-      message?.includes("remaining connection slots are reserved")
-      || message?.includes("too many connections for role")
-      || message?.includes("sorry, too many clients already")
-    ) {
-      return "connection_limit";
+    const messageCategory = DATABASE_POOL_FAILURE_BY_MESSAGE.find(
+      ([pattern]) => pattern.test(message ?? ""),
+    )?.[1];
+    if (messageCategory) {
+      return messageCategory;
     }
 
     if (candidate.depth >= DATABASE_POOL_FAILURE_TRAVERSAL_MAX_DEPTH) {

--- a/apps/web/test/prisma-database-retry-postgres.test.ts
+++ b/apps/web/test/prisma-database-retry-postgres.test.ts
@@ -172,6 +172,133 @@ describe.skipIf(!runPostgresRetryProof)(
       90_000,
     );
 
+    it.skipIf(!runTcpRetryProof)("recovers a model read after a real socket disconnect", async () => {
+      const fixture = await createRetryProofFixture("disconnect");
+      try {
+        await expect(fixture.prisma.hostedWorkspace.findUnique({
+          where: { userId: "synthetic-disconnect-proof" },
+        })).resolves.toBeNull();
+        expect(fixture.proxy.acceptedConnections()).toBe(2);
+        expect(loggedFailures(fixture.warn)).toContainEqual(expect.objectContaining({
+          category: "connection_closed", disposition: "retrying", source: "operation",
+        }));
+      } finally {
+        await fixture.close();
+      }
+    });
+
+    it.skipIf(!runTcpRetryProof)("retries a model read when its established socket loses the result", async () => {
+      const fixture = await createRetryProofFixture("pass");
+      try {
+        await fixture.prisma.$queryRaw`select 1`;
+        fixture.proxy.dropResponses();
+        const pending = Promise.resolve(fixture.prisma.hostedWorkspace.findUnique({
+          where: { userId: "synthetic-disconnect-proof" },
+        }));
+        const result = expect(pending).resolves.toBeNull();
+        await vi.waitFor(() => expect(fixture.proxy.droppedResponses()).toBeGreaterThan(0),
+          { interval: 10, timeout: 2_000 });
+        fixture.proxy.disconnectClients();
+        await result;
+        expect(fixture.proxy.acceptedConnections()).toBe(2);
+      } finally {
+        await fixture.close();
+      }
+    });
+
+    it.skipIf(!runTcpRetryProof)("does not retry a real disconnected batch containing a model read and a write", async () => {
+      const fixture = await createRetryProofFixture("disconnect");
+      try {
+        await expect(fixture.prisma.$transaction([
+          fixture.prisma.hostedWorkspace.findUnique({ where: { userId: "synthetic-disconnect-proof" } }),
+          fixture.prisma.$executeRawUnsafe(`insert into "${fixture.table}" (id) values ('synthetic')`),
+        ])).rejects.toThrow();
+        expect(fixture.proxy.acceptedConnections()).toBe(1);
+        expect(loggedFailures(fixture.warn).filter((failure) => failure.disposition === "retrying"))
+          .toEqual([]);
+        expect(await fixture.setup.$queryRawUnsafe(`select id from "${fixture.table}"`)).toEqual([]);
+      } finally {
+        await fixture.close();
+      }
+    });
+
+    it.skipIf(!runTcpRetryProof)("recovers a real socket disconnect before exactly one transaction callback", async () => {
+      const fixture = await createRetryProofFixture("disconnect");
+      let callbackRuns = 0;
+      try {
+        const rowId = randomUUID();
+        await fixture.prisma.$transaction(async (tx) => {
+          callbackRuns += 1;
+          await tx.$executeRawUnsafe(`insert into "${fixture.table}" (id) values ($1)`, rowId);
+        });
+        expect(callbackRuns).toBe(1);
+        expect(await fixture.setup.$queryRawUnsafe(`select id from "${fixture.table}"`))
+          .toEqual([{ id: rowId }]);
+        expect(fixture.proxy.acceptedConnections()).toBe(2);
+        expect(loggedFailures(fixture.warn)).toContainEqual(expect.objectContaining({
+          category: "connection_closed", disposition: "retrying", source: "transaction",
+        }));
+      } finally {
+        await fixture.close();
+      }
+    });
+
+    it.skipIf(!runTcpRetryProof)("does not retry a real disconnected read inside a transaction or repeat its callback", async () => {
+      const fixture = await createRetryProofFixture("pass");
+      let callbackRuns = 0;
+      try {
+        await expect(fixture.prisma.$transaction(async (tx) => {
+          callbackRuns += 1;
+          await tx.$executeRawUnsafe(`insert into "${fixture.table}" (id) values ('synthetic')`);
+          fixture.proxy.dropResponses();
+          const read = tx.hostedWorkspace.findUnique({ where: { userId: "synthetic-disconnect-proof" } });
+          // Force execution of Prisma's lazy promise before disconnecting.
+          const pending = Promise.resolve(read);
+          const rejection = expect(pending).rejects.toThrow();
+          await vi.waitFor(() => expect(fixture.proxy.droppedResponses()).toBeGreaterThan(0),
+            { interval: 10, timeout: 2_000 });
+          fixture.proxy.disconnectClients();
+          await rejection;
+          // Keep the failed transaction failed, rather than swallowing it.
+          return pending;
+        })).rejects.toThrow();
+        expect(callbackRuns).toBe(1);
+        expect(fixture.proxy.acceptedConnections()).toBe(1);
+        expect(loggedFailures(fixture.warn).filter((failure) => failure.disposition === "retrying"))
+          .toEqual([]);
+        expect(await fixture.setup.$queryRawUnsafe(`select id from "${fixture.table}"`)).toEqual([]);
+      } finally {
+        await fixture.close();
+      }
+    });
+
+    it.skipIf(!runTcpRetryProof)("never replays an ordinary write committed before its connection is lost", async () => {
+      const fixture = await createRetryProofFixture("pass");
+      try {
+        await fixture.prisma.$queryRaw`select 1`;
+        fixture.proxy.dropResponses();
+        const rowId = randomUUID();
+        const pending = Promise.resolve(fixture.prisma.$executeRawUnsafe(
+          `insert into "${fixture.table}" (id) values ($1)`, rowId,
+        ));
+        const rejection = expect(pending).rejects.toThrow();
+        // Observe the commit independently while its acknowledgement is withheld.
+        await vi.waitFor(async () => {
+          expect(await fixture.setup.$queryRawUnsafe(`select id from "${fixture.table}"`))
+            .toEqual([{ id: rowId }]);
+        }, { interval: 10, timeout: 2_000 });
+        fixture.proxy.disconnectClients();
+        await rejection;
+        expect(fixture.proxy.acceptedConnections()).toBe(1);
+        expect(loggedFailures(fixture.warn).filter((failure) => failure.disposition === "retrying"))
+          .toEqual([]);
+        expect(await fixture.setup.$queryRawUnsafe(`select id from "${fixture.table}"`))
+          .toEqual([{ id: rowId }]);
+      } finally {
+        await fixture.close();
+      }
+    });
+
     it("never replays a real transaction that opened and then expired", async () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
       const prisma = createPrismaClient({ databaseUrl, poolMax: 2 });
@@ -239,18 +366,23 @@ function loggedFailures(
     .map((call) => call[1] as LoggedDatabasePoolFailure);
 }
 
-interface FirstConnectionStallProxy {
+type FirstConnectionFault = "stall" | "disconnect" | "pass";
+
+interface ConnectionFaultProxy {
   acceptedConnections: () => number;
   close: () => Promise<void>;
   databaseUrl: string;
+  disconnectClients: () => void;
+  dropResponses: () => void;
+  droppedResponses: () => number;
 }
 
-async function createRetryProofFixture() {
+async function createRetryProofFixture(fault: FirstConnectionFault = "stall") {
   const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
   const setup = createPrismaClient({ databaseUrl, poolMax: 2 });
   const table = `murph_retry_proof_${randomUUID().replace(/-/g, "")}`;
   await setup.$executeRawUnsafe(`create table "${table}" (id text primary key)`);
-  const proxy = await startFirstConnectionStallProxy(databaseUrl);
+  const proxy = await startConnectionFaultProxy(databaseUrl, fault);
   const prisma = createPrismaClient({
     databaseUrl: proxy.databaseUrl,
     poolMax: 1,
@@ -285,13 +417,14 @@ async function createRetryProofFixture() {
 }
 
 /**
- * Keeps the first PostgreSQL startup socket local until pg times it out, then
- * transparently forwards the retry. No bytes from the failed attempt can reach
- * PostgreSQL, so a successful retry is safe to verify with an exactly-once row.
+ * Faults the first startup connection locally, then forwards later connections.
+ * Tests can also withhold server responses and disconnect only these owned
+ * sockets to prove recovery cannot replay an already-committed effect.
  */
-async function startFirstConnectionStallProxy(
+async function startConnectionFaultProxy(
   value: string,
-): Promise<FirstConnectionStallProxy> {
+  fault: FirstConnectionFault,
+): Promise<ConnectionFaultProxy> {
   if (!isClearlyLocalTcpPostgresUrl(value)) {
     throw new Error("The retry proxy requires a loopback TCP PostgreSQL URL.");
   }
@@ -301,6 +434,8 @@ async function startFirstConnectionStallProxy(
   const upstreamPort = Number.parseInt(directUrl.port || "5432", 10);
   const sockets = new Set<Socket>();
   let acceptedConnections = 0;
+  let dropResponses = false;
+  let droppedResponses = 0;
 
   const trackSocket = (socket: Socket) => {
     sockets.add(socket);
@@ -311,7 +446,11 @@ async function startFirstConnectionStallProxy(
     acceptedConnections += 1;
     trackSocket(downstream);
 
-    if (acceptedConnections === 1) {
+    if (acceptedConnections === 1 && fault !== "pass") {
+      if (fault === "disconnect") {
+        downstream.once("data", () => downstream.end());
+        return;
+      }
       // Consume the startup packet without forwarding it. pg owns the timeout
       // and closes this socket before the retry opens another connection.
       downstream.resume();
@@ -325,7 +464,10 @@ async function startFirstConnectionStallProxy(
     trackSocket(upstream);
     upstream.once("connect", () => {
       downstream.pipe(upstream);
-      upstream.pipe(downstream);
+      upstream.on("data", (data: Buffer) => {
+        if (dropResponses) droppedResponses += 1;
+        else downstream.write(data);
+      });
     });
     upstream.once("error", () => downstream.destroy());
     downstream.once("close", () => upstream.destroy());
@@ -352,6 +494,12 @@ async function startFirstConnectionStallProxy(
 
   return {
     acceptedConnections: () => acceptedConnections,
+    disconnectClients: () => {
+      for (const socket of sockets) socket.destroy();
+      dropResponses = false;
+    },
+    droppedResponses: () => droppedResponses,
+    dropResponses: () => { dropResponses = true; },
     close: async () => {
       for (const socket of sockets) {
         socket.destroy();

--- a/apps/web/test/prisma-database-retry-postgres.test.ts
+++ b/apps/web/test/prisma-database-retry-postgres.test.ts
@@ -172,6 +172,32 @@ describe.skipIf(!runPostgresRetryProof)(
       90_000,
     );
 
+    it.skipIf(!runTcpRetryProof)("teardown releases a query whose response is deliberately withheld", async () => {
+      const fixture = await createRetryProofFixture("pass");
+      let closing: Promise<void> | undefined;
+      try {
+        await fixture.prisma.$queryRaw`select 1`;
+        fixture.proxy.dropResponses();
+        const pending = Promise.resolve(fixture.prisma.$queryRaw`select 2`);
+        const rejection = expect(pending).rejects.toThrow();
+        await vi.waitFor(() => expect(fixture.proxy.droppedResponses()).toBeGreaterThan(0),
+          { interval: 10, timeout: 2_000 });
+        let closed = false;
+        closing = fixture.close().then(() => { closed = true; });
+        try {
+          await vi.waitFor(() => expect(closed).toBe(true), { interval: 10, timeout: 1_000 });
+        } finally {
+          // Also release the old cleanup order on assertion failure, so the
+          // regression itself cannot strand an owned socket or test database.
+          fixture.proxy.disconnectClients();
+          await closing;
+          await rejection;
+        }
+      } finally {
+        if (!closing) await fixture.close();
+      }
+    });
+
     it.skipIf(!runTcpRetryProof)("recovers a model read after a real socket disconnect", async () => {
       const fixture = await createRetryProofFixture("disconnect");
       try {
@@ -391,10 +417,12 @@ async function createRetryProofFixture(fault: FirstConnectionFault = "stall") {
   return {
     close: async () => {
       try {
-        await prisma.$disconnect();
+        // A fault may leave a query waiting for a withheld response. Release
+        // owned sockets before asking the pool to drain those active clients.
+        await proxy.close();
       } finally {
         try {
-          await proxy.close();
+          await prisma.$disconnect();
         } finally {
           try {
             await setup.$executeRawUnsafe(`drop table if exists "${table}"`);

--- a/apps/web/test/prisma-store-client.test.ts
+++ b/apps/web/test/prisma-store-client.test.ts
@@ -1208,6 +1208,171 @@ describe("prisma module", () => {
     }
   });
 
+  it.each(["findUnique", "findUniqueOrThrow", "findFirst", "findFirstOrThrow", "findMany", "count", "aggregate", "groupBy"])(
+    "retries a disconnected standalone model %s once",
+    async (operation) => {
+      vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { createPrismaClient } = await import("@/src/lib/prisma");
+      createPrismaClient({ databaseUrl: "postgresql://example.invalid/db" });
+      const extension = mocks.extensions[0]!;
+      const query = vi.fn()
+        .mockRejectedValueOnce(new Error("Connection terminated unexpectedly"))
+        .mockResolvedValueOnce("rows");
+
+      await expect(extension.query.$allOperations({
+        args: {}, model: "HostedWorkspace", operation, query,
+      })).resolves.toBe("rows");
+      expect(query).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each(["create", "createMany", "update", "updateMany", "upsert", "delete", "deleteMany", "$queryRaw", "$executeRawUnsafe"])(
+    "classifies a plain disconnect without replaying %s",
+    async (operation) => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      const { createPrismaClient } = await import("@/src/lib/prisma");
+      createPrismaClient({ databaseUrl: "postgresql://example.invalid/db" });
+      const failure = new Error("Connection terminated unexpectedly");
+      const query = vi.fn().mockRejectedValue(failure);
+
+      await expect(mocks.extensions[0]!.query.$allOperations({
+        args: {}, model: operation.startsWith("$") ? undefined : "HostedWorkspace",
+        operation, query,
+      })).rejects.toBe(failure);
+      expect(query).toHaveBeenCalledOnce();
+      expect(failureCategories(warn)).toEqual(["connection_closed"]);
+      expect(failureDispositions(warn)).toEqual(["terminal"]);
+    },
+  );
+
+  it.each([
+    new Error("outer", { cause: new Error("Connection terminated unexpectedly") }),
+    Object.assign(new Error("closed"), { code: "P1017" }),
+    Object.assign(new Error("closed"), { code: "ECONNRESET" }),
+  ])("retries classified disconnect shapes for model reads", async (failure) => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { createPrismaClient } = await import("@/src/lib/prisma");
+    createPrismaClient({ databaseUrl: "postgresql://example.invalid/db" });
+    const query = vi.fn().mockRejectedValueOnce(failure).mockResolvedValueOnce("rows");
+    await expect(mocks.extensions[0]!.query.$allOperations({
+      args: {}, model: "HostedWorkspace", operation: "findUnique", query,
+    })).resolves.toBe("rows");
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a disconnected read against a saturated pool", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { createPrismaClient } = await import("@/src/lib/prisma");
+    createPrismaClient({ databaseUrl: "postgresql://example.invalid/db", poolMax: 1 });
+    mocks.poolInstances[0]!.totalCount = 1;
+    const failure = new Error("Connection terminated unexpectedly");
+    const query = vi.fn().mockRejectedValue(failure);
+    await expect(mocks.extensions[0]!.query.$allOperations({
+      args: {}, model: "HostedWorkspace", operation: "findUnique", query,
+    })).rejects.toBe(failure);
+    expect(query).toHaveBeenCalledOnce();
+    expect(failureDispositions(warn)).toEqual(["terminal"]);
+  });
+
+  it("keeps transaction scope isolated from concurrent and subsequent standalone reads", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { createPrismaClient } = await import("@/src/lib/prisma");
+    const prisma = createPrismaClient({ databaseUrl: "postgresql://example.invalid/db" });
+    let release!: () => void;
+    let markEntered!: () => void;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    const entered = new Promise<void>((resolve) => { markEntered = resolve; });
+    mocks.transaction.mockImplementation(async (run: () => Promise<unknown>) => run());
+    const transaction = prisma.$transaction(async () => {
+      markEntered();
+      await held;
+    });
+    const read = async () => {
+      const query = vi.fn()
+        .mockRejectedValueOnce(new Error("Connection terminated unexpectedly"))
+        .mockResolvedValueOnce("rows");
+      await expect(mocks.extensions[0]!.query.$allOperations({
+        args: {}, model: "HostedWorkspace", operation: "findUnique", query,
+      })).resolves.toBe("rows");
+      expect(query).toHaveBeenCalledTimes(2);
+    };
+    try {
+      await entered;
+      await read();
+    } finally {
+      release();
+      await transaction;
+    }
+    await read();
+  });
+
+  it("stops a disconnected read after its only retry", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { createPrismaClient } = await import("@/src/lib/prisma");
+    createPrismaClient({ databaseUrl: "postgresql://example.invalid/db" });
+    const failure = new Error("Connection terminated unexpectedly");
+    const query = vi.fn().mockRejectedValue(failure);
+    await expect(mocks.extensions[0]!.query.$allOperations({
+      args: {}, model: "HostedWorkspace", operation: "findUnique", query,
+    })).rejects.toBe(failure);
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(failureDispositions(warn)).toEqual(["retrying", "terminal"]);
+  });
+
+  it("retries a disconnect before interactive callback entry only", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { createPrismaClient } = await import("@/src/lib/prisma");
+    const prisma = createPrismaClient({ databaseUrl: "postgresql://example.invalid/db" });
+    const callback = vi.fn().mockResolvedValue("committed");
+    mocks.transaction
+      .mockRejectedValueOnce(new Error("Connection terminated unexpectedly"))
+      .mockImplementationOnce(async (run: () => Promise<unknown>) => run());
+    await expect(prisma.$transaction(callback)).resolves.toBe("committed");
+    expect(callback).toHaveBeenCalledOnce();
+    expect(mocks.transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["callback", "commit"])("never replays a disconnect during %s", async (phase) => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { createPrismaClient } = await import("@/src/lib/prisma");
+    const prisma = createPrismaClient({ databaseUrl: "postgresql://example.invalid/db" });
+    const failure = new Error("Connection terminated unexpectedly");
+    const effect = vi.fn();
+    mocks.transaction.mockImplementation(async (run: () => Promise<unknown>) => {
+      await run();
+      throw failure;
+    });
+    await expect(prisma.$transaction(async () => {
+      effect();
+      if (phase === "callback") throw failure;
+    })).rejects.toBe(failure);
+    expect(effect).toHaveBeenCalledOnce();
+    expect(mocks.transaction).toHaveBeenCalledOnce();
+  });
+
+  it.each(["interactive", "batch"])("does not retry a disconnected read in %s transaction scope", async (kind) => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { createPrismaClient } = await import("@/src/lib/prisma");
+    const prisma = createPrismaClient({ databaseUrl: "postgresql://example.invalid/db" });
+    const failure = new Error("Connection terminated unexpectedly");
+    const query = vi.fn().mockRejectedValue(failure);
+    const read = () => mocks.extensions[0]!.query.$allOperations({
+      args: {}, model: "HostedWorkspace", operation: "findUnique", query,
+    });
+    mocks.transaction.mockImplementation(async (run: unknown) => {
+      return typeof run === "function" ? run() : read();
+    });
+    await expect(kind === "interactive" ? prisma.$transaction(read) : prisma.$transaction([]))
+      .rejects.toBe(failure);
+    expect(query).toHaveBeenCalledOnce();
+    expect(mocks.transaction).toHaveBeenCalledOnce();
+  });
+
   it("does not retry operation failures that may have reached Postgres", async () => {
     process.env = {
       ...process.env,


### PR DESCRIPTION
## Why and outcome

A transient database disconnect can surface as an untyped driver error and bypass Web's existing recovery policy. Recognize that error and allow the existing single jittered retry for standalone model reads and interactive transaction setup before callback entry.

Potentially dispatched writes, raw SQL, batch transactions, and reads inside transactions do not retry disconnects. Existing backpressure and attempt bounds remain in force.

## Product UX

- Effort: Patch.
- Result: Ready.
- Walkthrough: Reads and background progress preparation can recover from one brief interruption. An uncertain save preserves its existing failure boundary. No new surface, permissions, audience, or difference from the planned recovery scope.

## Evidence

- Direct: 111 focused tests passed across `prisma-store-client.test.ts`, `prisma-database-retry-postgres.test.ts`, and `changelog-page.test.tsx`. Run with `pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage` and those three paths; the PostgreSQL suite uses an isolated loopback test database and `MURPH_TEST_POSTGRES_CONCURRENCY=1`.
- Coverage: Real Prisma/pg sockets prove startup and established-connection read recovery, one transaction callback, no retry within transaction scope or a mixed batch, and no replay of a write independently confirmed committed before its acknowledgement is dropped. Unit tests cover every allowed model read, excluded write/raw operations, bounded attempts, classified error shapes, pool pressure, concurrent scope isolation, and callback/commit failures. Nineteen new cases failed before the implementation. A separate real-socket teardown regression failed before the test-only cleanup correction; all 12 PostgreSQL tests pass afterward.
- Checks: Web typecheck, focused ESLint, diff whitespace checks, and complexity guard passed. Changelog server rendering passed. Final ReviewGPT passed on the immutable first-reviewed head (verified model: gpt-6-pro). The later commit changes only isolated test cleanup and its regression; production source and contract are identical. Exact-head CI results are recorded in this PR’s required checks.

## Non-obvious affected surfaces

The shared Prisma owner also serves foreground reads. Existing transaction telemetry and checkout-timeout behavior retain their focused regression coverage.

## Architecture and reuse

- Existing systems reused: The shared Prisma query extension, transaction wrapper, bounded error classifier, and single retry helper.
- New logic: Allowlisted model reads and pre-callback transaction setup may retry a closed connection once.
- New abstractions: One in-memory async scope carried by the existing public transaction wrapper prevents individual reads from retrying within a transaction. No Prisma-private metadata is inspected.
- Complexity intentionally avoided: No pool replacement, route-level retry, queue, dependency, configuration, persistent state, or write-idempotency mechanism. Message fallbacks are consolidated alongside existing classifier maps.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: `resolveDatabasePoolFailureCategory` fell from 34 to 24; debt fell from 14 to 4. Its bounded traversal and precedence remain one owner.
- Agent judgment: Further extraction would add indirection without reducing the required policy. Production source changes are confined to one file.

## Hot reply path impact

- Path status: Touched through the shared database owner.
- Database calls: Successful operations are unchanged. An eligible disconnected read can issue one extra sequential attempt; an interactive transaction can repeat setup only before its callback starts. Model-write and raw-query disconnects remain terminal.
- Network/provider calls: No provider calls added. The database may establish one replacement connection for the eligible retry.
- Other awaited latency: Existing 50–250 ms jitter and attempt limits are reused; local pressure suppresses retries. Existing five-second connection acquisition and transaction wait limits are unchanged.
- Before/after proof: The new failing-before cases and real socket proxy count one retry, one callback, and one committed row. Concurrent and subsequent standalone reads remain outside transaction scope.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no instructions, tools, schemas, context builders, or other provider-visible input changed. No token measurement was run.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing Web, Cloudflare, Temporal, and database schemas remain compatible.
- Safe order: Ordinary Web rollout; no database migration or coordinated runtime deployment.
- Rollback floor: No new floor; previous Web retains its previous terminal-disconnect behavior.
- Expected exposure: Older instances may still return transient failures until the rollout drains.
- Reversibility: Code-only Web revert; no data conversion.
- Convergence proof: Local tests cover existing timeout behavior and new closed-connection recovery with unchanged callback and write fences.
- Post-deploy checks: Verify the Web revision and bounded disconnect retry/terminal categories and HTTP error counts. No production mutation or deployment performed by this task.

## Change-shape breakdown

Classification rule: Prisma implementation is source; test suites are tests; README and plan are docs; authored changelog JSON is other. No binary or generated changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 61 | 34 |
| Tests / fixtures | 353 | 12 |
| Docs | 79 | 12 |
| Config / tooling | 0 | 0 |
| Generated / other | 18 | 0 |
| **Total** | **511** | **58** |

## Changelog

- Changelog: updated
- Items: 2026-09-11 · brief-connection-interruptions

ReviewGPT context sensitivity: sensitive
Classification reason: Shared database retries and transaction replay safety.

ReviewGPT first-reviewed head: 87a8809e9973a602a3b3b7991ec6200a5cde2644

Post-baseline correction: only isolated fault-injection test cleanup and its regression changed after the first-reviewed head. Production source and the implemented contract are identical. Per the completion workflow, this alone does not require another substantive review round.
