### PR TITLE
refactor(assistant): simplify route capability planning

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-complexity-turn-planning.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-complexity-turn-planning.md
@@ -1,0 +1,34 @@
+# Simplify assistant route capability planning
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal
+
+Reduce the measured complexity of assistant route planning while preserving each route's exact instructions, tool authority, history/resume policy, and read ordering.
+
+## Scope and invariants
+
+The existing route planner remains the orchestration owner. Extract cohesive pure capability policies within that owner; add no state, dependency, registry, or external work. Preserve accepted-input authorization, scheduled scope, private/group isolation, and maintenance/output-only restrictions.
+
+## Evidence and design
+
+The cyclomatic guard identified resolveAssistantRouteTurnPlan at 215 with file debt 195. Most decisions are inline tool-availability checks and presentation policy. Existing composed route-plan fixtures exercise direct, group, scheduled, notification, maintenance, and resume behavior. Smaller capability policies clarify which facts authorize each family without relocating authority.
+
+## Tasks
+
+1. Extract narrow tool-family and response-card policies while preserving values and catalog ordering.
+2. Run composed route tests, relevant typecheck, and complexity guard; inspect complete diff.
+3. Open a scoped draft PR and hand stable candidate evidence to the parent for candidate review, CI, and ReviewGPT.
+
+## Verification
+
+- Focused composed route-planning suite: 104 tests passed. Existing full-plan digests for direct, group, maintenance, output-only, and scheduled-email routes are unchanged.
+- Assistant-engine typecheck passed.
+- Complexity guard passed: file debt 195 → 123; maximum function complexity 215 → 129. Private-member availability is 28 and communication availability is 26; their explicit, related capability rules remain together.
+- Parent preliminary diff review accepted the pure-policy boundaries and preserved boolean conditions.
+- No prompt text, tool schema, emitted tool order, persistent schema, deployment protocol, or awaited operation changed. Initial provider-input token measurement is not applicable because this refactor changes no provider-input surface.
+- Focused real-Codex journey passed using gpt-5.6-terra and an authenticated alternate local subscription home: 60 committed messages retained, exactly one provider request, one user/assistant transcript pair, and a concise correct reply. UX verdict: Ready. Earlier homes failed authentication before provider action; no credentials were copied or recorded.
+- Parent owns final candidate admission, exact-head CI, and ReviewGPT; implementation plan closure does not claim those gates passed.
+Completed: 2026-09-11

--- a/packages/assistant-engine/src/assistant/codex-turn/planning.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn/planning.ts
@@ -443,7 +443,7 @@ export async function buildCodexTurnAttemptPlan(input: {
   }
 }
 
-export async function resolveAssistantRouteTurnPlan(input: {
+interface AssistantRouteTurnPlanInput {
   acceptedInputItems?: readonly AssistantAcceptedTurnInputItemInput[] | null
   allowFinishWithoutReply?: boolean | null
   executionContext: ReturnType<typeof normalizeAssistantExecutionContext> | null
@@ -457,7 +457,215 @@ export async function resolveAssistantRouteTurnPlan(input: {
   progressDelivery?: AssistantProgressDelivery | null
   hostedToolContext?: AssistantHostedToolContext | null
   messageTargetAuthorizerAvailable?: boolean | null
-}): Promise<AssistantRouteTurnPlan> {
+}
+
+function resolvePrivateMemberToolAvailability({
+  input,
+  privateInteractiveAudience,
+  privateInteractiveProviderTurn,
+  userActionAcceptedInputIds,
+  scheduledInvocationScope,
+  currentAudienceDeliveryFields,
+}: {
+  input: AssistantRouteTurnPlanInput
+  privateInteractiveAudience: boolean
+  privateInteractiveProviderTurn: boolean
+  userActionAcceptedInputIds: readonly string[]
+  scheduledInvocationScope: ReturnType<typeof resolveAssistantHostedScheduledInvocationScope>
+  currentAudienceDeliveryFields: ReturnType<typeof resolveAssistantCurrentAudienceDeliveryFields>
+}) {
+  const privateUserAction =
+    privateInteractiveAudience && userActionAcceptedInputIds.length > 0
+  return {
+    assistantConfigurationAvailable:
+      privateInteractiveAudience &&
+      input.hostedToolContext?.assistantConfigurationTool != null,
+    computerToolsAvailable:
+      privateInteractiveAudience &&
+      input.hostedToolContext?.computerToolsAvailable === true,
+    deviceAvailable:
+      privateInteractiveAudience &&
+      input.hostedToolContext?.deviceTool != null,
+    clinicalRecordsConnectLinkAvailable:
+      privateInteractiveAudience &&
+      (userActionAcceptedInputIds.length > 0 ||
+        scheduledInvocationScope !== null) &&
+      input.hostedToolContext?.clinicalRecordsConnectLinkTool != null,
+    familyPlanAvailable:
+      privateInteractiveAudience &&
+      input.hostedToolContext?.familyPlanTool != null,
+    labsAvailable:
+      privateInteractiveProviderTurn &&
+      input.hostedToolContext?.labsTool != null,
+    planUsageAvailable:
+      privateInteractiveAudience &&
+      input.hostedToolContext?.planUsageTool != null,
+    imessageContactAvailable:
+      privateUserAction &&
+      currentAudienceDeliveryFields.channel === 'telegram' &&
+      currentAudienceDeliveryFields.threadIsDirect === true &&
+      input.hostedToolContext?.imessageContactTool != null,
+    subscriptionAvailable:
+      privateUserAction &&
+      input.hostedToolContext?.subscriptionTool != null,
+    pendingVaultFilesAvailable:
+      privateUserAction &&
+      input.hostedToolContext?.pendingVaultFilesAvailable === true,
+    vaultFileSendAvailable:
+      privateInteractiveAudience &&
+      input.hostedToolContext?.vaultFileSendAvailable === true,
+  }
+}
+
+function resolveGroupToolAvailability({
+  input,
+  authenticatedGroupChatRuntime,
+  hostedGroupRuntime,
+  userActionAcceptedInputIds,
+  assistantStyleSettingsAvailable,
+}: {
+  input: AssistantRouteTurnPlanInput
+  authenticatedGroupChatRuntime: boolean
+  hostedGroupRuntime: boolean
+  userActionAcceptedInputIds: readonly string[]
+  assistantStyleSettingsAvailable: boolean
+}) {
+  return {
+    groupAssistantConfigurationAvailable:
+      authenticatedGroupChatRuntime &&
+      userActionAcceptedInputIds.length > 0 &&
+      input.hostedToolContext?.assistantConfigurationTool != null,
+    groupAvailable: input.hostedToolContext?.groupTool != null,
+    groupRoomModelAvailable:
+      authenticatedGroupChatRuntime &&
+      userActionAcceptedInputIds.length > 0,
+    groupPermissionOfferAvailable:
+      hostedGroupRuntime &&
+      input.hostedToolContext?.groupPermissionOfferTool != null,
+    groupSharedReadAvailable:
+      hostedGroupRuntime &&
+      input.hostedToolContext?.groupSharedReader != null,
+    personalizationAvailable:
+      assistantStyleSettingsAvailable &&
+      input.hostedToolContext?.personalizationTool != null,
+  }
+}
+
+function resolveCommunicationToolAvailability({
+  input,
+  privateInteractiveAudience,
+  privateInteractiveProviderTurn,
+  authenticatedGroupChatRuntime,
+  authenticatedGroupProviderTurn,
+  userActionAcceptedInputIds,
+  scheduledPhoneCallScope,
+  currentAudienceDeliveryFields,
+  interactivePhoneCallAudience,
+}: {
+  input: AssistantRouteTurnPlanInput
+  privateInteractiveAudience: boolean
+  privateInteractiveProviderTurn: boolean
+  authenticatedGroupChatRuntime: boolean
+  authenticatedGroupProviderTurn: boolean
+  userActionAcceptedInputIds: readonly string[]
+  scheduledPhoneCallScope: ReturnType<typeof resolveAssistantHostedScheduledPhoneCallScope>
+  currentAudienceDeliveryFields: ReturnType<typeof resolveAssistantCurrentAudienceDeliveryFields>
+  interactivePhoneCallAudience: boolean
+}) {
+  const interactivePhoneCallAction =
+    interactivePhoneCallAudience && userActionAcceptedInputIds.length > 0
+  const physicalNoteAudience =
+    privateInteractiveAudience || authenticatedGroupChatRuntime
+  const conversationMediaTurn = isConversationMediaTurn(
+    privateInteractiveProviderTurn,
+    authenticatedGroupProviderTurn,
+    userActionAcceptedInputIds,
+  )
+  return {
+    physicalNotesAvailable:
+      physicalNoteAudience &&
+      input.hostedToolContext?.physicalNotes != null &&
+      input.hostedToolContext?.privateImageUrlPublisher != null,
+    physicalNoteRecoveryAvailable:
+      physicalNoteAudience &&
+      userActionAcceptedInputIds.length > 0 &&
+      typeof input.hostedToolContext?.physicalNotes?.resolve === 'function',
+    phoneCallsAvailable:
+      input.hostedToolContext?.phoneCalls != null &&
+      (
+        scheduledPhoneCallScope !== null ||
+        interactivePhoneCallAction
+      ),
+    phoneCallStatusAvailable:
+      interactivePhoneCallAction &&
+      typeof input.hostedToolContext?.phoneCalls?.status === 'function',
+    phoneCallStopAvailable:
+      interactivePhoneCallAction &&
+      typeof input.hostedToolContext?.phoneCalls?.stop === 'function',
+    calendarLinkAvailable:
+      privateInteractiveProviderTurn &&
+      currentAudienceDeliveryFields.channel === 'linq' &&
+      currentAudienceDeliveryFields.threadIsDirect === true &&
+      userActionAcceptedInputIds.length > 0,
+    conversationAttachmentsAvailable:
+      conversationMediaTurn &&
+      input.hostedToolContext?.currentConversationAttachmentAuthorities !== undefined,
+    analyzeVideoAvailable:
+      conversationMediaTurn &&
+      normalizeNullableString(
+        input.sharedPlan.cliAccess.env[HOSTED_GEMINI_VIDEO_ANALYSIS_API_KEY_ENV],
+      ) !== null,
+  }
+}
+
+function resolveResponseCardAvailability({
+  input,
+  privateInteractiveProviderTurn,
+  scheduledInvocationScope,
+  ordinaryInboundTurn,
+  resolvedChannel,
+  authenticatedGroupProviderTurn,
+}: {
+  input: AssistantRouteTurnPlanInput
+  privateInteractiveProviderTurn: boolean
+  scheduledInvocationScope: ReturnType<typeof resolveAssistantHostedScheduledInvocationScope>
+  ordinaryInboundTurn: boolean
+  resolvedChannel: string | null | undefined
+  authenticatedGroupProviderTurn: boolean
+}) {
+  const ordinaryOrScheduledInvocation =
+    scheduledInvocationScope !== null ||
+    (ordinaryInboundTurn && input.input.scheduledInvocationAuthority == null)
+  const responseCardsAvailable =
+    privateInteractiveProviderTurn &&
+    (ordinaryOrScheduledInvocation ||
+      input.input.scheduledInvocationAuthority?.automationId ===
+        MURPH_AUTOMATIC_MEAL_CLOSEOUT_AUTOMATION_ID)
+  const channel = resolvedChannel?.trim().toLowerCase()
+  const groupResponseCardsAvailable =
+    authenticatedGroupProviderTurn && ordinaryOrScheduledInvocation
+  const telegramPresentationResponseCardsAvailable =
+    channel === 'telegram' &&
+    (responseCardsAvailable || groupResponseCardsAvailable)
+  const exerciseRoutineResponseCardsAvailable =
+    telegramPresentationResponseCardsAvailable
+  const telegramRichContentResponseCardsAvailable =
+    telegramPresentationResponseCardsAvailable
+  const groupChallengeResponseCardsAvailable =
+    groupResponseCardsAvailable &&
+    channel === 'linq' &&
+    input.hostedToolContext?.groupSharedReader != null
+  return {
+    responseCardsAvailable,
+    exerciseRoutineResponseCardsAvailable,
+    telegramRichContentResponseCardsAvailable,
+    groupChallengeResponseCardsAvailable,
+  }
+}
+
+export async function resolveAssistantRouteTurnPlan(
+  input: AssistantRouteTurnPlanInput,
+): Promise<AssistantRouteTurnPlan> {
   const routePlanningStartedAt = Date.now()
   const preferenceContext =
     input.preferenceContext ?? DEFAULT_ASSISTANT_TURN_PREFERENCE_CONTEXT
@@ -559,39 +767,19 @@ export async function resolveAssistantRouteTurnPlan(input: {
       input.input.turnTrigger === 'manual-ask' ||
       input.input.turnTrigger === 'automation-auto-reply'
     )
-  const responseCardsAvailable =
-    privateInteractiveProviderTurn &&
-    (scheduledInvocationScope !== null ||
-      (ordinaryInboundTurn &&
-        input.input.scheduledInvocationAuthority == null) ||
-      input.input.scheduledInvocationAuthority?.automationId ===
-        MURPH_AUTOMATIC_MEAL_CLOSEOUT_AUTOMATION_ID)
-  const telegramPresentationResponseCardsAvailable =
-    resolvedChannel?.trim().toLowerCase() === 'telegram' &&
-    (
-      responseCardsAvailable ||
-      (
-        authenticatedGroupProviderTurn &&
-        (
-          scheduledInvocationScope !== null ||
-          (
-            ordinaryInboundTurn &&
-            input.input.scheduledInvocationAuthority == null
-          )
-        )
-      )
-    )
-  const exerciseRoutineResponseCardsAvailable =
-    telegramPresentationResponseCardsAvailable
-  const telegramRichContentResponseCardsAvailable =
-    telegramPresentationResponseCardsAvailable
-  const groupChallengeResponseCardsAvailable =
-    authenticatedGroupProviderTurn &&
-    resolvedChannel?.trim().toLowerCase() === 'linq' &&
-    input.hostedToolContext?.groupSharedReader != null &&
-    (scheduledInvocationScope !== null ||
-      (ordinaryInboundTurn &&
-        input.input.scheduledInvocationAuthority == null))
+  const {
+    responseCardsAvailable,
+    exerciseRoutineResponseCardsAvailable,
+    telegramRichContentResponseCardsAvailable,
+    groupChallengeResponseCardsAvailable,
+  } = resolveResponseCardAvailability({
+    input,
+    privateInteractiveProviderTurn,
+    scheduledInvocationScope,
+    ordinaryInboundTurn,
+    resolvedChannel,
+    authenticatedGroupProviderTurn,
+  })
   const shouldUseCommittedTranscriptHistory =
     input.profile.threadScope === 'session-thread' ||
     input.profile.promptProfile === 'assistant-ask-continuation' ||
@@ -981,63 +1169,28 @@ export async function resolveAssistantRouteTurnPlan(input: {
         allowFinishWithoutReply,
         imageGenerationAvailable,
         messageTargetingAvailable,
-        assistantConfigurationAvailable:
-          privateInteractiveAudience &&
-          input.hostedToolContext?.assistantConfigurationTool != null,
-        groupAssistantConfigurationAvailable:
-          authenticatedGroupChatRuntime &&
-          userActionAcceptedInputIds.length > 0 &&
-          input.hostedToolContext?.assistantConfigurationTool != null,
+        ...resolvePrivateMemberToolAvailability({
+          input,
+          privateInteractiveAudience,
+          privateInteractiveProviderTurn,
+          userActionAcceptedInputIds,
+          scheduledInvocationScope,
+          currentAudienceDeliveryFields,
+        }),
+        ...resolveGroupToolAvailability({
+          input,
+          authenticatedGroupChatRuntime,
+          hostedGroupRuntime,
+          userActionAcceptedInputIds,
+          assistantStyleSettingsAvailable,
+        }),
         followUpAttachmentAvailable: followUpAttachmentAllowed,
         automationAvailable: input.hostedToolContext?.automationTool != null,
-        computerToolsAvailable:
-          privateInteractiveAudience &&
-          input.hostedToolContext?.computerToolsAvailable === true,
         progressUpdatesAvailable: input.progressDelivery != null,
         progressUpdateMode:
           conversationScope === 'group' ? 'group' : 'direct',
         connectedAppsAvailable: input.hostedToolContext?.connectedApps != null,
         connectedAppsManageAvailable: privateInteractiveAudience,
-        deviceAvailable:
-          privateInteractiveAudience &&
-          input.hostedToolContext?.deviceTool != null,
-        clinicalRecordsConnectLinkAvailable:
-          privateInteractiveAudience &&
-          (userActionAcceptedInputIds.length > 0 ||
-            scheduledInvocationScope !== null) &&
-          input.hostedToolContext?.clinicalRecordsConnectLinkTool != null,
-        familyPlanAvailable:
-          privateInteractiveAudience &&
-          input.hostedToolContext?.familyPlanTool != null,
-        labsAvailable:
-          privateInteractiveProviderTurn &&
-          input.hostedToolContext?.labsTool != null,
-        planUsageAvailable:
-          privateInteractiveAudience &&
-          input.hostedToolContext?.planUsageTool != null,
-        imessageContactAvailable:
-          privateInteractiveAudience &&
-          currentAudienceDeliveryFields.channel === 'telegram' &&
-          currentAudienceDeliveryFields.threadIsDirect === true &&
-          userActionAcceptedInputIds.length > 0 &&
-          input.hostedToolContext?.imessageContactTool != null,
-        subscriptionAvailable:
-          privateInteractiveAudience &&
-          userActionAcceptedInputIds.length > 0 &&
-          input.hostedToolContext?.subscriptionTool != null,
-        groupAvailable: input.hostedToolContext?.groupTool != null,
-        groupRoomModelAvailable:
-          authenticatedGroupChatRuntime &&
-          userActionAcceptedInputIds.length > 0,
-        groupPermissionOfferAvailable:
-          hostedGroupRuntime &&
-          input.hostedToolContext?.groupPermissionOfferTool != null,
-        groupSharedReadAvailable:
-          hostedGroupRuntime &&
-          input.hostedToolContext?.groupSharedReader != null,
-        personalizationAvailable:
-          assistantStyleSettingsAvailable &&
-          input.hostedToolContext?.personalizationTool != null,
         productFeedbackAvailable:
           productFeedbackAuthorized &&
           typeof input.executionContext?.hosted?.productFeedbackCandidateSink
@@ -1046,54 +1199,20 @@ export async function resolveAssistantRouteTurnPlan(input: {
         exerciseRoutineResponseCardsAvailable,
         telegramRichContentResponseCardsAvailable,
         groupChallengeResponseCardsAvailable,
-        physicalNotesAvailable:
-          (privateInteractiveAudience || authenticatedGroupChatRuntime) &&
-          input.hostedToolContext?.physicalNotes != null &&
-          input.hostedToolContext?.privateImageUrlPublisher != null,
-        physicalNoteRecoveryAvailable:
-          (privateInteractiveAudience || authenticatedGroupChatRuntime) &&
-          userActionAcceptedInputIds.length > 0 &&
-          typeof input.hostedToolContext?.physicalNotes?.resolve === 'function',
-        phoneCallsAvailable:
-          input.hostedToolContext?.phoneCalls != null &&
-          (
-            scheduledPhoneCallScope !== null ||
-            (
-              userActionAcceptedInputIds.length > 0 &&
-              interactivePhoneCallAudience
-            )
-          ),
-        phoneCallStatusAvailable:
-          interactivePhoneCallAudience &&
-          userActionAcceptedInputIds.length > 0 &&
-          typeof input.hostedToolContext?.phoneCalls?.status === 'function',
-        phoneCallStopAvailable:
-          interactivePhoneCallAudience &&
-          userActionAcceptedInputIds.length > 0 &&
-          typeof input.hostedToolContext?.phoneCalls?.stop === 'function',
+        ...resolveCommunicationToolAvailability({
+          input,
+          privateInteractiveAudience,
+          privateInteractiveProviderTurn,
+          authenticatedGroupChatRuntime,
+          authenticatedGroupProviderTurn,
+          userActionAcceptedInputIds,
+          scheduledPhoneCallScope,
+          currentAudienceDeliveryFields,
+          interactivePhoneCallAudience,
+        }),
         voiceMemoGenerationAvailable: voiceMemoDeliveryChannel !== null,
-        calendarLinkAvailable:
-          privateInteractiveProviderTurn &&
-          currentAudienceDeliveryFields.channel === 'linq' &&
-          currentAudienceDeliveryFields.threadIsDirect === true &&
-          userActionAcceptedInputIds.length > 0,
-        conversationAttachmentsAvailable:
-          isConversationMediaTurn(privateInteractiveProviderTurn, authenticatedGroupProviderTurn, userActionAcceptedInputIds) &&
-          input.hostedToolContext?.currentConversationAttachmentAuthorities !== undefined,
-        analyzeVideoAvailable:
-          isConversationMediaTurn(privateInteractiveProviderTurn, authenticatedGroupProviderTurn, userActionAcceptedInputIds) &&
-          normalizeNullableString(
-            input.sharedPlan.cliAccess.env[HOSTED_GEMINI_VIDEO_ANALYSIS_API_KEY_ENV],
-          ) !== null,
         askGrokAvailable:
           resolveXaiApiKey(input.sharedPlan.cliAccess.env) !== null,
-        pendingVaultFilesAvailable:
-          privateInteractiveAudience &&
-          userActionAcceptedInputIds.length > 0 &&
-          input.hostedToolContext?.pendingVaultFilesAvailable === true,
-        vaultFileSendAvailable:
-          privateInteractiveAudience &&
-          input.hostedToolContext?.vaultFileSendAvailable === true,
       })
   const dynamicTools: readonly MurphDynamicTool[] =
     input.profile.promptProfile === 'creative-notification'


### PR DESCRIPTION
## Why and outcome

The route planner mixed private-member, group, communication, and response-card capability rules into a function with cyclomatic complexity 215. This change gives those policy families named pure helpers and derives repeated accepted-action and scheduled-card conditions once. Route instructions, emitted tools, accepted-input authority, history, native resume, and async planning order stay the same.

## Product UX

- Effort: Not applicable — internal behavior-preserving refactor.
- Result: Ready — deterministic route equivalence and focused real-Codex confirmation passed.
- Walkthrough: All 104 route-planning tests pass, including unchanged complete-plan digests for direct, group, maintenance, output-only, and scheduled-email turns, and explicit private/group capability denials.

## Evidence

- Direct: `pnpm exec vitest run --config packages/assistant-engine/vitest.config.ts --maxWorkers 1 packages/assistant-engine/test/assistant-codex-turn-planning.test.ts` — 104 passed.
- Typecheck: `pnpm --filter @murphai/assistant-engine typecheck` — passed.
- Coverage: Existing composed planner tests preserve complete emitted instructions/tool definitions and verify accepted-message targeting, scheduled phone and clinical access, group privacy, response cards, maintenance restrictions, and resume fingerprints.
- Live: `pnpm test:assistant:live -- --test "answers once from an early detail retained across sixty committed messages" --codex-home <AUTHENTICATED_CODEX_HOME>` — passed with `gpt-5.6-terra`, local subscription. The production-derived journey retained 60 committed messages, made exactly one provider request, and appended exactly one user/assistant transcript pair. The reply correctly used the earlier detail and was concise; UX verdict: Ready. Earlier authenticated-home candidates failed authentication before provider action; no credentials were copied or recorded.
- Parent candidate review, exact-head ReviewGPT, and all required CI checks passed on the reviewed head.

## Non-obvious affected surfaces

Tool availability feeds thread contract fingerprints. The unchanged planner digest fixtures and resume tests prove that the extraction retains those declarations and existing thread continuity.

## Architecture and reuse

- Existing systems reused: The route planner remains the orchestration owner; the existing dynamic-tool catalog, accepted-input resolvers, scheduled invocation scopes, channel adapters, and thread fingerprint builder remain authoritative.
- New logic: None; repeated private-action, phone-call-action, media-turn, and response-card invocation conditions are derived once.
- New abstractions: Four file-local pure policy helpers and a name for the existing planner input type. Each helper keeps one related capability family reviewable with explicit inputs.
- Complexity intentionally avoided: No registry, dependency, persistent state, new asynchronous work, or alternate authority resolver.

## Complexity impact

- Guard: pass — `pnpm complexity:diff -- packages/assistant-engine/src/assistant/codex-turn/planning.ts`; file debt 195 → 123 (−72), maximum 215 → 129 (−86).
- Hotspots: `resolveAssistantRouteTurnPlan` 129 retains ordered orchestration; `resolvePrivateMemberToolAvailability` 28 and `resolveCommunicationToolAvailability` 26 retain explicit capability-specific authority. Group and response-card helpers are below 20.
- Agent judgment: The named families remove repeated conditions and make authority review local. Further subdivision of the small capability families would hide the conditions behind more wrappers. The remaining orchestration can be addressed separately without widening this focused extraction.

## Hot reply path impact

- Path status: Touched — pure capability planning before provider start.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved; existing awaits, snapshot refresh budget, timeout, fallback, and retry behavior stay in place.
- Before/after proof: Unchanged complete-plan digests and all 104 route-planning tests pass. Helper calls perform synchronous condition evaluation only; no latency improvement is claimed.

## Murph initial provider input impact

Not applicable — this internal refactor changes no provider-input surface for individual or group Murph. The existing complete-plan fixtures retain their original digests, including instructions, dynamic tools, cache metadata, history/resume fields, and route declarations.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged; the same catalog resolves the same availability booleans in its existing output order.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed. This is deterministic equality evidence, not a token measurement.

ReviewGPT first-reviewed head: bf696aa632391b5a6b3cc676cdb00977bc225e14

ReviewGPT context sensitivity: sensitive

Classification reason: Refactors assistant capability authorization on the provider planning path.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal pure-policy extraction changes no persisted schema, provider contract, deployment protocol, or cross-version behavior.

## Change-shape breakdown

Classification rule: The planner is source; the implementation execution plan is documentation. No binary files, fixtures, configuration, or generated code change.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 249 | 130 |
| Tests / fixtures | 0 | 0 |
| Docs | 34 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **283** | **130** |

## Changelog

- Changelog: not applicable
- Reason: Internal refactoring preserves all member-facing behavior.

## ReviewGPT result

- Round 1: PASS on bf696aa632391b5a6b3cc676cdb00977bc225e14.
- Model: GPT-6 Pro, verified by captured response metadata; guarded full snapshot and exact committed turn verified.
- No qualifying findings; no review remediation required. All required CI checks passed on this same head.
