### PR TITLE
test: match fixed WHOOP authorization failure diagnostics

### DIFF
--- a/.agents/friction-log/20260911160329-whoop-headed-smoke/friction.md
+++ b/.agents/friction-log/20260911160329-whoop-headed-smoke/friction.md
@@ -1,0 +1,20 @@
+---
+title: 'WHOOP headed smoke expects the retired authorization error message'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The headed browser smoke should require the fixed authorization action and location categories while proving that page content and raw provider subdomains stay out of failure messages.
+
+## Current Behavior
+
+The shared browser helper now includes fixed diagnostic categories when an authorization click fails. The WHOOP headed smoke still expects the older category-only message, so the viewport CI job fails before checking layout.
+
+## Minimal Reproducible Example
+
+Run the headed browser smoke with its synthetic WHOOP consent button covered by an overlay. The timeout contains the fixed whoop_grant action and whoop.com/other location categories, while the assertion still requires only the timeout category.
+
+## Context
+
+Update the exact expected diagnostic message and preserve both private-content and raw-subdomain rejection assertions. This is test-only follow-up to the shared browser failure-evidence change.

--- a/apps/web/test/hosted-headed-browser-smoke.test.ts
+++ b/apps/web/test/hosted-headed-browser-smoke.test.ts
@@ -516,7 +516,9 @@ describe("hosted headed browser boundary", () => {
         } catch (error) {
           if (error instanceof Error) failure = error;
         }
-        expect(failure?.message).toBe("Authorization action failed (timeout).");
+        expect(failure?.message).toBe(
+          "Authorization action failed (timeout); action=whoop_grant; before=whoop.com/other; after=whoop.com/other.",
+        );
         expect(failure?.message).not.toContain("synthetic-private-marker");
         expect(failure?.message).not.toContain("id.whoop.com");
       } finally {


### PR DESCRIPTION
## Why and outcome

The shared wearable browser helper now emits fixed action and location categories on failed authorization clicks. The WHOOP headed smoke still expects the older category-only message, causing the viewport CI job to fail before layout checks.

Update that exact expectation to the current fixed diagnostic message. Preserve assertions that private page content and the raw provider subdomain are absent. No helper or authorization behavior changes.

## Product UX

- Effort: Not applicable — test expectation only.
- Result: Ready.
- Walkthrough: The existing synthetic blocked-button scenario verifies the current diagnostic contract.

## Evidence

- Direct: CI on #3305 reproduced the exact mismatch after base #3302 changed the helper output.
- Coverage: `MURPH_E2E_HEADED_BROWSER_SMOKE=1 pnpm exec vitest run --config apps/web/vitest.workspace.ts --no-coverage apps/web/test/hosted-headed-browser-smoke.test.ts` passed all 12 tests using real headed Chromium, including both private-content rejection assertions.
- `pnpm --dir apps/web typecheck`: passed.
- `pnpm complexity:diff` and `git diff --check`: passed.
- Final ReviewGPT: not applicable under the tests-only exemption; production code and authorization behavior are unchanged.
- All 36 exact-head CI checks passed on `db5adaa1300777259e65399cfed736ad3f2e88a7`, including the headed-browser/viewport job.
- Disposition: Superseded by main commit `5c701bdc5cd179e0143ab78b9ea894a397f5c5f9`, which contains the same expected string and unchanged privacy assertions. The only assertion difference is string-literal wrapping. Closing this duplicate without another merge.

## Non-obvious affected surfaces

The viewport CI job runs this smoke before layout verification. Correcting the expectation restores that existing prerequisite without changing the layout check.

## Architecture and reuse

- Existing systems reused: The current headed Chromium fixture and shared wearable authorization helper.
- New logic: None; update one exact expected message.
- New abstractions: None; the existing assertion is sufficient.
- Complexity intentionally avoided: No broad error matching, helper duplication, or production changes.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` found no authored production source changes.
- Hotspots: No production source functions change.
- Agent judgment: Exact text keeps the diagnostic output constrained while preserving explicit privacy assertions.

## Hot reply path impact

Not applicable — only a browser test expectation and friction documentation change.

## Murph initial provider input impact

Not applicable for individual and group runtimes — no production prompts, tools, schemas, or provider-input assembly changes.

## Deployment concerns

- Deployment: not applicable
- Reason: Test-only correction, held behind the active production hotfix to avoid restarting its release admission.

## Change-shape breakdown

Classification rule: The assertion is tests; the Frog entry is documentation. No binary files or generated output changed.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 3 | 1 |
| Docs | 20 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **23** | **1** |

## Changelog

- Changelog: not applicable
- Reason: Internal CI expectation repair with no member-visible behavior change.
