### PR TITLE
refactor(assistant): separate group tool request preparation

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-complexity-group-tool-preparation.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-complexity-group-tool-preparation.md
@@ -1,0 +1,67 @@
+# Simplify group tool preparation boundaries
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal and protected invariant
+
+Reduce the complexity of group tool execution while preserving every accepted
+request, rejection, provider call, notice, capture identity, usage record, and
+model-visible result. This is an internal refactor with no intended UX change.
+
+## Owner and evidence
+
+`dynamic-tools.ts` owns model-to-host request preparation. `executeGroupTool`
+currently mixes generated-image preflight/capture and current-sender notice
+coordination with unrelated group actions and final RPC result handling. Its
+baseline cyclomatic complexity is 167. The existing preparation and authorization
+owners remain authoritative; there is no new persistent state or API.
+
+## Scope and decisions
+
+Extract typed private preparation helpers for generated avatar/contact-card
+requests and current-sender asks. Each helper returns either the existing terminal
+result or the prepared request plus the metadata required by final dispatch.
+Consolidate duplicated referral participant selection only if its exact authority
+and error behavior remain explicit. Keep every preparation call before the existing
+RPC try/catch and preserve notice-before-request ordering and usage propagation.
+No prompt, schema, provider policy, retry, storage, or deployment contract changes.
+
+## Risks and proof
+
+The main risks are widened authorization, lost usage/error metadata, duplicate
+notices, and moving exceptions across the existing catch boundary. Review the
+moved statements and run group tool/current-sender/dynamic failure tests plus
+relevant typecheck and the complexity guard. Reuse the focused production-derived
+live current-sender/avatar journeys after deterministic proof, reviewing exact
+effects and reply truth. Existing extensive tests are the primary behavior proof.
+
+## Tasks
+
+1. Extract the two preparation workflows and inspect the full diff.
+2. Run focused tests, typecheck, and complexity measurement.
+3. Run focused live evidence if applicable; report unavailable evidence honestly.
+4. Commit and open a draft PR; parent owns candidate review and final ReviewGPT.
+
+## Verification
+
+- Completed the three private preparation helpers; the final RPC catch, usage
+  metadata, capture identities, and shared notice promise remain at their owners.
+- Focused group-tool, current-sender, dynamic-failure-boundary, and dynamic-runtime
+  suites: 4 files, 156 tests passed, including six referral rejection cases.
+- `MURPH_TSC_PACKAGE_MODE=single-threaded pnpm --dir packages/assistant-engine typecheck`: passed.
+- `pnpm complexity:diff --base 91d301576fd7ca076e65ba09591f0fda4ae91d91 -- packages/assistant-engine/src/assistant-codex/dynamic-tools.ts`: passed;
+  group execution 167 to 111, file debt 534 to 484. The new avatar helper is 26;
+  further splitting would scatter its cohesive preflight/capture workflow.
+- `pnpm test:assistant:live -- --test 'delivers one explicit current-sender consultation privately without a group notice' --codex-home <SUBSCRIPTION_HOME>`:
+  passed using gpt-5.6-terra through local subscription. One exact private
+  current-sender host request, no group notice, final action none. Ready: quiet
+  group output correctly preserves the private consultation. Default and two
+  earlier alternate homes failed before any provider action; the next allowed
+  alternate succeeded. No authentication content was inspected.
+- Full diff and privacy review passed. Parent inspected the candidate source
+  without findings. No product, deployment, or provider-input contract changed.
+- Implementation complete; parent owns final draft admission, exact-head CI,
+  and the user-requested ReviewGPT gate. No live artifacts are committed.
+Completed: 2026-09-11

--- a/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
+++ b/packages/assistant-engine/src/assistant-codex/dynamic-tools.ts
@@ -5169,6 +5169,263 @@ function resolveGroupJournalHostRequest(
   }
 }
 
+type PreparedGroupAvatar = {
+  request: HostedRuntimeGroupToolRequest;
+  usageDraft: AssistantProviderUsageDraft | null;
+  generatedAvatarCapture: {
+    savedCaptureId: string | null;
+    savedImageRef: string;
+  } | null;
+};
+
+async function prepareGroupAvatarToolRequest(
+  input: Omit<ExecuteGroupToolInput, "request"> & {
+    request: Extract<MurphGroupToolRequest, {
+      action: "share_contact_card" | "set_chat_avatar";
+      avatar: unknown;
+    }>;
+  },
+  groupTool: NonNullable<AssistantHostedToolContext["groupTool"]>,
+): Promise<PreparedGroupAvatar | MurphDynamicToolExecutionResult> {
+  let contactCardShareKey: string | null = null;
+  if (input.request.action === "share_contact_card") {
+    const userActionScope =
+      input.hostedToolContext?.currentUserActionScope?.() ?? null;
+    if (
+      userActionScope?.conversationScope !== "direct" ||
+      userActionScope.acceptedInputIds.length === 0
+    ) {
+      return toolTextResult(
+        false,
+        "personalized contact cards require a fresh user request in a personal direct conversation",
+        'authority_rejected',
+      );
+    }
+    // Refuse a route that can never carry the attachment before paying for
+    // generation, capture, and publication. The post-generation binding below
+    // still owns the authoritative thread.
+    const routeStatus = groupTool.directAttachmentRouteStatus?.() ?? null;
+    if (routeStatus && routeStatus.status !== "ok") {
+      return toolTextResult(
+        true,
+        safeToolPayloadText({
+          action: "share_contact_card",
+          result: routeStatus,
+        }),
+      );
+    }
+    contactCardShareKey = userActionScope.acceptedInputIds.at(-1) ?? null;
+    if (!contactCardShareKey) {
+      return toolTextResult(
+        false,
+        "personalized contact cards require fresh user-sourced input for this turn",
+        'authority_rejected',
+      );
+    }
+  } else {
+    let preflight: Extract<
+      HostedRuntimeGroupToolResponse,
+      { action: "preflight_set_chat_avatar" }
+    >;
+    try {
+      const preflightRequest = { action: "preflight_set_chat_avatar" } as const;
+      const preflightResult = input.abortSignal
+        ? await groupTool.request(preflightRequest, {
+            signal: input.abortSignal,
+          })
+        : await groupTool.request(preflightRequest);
+      if (preflightResult.action !== "preflight_set_chat_avatar") {
+        return groupAvatarUnavailableToolResult(
+          "group_avatar_preflight_unavailable",
+        );
+      }
+      preflight = preflightResult;
+    } catch {
+      return groupAvatarUnavailableToolResult(
+        "group_avatar_preflight_unavailable",
+      );
+    }
+    if (preflight.result.status !== "ok") {
+      return toolTextResult(
+        true,
+        safeToolPayloadText({
+          action: "set_chat_avatar",
+          result: preflight.result,
+        }),
+      );
+    }
+  }
+  const prepared = await prepareGroupAvatarRuntimeRequest({
+    abortSignal: input.abortSignal,
+    // Contact-card replays keep the accepted-input identity; group avatar
+    // requests retain their tool-call identity.
+    captureRequestId: contactCardShareKey ?? input.toolCallId,
+    captureScope: contactCardShareKey !== null
+      ? "contact-card-avatar"
+      : "group-avatar",
+    env: input.env,
+    fetchImpl: input.fetchImpl,
+    hostedToolContext: input.hostedToolContext,
+    materializeWorkspaceArtifacts: input.materializeWorkspaceArtifacts,
+    nextUsageOrdinal: input.nextUsageOrdinal,
+    request: { action: "set_chat_avatar", avatar: input.request.avatar },
+    vaultRoot: input.vaultRoot,
+  });
+  if (!prepared.rpcSuccess) {
+    return {
+      ...toolFailureMetadata(prepared),
+      rpcResult: {
+        contentItems: [{ text: prepared.rpcText, type: "inputText" }],
+        success: false,
+      },
+      usageDraft: prepared.usageDraft ?? null,
+    };
+  }
+  const request: HostedRuntimeGroupToolRequest = contactCardShareKey !== null
+    ? {
+        action: "share_contact_card",
+        contactCardImageUrl: prepared.request.groupChatIconUrl,
+        contactCardShareKey,
+      }
+    : prepared.request;
+  const usageDraft = prepared.usageDraft ?? null;
+  const generatedAvatarCapture = prepared.savedImageRef
+    ? {
+        savedCaptureId: prepared.savedCaptureId ?? null,
+        savedImageRef: prepared.savedImageRef,
+      }
+    : null;
+  return { request, usageDraft, generatedAvatarCapture };
+}
+
+async function prepareCurrentSenderGroupAsk(
+  input: Omit<ExecuteGroupToolInput, "request"> & {
+    request: Extract<MurphGroupToolRequest, { action: "ask_current_sender" }>;
+  },
+): Promise<MurphDynamicToolExecutionResult | {
+  request: HostedRuntimeGroupToolRequest;
+  currentSenderGroupPreviewSent: boolean;
+}> {
+  let currentSenderGroupPreviewSent = false;
+  const userActionScope =
+    input.hostedToolContext?.currentUserActionScope?.() ?? null;
+  if (
+    userActionScope?.conversationScope !== "group" ||
+    !userActionScope.acceptedInputIds.includes(input.request.messageRef)
+  ) {
+    return toolTextResult(
+      false,
+      "current-sender request requires the selected accepted message in this group turn",
+      'authority_rejected',
+    );
+  }
+  const decisionByMessageRef =
+    input.groupSharedReadTurnState?.currentSenderDecisionByMessageRef;
+  if (!decisionByMessageRef) {
+    return toolTextResult(
+      false,
+      "current-sender decision authority is unavailable for this turn",
+      'authority_rejected',
+    );
+  }
+  const decision = currentSenderTurnDecisionForGroupRequest(input.request);
+  const claim = decisionByMessageRef.get(input.request.messageRef);
+  if (!claim) {
+    return toolTextResult(
+      false,
+      "current-sender decision was not claimed at server request intake",
+      'authority_rejected',
+    );
+  }
+  if (claim.decision !== decision) {
+    return toolTextResult(
+      false,
+      "current-sender request conflicts with an earlier decision for this Message",
+      'conflict',
+    );
+  }
+  if (input.request.audience === "group" && claim.groupNotice === null) {
+    claim.groupNotice = sendCurrentSenderGroupNotice({
+      deliveryContextOrdinal: input.deliveryContextOrdinal,
+      messageRef: input.request.messageRef,
+      progressDelivery: input.progressDelivery,
+    });
+  }
+  if (input.request.audience === "group") {
+    const previewSent = claim.groupNotice ? await claim.groupNotice : false;
+    if (!previewSent) {
+      return toolTextResult(
+        false,
+        "group sharing is unavailable because the required advance notice could not be delivered",
+        'unavailable',
+      );
+    }
+    currentSenderGroupPreviewSent = true;
+  }
+  const request: HostedRuntimeGroupToolRequest = {
+    action: "ask_current_sender",
+    ...(input.request.audience === undefined
+      ? {}
+      : { audience: input.request.audience }),
+    mode: input.request.mode,
+    origin: {
+      assistantInputId: input.request.messageRef,
+      kind: "accepted_input",
+      sessionId: userActionScope.originSessionId,
+    },
+  };
+  return { request, currentSenderGroupPreviewSent };
+}
+
+async function prepareGroupReferralRequest(
+  input: Omit<ExecuteGroupToolInput, "request"> & {
+    request: Extract<MurphGroupToolRequest, {
+      action: "create_signup_referral_link" | "read_usage_referral";
+    }>;
+  },
+): Promise<HostedRuntimeGroupToolRequest | MurphDynamicToolExecutionResult> {
+  const userActionScope =
+    input.hostedToolContext?.currentUserActionScope?.() ?? null;
+  if (input.request.action === "create_signup_referral_link") {
+    if (!userActionScope || userActionScope.acceptedInputIds.length === 0) {
+      return toolTextResult(
+        false,
+        "signup referral links require a fresh explicit user request",
+        'authority_rejected',
+      );
+    }
+    if (userActionScope.conversationScope === "direct") {
+      return { action: "create_signup_referral_link" };
+    }
+    if (userActionScope.conversationScope !== "group") {
+      return toolTextResult(
+        false,
+        "signup referral links require a verified direct or group request",
+        'authority_rejected',
+      );
+    }
+  } else if (userActionScope?.conversationScope !== "group") {
+    return { action: "read_usage_referral" };
+  }
+
+  const messageRef = input.request.messageRef;
+  const rejectionText = input.request.action === "create_signup_referral_link"
+    ? "group signup referral links require the exact accepted Message ref from the requesting participant"
+    : "group usage options require the exact accepted Message ref from the requesting participant";
+  if (!messageRef || !userActionScope.acceptedInputIds.includes(messageRef)) {
+    return toolTextResult(false, rejectionText, 'authority_rejected');
+  }
+  const participant = await authorizeDynamicToolParticipant({
+    authorizer: input.authorizeAcceptedMessageTarget,
+    deliveryContextOrdinal: input.deliveryContextOrdinal,
+    messageRef,
+  });
+  if (!participant) {
+    return toolTextResult(false, rejectionText, 'authority_rejected');
+  }
+  return { action: input.request.action, participant };
+}
+
 async function executeGroupTool(
   input: ExecuteGroupToolInput,
 ): Promise<MurphDynamicToolExecutionResult> {
@@ -5224,10 +5481,7 @@ async function executeGroupTool(
 
   let request: HostedRuntimeGroupToolRequest;
   let usageDraft: AssistantProviderUsageDraft | null = null;
-  let generatedAvatarCapture: {
-    savedCaptureId: string | null;
-    savedImageRef: string;
-  } | null = null;
+  let generatedAvatarCapture: PreparedGroupAvatar["generatedAvatarCapture"] = null;
   const journalResolution = resolveGroupJournalHostRequest(input);
   if (journalResolution.kind === "result") {
     return journalResolution.result;
@@ -5259,114 +5513,14 @@ async function executeGroupTool(
     isPreparedContactCardRequest(input.request) ||
     isPreparedGroupAvatarRequest(input.request)
   ) {
-    let contactCardShareKey: string | null = null;
-    if (input.request.action === "share_contact_card") {
-      const userActionScope =
-        input.hostedToolContext?.currentUserActionScope?.() ?? null;
-      if (
-        userActionScope?.conversationScope !== "direct" ||
-        userActionScope.acceptedInputIds.length === 0
-      ) {
-        return toolTextResult(
-          false,
-          "personalized contact cards require a fresh user request in a personal direct conversation",
-          'authority_rejected',
-        );
-      }
-      // Refuse a route that can never carry the attachment before paying for
-      // generation, capture, and publication. The post-generation binding below
-      // still owns the authoritative thread.
-      const routeStatus = groupTool.directAttachmentRouteStatus?.() ?? null;
-      if (routeStatus && routeStatus.status !== "ok") {
-        return toolTextResult(
-          true,
-          safeToolPayloadText({
-            action: "share_contact_card",
-            result: routeStatus,
-          }),
-        );
-      }
-      contactCardShareKey = userActionScope.acceptedInputIds.at(-1) ?? null;
-      if (!contactCardShareKey) {
-        return toolTextResult(
-          false,
-          "personalized contact cards require fresh user-sourced input for this turn",
-          'authority_rejected',
-        );
-      }
-    } else {
-      let preflight: Extract<
-        HostedRuntimeGroupToolResponse,
-        { action: "preflight_set_chat_avatar" }
-      >;
-      try {
-        const preflightRequest = { action: "preflight_set_chat_avatar" } as const;
-        const preflightResult = input.abortSignal
-          ? await groupTool.request(preflightRequest, {
-              signal: input.abortSignal,
-            })
-          : await groupTool.request(preflightRequest);
-        if (preflightResult.action !== "preflight_set_chat_avatar") {
-          return groupAvatarUnavailableToolResult(
-            "group_avatar_preflight_unavailable",
-          );
-        }
-        preflight = preflightResult;
-      } catch {
-        return groupAvatarUnavailableToolResult(
-          "group_avatar_preflight_unavailable",
-        );
-      }
-      if (preflight.result.status !== "ok") {
-        return toolTextResult(
-          true,
-          safeToolPayloadText({
-            action: "set_chat_avatar",
-            result: preflight.result,
-          }),
-        );
-      }
+    const prepared = await prepareGroupAvatarToolRequest(
+      { ...input, request: input.request },
+      groupTool,
+    );
+    if ("rpcResult" in prepared) {
+      return prepared;
     }
-    const prepared = await prepareGroupAvatarRuntimeRequest({
-      abortSignal: input.abortSignal,
-      // Contact-card replays keep the accepted-input identity; group avatar
-      // requests retain their tool-call identity.
-      captureRequestId: contactCardShareKey ?? input.toolCallId,
-      captureScope: contactCardShareKey !== null
-        ? "contact-card-avatar"
-        : "group-avatar",
-      env: input.env,
-      fetchImpl: input.fetchImpl,
-      hostedToolContext: input.hostedToolContext,
-      materializeWorkspaceArtifacts: input.materializeWorkspaceArtifacts,
-      nextUsageOrdinal: input.nextUsageOrdinal,
-      request: { action: "set_chat_avatar", avatar: input.request.avatar },
-      vaultRoot: input.vaultRoot,
-    });
-    if (!prepared.rpcSuccess) {
-      return {
-        ...toolFailureMetadata(prepared),
-        rpcResult: {
-          contentItems: [{ text: prepared.rpcText, type: "inputText" }],
-          success: false,
-        },
-        usageDraft: prepared.usageDraft ?? null,
-      };
-    }
-    request = contactCardShareKey !== null
-      ? {
-          action: "share_contact_card",
-          contactCardImageUrl: prepared.request.groupChatIconUrl,
-          contactCardShareKey,
-        }
-      : prepared.request;
-    usageDraft = prepared.usageDraft ?? null;
-    generatedAvatarCapture = prepared.savedImageRef
-      ? {
-          savedCaptureId: prepared.savedCaptureId ?? null,
-          savedImageRef: prepared.savedImageRef,
-        }
-      : null;
+    ({ request, usageDraft, generatedAvatarCapture } = prepared);
   } else if (
     input.request.action === "ask" || input.request.action === "handoff"
   ) {
@@ -5403,73 +5557,14 @@ async function executeGroupTool(
           originAssistantInputId,
         };
   } else if (input.request.action === "ask_current_sender") {
-    const userActionScope =
-      input.hostedToolContext?.currentUserActionScope?.() ?? null;
-    if (
-      userActionScope?.conversationScope !== "group" ||
-      !userActionScope.acceptedInputIds.includes(input.request.messageRef)
-    ) {
-      return toolTextResult(
-        false,
-        "current-sender request requires the selected accepted message in this group turn",
-        'authority_rejected',
-      );
+    const prepared = await prepareCurrentSenderGroupAsk({
+      ...input,
+      request: input.request,
+    });
+    if ("rpcResult" in prepared) {
+      return prepared;
     }
-    const decisionByMessageRef =
-      input.groupSharedReadTurnState?.currentSenderDecisionByMessageRef;
-    if (!decisionByMessageRef) {
-      return toolTextResult(
-        false,
-        "current-sender decision authority is unavailable for this turn",
-        'authority_rejected',
-      );
-    }
-    const decision = currentSenderTurnDecisionForGroupRequest(input.request);
-    const claim = decisionByMessageRef.get(input.request.messageRef);
-    if (!claim) {
-      return toolTextResult(
-        false,
-        "current-sender decision was not claimed at server request intake",
-        'authority_rejected',
-      );
-    }
-    if (claim.decision !== decision) {
-      return toolTextResult(
-        false,
-        "current-sender request conflicts with an earlier decision for this Message",
-        'conflict',
-      );
-    }
-    if (input.request.audience === "group" && claim.groupNotice === null) {
-      claim.groupNotice = sendCurrentSenderGroupNotice({
-        deliveryContextOrdinal: input.deliveryContextOrdinal,
-        messageRef: input.request.messageRef,
-        progressDelivery: input.progressDelivery,
-      });
-    }
-    if (input.request.audience === "group") {
-      const previewSent = claim.groupNotice ? await claim.groupNotice : false;
-      if (!previewSent) {
-        return toolTextResult(
-          false,
-          "group sharing is unavailable because the required advance notice could not be delivered",
-          'unavailable',
-        );
-      }
-      currentSenderGroupPreviewSent = true;
-    }
-    request = {
-      action: "ask_current_sender",
-      ...(input.request.audience === undefined
-        ? {}
-        : { audience: input.request.audience }),
-      mode: input.request.mode,
-      origin: {
-        assistantInputId: input.request.messageRef,
-        kind: "accepted_input",
-        sessionId: userActionScope.originSessionId,
-      },
-    };
+    ({ request, currentSenderGroupPreviewSent } = prepared);
   } else if (input.request.action === "ask_member") {
     if (!invocationScope) {
       return toolTextResult(
@@ -5531,87 +5626,18 @@ async function executeGroupTool(
             originAssistantInputId,
           }
         : input.request;
-  } else if (input.request.action === "create_signup_referral_link") {
-    const userActionScope =
-      input.hostedToolContext?.currentUserActionScope?.() ?? null;
-    if (!userActionScope || userActionScope.acceptedInputIds.length === 0) {
-      return toolTextResult(
-        false,
-        "signup referral links require a fresh explicit user request",
-        'authority_rejected',
-      );
+  } else if (
+    input.request.action === "create_signup_referral_link" ||
+    input.request.action === "read_usage_referral"
+  ) {
+    const prepared = await prepareGroupReferralRequest({
+      ...input,
+      request: input.request,
+    });
+    if ("rpcResult" in prepared) {
+      return prepared;
     }
-    if (userActionScope.conversationScope === "direct") {
-      request = { action: "create_signup_referral_link" };
-    } else if (userActionScope.conversationScope === "group") {
-      const messageRef = input.request.messageRef;
-      if (
-        !messageRef ||
-        !userActionScope.acceptedInputIds.includes(messageRef)
-      ) {
-        return toolTextResult(
-          false,
-          "group signup referral links require the exact accepted Message ref from the requesting participant",
-          'authority_rejected',
-        );
-      }
-      const participant = await authorizeDynamicToolParticipant({
-        authorizer: input.authorizeAcceptedMessageTarget,
-        deliveryContextOrdinal: input.deliveryContextOrdinal,
-        messageRef,
-      });
-      if (!participant) {
-        return toolTextResult(
-          false,
-          "group signup referral links require the exact accepted Message ref from the requesting participant",
-          'authority_rejected',
-        );
-      }
-      request = {
-        action: "create_signup_referral_link",
-        participant,
-      };
-    } else {
-      return toolTextResult(
-        false,
-        "signup referral links require a verified direct or group request",
-        'authority_rejected',
-      );
-    }
-  } else if (input.request.action === "read_usage_referral") {
-    const userActionScope =
-      input.hostedToolContext?.currentUserActionScope?.() ?? null;
-    if (userActionScope?.conversationScope !== "group") {
-      request = { action: "read_usage_referral" };
-    } else {
-      const messageRef = input.request.messageRef;
-      if (
-        !messageRef ||
-        !userActionScope.acceptedInputIds.includes(messageRef)
-      ) {
-        return toolTextResult(
-          false,
-          "group usage options require the exact accepted Message ref from the requesting participant",
-          'authority_rejected',
-        );
-      }
-      const participant = await authorizeDynamicToolParticipant({
-        authorizer: input.authorizeAcceptedMessageTarget,
-        deliveryContextOrdinal: input.deliveryContextOrdinal,
-        messageRef,
-      });
-      if (!participant) {
-        return toolTextResult(
-          false,
-          "group usage options require the exact accepted Message ref from the requesting participant",
-          'authority_rejected',
-        );
-      }
-      request = {
-        action: "read_usage_referral",
-        participant,
-      };
-    }
+    request = prepared;
   } else if (input.request.action === "revoke_own_email_share") {
     const userActionScope =
       input.hostedToolContext?.currentUserActionScope?.() ?? null;

--- a/packages/assistant-engine/test/assistant-codex-group-tool.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-group-tool.test.ts
@@ -811,18 +811,21 @@ describe("murph.group dynamic tool", () => {
     expect(readGroupToolPayload(result)).toEqual(response);
   });
 
-  it.each([
-    ["no message ref", undefined],
-    ["a ref outside the accepted input set", EARLIER_ASSISTANT_INPUT_ID],
-  ])("rejects a group signup link with %s", async (_case, messageRef) => {
+  it.each(
+    ["create_signup_referral_link", "read_usage_referral"].flatMap((action) => [
+      { action, label: "no message ref", messageRef: undefined, authorizerCalls: 0 },
+      { action, label: "a ref outside the accepted input set", messageRef: EARLIER_ASSISTANT_INPUT_ID, authorizerCalls: 0 },
+      { action, label: "an accepted ref without participant authority", messageRef: FRESH_ASSISTANT_INPUT_ID, authorizerCalls: 1 },
+    ]),
+  )("rejects $action with $label", async ({ action, messageRef, authorizerCalls }) => {
     const request = readMurphDynamicToolRequest(groupToolCall({
-      action: "create_signup_referral_link",
+      action,
       ...(messageRef ? { message_ref: messageRef } : {}),
     }));
     if (!request || request.kind !== "group") {
       throw new Error("Expected signup referral request.");
     }
-    const authorizeAcceptedMessageTarget = vi.fn();
+    const authorizeAcceptedMessageTarget = vi.fn(async () => null);
     const groupRequest = vi.fn<GroupToolRequest>();
 
     const result = await executeMurphDynamicToolRequest({
@@ -848,7 +851,13 @@ describe("murph.group dynamic tool", () => {
     });
 
     expect(result.rpcResult.success).toBe(false);
-    expect(authorizeAcceptedMessageTarget).not.toHaveBeenCalled();
+    expect(result.rpcResult.contentItems).toEqual([{
+      type: "inputText",
+      text: action === "create_signup_referral_link"
+        ? "group signup referral links require the exact accepted Message ref from the requesting participant"
+        : "group usage options require the exact accepted Message ref from the requesting participant",
+    }]);
+    expect(authorizeAcceptedMessageTarget).toHaveBeenCalledTimes(authorizerCalls);
     expect(groupRequest).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Why and outcome

Group tool execution mixes independent image preparation, current-sender notice coordination, and referral participant authorization into one function with cyclomatic complexity 167. Separate those preparation workflows and consolidate the duplicated referral checks, reducing that function to 111 and file complexity debt from 534 to 484.

The accepted requests, authority checks, generated capture identities, notice ordering, provider calls, usage metadata, and model-visible responses remain the same.

## Product UX

- Effort: Not applicable — internal behavior-preserving refactor.
- Result: Ready — deterministic invariants and focused live private-consultation behavior passed.
- Walkthrough: Existing private contact-card and group-avatar preparation, current-sender private/group asks, and direct/group referral journeys retain their existing permissions and outcomes.

## Evidence

- Direct: `pnpm --dir packages/assistant-engine exec vitest run --config vitest.config.ts --no-coverage --maxWorkers 1 test/assistant-codex-group-tool.test.ts test/assistant-codex-group-current-sender.test.ts test/assistant-dynamic-tool-failure-boundary.test.ts test/assistant-codex-dynamic-tool-runtime.test.ts` — 4 suites, 156 tests passed.
- Typecheck: `MURPH_TSC_PACKAGE_MODE=single-threaded pnpm --dir packages/assistant-engine typecheck` — passed.
- Coverage: Existing tests cover avatar/contact-card preflight and capture outcomes, usage propagation, current-sender notice ordering and shared in-flight replay, authority rejection, and RPC failure handling. Expanded referral regressions cover both actions with missing, foreign, and accepted-but-unauthorized message refs, exact rejection text, and zero host requests.
- Live: `pnpm test:assistant:live -- --test 'delivers one explicit current-sender consultation privately without a group notice' --codex-home <SUBSCRIPTION_HOME>` — passed using `gpt-5.6-terra`, local subscription. Exactly one private current-sender host request, no group progress notice, final action none. Reply review: Ready; quiet group output preserves the requested private destination. The default and two earlier alternate homes failed before provider action; the next permitted alternate succeeded.
- Parent candidate review, exact-head ReviewGPT, and all required CI checks passed on the reviewed head.

## Non-obvious affected surfaces

The terminal RPC catch boundary remains in `executeGroupTool`; preparation errors retain their original outer failure handling. Generated-image usage and current-sender externally-visible-output metadata flow explicitly back to that same boundary.

## Architecture and reuse

- Existing systems reused: Existing group transport, accepted-message authorizer, current-sender decision map, avatar capture/publication helper, tool result and failure projections.
- New logic: None; preserve the existing contracts and consolidate duplicate referral participant resolution.
- New abstractions: Three private preparation functions with typed prepared-request or terminal-result returns; one shared avatar preparation result type.
- Complexity intentionally avoided: No handler registry, new module/API, state owner, retry mechanism, persisted record, or duplicated dispatcher.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff --base 91d301576fd7ca076e65ba09591f0fda4ae91d91 -- packages/assistant-engine/src/assistant-codex/dynamic-tools.ts`; debt 534 → 484 (-50), maximum 189 → 189.
- Hotspots: `executeGroupTool` 167 → 111; new `prepareGroupAvatarToolRequest` 26 retains the cohesive authorization/preflight/capture workflow. Other changed-file hotspots are unchanged: dispatcher 189, request parser 80, physical-note send 65, image generation 57, group parser 44, phone-call creation 41, physical-note resolution 36, group email 26, clinical connect link 23, assistant configuration 23, group failure classification 22, shared workout projection 21.
- Agent judgment: The extracted workflows each own a complete preparation decision. Further dispatcher and other group-action simplification is separate work; splitting this preflight solely to reach 20 would scatter its ordering and failure invariants.

## Hot reply path impact

- Path status: Touched only inside existing dynamic-tool execution after provider tool selection.
- Database calls: None added or moved.
- Network/provider calls: None added or moved; avatar preflight, capture/publication, notice delivery, participant authorization, and final host requests retain their original conditional call counts and serial order.
- Other awaited latency: Typed helper awaits replace inline preparation; no new I/O, timeout, retry, or fallback.
- Before/after proof: The existing avatar and current-sender suites preserve preflight failure short circuiting, notice-before-host ordering, duplicate-notice suppression, and failure metadata. Expanded referral tests assert authorizer call counts and no rejected host requests.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no instructions, tool definitions, schemas, tool availability, generated guidance, history, or provider-request builder changed. No provider-input measurement was run.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Private same-module refactor; no wire contracts, persisted formats, authority policy, deployment configuration, or independently deployed consumer changes.

## Change-shape breakdown

Classification rule: TypeScript implementation is source; the expanded regression is tests; the completed execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 283 | 257 |
| Tests / fixtures | 16 | 7 |
| Docs | 67 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | 366 | **264** |

## Changelog

- Changelog: not applicable
- Reason: Internal complexity reduction with no member-visible behavior change.

ReviewGPT first-reviewed head: a57aa86c320c25c41e9334fe3fdce5ffcc59c44f
ReviewGPT context sensitivity: sensitive
Classification reason: Refactors group-tool authorization, generated media preparation, and current-sender notice coordination.

## ReviewGPT result

- Round 1: PASS on a57aa86c320c25c41e9334fe3fdce5ffcc59c44f.
- Model: GPT-6 Pro, verified by captured response metadata; guarded full snapshot and exact committed turn verified.
- No qualifying findings; no review remediation required. All required CI checks passed on this same head.
