### PR TITLE
test: restore exhaustive foreground wake fixture

### DIFF
--- a/.agents/friction-log/20260911132158-foreground-priority-wake/friction.md
+++ b/.agents/friction-log/20260911132158-foreground-priority-wake/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Foreground priority wake fixture omits new clinical enrichment kind'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The foreground-priority release scenario constructs every system wake type accepted by the current hosted execution contract.
+
+## Current Behavior
+
+The canonical wake-kind list includes clinical-records.enrichment-requested, but buildEverySystemWake omits it. The exhaustive fixture assertion fails before the scenario reaches its foreground-priority checks, blocking Web production admission.
+
+## Possible Solution
+
+Add the missing wire-valid synthetic wake while preserving the exhaustive assertion. Consider checking fixture coverage before full hosted scenario startup.
+
+## Minimal Reproducible Example
+
+Run the foreground-reply-priority hosted-local scenario with standby allocation enabled against the current wake contract. Compare the kinds returned by buildEverySystemWake with HOSTED_EXECUTION_WAKE_KINDS after the scenario's existing conversation and environment-interview exclusions. The fixture lacks clinical-records.enrichment-requested.
+
+## Context
+
+Release verification fixture drift delays deployment of otherwise verified changes. This entry contains only repository contract names and synthetic reproduction steps.

--- a/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
@@ -3186,6 +3186,13 @@ function buildEverySystemWake(
       runId: `clinical_run_priority_${runId}`,
       userId: identity.userId,
     }),
+    {
+      eventId: `clinical-records.enrichment-requested:priority:${runId}`,
+      jobId: createHash("sha256").update(`clinical-enrichment:priority:${runId}`).digest("hex"),
+      kind: "clinical-records.enrichment-requested",
+      occurredAt: requestedAt,
+      userId: identity.userId,
+    },
     buildHostedExecutionDailyMetricReportedWake({
       date: requestedAt.slice(0, 10),
       eventId: `health.daily-metric.reported:priority:${runId}`,


### PR DESCRIPTION
## Why and outcome

The foreground-priority production admission scenario fails its exhaustive wake-kind assertion because its fixture omits `clinical-records.enrichment-requested`. Add the missing synthetic wake so the existing scenario can exercise every system wake and continue its foreground-priority proof.

This repairs the release gate blocking the Messages workout recovery in #3286. The exhaustive assertion remains intact.

## Product UX

- Effort: Not applicable — internal test fixture repair.
- Result: Ready.
- Walkthrough: Production behavior is unchanged; the existing hosted scenario now includes the current clinical enrichment wake contract.

## Evidence

- Direct: The hosted foreground-priority scenario failed solely at the wake-kind equality assertion, missing `clinical-records.enrichment-requested`. All four other production-core scenarios passed.
- Coverage: An executable local probe extracted and ran the actual `buildEverySystemWake` function from base and working tree. Base reproduces exactly the missing kind; head covers every expected kind and every generated wake passes the real parser (2 tests passed).
- `pnpm --dir apps/cloudflare typecheck`: passed.
- `pnpm complexity:diff` and `git diff --check`: passed.
- CI: All 36 final-head checks passed, including all required checks. Merged as `b8f3a0f072a188077786cd8735982b0c59312b49`. All five hosted production scenarios and final attestation passed on `77d953863f487588be93b0ee27756ac7ffacb62c`: [private proof](https://github.com/cobuildwithus/murph-cloud/actions/runs/34666585237) and [public admission](https://github.com/cobuildwithus/murph/actions/runs/34665620956). With explicit incident-specific approval, promoted Vercel deployment `dpl_CD2dR8wEuGQFEqAmMAdi2bjeccqg` after its GitHub-backed check remained stale despite successful admission. On 2026-09-12, verified `www.withmurph.ai` resolves to that deployment, its immutable source is `77d953863f487588be93b0ee27756ac7ffacb62c`, and it is promoted with domains assigned. Git ancestry confirms the workout fix is included. Post-deploy smoke: homepage HTTP 200 and unauthenticated member-action POST HTTP 401. These checks prove deployment and the auth boundary; an ordinary authenticated member retry remains unobserved. Repository-wide deployment policy was not changed.
- Final ReviewGPT: not applicable under the tests-only exemption; no production code, protocol, runtime control, assertion, or workflow policy changes.

## Non-obvious affected surfaces

None. The change adds one fixture to the existing exhaustive system-mailbox scenario.

## Architecture and reuse

- Existing systems reused: The existing wake fixture, SHA-256 helper, canonical wake contract, and exhaustive assertion.
- New logic: One synthetic clinical-enrichment wake with a valid job digest and existing probe identity.
- New abstractions: None; the existing fixture array owns this test data.
- Complexity intentionally avoided: No new builder, schema relaxation, special exclusion, workflow bypass, or runtime change.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` found no authored production source changes.
- Hotspots: No production source functions changed in this test fixture repair.
- Agent judgment: Adding the missing fixture is the smallest correction that preserves exhaustive coverage.

## Hot reply path impact

Not applicable — only synthetic E2E test data changes; no production database, network, provider, or awaited operations change.

## Murph initial provider input impact

Not applicable for individual and group runtimes — no production prompts, tools, schemas, or provider-input assembly changes.

## Deployment concerns

- Deployment: not applicable
- Reason: Test fixture and developer-friction documentation only. The ordinary exact-main production admission workflow will replay the repaired scenario before promoting the pending Web deployment.

## Change-shape breakdown

Classification rule: E2E fixture additions are tests; the Frog entry is documentation. No binary files or generated output changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 7 | 0 |
| Docs | 24 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **31** | **0** |

## Changelog

- Changelog: not applicable
- Reason: Internal release-test fixture repair; the member-visible workout recovery is documented in #3286.
