### PR TITLE
fix(tooling): include CI and assistant contracts in review archives

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-frog-review-context.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-frog-review-context.md
@@ -1,0 +1,47 @@
+# Restore complete review context for Frog backlog fixes
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal
+
+Resolve Frog #3255 and the surviving archive omission behind #2390. Reconcile
+already-landed and duplicate Frog reports separately through GitHub issues.
+
+## Scope and invariants
+
+The existing guarded archive manifest owns inclusion. Add only the tracked
+native CI controller policy, PR evidence template, and assistant verification
+skill. Preserve all private-file and generated-artifact exclusions. No runtime,
+provider calls, dependency changes, or new persisted state are involved.
+
+## Cause and design
+
+CI scanning starts at `.github/workflows` and ordinary source scanning omits
+`.agents`. These unchanged required inputs therefore disappear from review
+archives. Reuse the exact always-path list rather than widen directory scans.
+
+## Tasks
+
+1. Add regression assertions for actual ZIP entries and byte-identical content.
+2. Extend the existing manifest and document its current contract.
+3. Run the archive test, CLI typecheck, shell syntax, and complexity checks.
+4. Review the scoped diff, close this plan, open the draft PR, admit CI, and
+   merge after required checks. Low-risk internal tooling needs no final
+   ReviewGPT under the completion workflow.
+
+## Verification
+
+- The new archive regression failed before the manifest correction because the
+  native controller policy was absent.
+- The focused real archive regression passes after the correction, including
+  byte-identical content for all three inputs in both archive modes.
+- CLI package typecheck, shell syntax, and `pnpm complexity:diff` pass. The
+  complexity guard reports no authored JS/TS source changes.
+- Parent diff review confirms three explicit public tracked paths with no
+  widened scans or changed exclusions. No final ReviewGPT is required for
+  this low-risk internal tooling correction.
+- Required exact-head CI and merge remain delivery gates tracked in the PR.
+  Internal-only change; no changelog or Product UX journey applies.
+Completed: 2026-09-11

--- a/agent-docs/index.md
+++ b/agent-docs/index.md
@@ -168,7 +168,7 @@ Generated-image retirement after hosted media expiry is owned by
 | `agent-docs/operations/imessage-deliverability.md` | Phone-number messaging policy. | Phone-number messaging policy | High | 2026-08-11 |
 | `agent-docs/operations/local-storage-lifecycle.md` | Local rebuildable-storage lifecycle and guarded partial-retirement recovery. | Local rebuildable-storage lifecycle | High | 2026-09-06 |
 | `agent-docs/operations/hosted-local-worktree-dev.md` | Local hosted runtime workflow, call-scoped cancellation, and exact-child startup/exit cleanup ownership. | Local hosted runtime workflow | Medium | 2026-09-05 |
-| `agent-docs/operations/pr-reviewgpt-loop.md` | PR review for realistic serious bugs and material Complexity Collapse, with a three-round review cap, no base-update limit, response timing and evidence requirements, and same-session waiting or paced polling by default. | Final PR ReviewGPT loop | Medium | 2026-09-10 |
+| `agent-docs/operations/pr-reviewgpt-loop.md` | PR review for realistic serious bugs and material Complexity Collapse, with a three-round review cap, exact tracked archive inputs, no base-update limit, response timing and evidence requirements, and same-session waiting or paced polling by default. | Final PR ReviewGPT loop | Medium | 2026-09-11 |
 | `agent-docs/operations/device-sync-ingestion-invariants.md` | Device-sync push/pull ingestion invariants. | Device-sync ingestion contract | High | 2026-08-20 |
 | `agent-docs/PLANS.md` | Execution-plan lifecycle and storage rules. | Plan workflow | Medium | 2026-03-31 |
 | `agent-docs/exec-plans/completed/README.md` | Completed-plan archive interpretation. | Completed-plan archive interpretation | Medium | 2026-07-22 |

--- a/agent-docs/operations/pr-reviewgpt-loop.md
+++ b/agent-docs/operations/pr-reviewgpt-loop.md
@@ -24,6 +24,11 @@ invariants without replacement machinery. Minor refactoring, UX polish,
 disclosure gaps, and speculative edge cases are not blocking findings. The
 targeted exploratory presets remain available separately.
 
+Both lean and full guarded archives include the tracked native CI controller
+policy, PR evidence template, and assistant verification skill through the
+existing exact always-path manifest. These inputs remain available when they
+are unchanged by the candidate.
+
 Round 1 is always a full-patch audit. On round 2 or later, the packager reads the
 PR body's explicit context
 sensitivity and measures the complete current PR against its base. Sensitive or

--- a/packages/cli/test/release-script-coverage-audit.test.ts
+++ b/packages/cli/test/release-script-coverage-audit.test.ts
@@ -4698,6 +4698,18 @@ printf 'ZIP: %s (%s bytes)\n' \
       const leanEntries = listZipEntries(leanBundle.zipPath)
       const fullEntries = listZipEntries(fullBundle.zipPath)
 
+      for (const relativePath of [
+        '.github/native-hosted-e2e-controller.json',
+        '.github/pull_request_template.md',
+        '.agents/skills/verify-murph-assistant/SKILL.md',
+      ]) {
+        for (const bundle of [leanBundle, fullBundle]) {
+          expect(listZipEntries(bundle.zipPath)).toContain(relativePath)
+          expect(execFileSync('unzip', ['-p', bundle.zipPath, relativePath]))
+            .toEqual(readFileSync(path.join(repoRoot, relativePath)))
+        }
+      }
+
       expect(leanEntries).toContain('agent-docs/operations/verification-and-runtime.md')
       expect(leanEntries).toContain('agent-docs/operations/pr-reviewgpt-loop.md')
       expect(leanEntries).toContain('agent-docs/product-specs/repo.md')

--- a/scripts/repo-tools.config.sh
+++ b/scripts/repo-tools.config.sh
@@ -99,6 +99,9 @@ repo_tools_join_lines COBUILD_AUDIT_CONTEXT_EXCLUDE_GLOBS \
   "apps/*/**/*.test.*" \
   "apps/*/**/*.spec.*"
 repo_tools_join_lines COBUILD_AUDIT_CONTEXT_ALWAYS_PATHS \
+  ".github/native-hosted-e2e-controller.json" \
+  ".github/pull_request_template.md" \
+  ".agents/skills/verify-murph-assistant/SKILL.md" \
   ".dockerignore" \
   ".githooks/pre-commit" \
   "AGENTS.md" \


### PR DESCRIPTION
## Why and outcome

Guarded review archives omitted unchanged CI authority, the PR evidence template, and the assistant verification skill. Add these three tracked files to the existing exact inclusion manifest so reviewers can inspect the contracts the candidate uses.

Fixes #3255. Fixes #2390 (the old specialist route is retired; the missing skill is corrected in current guarded archives).

## Product UX

- Effort: Not applicable; internal repository review tooling only.
- Result: Not applicable; no member-facing behavior changes.
- Walkthrough: Generated both archive modes and inspected actual file entries and bytes.

## Evidence

- Direct: The archive regression failed on the missing native policy before the fix and passes afterward, checking all three files byte-for-byte in both lean and full ZIPs.
- Coverage: `pnpm exec vitest run --config packages/cli/vitest.workspace.ts --no-coverage packages/cli/test/release-script-coverage-audit.test.ts -t 'keeps audit bundles scoped'` passed.
- CLI package typecheck, `bash -n scripts/repo-tools.config.sh`, `pnpm docs:drift`, `git diff --check`, and `pnpm complexity:diff` passed.
- Parent candidate review complete. Final ReviewGPT is not required for this low-risk internal tooling change under the completion workflow. Required CI will verify the pushed head.

## Non-obvious affected surfaces

Both lean and full archives inherit the manifest. Existing private-file and generated-artifact exclusions remain covered by the archive regression.

## Architecture and reuse

- Existing systems reused: The guarded packager and its exact always-path manifest.
- New logic: Three additional tracked public inputs are included in existing archives.
- New abstractions: None; the existing manifest expresses this requirement directly.
- Complexity intentionally avoided: No broader directory scans, archive implementation, or dependency changes.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; no authored JS/TS source changes were found.
- Hotspots: None introduced; the TypeScript change extends an existing archive regression.
- Agent judgment: Three manifest entries are the smallest correction at the existing owner.

## Hot reply path impact

- Path status: Not applicable; repository packaging does not run during member replies.
- Database calls: None added.
- Network/provider calls: None added.
- Other awaited latency: None added to the runtime.
- Before/after proof: Archive regression covers the changed operational path.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no runtime prompts, tools, schemas, or provider requests change. No token measurement was needed.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal review archive configuration only; no runtime deployment boundary changes.

## Change-shape breakdown

Classification rule: Markdown is docs, the archive test is tests, and the shell manifest is tooling. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 0 | 0 |
| Tests / fixtures | 12 | 0 |
| Docs | 53 | 1 |
| Config / tooling | 3 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **68** | **1** |

## Changelog

- Changelog: not applicable
- Reason: Internal repository review tooling only.
