### PR TITLE
Add per-user jitter to background recovery wakes

### DIFF
--- a/agent-docs/RELIABILITY.md
+++ b/agent-docs/RELIABILITY.md
@@ -571,6 +571,22 @@ Last verified: 2026-09-04
   rather than introducing a daemon or lease-recovery owner.
 - Use the concrete runtime contracts first: hosted runner wake/checkpoint behavior lives in `agent-docs/references/hosted-runtime-protocol.md` plus `apps/cloudflare/README.md`; deploy recovery and smoke expectations live in `apps/cloudflare/DEPLOY.md`; local device-sync and assistant daemon retry/control-plane behavior live in their package READMEs and tests.
 
+- Web recovery sweeps spread each selected due-device wake and shared mailbox
+  handoff across a stable zero-to-five-second per-user jitter window. The
+  existing 25-item default, 250-item limit, and five-operation concurrency cap
+  remain; selection/access checks stay bounded and selected items are ordered
+  by offset before taking execution slots. Pacing happens before transaction or
+  signal entry and holds no pooled connection. Offsets use monotonic elapsed
+  time within each batch, so delays do not accumulate per item. The shared
+  handoff deadline includes the pacing window in addition to its existing work
+  budget; both sequential phases add at most ten seconds of intentional pacing
+  to the existing callback. Slow operations can still bunch eligible work under
+  the concurrency cap. No new persistence, retry owner, or schedule is added;
+  interrupted work remains discoverable through existing due state and mailbox
+  ownership. Direct ingress, exact reminders, and runtime/provider retry
+  deadlines do not enter this executor. Jitter reduces recovery bursts, not
+  total work or a guaranteed global requests-per-second ceiling.
+
 ## Runtime Expectations
 
 - Cloudflare ready inventory is a bounded allocation optimization within the

--- a/agent-docs/exec-plans/active/2026-09-11-recovery-wake-jitter.md
+++ b/agent-docs/exec-plans/active/2026-09-11-recovery-wake-jitter.md
@@ -1,0 +1,33 @@
+# Spread individual recovery wakes with bounded jitter
+
+Status: active
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Outcome and scope
+
+Spread each selected user recovery operation over a stable zero-to-five-second window instead of starting the whole cohort immediately. Web owns both due-device wake append and shared mailbox recovery dispatch. Preserve the 25-item default, 250-item cap, five concurrent operations, exact durable pointers, authority checks, failure counts, and retry ownership. The private global Schedule phase change is independent.
+
+Product UX effort: Patch. Outcome: reduce background recovery bursts. Reaches: scheduled device reconciliation and shared preference, device, runtime-control, and Clinical Records handoff recovery. Proof: timed execution through both existing sweeps, retry/deadline preservation, and maximum-cardinality concurrency. Direct ingress, exact reminders, provider retry timestamps, and per-user runtime timers are outside these sweep call paths and remain unchanged.
+
+## Evidence and design
+
+Both sweeps currently dispatch five operations immediately and refill their slots without pacing. Replace their duplicate executors with one bounded executor: stable SHA-256 user offsets, offset ordering before slot acquisition, monotonic elapsed time, and no cumulative delays. Wait before calling the existing transaction/signal owner. No new durable state, queue, configuration, or dependency. Preserve the existing handoff-work timeout by allowing its five-second pacing window separately. Two sequential sweep phases add at most ten seconds of intentional pacing to the existing 30-second callback budget; execution overhead and backpressure remain additional.
+
+## Failure and deployment
+
+Ordinary failures retain per-item accounting; unexpected worker failures drain started siblings before propagation. An interrupted request leaves existing durable due state or mailbox ownership for the next sweep. Duplicate attempts retain canonical dedupe and signal coalescing. Deploy Web independently, with no schema or wire changes; old Web remains compatible and only lacks pacing. Rollback removes pacing without rewriting state. No production mutation is authorized by this PR task.
+
+## Tasks and proof
+
+- [x] Trace owners, prove eager fan-out, and inspect callback/handoff budgets.
+- [x] Implement bounded jitter and update the reliability owner.
+- [x] Prove distribution, stable retries, maximum cardinality/concurrency, draining, timeout allowance, and both composed dispatch paths.
+- [x] Run focused tests, Web typecheck, complexity guard, and parent review.
+- [ ] Commit, open companion PR, run final ReviewGPT and exact-head CI, close this plan.
+
+## Validation results
+
+The five focused suites passed all 31 tests, including actual dispatch through both sweeps at 250-user cardinality. The helper cohort spans all five one-second bins, with more than 230 distinct millisecond dispatch times; slow work peaks at five active operations. Reversing the retry input preserves per-user offsets. Both new composed timing assertions fail against the original source because every start shares one instant. Existing consent, dedupe, orphaned-work identity, failure-accounting, and bounded hung-handoff tests pass.
+
+Web dependency builds, Web typecheck, scoped ESLint, diff whitespace, and complexity guard passed. No changed function exceeds complexity 20. Parent Product UX walkthrough: Ready for eligible recovery timing; direct ingress and exact reminder/provider deadlines remain outside the executor. No measured production pressure reduction is claimed. Final ReviewGPT, exact-head CI, and plan closure remain pending.

--- a/agent-docs/exec-plans/completed/2026-09-11-recovery-wake-jitter.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-recovery-wake-jitter.md
@@ -1,6 +1,6 @@
 # Spread individual recovery wakes with bounded jitter
 
-Status: active
+Status: completed
 Created: 2026-09-11
 Updated: 2026-09-11
 
@@ -24,10 +24,11 @@ Ordinary failures retain per-item accounting; unexpected worker failures drain s
 - [x] Implement bounded jitter and update the reliability owner.
 - [x] Prove distribution, stable retries, maximum cardinality/concurrency, draining, timeout allowance, and both composed dispatch paths.
 - [x] Run focused tests, Web typecheck, complexity guard, and parent review.
-- [ ] Commit, open companion PR, run final ReviewGPT and exact-head CI, close this plan.
+- [x] Commit, open companion PR, complete the initial full ReviewGPT audit, and prepare the final verified candidate. Final-head review and CI remain tracked on PR #3310.
 
 ## Validation results
 
 The five focused suites passed all 31 tests, including actual dispatch through both sweeps at 250-user cardinality. The helper cohort spans all five one-second bins, with more than 230 distinct millisecond dispatch times; slow work peaks at five active operations. Reversing the retry input preserves per-user offsets. Both new composed timing assertions fail against the original source because every start shares one instant. Existing consent, dedupe, orphaned-work identity, failure-accounting, and bounded hung-handoff tests pass.
 
-Web dependency builds, Web typecheck, scoped ESLint, diff whitespace, and complexity guard passed. No changed function exceeds complexity 20. Parent Product UX walkthrough: Ready for eligible recovery timing; direct ingress and exact reminder/provider deadlines remain outside the executor. No measured production pressure reduction is claimed. Final ReviewGPT, exact-head CI, and plan closure remain pending.
+Web dependency builds, Web typecheck, scoped ESLint, diff whitespace, and complexity guard passed. No changed function exceeds complexity 20. Parent Product UX walkthrough: Ready for eligible recovery timing; direct ingress and exact reminder/provider deadlines remain outside the executor. No measured production pressure reduction is claimed. ReviewGPT round 1 passed on the initial candidate with no qualifying findings. It independently validated the composed sweeps and real-timer distribution. Parent review then tightened unexpected-error propagation to preserve the first observed failure after sibling draining; its two-failure regression and all 31 focused tests pass, as do Web typecheck, lint, and the complexity guard (helper maximum 4). This closes implementation tracking; the final candidate review and exact-head CI remain pending on PR #3310. Neither deployment nor production pressure improvement has been verified.
+Completed: 2026-09-11

--- a/apps/web/src/lib/device-sync/due-reconcile-sweeper.ts
+++ b/apps/web/src/lib/device-sync/due-reconcile-sweeper.ts
@@ -1,3 +1,4 @@
+import { runHostedRecoveryBatch } from "../hosted-orchestration/recovery-batch";
 import { getPrisma } from "../prisma";
 import {
   formatHostedExecutionSafeLogErrorDetails,
@@ -11,7 +12,6 @@ import {
 const DEFAULT_WAKE_LIMIT = 25;
 const DUE_RECONCILE_WAKE_BUCKET_MS = 5 * 60_000;
 const MAX_WAKE_LIMIT = 250;
-const WAKE_CONCURRENCY = 5;
 
 export interface HostedDeviceSyncDueReconcileSweeperResult {
   dueConnections: number;
@@ -69,9 +69,8 @@ export async function runHostedDeviceSyncDueReconcileSweeper(input: {
   let wakeFailed = 0;
   let wakeNotAccepted = 0;
 
-  await runWithConcurrency(
+  await runHostedRecoveryBatch(
     selectedDueConnections,
-    WAKE_CONCURRENCY,
     async (dueConnection) => {
       wakeAttempted += 1;
 
@@ -130,6 +129,7 @@ export async function runHostedDeviceSyncDueReconcileSweeper(input: {
         reason: wake.reason ?? null,
       });
     },
+    true,
   );
 
   const skippedDueConnections = Math.max(0, dueConnections.length - selectedDueConnections.length);
@@ -167,21 +167,4 @@ function normalizeLimit(value: number | null | undefined, fallback: number, max:
   }
 
   return Math.max(1, Math.min(Math.floor(value), max));
-}
-
-async function runWithConcurrency<T>(
-  items: readonly T[],
-  concurrency: number,
-  worker: (item: T) => Promise<void>,
-): Promise<void> {
-  let nextIndex = 0;
-  const workerCount = Math.min(concurrency, items.length);
-
-  await Promise.all(Array.from({ length: workerCount }, async () => {
-    while (nextIndex < items.length) {
-      const item = items[nextIndex];
-      nextIndex += 1;
-      await worker(item);
-    }
-  }));
 }

--- a/apps/web/src/lib/hosted-orchestration/preference-handoff-sweeper.ts
+++ b/apps/web/src/lib/hosted-orchestration/preference-handoff-sweeper.ts
@@ -13,11 +13,14 @@ import {
   createHostedPostCommitDeadline,
   waitForHostedPostCommitOperation,
 } from "../hosted-onboarding/bounded-post-commit";
+import {
+  HOSTED_RECOVERY_JITTER_WINDOW_MS,
+  runHostedRecoveryBatch,
+} from "./recovery-batch";
 import { signalHostedMailboxAppendRuntime } from "./signal-runtime";
 
 const DEFAULT_HANDOFF_LIMIT = 25;
 const MAX_HANDOFF_LIMIT = 250;
-const HANDOFF_CONCURRENCY = 5;
 
 export interface HostedPreferenceHandoffSweepResult {
   candidateUsers: number;
@@ -78,9 +81,8 @@ export async function runHostedPreferenceHandoffSweeper(input: {
   // The production query selects active members before LIMIT. Recheck through
   // the canonical async gate to fail closed if access changes after selection;
   // those races do not consume the handoff-attempt budget.
-  await runWithConcurrency(
+  await runHostedRecoveryBatch(
     uniqueCandidates,
-    HANDOFF_CONCURRENCY,
     async (candidate) => {
       if (await hasActiveAccess(candidate.userId)) {
         activeUserIds.add(candidate.userId);
@@ -88,16 +90,18 @@ export async function runHostedPreferenceHandoffSweeper(input: {
         handoffSkippedInactive += 1;
       }
     },
+    false,
   );
   const activeCandidates = uniqueCandidates.filter((candidate) =>
     activeUserIds.has(candidate.userId)
   );
   const selectedCandidates = activeCandidates.slice(0, handoffLimit);
-  const handoffDeadlineMs = createHostedPostCommitDeadline(input.handoffTimeoutMs);
+  // Keep the existing handoff-work budget in addition to the bounded pacing window.
+  const handoffDeadlineMs = createHostedPostCommitDeadline(input.handoffTimeoutMs)
+    + HOSTED_RECOVERY_JITTER_WINDOW_MS;
 
-  await runWithConcurrency(
+  await runHostedRecoveryBatch(
     selectedCandidates,
-    HANDOFF_CONCURRENCY,
     async (candidate) => {
       handoffAttempted += 1;
       try {
@@ -121,6 +125,7 @@ export async function runHostedPreferenceHandoffSweeper(input: {
         });
       }
     },
+    true,
   );
 
   const skippedCandidateUsers = Math.max(
@@ -343,20 +348,4 @@ function normalizeLimit(
     return fallback;
   }
   return Math.max(1, Math.min(Math.floor(value), max));
-}
-
-async function runWithConcurrency<T>(
-  items: readonly T[],
-  concurrency: number,
-  worker: (item: T) => Promise<void>,
-): Promise<void> {
-  let nextIndex = 0;
-  const workerCount = Math.min(concurrency, items.length);
-  await Promise.all(Array.from({ length: workerCount }, async () => {
-    while (nextIndex < items.length) {
-      const item = items[nextIndex];
-      nextIndex += 1;
-      await worker(item);
-    }
-  }));
 }

--- a/apps/web/src/lib/hosted-orchestration/recovery-batch.ts
+++ b/apps/web/src/lib/hosted-orchestration/recovery-batch.ts
@@ -1,0 +1,45 @@
+import { createHash } from "node:crypto";
+
+export const HOSTED_RECOVERY_JITTER_WINDOW_MS = 5_000;
+const RECOVERY_CONCURRENCY = 5;
+
+// Only the two bounded recovery sweeps use this executor. Direct ingress and
+// runtime-owned deadlines never enter it. Waiting starts before any item work,
+// so it cannot retain a transaction or a pooled database connection.
+export async function runHostedRecoveryBatch<T extends { userId: string }>(
+  items: readonly T[],
+  worker: (item: T) => Promise<void>,
+  jitter: boolean,
+): Promise<void> {
+  const startedAt = performance.now();
+  const pending = items.map((item) => ({
+    item,
+    offsetMs: jitter
+      ? createHash("sha256").update(item.userId).digest().readUInt32BE(0)
+        % (HOSTED_RECOVERY_JITTER_WINDOW_MS + 1)
+      : 0,
+  })).sort((left, right) => left.offsetMs - right.offsetMs);
+  let nextIndex = 0;
+
+  // Order by eligibility before taking slots: a late offset must not hide an
+  // earlier one behind it. Offsets are relative to the batch, not cumulative.
+  const results = await Promise.allSettled(Array.from({
+    length: Math.min(RECOVERY_CONCURRENCY, pending.length),
+  }, async () => {
+    while (nextIndex < pending.length) {
+      const { item, offsetMs } = pending[nextIndex++];
+      const remainingMs = offsetMs - (performance.now() - startedAt);
+      if (remainingMs > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, remainingMs));
+      }
+      await worker(item);
+    }
+  }));
+  // Drain owned siblings before reporting an unexpected failure. Ordinary
+  // per-item recovery failures are accounted for by the sweep's worker.
+  for (const result of results) {
+    if (result.status === "rejected") {
+      throw result.reason;
+    }
+  }
+}

--- a/apps/web/src/lib/hosted-orchestration/recovery-batch.ts
+++ b/apps/web/src/lib/hosted-orchestration/recovery-batch.ts
@@ -23,23 +23,26 @@ export async function runHostedRecoveryBatch<T extends { userId: string }>(
 
   // Order by eligibility before taking slots: a late offset must not hide an
   // earlier one behind it. Offsets are relative to the batch, not cumulative.
-  const results = await Promise.allSettled(Array.from({
+  const failures: unknown[] = [];
+  await Promise.all(Array.from({
     length: Math.min(RECOVERY_CONCURRENCY, pending.length),
   }, async () => {
-    while (nextIndex < pending.length) {
-      const { item, offsetMs } = pending[nextIndex++];
-      const remainingMs = offsetMs - (performance.now() - startedAt);
-      if (remainingMs > 0) {
-        await new Promise<void>((resolve) => setTimeout(resolve, remainingMs));
+    try {
+      while (nextIndex < pending.length) {
+        const { item, offsetMs } = pending[nextIndex++];
+        const remainingMs = offsetMs - (performance.now() - startedAt);
+        if (remainingMs > 0) {
+          await new Promise<void>((resolve) => setTimeout(resolve, remainingMs));
+        }
+        await worker(item);
       }
-      await worker(item);
+    } catch (error) {
+      failures.push(error);
     }
   }));
   // Drain owned siblings before reporting an unexpected failure. Ordinary
   // per-item recovery failures are accounted for by the sweep's worker.
-  for (const result of results) {
-    if (result.status === "rejected") {
-      throw result.reason;
-    }
+  if (failures.length > 0) {
+    throw failures[0];
   }
 }

--- a/apps/web/test/hosted-device-sync-due-reconcile-sweeper.test.ts
+++ b/apps/web/test/hosted-device-sync-due-reconcile-sweeper.test.ts
@@ -33,6 +33,40 @@ describe("hosted device-sync due reconcile sweeper", () => {
     });
   });
 
+  it("jitters individual scheduled wake transactions across the selected cohort", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "performance", "setTimeout", "clearTimeout"] });
+    vi.setSystemTime(0);
+    try {
+      const starts: number[] = [];
+      const rows = Array.from({ length: 250 }, (_, index) => ({
+        connectionId: `synthetic-connection-${index}`,
+        connectedAt: "2026-01-01T00:00:00.000Z",
+        nextReconcileAt: "2026-01-02T00:00:00.000Z",
+        provider: "whoop",
+        userId: `synthetic-member-${index}`,
+      }));
+      mocks.appendHostedDeviceSyncScheduledReconcileWake.mockImplementation(async () => {
+        starts.push(performance.now());
+        return { wakeAccepted: true };
+      });
+      const sweep = runHostedDeviceSyncDueReconcileSweeper({
+        logger: buildLogger(), store: buildStore(rows), wakeLimit: 250,
+        now: new Date("2026-01-02T00:01:00.000Z"),
+      });
+      await vi.runAllTimersAsync();
+      expect(await sweep).toMatchObject({ wakeAccepted: 250, wakeAttempted: 250 });
+      expect(new Set(starts).size).toBeGreaterThan(230);
+      expect(Math.max(...starts) - Math.min(...starts)).toBeGreaterThan(3_000);
+      expect(Math.max(...starts)).toBeLessThanOrEqual(5_000);
+      for (const [wake] of mocks.appendHostedDeviceSyncScheduledReconcileWake.mock.calls) {
+        expect(wake.nextReconcileAt).toBe("2026-01-02T00:00:00.000Z");
+        expect(wake.expectedConnectedAt).toBe("2026-01-01T00:00:00.000Z");
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("requests scheduled mailbox wakes for active due connections", async () => {
     const logger = buildLogger();
     const store = buildStore([
@@ -140,7 +174,9 @@ describe("hosted device-sync due reconcile sweeper", () => {
       store,
     });
 
-    expect(mocks.appendHostedDeviceSyncScheduledReconcileWake.mock.calls).toEqual([
+    expect([...mocks.appendHostedDeviceSyncScheduledReconcileWake.mock.calls].sort(
+      ([left], [right]) => left.connectionId.localeCompare(right.connectionId),
+    )).toEqual([
       [{
         connectionId: "dsc_due_1",
         createdAt: "2026-05-05T00:01:00.000Z",

--- a/apps/web/test/hosted-preference-handoff-sweeper.test.ts
+++ b/apps/web/test/hosted-preference-handoff-sweeper.test.ts
@@ -19,6 +19,41 @@ import {
 } from "@/src/lib/hosted-orchestration/preference-handoff-sweeper";
 
 describe("hosted preference handoff sweeper", () => {
+  it("spreads individual handoffs without spending their timeout on jitter", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "performance", "setTimeout", "clearTimeout"] });
+    vi.setSystemTime(0);
+    try {
+      const starts: number[] = [];
+      const candidates = Array.from({ length: 250 }, (_, index) => ({
+        userId: `synthetic-member-${index}`,
+        mailboxItemId: `synthetic-mailbox-${index}`,
+      }));
+      const requestHandoff = vi.fn(async () => {
+        starts.push(performance.now());
+        return { signalAccepted: true as const, workflowId: "synthetic-workflow" };
+      });
+      const sweep = runHostedPreferenceHandoffSweeper({
+        handoffTimeoutMs: 1,
+        handoffLimit: 250,
+        hasActiveAccess: vi.fn(async () => true),
+        logger: buildLogger(), requestHandoff, store: buildStore(candidates),
+      });
+      await vi.runAllTimersAsync();
+      expect(await sweep).toMatchObject({ handoffAccepted: 250, handoffFailed: 0 });
+      expect(new Set(starts).size).toBeGreaterThan(230);
+      expect(Math.max(...starts) - Math.min(...starts)).toBeGreaterThan(3_000);
+      expect(Math.max(...starts)).toBeLessThanOrEqual(5_000);
+      for (const candidate of candidates) {
+        expect(requestHandoff).toHaveBeenCalledWith({
+          abortSignal: expect.any(AbortSignal), expectedUserId: candidate.userId,
+          mailboxItemId: candidate.mailboxItemId,
+        });
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("signals a pending preference row without logging its owner or item id", async () => {
     const logger = buildLogger();
     const requestHandoff = vi.fn(async () => ({

--- a/apps/web/test/hosted-recovery-batch.test.ts
+++ b/apps/web/test/hosted-recovery-batch.test.ts
@@ -63,22 +63,23 @@ describe("bounded individual recovery jitter", () => {
     expect(performance.now() - startedAt).toBeLessThanOrEqual(15_000);
   });
 
-  it("drains started siblings before propagating an unexpected failure", async () => {
+  it("drains started siblings and preserves the first observed failure", async () => {
     const failure = new Error("synthetic recovery failure");
     let release: () => void = () => {};
     const held = new Promise<void>((resolve) => { release = resolve; });
     const started: string[] = [];
     let settled = false;
     const batch = runHostedRecoveryBatch([
-      { userId: "fails" }, { userId: "held" },
+      { userId: "held" }, { userId: "fails" },
     ], async ({ userId }) => {
       started.push(userId);
       if (userId === "fails") throw failure;
       await held;
+      throw new Error("later failure from the earlier slot");
     }, false);
     const observed = batch.catch((error: unknown) => { settled = true; return error; });
     await vi.advanceTimersByTimeAsync(0);
-    expect(started).toEqual(["fails", "held"]);
+    expect(started).toEqual(["held", "fails"]);
     expect(settled).toBe(false);
     release();
     expect(await observed).toBe(failure);

--- a/apps/web/test/hosted-recovery-batch.test.ts
+++ b/apps/web/test/hosted-recovery-batch.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runHostedRecoveryBatch } from "@/src/lib/hosted-orchestration/recovery-batch";
+
+describe("bounded individual recovery jitter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date", "performance", "setTimeout", "clearTimeout"] });
+    vi.setSystemTime(0);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("spreads 250 users across five seconds and keeps the same offsets on retry", async () => {
+    const users = Array.from({ length: 250 }, (_, index) => ({
+      userId: `synthetic-member-${index}`,
+    }));
+    async function record(items: typeof users) {
+      const starts = new Map<string, number>();
+      const start = performance.now();
+      const batch = runHostedRecoveryBatch(items, async (item) => {
+        starts.set(item.userId, performance.now() - start);
+      }, true);
+      expect(starts.size).toBe(0);
+      await vi.runAllTimersAsync();
+      await batch;
+      return starts;
+    }
+    const first = await record(users);
+    const retry = await record([...users].reverse());
+    expect(first.size).toBe(250);
+    expect(retry).toEqual(first);
+    const times = [...first.values()];
+    expect(Math.min(...times)).toBeGreaterThanOrEqual(0);
+    expect(Math.max(...times)).toBeLessThanOrEqual(5_000);
+    expect(new Set(times).size).toBeGreaterThan(230);
+    for (let second = 0; second < 5; second++) {
+      const count = times.filter((time) => time >= second * 1_000 && time < (second + 1) * 1_000).length;
+      expect(count).toBeGreaterThan(25);
+      expect(count).toBeLessThan(80);
+    }
+  });
+
+  it("caps slow work at five in flight and does not compound per-item delays", async () => {
+    let active = 0;
+    let peak = 0;
+    let completed = 0;
+    const startedAt = performance.now();
+    const batch = runHostedRecoveryBatch(
+      Array.from({ length: 250 }, (_, index) => ({ userId: `synthetic-slow-${index}` })),
+      async () => {
+        active++;
+        peak = Math.max(peak, active);
+        await new Promise<void>((resolve) => setTimeout(resolve, 200));
+        active--;
+        completed++;
+      },
+      true,
+    );
+    await vi.runAllTimersAsync();
+    await batch;
+    expect(completed).toBe(250);
+    expect(active).toBe(0);
+    expect(peak).toBe(5);
+    expect(performance.now() - startedAt).toBeLessThanOrEqual(15_000);
+  });
+
+  it("drains started siblings before propagating an unexpected failure", async () => {
+    const failure = new Error("synthetic recovery failure");
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    const started: string[] = [];
+    let settled = false;
+    const batch = runHostedRecoveryBatch([
+      { userId: "fails" }, { userId: "held" },
+    ], async ({ userId }) => {
+      started.push(userId);
+      if (userId === "fails") throw failure;
+      await held;
+    }, false);
+    const observed = batch.catch((error: unknown) => { settled = true; return error; });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(started).toEqual(["fails", "held"]);
+    expect(settled).toBe(false);
+    release();
+    expect(await observed).toBe(failure);
+    expect(settled).toBe(true);
+  });
+
+  it("does no work or waiting for an empty batch", async () => {
+    const worker = vi.fn();
+    await runHostedRecoveryBatch([], worker, true);
+    expect(worker).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why and outcome

Recovery sweeps currently fill five dispatch slots immediately and refill them without pacing, so a cohort of due users can wake together. Spread each selected user operation over a stable zero-to-five-second window, while retaining the existing five-operation concurrency limit.

This changes individual dispatch timing inside the due-device and shared mailbox recovery batches. It does not reduce total work or provide a global requests-per-second limit.

## Product UX

- Effort: Patch.
- Result: Ready.
- Walkthrough: Due device work and delayed preference, device, runtime-control, and Clinical Records handoffs receive bounded pacing before their existing operation. Durable wake identities, ownership, access/consent checks, and retry paths are preserved. Direct message ingress, exact reminders, and runtime/provider retry deadlines do not use this executor. Slow work can still bunch already-eligible items under the concurrency cap.

## Evidence

- Direct: 31 tests passed across the recovery-batch, due-device sweep, shared handoff sweep, combined recovery sweep, and signed recovery-route suites. Both real sweep functions dispatch 250 synthetic users at more than 230 distinct times within five seconds, without changing wake identity or exhausting the handoff budget on jitter.
- Coverage: Maximum-cardinality slow work stays at five concurrent operations; retries with reversed input preserve each user's offset; unexpected errors drain started siblings; existing consent, duplicate acceptance, exact Clinical retry, and bounded hung-handoff tests pass. The original source fails both new composed timing assertions because all starts share one instant.
- Checks: Web dependency builds, Web typecheck, scoped ESLint, `git diff --check`, and `pnpm complexity:diff` passed. ReviewGPT round 1 passed with no findings: https://chatgpt.com/c/6aa463c1-4aa4-83ea-a7c7-16e7eebe81d8. The final candidate includes a parent-reviewed correction preserving the first observed unexpected failure after draining siblings, covered by a two-failure regression test. All 31 focused tests, Web typecheck, lint, and complexity passed again. ReviewGPT round 2 passed on final head `cc32da3849a451c4311f63f0c7c87114a0a7ad8a` with no findings; captured model metadata confirms `gpt-6-pro`. It independently exercised 18 checks against the supplied production code, including both 250-user sweeps, shared timeout exhaustion, and retry after hung handoffs. Exact-head CI passed, including release build/typecheck, all four Web test and PostgreSQL shards, package coverage, Cloudflare verification, runner budget, Temporal compatibility, billing, foreground reply cardinality, repository hygiene, viewport checks, and PR evidence.
- Limits: Timing proof uses the production executor and sweep functions with a fake monotonic clock and synthetic downstream boundaries. It proves dispatch timing, not production database pressure or completed provider synchronization. No production mutation was performed.
- Load: Both existing selectors retain their 25-item default and 250-item cap. No database queries, selected fields, decryptions, or external calls are added. The due batch admits at most 250 wake operations with at most five active operations; the handoff selector admits at most 251 access checks and 250 signals, each phase capped at five. Existing mutation/signal owners retain live authority checks. Waiting happens before item work, outside transactions.

## Non-obvious affected surfaces

Shared mailbox recovery includes preferences, wearable wakes, runtime control, synthetic room runtimes, and Clinical Records. All use the same stable user offset. Extend only that sweep's shared handoff deadline by the five-second pacing allowance, preserving its existing work budget. Two sequential phases add at most ten seconds of intentional pacing; execution overhead and backpressure remain additional. Existing request timeouts and durable recovery remain authoritative if a request is interrupted.

## Architecture and reuse

- Existing systems reused: Existing bounded sweep selectors, canonical wake append, mailbox signal, durable dedupe, and handoff timeout owner.
- New logic: Stable SHA-256 user offset, ascending offset admission, monotonic elapsed time, and sibling draining before unexpected error propagation.
- New abstractions: One small recovery-batch executor replaces two duplicate concurrency executors and serves their three existing call sites. The preliminary access-check pass stays unjittered.
- Complexity intentionally avoided: No new state, scheduler, queue, lease, configuration, dependency, or protocol field. Per-item waits do not accumulate their full offset after earlier work.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: None above 20; existing changed sweep functions remain at maximum 7, new helper maximum 4.
- Agent judgment: The shared executor removes duplicated slot ownership. Further abstraction is unnecessary.

## Hot reply path impact

- Path status: Not applicable — only the two background recovery sweeps call the new executor. Direct ingress and exact runtime wake scheduling are unchanged.
- Database calls: None added or moved onto the foreground path.
- Network/provider calls: None added or moved onto the foreground path.
- Other awaited latency: None on foreground entry. Each recovery batch gains at most five seconds of intentional pacing.
- Before/after proof: Composed sweep timing assertions fail against original source and pass with the change; call-site inspection bounds the change to recovery dispatch.

## Murph initial provider input impact

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no individual or group provider-input surface changes.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing callers and Web responses remain wire-compatible. Older Web dispatches immediately; new Web paces the same operations.
- Safe order: Web-only deployment; independent of any global Schedule phase change.
- Rollback floor: No migration or durable-state rewrite; rollback to the existing Web version removes pacing.
- Expected exposure: Every selected user in both bounded recovery batches, including existing durable candidates. Total work and selection caps remain unchanged.
- Reversibility: Reversible through ordinary Web release; no new cleanup operation.
- Convergence proof: Existing dedupe/retry assertions and reversed-input stable-offset proof. The request, response, wake identity, and persisted state remain unchanged.
- Post-deploy checks: Compare aggregate recovery failures, dispatch timing, callback durations, and database pool pressure over aligned windows; verify recovery work still progresses. No live pressure reduction is claimed before measurement.

## Change-shape breakdown

Classification rule: runtime TypeScript is source; test suites are tests; the reliability owner and execution plan are docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 62 | 42 |
| Tests / fixtures | 167 | 1 |
| Docs | 50 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **279** | **43** |

## Changelog

- Changelog: not applicable
- Reason: Internal recovery dispatch pacing; no new member-facing capability, copy, control, or measured performance claim.

ReviewGPT context sensitivity: sensitive

Classification reason: Background recovery timing, bounded concurrency, and handoff deadline behavior.

ReviewGPT first-reviewed head: c805a9c5bd0e943ca677a209659b764494d9423a
