### PR TITLE
refactor(web): simplify Linq webhook event phases

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-complexity-linq-webhook-sep11.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-complexity-linq-webhook-sep11.md
@@ -1,0 +1,53 @@
+# Simplify Linq webhook event dispatch and delivery outcomes
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal
+
+Reduce the complexity of the Linq webhook request owner without changing authenticated ingress, durable planning, delivery outcomes, or request cleanup.
+
+## Success criteria
+
+- Reduce measured handler maximum and file complexity debt.
+- Preserve reaction, provider-event, message-edit, signup and group-recovery responses and side-effect order.
+- Pass focused composed Web tests, Web typecheck, and complexity guard; open a scoped draft PR for parent review.
+
+## Scope
+
+- In scope: private phase helpers in webhook-service.ts and focused proof.
+- Out of scope: provider planner, schemas, prompts, runtime protocols, product policy, merging and deployment.
+
+## Constraints
+
+The existing Web owners retain state and authority. Verification precedes dispatch; provider ingestion precedes reaction handling; route preparation and transaction retry boundaries stay intact. Activation wake and typing cleanup remain request-local and retain their existing failure behavior. No new database/provider calls, concurrency, retry, persistence, or dependency.
+
+## Risks and mitigations
+
+1. Moving branches may alter terminal response precedence or timing. Preserve expressions and ordering, exercise composed service suites, and inspect the complete diff.
+2. New helpers might merely hide complexity. Extract independently understandable event and delivery phases; keep request lifecycle visible and inspect per-function guard output.
+
+## Tasks
+
+1. Trace current source and relevant owner contracts; measure baseline.
+2. Extract event dispatch and delivery result phases with explicit typed inputs/results.
+3. Run focused tests, typecheck and complexity guard; review privacy and complete diff.
+4. Commit through finish-task, push, open draft PR, hand off exact-head evidence to parent.
+
+## Decisions
+
+- Internal behavior-preserving refactor: no member-facing changelog or provider-input measurement needed.
+- Existing composed tests exercise the actual service boundary; no exported helper-only API or new state owner.
+- Parent owns candidate review, Ready admission, final ReviewGPT and exact-head CI.
+
+## Verification
+
+- PASS: `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir apps/web test test/hosted-onboarding-webhook-idempotency.test.ts test/hosted-onboarding-linq-home-route-recovery-service.test.ts test/hosted-onboarding-linq-webhook-auth.test.ts` — 43 tests across three files.
+- PASS: `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir apps/web test:prepared test/hosted-onboarding-linq-dispatch.test.ts test/hosted-onboarding-linq-thread-route.test.ts test/hosted-onboarding-linq-mailbox-root-prewarm.test.ts test/hosted-onboarding-linq-read-receipt-authority.test.ts` — 401 tests across four files.
+- PASS: `pnpm --dir apps/web typecheck`.
+- PASS: `pnpm complexity:diff --base HEAD` against the starting checkout — handler 147 to 93, file debt 151 to 97. All five new private helpers are at or below 20. Existing unrelated hotspots are unchanged.
+- PASS: `git diff --check` and full source/test diff review; no private identifiers or generated files included.
+- Existing Frog entries inspected after frozen install; no new repository friction entry needed.
+- Draft PR publication follows the scoped commit. Parent owns candidate review, Ready, final ReviewGPT and required exact-head CI; these are separate completion gates, not local proof claims.
+Completed: 2026-09-11

--- a/apps/web/src/lib/hosted-onboarding/webhook-service.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-service.ts
@@ -12,6 +12,7 @@ import {
   inspectHostedLinqMessageReceivedParts,
   sendHostedLinqReadReceipt,
   type HostedLinqMessageReceivedPartsInspection,
+  type HostedLinqWebhookEvent,
   verifyAndParseHostedLinqWebhookRequest,
 } from "./linq";
 import {
@@ -76,6 +77,7 @@ import {
 } from "./linq-terminal-retry";
 import {
   parseHostedLinqProviderEvent,
+  type ParsedHostedLinqProviderEvent,
 } from "./linq-provider-events";
 import {
   deriveHostedOnboardingTimingErrorName,
@@ -361,206 +363,69 @@ export async function handleHostedOnboardingLinqWebhook(input: {
       && (event.event_type === "reaction.added" || event.event_type === "reaction.removed")
     ) {
       const prisma = input.prisma ?? getPrisma();
-      const providerResult = await ingestHostedLinqProviderEventDirect({
+      const reaction = await resolveHostedLinqReactionWebhook({
         event: providerEvent,
         prisma,
         scheduleAfterResponse: input.scheduleAfterResponse,
-      });
-      if (providerResult.groupJoinOfferHandled) {
-        const response: HostedOnboardingLinqWebhookResponse = {
-          duplicate: true,
-          ignored: true,
-          ok: true,
-          reason: "duplicate-linq-group-join-offer-reaction",
-        };
-        responseReason = response.reason ?? null;
-        finishHostedOnboardingTiming(timing, "completed", {
-          duplicate: true,
-          eventIdSuffix: toHostedOnboardingLogIdSuffix(eventId),
-          eventType,
-          responseReason,
-        });
-        return response;
-      }
-      const reactionResult = await handleHostedGroupJoinOfferReaction({
-        event: providerEvent,
-        prisma,
         signal: input.signal,
       });
-      // Every terminal outcome for a proven canonical join offer is consumed
-      // here. Falling through would turn a decided reaction into ordinary group
-      // runtime work.
-      if (
-        reactionResult.status === "accepted"
-        || reactionResult.reason === "already_group_member"
-        || reactionResult.reason === "member_suspended"
-        || reactionResult.reason === "recipient_region_unsupported"
-      ) {
-        const response: HostedOnboardingLinqWebhookResponse = {
-          duplicate: providerResult.duplicate || undefined,
-          ignored: reactionResult.status !== "accepted",
-          ok: true,
-          reason: reactionResult.status === "accepted"
-            ? "accepted-linq-group-join-offer-reaction"
-            : reactionResult.reason === "member_suspended"
-              ? "ignored-linq-group-join-offer-member-suspended"
-              : reactionResult.reason === "already_group_member"
-                ? "ignored-linq-group-join-offer-already-member"
-                : "ignored-linq-group-join-offer-region-unsupported",
-        };
-        responseReason = response.reason ?? null;
+      if ("response" in reaction) {
+        responseReason = reaction.response.reason ?? null;
         finishHostedOnboardingTiming(timing, "completed", {
-          duplicate: providerResult.duplicate,
+          duplicate: reaction.duplicate,
           eventIdSuffix: toHostedOnboardingLogIdSuffix(eventId),
           eventType,
           responseReason,
         });
-        return response;
+        return reaction.response;
       }
-
-      const messageEvent = await buildHostedLinqAffirmativeReactionMessageEvent({
-        event: providerEvent,
-        ...(input.signal ? { signal: input.signal } : {}),
-      });
-      if (messageEvent) {
-        event = messageEvent;
-        affirmativeReaction = true;
-        providerEvent = null;
-      } else {
-        const contextStaged = providerResult.duplicate
-          ? false
-          : await stageHostedLinqGroupReactionContext({
-              event: providerEvent,
-              prisma,
-              ...(input.signal ? { signal: input.signal } : {}),
-            });
-        const response: HostedOnboardingLinqWebhookResponse = {
-          duplicate: providerResult.duplicate || undefined,
-          ignored: !contextStaged,
-          ok: true,
-          reason: contextStaged
-            ? "staged-linq-group-reaction-context"
-            : `skipped-linq-group-join-offer-reaction:${reactionResult.reason}`,
-        };
-        responseReason = response.reason ?? null;
-        finishHostedOnboardingTiming(timing, "completed", {
-          duplicate: providerResult.duplicate,
-          eventIdSuffix: toHostedOnboardingLogIdSuffix(eventId),
-          eventType,
-          responseReason,
-        });
-        return response;
-      }
+      event = reaction.messageEvent;
+      affirmativeReaction = true;
+      providerEvent = null;
     }
+
     if (
       providerEvent
       && event.event_type !== "message.received"
       && event.event_type !== "message.edited"
     ) {
       const prisma = input.prisma ?? getPrisma();
-      const providerResult = event.event_type === "participant.added"
-        || event.event_type === "participant.removed"
-        ? await ingestHostedLinqParticipantEventDirect({
-            event: providerEvent,
-            participantChange: requireHostedLinqParticipantChangedEvent(event),
-            prisma,
-          })
-        : await ingestHostedLinqProviderEventDirect({
-            event: providerEvent,
-            prisma,
-            scheduleAfterResponse: input.scheduleAfterResponse,
-          });
-      await scheduleHostedLinqProviderAlertEmails({
-        alertIds: providerResult.alertIds,
+      const result = await handleHostedLinqProviderOnlyWebhook({
+        event,
+        providerEvent,
         prisma,
         scheduleAfterResponse: input.scheduleAfterResponse,
       });
-      await retryHostedLinqTerminalSendForEvent({ event: providerEvent, prisma });
-      const response: HostedOnboardingLinqWebhookResponse = {
-        duplicate: providerResult.duplicate || undefined,
-        ignored: true,
-        ok: true,
-        reason: providerResult.duplicate
-          ? "duplicate-linq-provider-event"
-          : `recorded-linq-provider-event:${providerEvent.eventType}`,
-      };
-      responseReason = response.reason ?? null;
+      responseReason = result.response.reason ?? null;
       finishHostedOnboardingTiming(timing, "completed", {
-        alertCount: providerResult.alertIds.length,
-        duplicate: providerResult.duplicate,
+        ...result.details,
         eventIdSuffix: toHostedOnboardingLogIdSuffix(eventId),
         eventType,
-        ...(providerEvent.eventType === "chat.group_icon_updated"
-          || providerEvent.eventType === "chat.group_icon_update_failed"
-            ? {
-                chatIdSuffix: toHostedOnboardingLogIdSuffix(providerEvent.linqChatId),
-                failureCode: providerEvent.failureCode,
-                providerStatus: providerEvent.providerStatus,
-              }
-            : {}),
         responseReason,
       });
-      return response;
+      return result.response;
     }
 
     input.signal?.throwIfAborted();
     const prisma = input.prisma ?? getPrisma();
     if (event.event_type === "message.edited") {
-      const editedEvent = requireHostedLinqMessageEditedEvent(event);
-      const planTiming = startHostedOnboardingTiming(
-        "hosted-onboarding.webhook.linq.plan-message-edit",
-        {
-          eventIdSuffix: toHostedOnboardingLogIdSuffix(event.event_id),
-          eventType: event.event_type,
-        },
-      );
-      let editPlan: Awaited<ReturnType<typeof planHostedLinqMessageEditedWebhook>>;
-      try {
-        editPlan = await runHostedLinqMessageEditPreparedTransaction({
-          event: editedEvent,
-          prisma,
-        });
-      } catch (error) {
-        finishHostedOnboardingTiming(planTiming, "failed", {
-          errorName: deriveHostedOnboardingTimingErrorName(error),
-        });
-        throw error;
-      }
-      finishHostedOnboardingTiming(
-        planTiming,
-        editPlan.response.reason ?? "completed",
-        {
-          duplicate: Boolean(editPlan.response.duplicate),
-          ok: editPlan.response.ok,
-          wakeUserPresent: Boolean(
-            editPlan.wakeHandoffs?.some((handoff) => handoff.userId),
-          ),
-        },
-      );
-
-      scheduleHostedLinqProviderEventIngestionBestEffort({
-        event: providerEvent,
+      const { editPlan, wakeHandoffResult } = await handleHostedLinqMessageEditWebhook({
+        event,
+        providerEvent,
         prisma,
-        scheduleAfterResponse: input.scheduleAfterResponse,
-      });
-      const wakeHandoff = editPlan.wakeHandoffs?.[0];
-      const wakeHandoffResult = await maybeHandoffHostedExecutionWebhookWake({
         webhookReceivedAt: input.webhookReceivedAt,
-        response: editPlan.response,
         scheduleAfterResponse: input.scheduleAfterResponse,
         signal: input.signal,
-        wakeHandoff,
       });
       responseReason = editPlan.response.reason ?? null;
-      finishHostedOnboardingTiming(timing, "completed", {
-        duplicate: Boolean(editPlan.response.duplicate),
-        eventIdSuffix: toHostedOnboardingLogIdSuffix(eventId),
+      finishHostedLinqWebhookWakeTiming({
+        timing,
+        response: editPlan.response,
+        eventId,
         eventType,
         responseReason,
-        signalAbortedBeforeReturn: input.signal?.aborted ?? false,
-        wakeHandoffReason: wakeHandoffResult?.reason ?? null,
-        wakeHandoffSignalAccepted: wakeHandoffResult?.signalAccepted ?? false,
-        wakeHandoffStarted: wakeHandoffResult?.started ?? false,
+        signal: input.signal,
+        wakeHandoffResult,
       });
       return editPlan.response;
     }
@@ -1042,91 +907,12 @@ export async function handleHostedOnboardingLinqWebhook(input: {
     });
 
     if (plan.desiredSideEffects.length > 0) {
-      const drainResult = await drainHostedLinqSideEffectsDirect({
+      plan = await drainHostedLinqWebhookPlan({
+        plan,
         prisma,
         scheduleAfterResponse: input.scheduleAfterResponse,
-        sideEffects: plan.desiredSideEffects,
         signal: input.signal,
       });
-      const pendingRequiredDelivery = drainResult.skipped.find(
-        (skip) =>
-          (
-            skip.template === "invite_signup"
-            || skip.template === "invite_signup_fallback"
-            || skip.template === HOSTED_LINQ_GROUP_SETUP_TEMPLATE
-            || skip.template === HOSTED_LINQ_GROUP_LINE_RECOVERY_TEMPLATE
-          )
-          && skip.reason === "notice_in_flight",
-      );
-      if (pendingRequiredDelivery) {
-        const groupLineRecoveryInFlight =
-          pendingRequiredDelivery.template
-            === HOSTED_LINQ_GROUP_LINE_RECOVERY_TEMPLATE;
-        const groupSetupInFlight = pendingRequiredDelivery.template
-          === HOSTED_LINQ_GROUP_SETUP_TEMPLATE;
-        throw hostedOnboardingError({
-          code: groupSetupInFlight
-            ? "HOSTED_LINQ_GROUP_SETUP_DELIVERY_IN_FLIGHT"
-            : groupLineRecoveryInFlight
-              ? "HOSTED_LINQ_GROUP_LINE_RECOVERY_IN_FLIGHT"
-              : "HOSTED_LINQ_SIGNUP_DELIVERY_IN_FLIGHT",
-          httpStatus: 503,
-          message: groupSetupInFlight
-            ? "The group setup message is still recovering. Retry this webhook after the current delivery attempt expires."
-            : groupLineRecoveryInFlight
-              ? "The group line recovery message is still recovering. Retry this webhook after the current delivery attempt expires."
-              : "The signup link is still recovering. Retry this webhook after the current delivery attempt expires.",
-          retryable: true,
-        });
-      }
-      const decidedUnsentGroupLineRecovery = drainResult.skipped.find(
-        (skip) =>
-          skip.template === HOSTED_LINQ_GROUP_LINE_RECOVERY_TEMPLATE
-          && (
-            skip.reason === "effect_unresolved"
-            || skip.reason === "notice_target_unauthorized"
-          ),
-      );
-      if (decidedUnsentGroupLineRecovery && drainResult.sentCount === 0) {
-        plan = {
-          ...plan,
-          desiredSideEffects: [],
-          response: {
-            ignored: true,
-            ok: true,
-            reason: "group-chat-line-unavailable",
-          },
-        };
-      }
-      const decidedUnsentSignup = drainResult.skipped.find(
-        (skip) =>
-          (
-            skip.template === "invite_signup"
-            || skip.template === "invite_signup_fallback"
-          )
-          && (
-            skip.reason === "effect_unresolved"
-            || skip.reason === "notice_already_claimed"
-            || skip.reason === "notice_target_unauthorized"
-          ),
-      );
-      if (decidedUnsentSignup && drainResult.sentCount === 0) {
-        plan = {
-          ...plan,
-          desiredSideEffects: [],
-          response: {
-            ...(decidedUnsentSignup.reason === "notice_already_claimed"
-              ? { duplicate: true }
-              : { ignored: true }),
-            ok: true,
-            reason: decidedUnsentSignup.reason === "effect_unresolved"
-              ? "signup-link-attempts-exhausted"
-              : decidedUnsentSignup.reason === "notice_already_claimed"
-                ? "signup-link-already-sent"
-                : "signup-link-target-unavailable",
-          },
-        };
-      }
     }
 
     responseReason = plan.response.reason ?? null;
@@ -1218,15 +1004,14 @@ export async function handleHostedOnboardingLinqWebhook(input: {
       await sendReadReceipt();
     }
 
-    finishHostedOnboardingTiming(timing, "completed", {
-      duplicate: Boolean(plan.response.duplicate),
-      eventIdSuffix: toHostedOnboardingLogIdSuffix(eventId),
+    finishHostedLinqWebhookWakeTiming({
+      timing,
+      response: plan.response,
+      eventId,
       eventType,
       responseReason,
-      signalAbortedBeforeReturn: input.signal?.aborted ?? false,
-      wakeHandoffReason: wakeHandoffResult?.reason ?? null,
-      wakeHandoffSignalAccepted: wakeHandoffResult?.signalAccepted ?? false,
-      wakeHandoffStarted: wakeHandoffResult?.started ?? false,
+      signal: input.signal,
+      wakeHandoffResult,
     });
     return plan.response;
   } catch (error) {
@@ -1263,6 +1048,310 @@ export async function handleHostedOnboardingLinqWebhook(input: {
     });
     throw error;
   }
+}
+
+function finishHostedLinqWebhookWakeTiming(input: {
+  timing: ReturnType<typeof startHostedOnboardingTiming>;
+  response: HostedOnboardingLinqWebhookResponse;
+  eventId: string | null;
+  eventType: string | null;
+  responseReason: string | null;
+  signal?: AbortSignal;
+  wakeHandoffResult: Awaited<ReturnType<typeof maybeHandoffHostedExecutionWebhookWake>>;
+}): void {
+  const { wakeHandoffResult } = input;
+  finishHostedOnboardingTiming(input.timing, "completed", {
+    duplicate: Boolean(input.response.duplicate),
+    eventIdSuffix: toHostedOnboardingLogIdSuffix(input.eventId),
+    eventType: input.eventType,
+    responseReason: input.responseReason,
+    signalAbortedBeforeReturn: input.signal?.aborted ?? false,
+    wakeHandoffReason: wakeHandoffResult?.reason ?? null,
+    wakeHandoffSignalAccepted: wakeHandoffResult?.signalAccepted ?? false,
+    wakeHandoffStarted: wakeHandoffResult?.started ?? false,
+  });
+}
+
+async function resolveHostedLinqReactionWebhook(input: {
+  event: ParsedHostedLinqProviderEvent;
+  prisma: PrismaClient;
+  scheduleAfterResponse?: HostedWebhookPostResponseScheduler;
+  signal?: AbortSignal;
+}): Promise<
+  | { messageEvent: HostedLinqWebhookEvent }
+  | { response: HostedOnboardingLinqWebhookResponse; duplicate: boolean }
+> {
+  const { prisma } = input;
+  const providerResult = await ingestHostedLinqProviderEventDirect({
+    event: input.event,
+    prisma,
+    scheduleAfterResponse: input.scheduleAfterResponse,
+  });
+  if (providerResult.groupJoinOfferHandled) {
+    const response: HostedOnboardingLinqWebhookResponse = {
+      duplicate: true,
+      ignored: true,
+      ok: true,
+      reason: "duplicate-linq-group-join-offer-reaction",
+    };
+    return { response, duplicate: true };
+  }
+  const reactionResult = await handleHostedGroupJoinOfferReaction({
+    event: input.event,
+    prisma,
+    signal: input.signal,
+  });
+  // Every terminal outcome for a proven canonical join offer is consumed
+  // here. Falling through would turn a decided reaction into ordinary group
+  // runtime work.
+  if (
+    reactionResult.status === "accepted"
+    || reactionResult.reason === "already_group_member"
+    || reactionResult.reason === "member_suspended"
+    || reactionResult.reason === "recipient_region_unsupported"
+  ) {
+    const response: HostedOnboardingLinqWebhookResponse = {
+      duplicate: providerResult.duplicate || undefined,
+      ignored: reactionResult.status !== "accepted",
+      ok: true,
+      reason: reactionResult.status === "accepted"
+        ? "accepted-linq-group-join-offer-reaction"
+        : reactionResult.reason === "member_suspended"
+          ? "ignored-linq-group-join-offer-member-suspended"
+          : reactionResult.reason === "already_group_member"
+            ? "ignored-linq-group-join-offer-already-member"
+            : "ignored-linq-group-join-offer-region-unsupported",
+    };
+    return { response, duplicate: providerResult.duplicate };
+  }
+
+  const messageEvent = await buildHostedLinqAffirmativeReactionMessageEvent({
+    event: input.event,
+    ...(input.signal ? { signal: input.signal } : {}),
+  });
+  if (messageEvent) {
+    return { messageEvent };
+  }
+  const contextStaged = providerResult.duplicate
+    ? false
+    : await stageHostedLinqGroupReactionContext({
+        event: input.event,
+        prisma,
+        ...(input.signal ? { signal: input.signal } : {}),
+      });
+  const response: HostedOnboardingLinqWebhookResponse = {
+    duplicate: providerResult.duplicate || undefined,
+    ignored: !contextStaged,
+    ok: true,
+    reason: contextStaged
+      ? "staged-linq-group-reaction-context"
+      : `skipped-linq-group-join-offer-reaction:${reactionResult.reason}`,
+  };
+  return { response, duplicate: providerResult.duplicate };
+}
+
+async function handleHostedLinqProviderOnlyWebhook(input: {
+  event: HostedLinqWebhookEvent;
+  providerEvent: ParsedHostedLinqProviderEvent;
+  prisma: PrismaClient;
+  scheduleAfterResponse?: HostedWebhookPostResponseScheduler;
+}) {
+  const { event, providerEvent, prisma } = input;
+  const providerResult = event.event_type === "participant.added"
+    || event.event_type === "participant.removed"
+    ? await ingestHostedLinqParticipantEventDirect({
+        event: providerEvent,
+        participantChange: requireHostedLinqParticipantChangedEvent(event),
+        prisma,
+      })
+    : await ingestHostedLinqProviderEventDirect({
+        event: providerEvent,
+        prisma,
+        scheduleAfterResponse: input.scheduleAfterResponse,
+      });
+  await scheduleHostedLinqProviderAlertEmails({
+    alertIds: providerResult.alertIds,
+    prisma,
+    scheduleAfterResponse: input.scheduleAfterResponse,
+  });
+  await retryHostedLinqTerminalSendForEvent({ event: providerEvent, prisma });
+  const response: HostedOnboardingLinqWebhookResponse = {
+    duplicate: providerResult.duplicate || undefined,
+    ignored: true,
+    ok: true,
+    reason: providerResult.duplicate
+      ? "duplicate-linq-provider-event"
+      : `recorded-linq-provider-event:${providerEvent.eventType}`,
+  };
+
+  return {
+    response,
+    details: {
+      alertCount: providerResult.alertIds.length,
+      duplicate: providerResult.duplicate,
+      ...(providerEvent.eventType === "chat.group_icon_updated"
+        || providerEvent.eventType === "chat.group_icon_update_failed"
+          ? {
+              chatIdSuffix: toHostedOnboardingLogIdSuffix(providerEvent.linqChatId),
+              failureCode: providerEvent.failureCode,
+              providerStatus: providerEvent.providerStatus,
+            }
+          : {}),
+    },
+  };
+}
+
+async function handleHostedLinqMessageEditWebhook(input: {
+  event: HostedLinqWebhookEvent;
+  providerEvent: ParsedHostedLinqProviderEvent | null;
+  prisma: PrismaClient;
+  webhookReceivedAt?: Date;
+  scheduleAfterResponse?: HostedWebhookPostResponseScheduler;
+  signal?: AbortSignal;
+}) {
+  const { event, providerEvent, prisma } = input;
+  const editedEvent = requireHostedLinqMessageEditedEvent(event);
+  const planTiming = startHostedOnboardingTiming(
+    "hosted-onboarding.webhook.linq.plan-message-edit",
+    {
+      eventIdSuffix: toHostedOnboardingLogIdSuffix(event.event_id),
+      eventType: event.event_type,
+    },
+  );
+  let editPlan: Awaited<ReturnType<typeof planHostedLinqMessageEditedWebhook>>;
+  try {
+    editPlan = await runHostedLinqMessageEditPreparedTransaction({
+      event: editedEvent,
+      prisma,
+    });
+  } catch (error) {
+    finishHostedOnboardingTiming(planTiming, "failed", {
+      errorName: deriveHostedOnboardingTimingErrorName(error),
+    });
+    throw error;
+  }
+  finishHostedOnboardingTiming(
+    planTiming,
+    editPlan.response.reason ?? "completed",
+    {
+      duplicate: Boolean(editPlan.response.duplicate),
+      ok: editPlan.response.ok,
+      wakeUserPresent: Boolean(
+        editPlan.wakeHandoffs?.some((handoff) => handoff.userId),
+      ),
+    },
+  );
+
+  scheduleHostedLinqProviderEventIngestionBestEffort({
+    event: providerEvent,
+    prisma,
+    scheduleAfterResponse: input.scheduleAfterResponse,
+  });
+  const wakeHandoff = editPlan.wakeHandoffs?.[0];
+  const wakeHandoffResult = await maybeHandoffHostedExecutionWebhookWake({
+    webhookReceivedAt: input.webhookReceivedAt,
+    response: editPlan.response,
+    scheduleAfterResponse: input.scheduleAfterResponse,
+    signal: input.signal,
+    wakeHandoff,
+  });
+  return { editPlan, wakeHandoffResult };
+}
+
+async function drainHostedLinqWebhookPlan(input: {
+  plan: Awaited<ReturnType<typeof planHostedOnboardingLinqWebhook>>;
+  prisma: PrismaClient;
+  scheduleAfterResponse?: HostedWebhookPostResponseScheduler;
+  signal?: AbortSignal;
+}): Promise<Awaited<ReturnType<typeof planHostedOnboardingLinqWebhook>>> {
+  const { prisma } = input;
+  let { plan } = input;
+  const drainResult = await drainHostedLinqSideEffectsDirect({
+    prisma,
+    scheduleAfterResponse: input.scheduleAfterResponse,
+    sideEffects: plan.desiredSideEffects,
+    signal: input.signal,
+  });
+  const pendingRequiredDelivery = drainResult.skipped.find(
+    (skip) =>
+      (
+        skip.template === "invite_signup"
+        || skip.template === "invite_signup_fallback"
+        || skip.template === HOSTED_LINQ_GROUP_SETUP_TEMPLATE
+        || skip.template === HOSTED_LINQ_GROUP_LINE_RECOVERY_TEMPLATE
+      )
+      && skip.reason === "notice_in_flight",
+  );
+  if (pendingRequiredDelivery) {
+    const groupLineRecoveryInFlight =
+      pendingRequiredDelivery.template
+        === HOSTED_LINQ_GROUP_LINE_RECOVERY_TEMPLATE;
+    const groupSetupInFlight = pendingRequiredDelivery.template
+      === HOSTED_LINQ_GROUP_SETUP_TEMPLATE;
+    throw hostedOnboardingError({
+      code: groupSetupInFlight
+        ? "HOSTED_LINQ_GROUP_SETUP_DELIVERY_IN_FLIGHT"
+        : groupLineRecoveryInFlight
+          ? "HOSTED_LINQ_GROUP_LINE_RECOVERY_IN_FLIGHT"
+          : "HOSTED_LINQ_SIGNUP_DELIVERY_IN_FLIGHT",
+      httpStatus: 503,
+      message: groupSetupInFlight
+        ? "The group setup message is still recovering. Retry this webhook after the current delivery attempt expires."
+        : groupLineRecoveryInFlight
+          ? "The group line recovery message is still recovering. Retry this webhook after the current delivery attempt expires."
+          : "The signup link is still recovering. Retry this webhook after the current delivery attempt expires.",
+      retryable: true,
+    });
+  }
+  const decidedUnsentGroupLineRecovery = drainResult.skipped.find(
+    (skip) =>
+      skip.template === HOSTED_LINQ_GROUP_LINE_RECOVERY_TEMPLATE
+      && (
+        skip.reason === "effect_unresolved"
+        || skip.reason === "notice_target_unauthorized"
+      ),
+  );
+  if (decidedUnsentGroupLineRecovery && drainResult.sentCount === 0) {
+    plan = {
+      ...plan,
+      desiredSideEffects: [],
+      response: {
+        ignored: true,
+        ok: true,
+        reason: "group-chat-line-unavailable",
+      },
+    };
+  }
+  const decidedUnsentSignup = drainResult.skipped.find(
+    (skip) =>
+      (
+        skip.template === "invite_signup"
+        || skip.template === "invite_signup_fallback"
+      )
+      && (
+        skip.reason === "effect_unresolved"
+        || skip.reason === "notice_already_claimed"
+        || skip.reason === "notice_target_unauthorized"
+      ),
+  );
+  if (decidedUnsentSignup && drainResult.sentCount === 0) {
+    plan = {
+      ...plan,
+      desiredSideEffects: [],
+      response: {
+        ...(decidedUnsentSignup.reason === "notice_already_claimed"
+          ? { duplicate: true }
+          : { ignored: true }),
+        ok: true,
+        reason: decidedUnsentSignup.reason === "effect_unresolved"
+          ? "signup-link-attempts-exhausted"
+          : decidedUnsentSignup.reason === "notice_already_claimed"
+            ? "signup-link-already-sent"
+            : "signup-link-target-unavailable",
+      },
+    };
+  }
+  return plan;
 }
 
 function logHostedLinqMessageReceivedPartsWarning(input: {

--- a/apps/web/test/hosted-onboarding-linq-home-route-recovery-service.test.ts
+++ b/apps/web/test/hosted-onboarding-linq-home-route-recovery-service.test.ts
@@ -246,6 +246,27 @@ describe("Linq group-line recovery inside the canonical webhook owner", () => {
     });
   });
 
+  it("acknowledges exhausted recovery without reporting a send", async () => {
+    mocks.drainHostedLinqSideEffectsDirect.mockResolvedValue({
+      sentCount: 0,
+      skipped: [{
+        effectId: sideEffect.effectId,
+        reason: "effect_unresolved",
+        template: "group_line_recovery",
+      }],
+    });
+
+    await expect(handleHostedOnboardingLinqWebhook({
+      rawBody: "{}",
+      signature: null,
+      timestamp: null,
+    })).resolves.toEqual({
+      ignored: true,
+      ok: true,
+      reason: "group-chat-line-unavailable",
+    });
+  });
+
   it("returns sent when the stale recovery claim is reclaimed and dispatched", async () => {
     await expect(handleHostedOnboardingLinqWebhook({
       rawBody: "{}",


### PR DESCRIPTION
## Why and outcome

The Linq webhook request handler mixes reaction dispatch, provider receipts, message edits, delivery-result handling, and the conversation lifecycle in one function. Separate those event phases into private helpers and reuse the identical wake-completion diagnostics, reducing its cyclomatic complexity from 147 to 93 and file debt from 151 to 97.

Authentication, transaction preparation, admission, activation cleanup, response reasons, delivery suppression, and wake ordering retain their existing owners and behavior.

## Product UX

- Effort: Not applicable — internal behavior-preserving refactor.
- Result: Not applicable.
- Walkthrough: Existing direct-message, reaction, edit, and recovery journeys retain their responses and side effects; no presentation, audience, or permission change.

## Evidence

- Direct: 444 tests passed across seven focused service suites with `MURPH_VITEST_MAX_WORKERS=1`:
  - `pnpm --dir apps/web test test/hosted-onboarding-webhook-idempotency.test.ts test/hosted-onboarding-linq-home-route-recovery-service.test.ts test/hosted-onboarding-linq-webhook-auth.test.ts` — 43 passed.
  - `pnpm --dir apps/web test:prepared test/hosted-onboarding-linq-dispatch.test.ts test/hosted-onboarding-linq-thread-route.test.ts test/hosted-onboarding-linq-mailbox-root-prewarm.test.ts test/hosted-onboarding-linq-read-receipt-authority.test.ts` — 401 passed.
  - `pnpm --dir apps/web typecheck` — passed.
  - `git diff --check` — passed.
- Parent candidate review, exact-head ReviewGPT, and all required CI checks passed on the reviewed head.
- Coverage: Existing composed service tests cover authenticated ingress, reaction dedupe and promotion, prepared message edits, first-contact planning, instant-start cleanup, read receipts and required-delivery recovery. Added exhausted-recovery proof verifies no false sent response.

## Non-obvious affected surfaces

Provider receipt alerts and terminal-send retry still execute after provider ingestion; affirmative reactions still re-enter ordinary planning. Group join confirmations and deferred activation still follow the conversation wake, including existing failure cleanup.

## Architecture and reuse

- Existing systems reused: Canonical Web provider-event ingestion, planner, prepared transactions, delivery transport and wake owners.
- New logic: None; existing branches and side-effect ordering are retained.
- New abstractions: Five private same-file functions for reaction resolution, provider-only events, message edits, delivery-result handling and shared wake diagnostics. No exported API or new state owner.
- Complexity intentionally avoided: No dispatcher framework, persisted state, queue, transaction wrapper, dependency or change to provider planning.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base HEAD` against the starting checkout; file debt 151 → 97, maximum 147 → 93.
- Hotspots: `handleHostedOnboardingLinqWebhook` 93 retains coupled admission/enrollment and request cleanup. Existing `maybeSendHostedLinqIngressReadReceipt` 31, `resolveHostedLinqPlanningEvent` 27, `runHostedThreadRoutingPreparedTransaction` 24 and `prepareHostedDirectTelegramThreadRoutingCrypto` 22 are unchanged. All five new helpers are at or below 20.
- Agent judgment: The extracted phases have distinct event or delivery responsibilities. Keeping request-local activation and typing cleanup together preserves visible error ownership; broader lifecycle redesign is outside this behavior-preserving seam.

## Hot reply path impact

- Path status: Touched — same Linq ingress and wake path, with phase extraction only.
- Database calls: None added or moved; existing counts, transaction boundaries and preparation retries remain unchanged.
- Network/provider calls: None added or moved; current serial ordering, speculative first-turn overlap, timeouts, retries and fallbacks are unchanged.
- Other awaited latency: No new external or background work. Empty delivery plans retain the existing no-await branch; populated plans await the same transport operation through a private helper.
- Before/after proof: Source comparison preserves call order; composed service tests retain duplicate, no-send, no-wake and delivery error assertions. No wall-clock benchmark claim.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no prompt, tool/schema, guidance, mailbox content, history or provider request builder changes.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Private functions in one Web artifact only; no schema, configuration, deployment protocol or externally consumed payload changes. Existing Web/runtime versions retain the same contract.

## Change-shape breakdown

Classification rule: TypeScript service is source, Vitest test is tests, and execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 338 | 249 |
| Tests / fixtures | 21 | 0 |
| Docs | 53 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | 412 | **249** |

## Changelog

- Changelog: not applicable
- Reason: Internal complexity reduction preserves member-visible behavior.

ReviewGPT context sensitivity: sensitive
Classification reason: Refactors hosted messaging ingress, dedupe, external delivery and wake boundaries while preserving their behavior.

ReviewGPT first-reviewed head: 52a941747425caba11d9147cc58404eed557cbfa

## ReviewGPT result

- Round 1: PASS on 52a941747425caba11d9147cc58404eed557cbfa.
- Model: GPT-6 Pro, verified by captured response metadata; guarded full snapshot and exact committed turn verified.
- No qualifying findings; no review remediation required. All required CI checks passed on this same head.
