### PR TITLE
refactor(core): simplify canonical device revision reconciliation

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-complexity-core-device-reconciliation.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-complexity-core-device-reconciliation.md
@@ -1,0 +1,54 @@
+# Simplify canonical device reconciliation
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal
+
+- Reduce the 135-branch device-event reconciliation hotspot while preserving canonical identity, provider revision ordering, member overlays, and atomic batch rejection.
+
+## Success criteria
+
+- Collapse duplicated provider/member revision construction; keep policy separate from ordered in-memory staging.
+- Pass public device-import regression tests, core typecheck, and the complexity guard with reduced debt.
+
+## Scope
+
+- In scope: private helpers in core mutations, focused public mutation regression evidence.
+- Out of scope: provider normalization, storage formats, new persistence owners, behavior changes.
+
+## Constraints
+
+- Technical constraints: existing canonical write lock and staged batch commit remain authoritative; no new I/O or dependencies.
+- Product/process constraints: preserve immutable conflicts, aliases, complete-set retractions, replay counters, historical-member edits, and shard paths.
+
+## Risks and mitigations
+
+1. Reordered policy checks could accept a previously rejected event or lose a member overlay. Preserve call order and prove public import behavior, including unchanged-content provider advancement after a member edit.
+
+## Tasks
+
+1. Read the reconciliation owner and current device ingestion invariants.
+2. Share provider/member revision construction and isolate source-specific revision policy.
+3. Run focused proof, review the complete diff, close this implementation plan, and open a draft PR for parent-owned final review.
+
+## Decisions
+
+- Canonical state remains in the existing event spine. Helpers only derive revision entries or retention decisions; the existing reconciler stages them and owns counters/index changes. No schema, deployment, retry, or public API changes are required.
+
+## Verification
+
+- Commands: focused core device-import, validation, canonical-boundary, and session tests; core typecheck; `pnpm complexity:diff`.
+- Expected outcomes: equivalent public import results and persisted revision ordering, with lower complexity debt. Exact-head CI and ReviewGPT remain parent-owned gates.
+
+## Implementation evidence
+
+- Core device-import, batch validation, canonical mutation boundary, and import-session tests: 212 passed.
+- Importer Junction tests matching sparse intervals, profiles, authoritative sets, and member deletions: 30 passed, 223 unrelated tests skipped.
+- Core typecheck and diff whitespace checks passed.
+- Complexity guard passed: reconciler 135 to 100; file debt 326 to 291. All three new private helpers are below the threshold of 20.
+- Extended the public mutation regression through a version-only update after two content updates: provider/member revisions remain ordered, exactly two canonical events survive, and an exact replay leaves the complete vault snapshot unchanged.
+- The source diff preserves provider-policy order and error codes, shares revision construction and successful staging bookkeeping, and leaves canonical locking, aliases, authoritative retraction, and writes with their existing owners. No member-visible behavior, prompt, or schema changed.
+- Implementation is complete; parent owns draft candidate review, Ready transition, exact-head CI, and final ReviewGPT.
+Completed: 2026-09-11

--- a/packages/core/src/mutations.ts
+++ b/packages/core/src/mutations.ts
@@ -4695,6 +4695,128 @@ function mapCurrentDeviceEventOwners(
   };
 }
 
+// A provider update and the member overlay above it are one ordered revision
+// pair, regardless of whether the provider changed content or only its version.
+function buildDeviceProviderRevisionEntries(input: {
+  entry: PreparedDeviceEventEntry;
+  externalRef: ExternalRef;
+  latest: EventRecord;
+  maxRevision: number;
+  memberMatch?: IndexedEventExternalRefMatch;
+  migratesIdentity: boolean;
+  migratesTimestamp: boolean;
+  indexedProviderRecord?: EventRecord;
+}): {
+  providerEntry: PreparedJsonlEntry<EventRecord>;
+  memberEntry?: PreparedJsonlEntry<EventRecord>;
+} {
+  const { entry, externalRef, latest, memberMatch } = input;
+  const revision = Math.max(eventSpineRevision(latest), input.maxRevision) + 1;
+  const providerEntry = {
+    relativePath: entry.relativePath,
+    record: {
+      ...entry.record,
+      id: latest.id,
+      lifecycle: buildEventSpineLifecycle(revision),
+    },
+  };
+  if (!memberMatch) {
+    return { providerEntry };
+  }
+  const migratesMemberOccurrence = input.migratesTimestamp
+    && input.indexedProviderRecord !== undefined
+    && latest.occurredAt === input.indexedProviderRecord.occurredAt
+    && latest.dayKey === input.indexedProviderRecord.dayKey;
+  const memberEntry = {
+    relativePath: migratesMemberOccurrence
+      ? entry.relativePath
+      : memberMatch.relativePath || toEventLedgerFile(latest.occurredAt),
+    record: {
+      ...latest,
+      ...(migratesMemberOccurrence
+        ? { occurredAt: entry.record.occurredAt, dayKey: entry.record.dayKey }
+        : {}),
+      ...(input.migratesTimestamp || input.migratesIdentity
+        ? { externalRef, dataOrigin: entry.record.dataOrigin }
+        : {}),
+      lifecycle: buildEventSpineLifecycle(revision + 1),
+    },
+  };
+  return { providerEntry, memberEntry };
+}
+
+function shouldRetainJunctionSparseRevision(
+  indexedExternalRef: ExternalRef,
+  externalRef: ExternalRef,
+): boolean {
+  if (
+    !isJunctionSparseIntervalExternalRef(indexedExternalRef)
+    || !isJunctionSparseIntervalExternalRef(externalRef)
+    || (indexedExternalRef.version === undefined && externalRef.version === undefined)
+  ) {
+    return false;
+  }
+  const comparison = compareIncomingExternalRefVersion(indexedExternalRef, externalRef);
+  if (comparison === null) {
+    const incomingVersion = externalRef.version;
+    const existingVersion = indexedExternalRef.version;
+    const replacesUnorderedBaseline = incomingVersion !== undefined
+      && isWritableIsoDateTime(incomingVersion)
+      && (existingVersion === undefined || !isWritableIsoDateTime(existingVersion));
+    if (!replacesUnorderedBaseline) {
+      throw new VaultError(
+        "EVENT_SOURCE_REVISION_UNORDERED",
+        "Changed Junction sparse intervals require comparable explicit provider revisions; nothing was imported.",
+      );
+    }
+  }
+  if (comparison === 0) {
+    throw new VaultError(
+      "EVENT_SOURCE_REVISION_CONFLICT",
+      "Junction sparse interval content conflicts at the same provider revision; nothing was imported.",
+    );
+  }
+  return comparison !== null && comparison < 0;
+}
+
+function shouldRetainWhoopProviderRevision(input: {
+  index: EventExternalRefIndex;
+  refKey: string;
+  latest: EventRecord;
+  incoming: EventRecord;
+  externalRef: ExternalRef;
+  indexedExternalRef: ExternalRef;
+  matchedEntries: ResolvedDeviceEventIdentity["matchedEntries"];
+}): boolean {
+  const { index, refKey, latest, incoming, externalRef, indexedExternalRef, matchedEntries } = input;
+  if (indexedExternalRef.system !== "whoop" || externalRef.system !== "whoop") {
+    return false;
+  }
+  const comparison = compareIncomingExternalRefVersion(indexedExternalRef, externalRef);
+  if (comparison !== null && comparison < 0) {
+    return true;
+  }
+  if (comparison !== 0) {
+    return false;
+  }
+  const baselineRevision = whoopSleepTypeProviderBaselineRevision(index, refKey, latest.id, incoming);
+  if (baselineRevision === null) {
+    throw new VaultError(
+      "EVENT_SOURCE_REVISION_CONFLICT",
+      `Event externalRef "${externalRef.system}/${externalRef.resourceType}/${externalRef.resourceId}` +
+        `${externalRef.facet ? `#${externalRef.facet}` : ""}" has conflicting content for source revision ` +
+        `"${externalRef.version}"; nothing was imported.`,
+    );
+  }
+  // sleepType normalization cannot resurrect deletions or replace a newer
+  // canonical/member revision. Unrelated snapshot resources may still commit.
+  return isDeletedEventSpineRecord(latest)
+    || eventSpineRevision(latest) !== baselineRevision
+    || matchedEntries.some((match) =>
+      hasHistoricalExternalRefUserAuthoredChanges(match.indexedMatch)
+    );
+}
+
 // Device-sync ingestion invariant 4: merge is idempotent on the record's own
 // externalRef, so overlapping push/pull re-imports of the same provider record
 // must not mint new events. Re-imports with identical content (ignoring
@@ -4732,6 +4854,7 @@ async function reconcileDeviceEventEntriesByExternalRef(
   // Keep the provider baseline and optional member overlay together in both
   // the in-memory index and the ordered append list.
   const stageProviderRevision = (input: {
+    entryIndex?: number;
     refKey: string;
     externalRef: ExternalRef;
     providerEntry: PreparedJsonlEntry<EventRecord>;
@@ -4764,6 +4887,14 @@ async function reconcileDeviceEventEntriesByExternalRef(
     appendEntries.push(providerEntry);
     if (memberEntry) {
       appendEntries.push(memberEntry);
+    }
+    if (input.entryIndex !== undefined) {
+      appendRecordIdByPreparedRecordId.set(
+        entries[input.entryIndex]!.record.id,
+        providerEntry.record.id,
+      );
+      recordsByEntryIndex.set(input.entryIndex, current);
+      supersededCount += 1;
     }
   };
 
@@ -4989,43 +5120,30 @@ async function reconcileDeviceEventEntriesByExternalRef(
       continue;
     }
 
+    const historicalUserEditMatch = matchedEntries.find((match) =>
+      hasHistoricalExternalRefUserAuthoredChanges(match.indexedMatch)
+    );
     if (matchesIndexedProviderContent && !reassertsUnversionedSetMember) {
-      const historicalUserEditMatch = matchedEntries.find((match) =>
-        hasHistoricalExternalRefUserAuthoredChanges(match.indexedMatch)
-      );
       if (
         historicalUserEditMatch
         && indexedSourceVersionComparison !== null
         && indexedSourceVersionComparison > 0
       ) {
-        const providerRevision = Math.max(
-          eventSpineRevision(latest),
-          index.maxRevisionById.get(latest.id) ?? 0,
-        ) + 1;
-        const providerBaseline: EventRecord = {
-          ...entry.record,
-          id: latest.id,
-          lifecycle: buildEventSpineLifecycle(providerRevision),
-        };
-        const retainedMemberRevision: EventRecord = {
-          ...latest,
-          ...(migratesJunctionNoIdProfileIdentity
-            ? { externalRef, dataOrigin: entry.record.dataOrigin }
-            : {}),
-          lifecycle: buildEventSpineLifecycle(providerRevision + 1),
-        };
-        const retainedMemberPath = historicalUserEditMatch.indexedMatch.relativePath
-          || toEventLedgerFile(latest.occurredAt);
         stageProviderRevision({
+          entryIndex,
           refKey,
           externalRef,
-          providerEntry: { relativePath: entry.relativePath, record: providerBaseline },
-          memberEntry: { relativePath: retainedMemberPath, record: retainedMemberRevision },
+          ...buildDeviceProviderRevisionEntries({
+            entry,
+            externalRef,
+            latest,
+            maxRevision: index.maxRevisionById.get(latest.id) ?? 0,
+            memberMatch: historicalUserEditMatch.indexedMatch,
+            migratesIdentity: migratesJunctionNoIdProfileIdentity,
+            migratesTimestamp: false,
+          }),
           matchedEntries,
         });
-        appendRecordIdByPreparedRecordId.set(entry.record.id, providerBaseline.id);
-        recordsByEntryIndex.set(entryIndex, retainedMemberRevision);
-        supersededCount += 1;
         continue;
       }
       if (indexedSourceVersionComparison === null || indexedSourceVersionComparison === 0) {
@@ -5044,91 +5162,22 @@ async function reconcileDeviceEventEntriesByExternalRef(
 
     if (
       indexedProviderMatch
-      && isJunctionSparseIntervalExternalRef(indexedProviderMatch.indexedExternalRef)
-      && isJunctionSparseIntervalExternalRef(externalRef)
       && (
-        indexedProviderMatch.indexedExternalRef.version !== undefined
-        || externalRef.version !== undefined
+        shouldRetainJunctionSparseRevision(indexedProviderMatch.indexedExternalRef, externalRef)
+        || shouldRetainWhoopProviderRevision({
+          index,
+          refKey,
+          latest,
+          incoming: entry.record,
+          externalRef,
+          indexedExternalRef: indexedProviderMatch.indexedExternalRef,
+          matchedEntries,
+        })
       )
     ) {
-      const sourceVersionComparison = compareIncomingExternalRefVersion(
-        indexedProviderMatch.indexedExternalRef,
-        externalRef,
-      );
-      if (sourceVersionComparison === null) {
-        const incomingVersion = externalRef.version;
-        const existingVersion = indexedProviderMatch.indexedExternalRef.version;
-        const replacesUnorderedBaseline = incomingVersion !== undefined
-          && isWritableIsoDateTime(incomingVersion)
-          && (existingVersion === undefined || !isWritableIsoDateTime(existingVersion));
-        if (!replacesUnorderedBaseline) {
-          throw new VaultError(
-            "EVENT_SOURCE_REVISION_UNORDERED",
-            "Changed Junction sparse intervals require comparable explicit provider revisions; nothing was imported.",
-          );
-        }
-      }
-      if (sourceVersionComparison !== null && sourceVersionComparison < 0) {
-        skippedDuplicateCount += 1;
-        retainRecord(entryIndex, latest, eventSpineRevisionsAreComplete(index, latest.id));
-        continue;
-      }
-      if (sourceVersionComparison === 0) {
-        throw new VaultError(
-          "EVENT_SOURCE_REVISION_CONFLICT",
-          "Junction sparse interval content conflicts at the same provider revision; nothing was imported.",
-        );
-      }
-    }
-
-    if (
-      indexedProviderMatch
-      && indexedProviderMatch.indexedExternalRef.system === "whoop"
-      && externalRef.system === "whoop"
-    ) {
-      const sourceVersionComparison = compareIncomingExternalRefVersion(
-        indexedProviderMatch.indexedExternalRef,
-        externalRef,
-      );
-      if (sourceVersionComparison !== null && sourceVersionComparison < 0) {
-        skippedDuplicateCount += 1;
-        retainRecord(entryIndex, latest, eventSpineRevisionsAreComplete(index, latest.id));
-        continue;
-      }
-      const sleepTypeBaselineRevision = sourceVersionComparison === 0
-        ? whoopSleepTypeProviderBaselineRevision(index, refKey, latest.id, entry.record)
-        : null;
-      const hasSleepTypeProviderBaseline = sleepTypeBaselineRevision !== null;
-      if (
-        sourceVersionComparison === 0
-        && !hasSleepTypeProviderBaseline
-      ) {
-        throw new VaultError(
-          "EVENT_SOURCE_REVISION_CONFLICT",
-          `Event externalRef "${externalRef.system}/${externalRef.resourceType}/${externalRef.resourceId}` +
-            `${externalRef.facet ? `#${externalRef.facet}` : ""}" has conflicting content for source revision ` +
-            `"${externalRef.version}"; nothing was imported.`,
-        );
-      }
-      if (
-        hasSleepTypeProviderBaseline
-        && (
-          isDeletedEventSpineRecord(latest)
-          || eventSpineRevision(latest)
-            !== sleepTypeBaselineRevision
-          || matchedEntries.some((match) =>
-            hasHistoricalExternalRefUserAuthoredChanges(match.indexedMatch)
-          )
-        )
-      ) {
-        // sleepType is provider normalization metadata. Never resurrect a
-        // deleted event or replace a newer canonical revision merely to
-        // backfill it; preserving this row also lets unrelated snapshot
-        // resources commit.
-        skippedDuplicateCount += 1;
-        retainRecord(entryIndex, latest, eventSpineRevisionsAreComplete(index, latest.id));
-        continue;
-      }
+      skippedDuplicateCount += 1;
+      retainRecord(entryIndex, latest, eventSpineRevisionsAreComplete(index, latest.id));
+      continue;
     }
 
     // Companion HealthKit sync versions are nonnegative monotonic integers.
@@ -5176,57 +5225,22 @@ async function reconcileDeviceEventEntriesByExternalRef(
       continue;
     }
 
-    const historicalUserEditMatch = matchedEntries.find((match) =>
-      hasHistoricalExternalRefUserAuthoredChanges(match.indexedMatch)
-    );
-
-    const revision = Math.max(
-      eventSpineRevision(latest),
-      index.maxRevisionById.get(latest.id) ?? 0,
-    ) + 1;
-    const superseding: EventRecord = {
-      ...entry.record,
-      id: latest.id,
-      lifecycle: buildEventSpineLifecycle(revision),
-    };
-    const migratesRetainedMemberOccurrence = migratesJunctionStableProfileTimestamp
-      && indexedProviderMatch !== undefined
-      && latest.occurredAt === indexedProviderMatch.indexedRecord.occurredAt
-      && latest.dayKey === indexedProviderMatch.indexedRecord.dayKey;
-    const retainedMemberRevision = historicalUserEditMatch
-      ? {
-          ...latest,
-          ...(migratesJunctionStableProfileTimestamp
-            ? {
-                ...(migratesRetainedMemberOccurrence
-                  ? { occurredAt: entry.record.occurredAt, dayKey: entry.record.dayKey }
-                  : {}),
-                externalRef,
-                dataOrigin: entry.record.dataOrigin,
-              }
-            : migratesJunctionNoIdProfileIdentity
-              ? { externalRef, dataOrigin: entry.record.dataOrigin }
-              : {}),
-          lifecycle: buildEventSpineLifecycle(revision + 1),
-        }
-      : null;
-    const retainedMemberPath = migratesRetainedMemberOccurrence
-      ? entry.relativePath
-      : historicalUserEditMatch?.indexedMatch.relativePath
-        || toEventLedgerFile(latest.occurredAt);
-
     stageProviderRevision({
+      entryIndex,
       refKey,
       externalRef,
-      providerEntry: { relativePath: entry.relativePath, record: superseding },
-      memberEntry: retainedMemberRevision
-        ? { relativePath: retainedMemberPath, record: retainedMemberRevision }
-        : undefined,
+      ...buildDeviceProviderRevisionEntries({
+        entry,
+        externalRef,
+        latest,
+        maxRevision: index.maxRevisionById.get(latest.id) ?? 0,
+        memberMatch: historicalUserEditMatch?.indexedMatch,
+        migratesIdentity: migratesJunctionNoIdProfileIdentity,
+        migratesTimestamp: migratesJunctionStableProfileTimestamp,
+        indexedProviderRecord: indexedProviderMatch?.indexedRecord,
+      }),
       matchedEntries,
     });
-    appendRecordIdByPreparedRecordId.set(entry.record.id, superseding.id);
-    recordsByEntryIndex.set(entryIndex, retainedMemberRevision ?? superseding);
-    supersededCount += 1;
   }
 
   for (const set of authoritativeEventSets) {

--- a/packages/core/test/device-import.test.ts
+++ b/packages/core/test/device-import.test.ts
@@ -8493,6 +8493,32 @@ test("importDeviceBatch retains member edits while advancing provider siblings a
     && event.externalRef?.version === "2026-06-12T09:00:00.000Z"
     && eventObservationValue(event) === 3
   ));
+
+  // Advancing only the provider version must use the same revision ordering
+  // without replacing the member's correction or inventing another event.
+  const unchangedContent = buildInput({
+    editedValue: 3,
+    importedAt: "2026-06-13T10:00:00.000Z",
+    siblingValue: 12,
+    version: "2026-06-13T09:00:00.000Z",
+  });
+  assert.equal((await importDeviceBatch(unchangedContent)).applied, true);
+  const advancedRows = (await readJsonlRecords({ vaultRoot, relativePath: shardPath })) as EventRecord[];
+  assert.deepEqual(
+    advancedRows.filter((event) => event.id === edited.id).slice(-2).map((event) => ({
+      source: event.source,
+      revision: event.lifecycle?.revision,
+      value: eventObservationValue(event),
+    })),
+    [
+      { source: "device", revision: 7, value: 3 },
+      { source: "manual", revision: 8, value: 7 },
+    ],
+  );
+  assert.equal(collapseEventSpines(advancedRows).length, 2);
+  const beforeReplay = await snapshotVaultFiles(vaultRoot);
+  assert.equal((await importDeviceBatch(unchangedContent)).applied, false);
+  assert.deepEqual(await snapshotVaultFiles(vaultRoot), beforeReplay);
 });
 
 test("importDeviceBatch scopes no-id Junction profile predecessor claims to one source instance", async () => {


### PR DESCRIPTION
## Why and outcome

Canonical device reconciliation duplicated provider/member revision construction and mixed source-specific revision policy with staging. Share the ordered revision-pair construction and isolate Junction sparse and WHOOP retention/conflict decisions, reducing the reconciler's cyclomatic complexity from 135 to 100 and file debt from 326 to 291.

Provider updates still preserve member corrections, source ordering, replay identity, tombstones, and atomic rejection. The existing canonical lock and staging owner remain responsible for every write.

## Product UX

- Effort: Not applicable — internal behavior-preserving refactor.
- Result: Not applicable — no presentation or product contract changes.
- Walkthrough: Public import regressions cover changed and unchanged provider updates, member overlays, immutable conflicts, sparse revisions, profile migrations, tombstones, aliases, and exact replay.

## Evidence

- Direct: `pnpm --dir packages/core exec vitest run --config vitest.config.ts --no-coverage test/device-import.test.ts test/import-device-batch-validation.test.ts test/canonical-mutations-boundary.test.ts test/device-import-session.test.ts --maxWorkers=2` — 212 passed.
- Direct: `pnpm --dir packages/importers exec vitest run --config vitest.config.ts --no-coverage test/device-providers-junction.test.ts -t 'sparse|profile|authoritative|member deletions' --maxWorkers=1` — 30 passed; 223 unrelated cases skipped.
- Direct: `pnpm --filter @murphai/core typecheck` and `git diff --check` passed.
- Coverage: Extended the public mutation regression through a version-only provider update after member correction. It verifies ordered provider/member revisions 7/8, two surviving canonical events, and byte-for-byte unchanged vault contents on exact replay. Existing provider-shaped tests exercise migrations, conflicting source revisions, and deletion protection through the real import boundary.
- Parent candidate review, exact-head ReviewGPT, and all required CI checks passed on the reviewed head.

## Non-obvious affected surfaces

Junction profile timestamp migrations and WHOOP sleep-type backfills share this canonical writer. Focused importer migration/deletion cases and core WHOOP enrichment/conflict tests passed. Authoritative-set retractions still use the existing staging primitive without entering supersession bookkeeping.

## Architecture and reuse

- Existing systems reused: Canonical write lock, event-spine revision index, existing provider comparators, member-edit detection, and provider revision staging.
- New logic: None; source-specific retention decisions preserve their previous ordering and error codes.
- New abstractions: Three private pure helpers derive the provider/member revision pair and the Junction sparse/WHOOP retention decisions. Successful supersession accounting now belongs to the existing staging helper.
- Complexity intentionally avoided: No new persistence owner, state machine, policy registry, package dependency, public API, or I/O. Duplicate revision construction and retention bookkeeping were removed.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base HEAD^ --head HEAD`; file debt 326 → 291, maximum 135 → 100.
- Hotspots: Changed `reconcileDeviceEventEntriesByExternalRef` remains 100; all three new helpers are below 20. Unchanged hotspots are `preparePersistence` 57, `reconcileEventImportDecisionsByExternalRef` 51, `importDeviceBatchWithExecutionOptions` 47, `parseJunctionDailyAggregateAliasEvidence` 44, `resolveJunctionFloatingFallbackTime` 41, `visit` 34, `resolveStructuralJunctionDailyAggregateAliasOwnerSplit` 32, `isExactJunctionProfileCreatedAtTimestampReplay` 31, `analyzeJunctionDailyAggregateAliasHistoryEvolution` 31, an anonymous callback 27, `mapCurrentDeviceEventOwners` 27, `buildLegacyExternalRefReservations` 24, `dedupeDeviceEventsByExternalRef` 23, and `importEventBatch` 22. Those independent owners are outside this revision-policy seam.
- Agent judgment: The reduction removes duplicated construction and exposes provider policy without moving canonical authority. Further broad extraction would mix independent alias repair and complete-set membership contracts into this bounded change; those remain explicit in the owner.

## Hot reply path impact

- Path status: Not applicable — device ingestion revision planning does not alter conversation admission or reply execution.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved; the helpers are synchronous derivations.
- Before/after proof: Diff preserves the canonical write-lock boundary and existing staged persistence sequence; public import/session tests passed.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no prompt assembly, tool schema, generated guidance, or provider request input surface changed. No input measurement was needed.

ReviewGPT first-reviewed head: b18687d9006e0e0d774a178d7bdcb8431894eca5
ReviewGPT context sensitivity: sensitive
Classification reason: Canonical health-event reconciliation and idempotency refactor.

## Deployment concerns

- Deployment: not applicable
- Reason: Private synchronous refactor preserves public APIs, persisted schemas, event ordering, and provider errors. No coordinated deployment, migration, or new rollback floor is introduced.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source, the public import regression is tests, and the completed execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 168 | 154 |
| Tests / fixtures | 26 | 0 |
| Docs | 54 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **248** | **154** |

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving reconciliation refactor; no member-visible feature or behavior changes.

## ReviewGPT result

- Round 1: PASS on b18687d9006e0e0d774a178d7bdcb8431894eca5.
- Model: GPT-6 Pro, verified by captured response metadata; guarded full snapshot and exact committed turn verified.
- No qualifying findings; no review remediation required. All required CI checks passed on this same head.
