### PR TITLE
Refactor Junction resource job execution into explicit phases

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-complexity-junction-jobs.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-complexity-junction-jobs.md
@@ -1,0 +1,55 @@
+# Simplify Junction resource job execution
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal
+
+Reduce the branching burden in Junction resource execution while preserving its current import, source-authority, retry, and continuation behavior.
+
+## Success criteria
+
+- The resource dispatcher exposes distinct companion, calendar, temporal, direct-inline, and timeseries phases.
+- Existing provider-shaped regressions and device-syncd typecheck pass.
+- The cyclomatic guard passes with lower changed-file debt and maximum complexity.
+
+## Scope
+
+- In scope: private resource-job helpers inside the existing Junction provider factory.
+- Out of scope: full-job scheduling, hydration, new policy, new persistence, and concurrent temporal-efficiency work.
+
+## Constraints
+
+Keep dispatch and external-effect ordering, live source/epoch admission, credential-free inline payload authority, canonical receipt checks, retry ladders, and continuation payloads unchanged. Reuse the current inventory loader, importer, and follow-up owners. Add no dependency or new state owner.
+
+## Risks and mitigations
+
+Extraction can accidentally change early returns or a mutable skip list. Pass the existing per-job values directly, preserve return wrappers, inspect a whitespace-insensitive diff, and run the existing resource/history/backfill/workout/admission suites. Review concurrent temporal work for merge overlap without modifying its branch.
+
+## Tasks
+
+1. Extract coherent resource execution phases within the current provider factory.
+2. Run focused provider regressions, package typecheck, and complexity guard.
+3. Inspect the final diff and close this implementation plan in the scoped commit.
+4. Open a draft PR and hand off candidate review, CI admission, and ReviewGPT to the parent.
+
+## Decisions
+
+- The measured starting resource function complexity is 143; full-job execution is 106 and remains outside this refactor.
+- Helper boundaries follow distinct payload and receipt authority; no generic dispatcher framework or cross-module dependency bag is needed.
+- Internal refactor only: product behavior, public contracts, and changelog are unchanged.
+
+## Verification
+
+- `pnpm --filter @murphai/device-syncd test -- test/junction-provider-resources.test.ts test/junction-provider-history.test.ts test/junction-provider-history-recovery.test.ts test/junction-provider-backfill.test.ts test/junction-provider-workout-stream.test.ts test/junction-provider-webhooks.test.ts test/junction-admission-source-reads.test.ts test/junction-blood-pressure-backfill.test.ts test/junction-provider-identity.test.ts test/junction-timeseries-source-reuse.test.ts` passed: 63 files, 1,424 tests. The forwarded separator caused package-wide selection, which also covered strict calendar diagnostics.
+- `pnpm --filter @murphai/device-syncd typecheck` passed.
+- `pnpm complexity:diff -- --base-ref HEAD -- packages/device-syncd/src/providers/junction.ts` passed: resource dispatcher 143 to 21, timeseries collection/completion 56/39, file debt 405 to 338, maximum 143 to 106. The unchanged full-job executor is now the maximum.
+- `git diff --check` passed. Whitespace-insensitive diff inspection confirms preserved phase bodies, source admission, effect order, and return wrappers; the three no-collection receipts now share one constructor.
+- No new test, dependency, state owner, or product contract was needed. Existing provider-shaped suites cover the extraction boundaries.
+- Parent owns candidate review, Ready admission, required CI, and requested ReviewGPT after draft creation. These remain external completion gates.
+
+## Implementation handoff
+
+Implementation and local proof are complete. Concurrent PR #3311 changes the dense-fidelity return block moved into `executeTimeseriesResourceJob`; a later base reconciliation must preserve its temporal-refresh wrapper. Full-job temporal scheduling stays untouched here. This plan closes implementation only; it does not claim final review or CI completion.
+Completed: 2026-09-11

--- a/packages/device-syncd/src/providers/junction.ts
+++ b/packages/device-syncd/src/providers/junction.ts
@@ -2565,58 +2565,12 @@ export function createJunctionDeviceSyncProvider(
     const resourceName = normalizeString(job.payload.resource);
 
     if (resourceName === COMPANION_HRV_RMSSD_RESOURCE) {
-      let observation;
-      let admissionId;
-      try {
-        observation = parseSerializedCompanionHrvRmssdObservation(
-          job.payload.companionObservationJson,
-        );
-        admissionId = parseCompanionHrvRmssdAdmissionId(
-          job.payload.companionAdmissionId,
-        );
-        const expectedAdmissionId = createHash("sha256")
-          .update(serializeCompanionHrvRmssdObservation(observation))
-          .digest("hex");
-        if (admissionId !== expectedAdmissionId) {
-          throw new TypeError("Companion HRV admission identity did not match its observation.");
-        }
-      } catch {
-        throw deviceSyncError({
-          code: JUNCTION_COMPANION_HRV_OBSERVATION_INVALID_CODE,
-          message: "Companion HRV observation payload was invalid.",
-          retryable: false,
-        });
-      }
-
-      if (!await isJunctionCompanionSourceCurrentlyAdmitted(
-        context,
-        JUNCTION_COMPANION_HRV_SOURCE_PROVIDER,
-      )) {
-        return {};
-      }
-      await context.importSnapshot({
-        provider: "junction",
-        accountId: buildJunctionImportAccountId(context.account.externalAccountId),
-        connectionId: context.account.id,
-        importedAt: context.now,
-        companionHrvRmssd: { admissionId, observation },
-      });
-      return {};
+      return executeCompanionHrvResourceJob(context, job);
     }
 
     const window = resolveJobWindow(job, context.now, reconcileDays);
-    if (normalizeString(job.payload.resource) === JUNCTION_COMPANION_HEALTH_METADATA_RESOURCE) {
-      const records = parseJunctionCompanionHealthMetadataJob(job);
-      if (!await isJunctionCompanionSourceCurrentlyAdmitted(
-        context,
-        JUNCTION_COMPANION_HEALTH_METADATA_SOURCE_PROVIDER,
-      )) {
-        return {};
-      }
-      await importJunctionCompanionHealthMetadataSnapshot(context, records);
-      return {
-        nextReconcileAt: clampWebhookJobNextReconcileAt(context),
-      };
+    if (resourceName === JUNCTION_COMPANION_HEALTH_METADATA_RESOURCE) {
+      return executeCompanionHealthMetadataResourceJob(context, job);
     }
 
     const calendarRefreshDay = readJunctionSparseCalendarRefreshDay(job);
@@ -2641,97 +2595,17 @@ export function createJunctionDeviceSyncProvider(
     ) {
       return {};
     }
-    const { loadSourceProviders, loadAndProjectSourceProviders } =
-      createJobInventoryLoader(context, job, passInventories);
+    const inventory = createJobInventoryLoader(context, job, passInventories);
 
     if (calendarRefreshDay) {
-      if (
-        !resource
-        || !JUNCTION_SPARSE_CALENDAR_AGGREGATE_RESOURCE_SET.has(resource)
-        || !isConfiguredJunctionResource("timeseries", resource)
-      ) {
-        throw deviceSyncError({
-          code: JUNCTION_CALENDAR_REFRESH_JOB_INVALID_CODE,
-          message: "Junction calendar refresh job did not name an admitted sparse resource.",
-          retryable: false,
-        });
-      }
-      const queuedCalendarSourceIdentity = readJunctionSparseCalendarSourceIdentity(job);
-      const currentSources = context.listConnectionSources
-        ? await context.listConnectionSources()
-        : context.account.sources ?? [];
-      const accountSourceIdentity = resolveJunctionAccountSourceIdentity(
-        currentSources,
-        queuedCalendarSourceIdentity.sourceProviderSlug,
-        context.connectionSourceAdmissionMode !== "listed_only",
-      );
-      if (
-        !accountSourceIdentity
-        || !isJunctionSourceAdmittedForImport(
-          currentSources,
-          sourceProviderSlug,
-          context.connectionSourceAdmissionMode !== "listed_only",
-          "connected",
-        )
-      ) {
-        throw deviceSyncError({
-          code: "JUNCTION_CALENDAR_REFRESH_SOURCE_AUTHORITY_UNAVAILABLE",
-          message: "Junction calendar source authority is temporarily unavailable.",
-          retryable: true,
-        });
-      }
-      const sourceProviders = await loadAndProjectSourceProviders();
-      const calendarSourceIdentity = {
-        ...queuedCalendarSourceIdentity,
-        sourceProviderSlug: accountSourceIdentity.sourceProviderSlug,
-        ...(accountSourceIdentity.sourceInstanceId
-          ? { sourceInstanceId: accountSourceIdentity.sourceInstanceId }
-          : {}),
-      };
-      const calendarFetchSourceProviderSlug = resolveJunctionProviderRouteSlug(
-        queuedCalendarSourceIdentity.sourceProviderSlug,
-      );
-      const windowStart = `${calendarRefreshDay}T00:00:00.000Z`;
-      const dailyImport = await importTimeseriesDailyAggregateSnapshots(
+      return executeSparseCalendarRefreshResourceJob(
         context,
-        sourceProviders,
-        windowStart,
-        addMilliseconds(windowStart, TIMESERIES_CHUNK_MS),
-        skippedOptionalResources,
-        [resource],
-        calendarFetchSourceProviderSlug,
-        calendarSourceIdentity,
-      );
-      const expectedDailyAggregateResourceId = buildJunctionDailyTimeseriesAggregateResourceId({
-        dayKey: calendarRefreshDay,
+        job,
         resource,
-        ...calendarSourceIdentity,
-      });
-      if (
-        !dailyImport.yieldedAt
-        && !dailyImport.appliedDailyAggregateResourceIds?.includes(expectedDailyAggregateResourceId)
-      ) {
-        throw deviceSyncError({
-          code: "JUNCTION_CALENDAR_REFRESH_DAILY_STATE_NOT_APPLIED",
-          message: "Junction calendar refresh did not apply its owned daily state.",
-          retryable: true,
-        });
-      }
-      const followUp = dailyImport.yieldedAt
-        ? buildJunctionSparseCalendarRefreshJob({
-            dayKey: calendarRefreshDay,
-            priority: job.priority,
-            resource,
-            ...calendarSourceIdentity,
-          })
-        : null;
-      return withJunctionSkippedResourceMetadata(
-        context,
-        {
-          ...(followUp ? { scheduledJobs: [followUp] } : {}),
-          nextReconcileAt: clampWebhookJobNextReconcileAt(context),
-        },
+        sourceProviderSlug,
+        calendarRefreshDay,
         skippedOptionalResources,
+        inventory,
       );
     }
 
@@ -2739,117 +2613,19 @@ export function createJunctionDeviceSyncProvider(
 
     const temporalAuthorityJob = readJunctionTemporalAuthorityJob(job);
     if (temporalAuthorityJob) {
-      if (context.shouldYield?.()) {
-        throw deviceSyncError({
-          code: "JUNCTION_TEMPORAL_AUTHORITY_JOB_YIELDED",
-          message: "Junction temporal catch-up yielded before collection.",
-          retryable: true,
-        });
-      }
-      if (!context.vaultTimeZone) {
-        throw deviceSyncError({
-          code: "JUNCTION_TEMPORAL_AUTHORITY_TIMEZONE_UNAVAILABLE",
-          message: "Junction temporal catch-up requires the vault timezone.",
-          retryable: true,
-        });
-      }
-      if (context.vaultTimeZone !== temporalAuthorityJob.timeZone) {
-        return {};
-      }
-      const expectedWindow = resolveVaultLocalDayWindow(
-        temporalAuthorityJob.dayKey,
-        temporalAuthorityJob.timeZone,
-      );
-      if (
-        !expectedWindow
-        || expectedWindow.windowStart !== window.windowStart
-        || expectedWindow.windowEnd !== window.windowEnd
-        || Date.parse(expectedWindow.windowEnd) + JUNCTION_TEMPORAL_AUTHORITY_LAG_MS
-          > Date.parse(context.now)
-      ) {
-        throw deviceSyncError({
-          code: "JUNCTION_TEMPORAL_AUTHORITY_JOB_INVALID",
-          message: "Junction temporal catch-up job did not describe an eligible complete local day.",
-          retryable: false,
-        });
-      }
-      const skippedResourceCountBeforeFetch = skippedOptionalResources.length;
-      const sourceProviders = await loadAndProjectSourceProviders();
-      await importJunctionTimeseriesResourceSnapshot({
-        authorizedLocalDay: {
-          dayKey: temporalAuthorityJob.dayKey,
-          timeZone: temporalAuthorityJob.timeZone,
-        },
+      return executeTemporalAuthorityResourceJob(
         context,
-        dateQueryFormat: "datetime",
-        resource: temporalAuthorityJob.resource,
+        window,
+        temporalAuthorityJob,
         skippedOptionalResources,
-        sourceProviders,
-        windowEnd: expectedWindow.windowEnd,
-        windowStart: expectedWindow.windowStart,
-      });
-      if (skippedOptionalResources.length > skippedResourceCountBeforeFetch) {
-        throw deviceSyncError({
-          code: "JUNCTION_TEMPORAL_AUTHORITY_RESOURCE_UNAVAILABLE",
-          message: "Junction temporal catch-up resource was unavailable.",
-          retryable: true,
-        });
-      }
-      return {
-        nextReconcileAt: clampWebhookJobNextReconcileAt(context),
-      };
+        inventory,
+      );
     }
 
     if (resource) {
       const directInput = readJunctionDirectResourceJobInput(job, window);
       if (directInput) {
-        if (
-          !isJunctionSourceAdmittedForImport(
-            context.account.sources ?? [],
-            directInput.sourceProviderSlug,
-          )
-        ) {
-          return {};
-        }
-        // This lookup uses the stable provider-config authority, not the
-        // replaceable per-connection credential epoch. It resolves source
-        // provenance only; the accepted inline payload remains the data
-        // carrier and the floor remains the sole projection owner.
-        const sourceProviders = shouldLoadJunctionDirectResourceSourceProviders(directInput)
-          ? await loadSourceProviders()
-          : [];
-        const connectHistoricalWindow = buildConnectHistoricalBackfillWindow(
-          context.account,
-          summaryBackfillDays,
-        );
-        const importResult = await importJunctionDirectResourceSnapshot(
-          context,
-          sourceProviders,
-          directInput.windowStart,
-          directInput.windowEnd,
-          directInput.resource,
-          [directInput.record],
-          connectHistoricalWindow,
-        );
-        const directHistoricalWindow = readJunctionDirectHistoricalEvidenceWindow(
-          directInput,
-          connectHistoricalWindow,
-          importResult.normalizationEvidence,
-          providerFilter,
-        );
-        return withJunctionHistoricalCoverageVerification(
-          context,
-          job,
-          directHistoricalWindow,
-          withJunctionDirectHistoricalBackfillEvidence(
-            context,
-            job,
-            directInput,
-            directHistoricalWindow,
-            importResult,
-            { nextReconcileAt: clampWebhookJobNextReconcileAt(context) },
-          ),
-        );
+        return executeDirectResourceJob(context, job, directInput, inventory);
       }
 
       let effectiveResource = resource;
@@ -2908,534 +2684,15 @@ export function createJunctionDeviceSyncProvider(
       }
 
       if (inferredCategory === "timeseries") {
-        const extendedHistoricalBackfill =
-          isJunctionExtendedTimeseriesBackfillJob(job, effectiveResource);
-        const extendedHistoricalPolicy = extendedHistoricalBackfill
-          ? resolveJunctionExtendedTimeseriesBackfillPolicy(effectiveResource)
-          : null;
-        if (
-          extendedHistoricalPolicy
-          && !canCurrentRuntimeMutateJunctionExtendedTimeseriesHistoryBackfillCoverage(
-            context.account.metadata,
-            effectiveResource,
-            extendedHistoricalPolicy.version,
-          )
-        ) {
-          return {};
-        }
-        if (
-          extendedHistoricalPolicy
-          && sourceProviderSlug
-          && !canRepresentJunctionExtendedTimeseriesHistoryBackfillCoverage(
-            context.account.metadata,
-            sourceProviderSlug,
-            effectiveResource,
-            extendedHistoricalPolicy.version,
-          )
-        ) {
-          throw deviceSyncError({
-            code: "JUNCTION_EXTENDED_HISTORY_COVERAGE_UNREPRESENTABLE",
-            message: "Junction extended-history completion could not be retained exactly.",
-            retryable: false,
-          });
-        }
-        const sourceLifecycleEpoch = extendedHistoricalPolicy
-          ? readSafeInteger(job.payload.sourceLifecycleEpoch)
-          : null;
-        if (
-          extendedHistoricalPolicy
-          && (sourceLifecycleEpoch === null || sourceLifecycleEpoch < 1)
-        ) {
-          return {};
-        }
-        const historicalWindowStart =
-          toIsoTimestampIfValid(normalizeString(job.payload.historicalWindowStart))
-          ?? window.windowStart;
-        const dailyAggregateRetryAttempts = readHistoricalBackfillJobEmptyAttempts(job);
-        let sourceProviders: readonly JunctionProviderConnection[];
-        let sourceIdentityAuthority: readonly JunctionImportAdmissionSource[] | undefined;
-        let currentSourceAdmission: JunctionCurrentSourceAdmission = "admitted";
-        try {
-          if (
-            extendedHistoricalBackfill
-            && sourceProviderSlug
-            && sourceLifecycleEpoch !== null
-          ) {
-            currentSourceAdmission = resolveJunctionCurrentSourceAdmissionFromSources(
-              context.account.sources ?? [],
-              sourceProviderSlug,
-              context.connectionSourceAdmissionMode !== "listed_only",
-              sourceLifecycleEpoch,
-            );
-            if (currentSourceAdmission === "fenced") {
-              return {};
-            }
-          }
-          if (extendedHistoricalBackfill && sourceProviderSlug) {
-            sourceProviders = await loadSourceProviders();
-            sourceIdentityAuthority = await readJunctionImportSources(context);
-            // Projection only writes local source observations. Reuse its fresh
-            // authority for admission before the next provider request.
-            await projectJunctionSources(context, sourceProviders, {
-              admissionSources: sourceIdentityAuthority,
-            });
-            currentSourceAdmission = resolveJunctionCurrentSourceAdmissionFromSources(
-              sourceIdentityAuthority,
-              sourceProviderSlug,
-              context.connectionSourceAdmissionMode !== "listed_only",
-              sourceLifecycleEpoch ?? undefined,
-            );
-          } else {
-            sourceProviders = await loadAndProjectSourceProviders();
-          }
-        } catch (error) {
-          if (
-            extendedHistoricalBackfill
-            && (
-              job.payload.historicalProviderRecordsSeen === true
-              || job.payload.historicalRecordsSeen === true
-            )
-            && isRetryableDeviceSyncFailure(error)
-          ) {
-            return withJunctionExtendedTimeseriesBackfillFollowUp({
-              context,
-              importResult: {
-                acceptedProviderRecordCount: 0,
-                canonicalProviderRecordIdentities: [],
-                canonicalEventCount: 0,
-                canonicalEventDayKeys: [],
-                canonicalSparseCalendarTargets: [],
-                fetchComplete: false,
-                providerRecordsExamined: false,
-                providerRecordCount: 0,
-                unresolvedProviderRecordIdentities: [],
-                unresolvedProviderRecordCount: 0,
-                unresolvedProviderRecordsWithoutStableIdentity: false,
-                yieldedAt: null,
-              },
-              job,
-              resource: effectiveResource,
-              result: {
-                nextReconcileAt: clampWebhookJobNextReconcileAt(context),
-              },
-              window,
-            });
-          }
-          throw error;
-        }
-        if (currentSourceAdmission === "fenced") {
-          return {};
-        }
-        if (
-          extendedHistoricalBackfill
-          && (
-            currentSourceAdmission !== "admitted"
-            || !isJunctionSourceResourceCurrentlyAvailable({
-              connectionId: context.account.id,
-              providers: sourceProviders,
-              resource: effectiveResource,
-              sourceProviderSlug,
-            })
-          )
-        ) {
-          const result = {
-            nextReconcileAt: clampWebhookJobNextReconcileAt(context),
-          };
-          if (
-            job.payload.historicalProviderRecordsSeen !== true
-            && job.payload.historicalRecordsSeen !== true
-          ) {
-            return result;
-          }
-          return withJunctionExtendedTimeseriesBackfillFollowUp({
-            context,
-            importResult: {
-              acceptedProviderRecordCount: 0,
-              canonicalProviderRecordIdentities: [],
-              canonicalEventCount: 0,
-              canonicalEventDayKeys: [],
-              canonicalSparseCalendarTargets: [],
-              fetchComplete: false,
-              providerRecordsExamined: false,
-              providerRecordCount: 0,
-              unresolvedProviderRecordIdentities: [],
-              unresolvedProviderRecordCount: 0,
-              unresolvedProviderRecordsWithoutStableIdentity: false,
-              yieldedAt: null,
-            },
-            job,
-            resource: effectiveResource,
-            result,
-            window,
-          });
-        }
-        if (
-          requiresJunctionHistoricalPullReadiness(extendedHistoricalPolicy)
-          && window.windowStart === historicalWindowStart
-        ) {
-          const historicalPullReadiness = await readHistoricalPullReadiness(
-            context,
-            effectiveResource,
-            sourceProviderSlug,
-          );
-          if (historicalPullReadiness === "no_obligation") {
-            return withJunctionExtendedTimeseriesBackfillFollowUp({
-              context,
-              historicalPullReadiness,
-              importResult: {
-                acceptedProviderRecordCount: 0,
-                canonicalProviderRecordIdentities: [],
-                canonicalEventCount: 0,
-                canonicalEventDayKeys: [],
-                canonicalSparseCalendarTargets: [],
-                fetchComplete: true,
-                providerRecordsExamined: false,
-                providerRecordCount: 0,
-                unresolvedProviderRecordIdentities: [],
-                unresolvedProviderRecordCount: 0,
-                unresolvedProviderRecordsWithoutStableIdentity: false,
-                yieldedAt: null,
-              },
-              job,
-              resource: effectiveResource,
-              result: { nextReconcileAt: clampWebhookJobNextReconcileAt(context) },
-              window,
-            });
-          }
-          if (historicalPullReadiness === "pending") {
-            const retryDelayMs = EMPTY_HISTORICAL_BACKFILL_RETRY_DELAYS_MS.at(-1) ?? 0;
-            return {
-              nextReconcileAt: clampWebhookJobNextReconcileAt(context),
-              scheduledJobs: [buildExtendedTimeseriesBackfillFollowUp(job, {
-                availableAt: addMilliseconds(context.now, retryDelayMs),
-                windowEnd: window.windowEnd,
-                windowStart: window.windowStart,
-              })],
-            };
-          }
-          if (historicalPullReadiness === "terminal_failure") {
-            return { nextReconcileAt: clampWebhookJobNextReconcileAt(context) };
-          }
-        }
-        const timeseriesPolicy = resolveJunctionTimeseriesResourcePolicy(effectiveResource);
-        const historicalResourceJobWorkBudget =
-          createJunctionHistoricalResourceJobWorkBudget(job);
-        if (JUNCTION_DENSE_FIDELITY_RESOURCE_SET.has(effectiveResource)) {
-          const dailyImport = await importTimeseriesDailyAggregateSnapshots(
-            context,
-            sourceProviders,
-            window.windowStart,
-            window.windowEnd,
-            skippedOptionalResources,
-            [effectiveResource],
-            sourceProviderSlug,
-            undefined,
-            historicalResourceJobWorkBudget,
-          );
-          if (dailyImport.yieldedAt) {
-            return withJunctionSkippedResourceMetadata(
-              context,
-              buildYieldedJunctionJobResult({
-                context,
-                job,
-                windowEnd: window.windowEnd,
-                windowStart: dailyImport.yieldedAt,
-              }),
-              skippedOptionalResources,
-            );
-          }
-
-          return withJunctionHistoricalCoverageVerification(
-            context,
-            job,
-            window,
-            withJunctionSkippedResourceMetadata(
-              context,
-              { nextReconcileAt: clampWebhookJobNextReconcileAt(context) },
-              skippedOptionalResources,
-            ),
-          );
-        }
-        if (
-          timeseriesPolicy?.historyWindow === "dense_timeseries"
-          && (
-            timeseriesPolicy.enabledByDefault === false
-            || JUNCTION_CLOSED_DAY_TIMESERIES_RESOURCES.has(effectiveResource)
-          )
-        ) {
-          const dailyImport = await importTimeseriesDailySnapshots(
-            context,
-            sourceProviders,
-            window.windowStart,
-            window.windowEnd,
-            skippedOptionalResources,
-            effectiveResource,
-            sourceProviderSlug,
-            completedWorkoutStreamIdentities,
-            job.payload.workoutStreamEmptySeen === true,
-            historicalResourceJobWorkBudget,
-          );
-          const result = withJunctionSkippedResourceMetadata(
-            context,
-            dailyImport.yieldedAt
-              ? buildYieldedJunctionJobResult({
-                  context,
-                  job,
-                  windowEnd: window.windowEnd,
-                  windowStart: dailyImport.yieldedAt,
-                  workoutStreamCursor: effectiveResource === "workout_stream"
-                    ? dailyImport.workoutStreamCursor
-                    : undefined,
-                  workoutStreamEmptySeen: dailyImport.workoutStreamEmptySeen,
-                })
-              : { nextReconcileAt: clampWebhookJobNextReconcileAt(context) },
-            skippedOptionalResources,
-          );
-          return withJunctionWorkoutStreamEmptyReplay({
-            job,
-            now: context.now,
-            replayWindow: dailyImport.emptyWorkoutStreamReplayWindow,
-            result,
-            sourceProviderSlug,
-          });
-        }
-        if (
-          !extendedHistoricalBackfill
-          && timeseriesPolicy?.maxCanonicalRecordsPerWindow !== undefined
-        ) {
-          const [boundedWindow] = buildPreciseTimeseriesWindows(
-            window.windowStart,
-            window.windowEnd,
-          );
-          if (!boundedWindow) {
-            return withJunctionSkippedResourceMetadata(
-              context,
-              { nextReconcileAt: clampWebhookJobNextReconcileAt(context) },
-              skippedOptionalResources,
-            );
-          }
-          await importJunctionTimeseriesResourceSnapshot({
-            context,
-            dateQueryFormat: "datetime",
-            resource: effectiveResource,
-            skippedOptionalResources,
-            sourceProviderSlug,
-            sourceProviders,
-            windowEnd: boundedWindow.windowEnd,
-            windowStart: boundedWindow.windowStart,
-          });
-          return withJunctionSkippedResourceMetadata(
-            context,
-            Date.parse(boundedWindow.windowEnd) < Date.parse(window.windowEnd)
-              ? buildYieldedJunctionJobResult({
-                  context,
-                  job,
-                  windowEnd: window.windowEnd,
-                  windowStart: boundedWindow.windowEnd,
-                })
-              : { nextReconcileAt: clampWebhookJobNextReconcileAt(context) },
-            skippedOptionalResources,
-          );
-        }
-        const timeseriesImport = await importTimeseriesPreciseSnapshots(
+        return executeTimeseriesResourceJob(
           context,
-          sourceProviders,
-          window.windowStart,
-          window.windowEnd,
-          skippedOptionalResources,
+          job,
           effectiveResource,
           sourceProviderSlug,
-          {
-            dateQueryFormat: extendedHistoricalPolicy?.completion === "daily_aggregate"
-              ? "date"
-              : "datetime",
-            historicalProviderRecordsSeen:
-              job.payload.historicalProviderRecordsSeen === true,
-            preservePartialRetryableFailure: extendedHistoricalBackfill,
-            ...(sourceIdentityAuthority ? { sourceIdentityAuthority } : {}),
-            sourceLifecycleEpoch: extendedHistoricalBackfill
-              ? sourceLifecycleEpoch ?? undefined
-              : undefined,
-            sourceStatusRequirement: extendedHistoricalBackfill
-              ? "connected"
-              : undefined,
-          },
-          historicalResourceJobWorkBudget,
-        );
-        const calendarRefreshJobs =
-          JUNCTION_SPARSE_CALENDAR_AGGREGATE_RESOURCE_SET.has(effectiveResource)
-            ? buildJunctionSparseCalendarRefreshJobs({
-                asOf: context.now,
-                priority: job.priority,
-                resource: effectiveResource,
-                targets: timeseriesImport.canonicalSparseCalendarTargets,
-              })
-            : [];
-        const finalizePreciseImportResult = (
-          result: ProviderJobResult,
-        ): ProviderJobResult =>
-          calendarRefreshJobs.length === 0
-            ? result
-            : {
-                ...result,
-                scheduledJobs: [
-                  ...(result.scheduledJobs ?? []),
-                  ...calendarRefreshJobs,
-                ],
-              };
-        if (
-          extendedHistoricalBackfill
-          && timeseriesImport.postFetchSourceAdmission === "fenced"
-        ) {
-          return finalizePreciseImportResult({});
-        }
-        if (
-          extendedHistoricalBackfill
-          && timeseriesImport.postFetchSourceAdmission === "pending"
-          && job.payload.historicalProviderRecordsSeen !== true
-          && job.payload.historicalRecordsSeen !== true
-          && timeseriesImport.providerRecordCount === 0
-        ) {
-          return finalizePreciseImportResult(
-            withJunctionSkippedResourceMetadata(
-              context,
-              {
-                nextReconcileAt: clampWebhookJobNextReconcileAt(context),
-              },
-              skippedOptionalResources,
-            ),
-          );
-        }
-        const historicalRecordsSeen = extendedHistoricalBackfill
-          ? job.payload.historicalRecordsSeen === true
-            || timeseriesImport.canonicalEventCount > 0
-            || (
-              doesJunctionImportReceiptResolveDeliveredRows(effectiveResource)
-              && timeseriesImport.providerRecordsExamined
-            )
-          : undefined;
-        const dailyAggregateNeedsRetry =
-          extendedHistoricalPolicy?.completion === "daily_aggregate"
-          && timeseriesImport.providerRecordCount > 0
-          && timeseriesImport.acceptedProviderRecordCount < timeseriesImport.providerRecordCount
-          && dailyAggregateRetryAttempts < EMPTY_HISTORICAL_BACKFILL_RETRY_DELAYS_MS.length;
-        if (dailyAggregateNeedsRetry) {
-          const retryAttempts = dailyAggregateRetryAttempts + 1;
-          const retryDelayMs = EMPTY_HISTORICAL_BACKFILL_RETRY_DELAYS_MS[retryAttempts - 1] ?? 0;
-          return finalizePreciseImportResult(
-            withJunctionSkippedResourceMetadata(
-              context,
-              {
-                nextReconcileAt: clampWebhookJobNextReconcileAt(context),
-                scheduledJobs: [buildExtendedTimeseriesBackfillFollowUp(job, {
-                  availableAt: addMilliseconds(context.now, retryDelayMs),
-                  payload: {
-                    emptyBackfillAttempts: retryAttempts,
-                    historicalRecordsSeen,
-                  },
-                  windowEnd: window.windowEnd,
-                  windowStart: window.windowStart,
-                })],
-              },
-              skippedOptionalResources,
-            ),
-          );
-        }
-        const historicalUnresolvedProviderRecords = extendedHistoricalBackfill
-          && extendedHistoricalPolicy?.completion !== "daily_aggregate"
-          ? isJunctionBodyTimeseriesResource(effectiveResource)
-              && timeseriesImport.fetchComplete
-              && timeseriesImport.unresolvedProviderRecordCount === 0
-            ? { identities: [], withoutStableIdentity: false }
-            : resolveJunctionHistoricalUnresolvedProviderRecords(
-                job,
-                timeseriesImport,
-              )
-          : undefined;
-        const historicalUnresolvedProviderRecordCount =
-          historicalUnresolvedProviderRecords === undefined
-            ? undefined
-            : countJunctionHistoricalUnresolvedProviderRecords(
-                historicalUnresolvedProviderRecords,
-              );
-        const historicalUnresolvedProviderRecordIdentitiesJson =
-          historicalUnresolvedProviderRecords === undefined
-            ? undefined
-            : encodeJunctionHistoricalUnresolvedProviderRecords(
-                historicalUnresolvedProviderRecords,
-              );
-        const historicalProviderRecordsSeen =
-          historicalUnresolvedProviderRecordCount === undefined
-            ? undefined
-            : historicalUnresolvedProviderRecordCount > 0;
-        if (timeseriesImport.yieldedAt) {
-          const yieldedResult = buildYieldedJunctionJobResult({
-            context,
-            emptyBackfillAttempts:
-              extendedHistoricalPolicy?.completion === "daily_aggregate"
-                ? 0
-                : undefined,
-            historicalProviderRecordsSeen,
-            historicalRecordsSeen,
-            historicalUnresolvedProviderRecordIdentitiesJson,
-            historicalUnresolvedProviderRecordCount,
-            job,
-            windowEnd: window.windowEnd,
-            windowStart: timeseriesImport.yieldedAt,
-          });
-          return finalizePreciseImportResult(
-            withJunctionSkippedResourceMetadata(
-              context,
-              yieldedResult,
-              skippedOptionalResources,
-            ),
-          );
-        }
-
-        const result = withJunctionSkippedResourceMetadata(
-          context,
-          {
-            nextReconcileAt: clampWebhookJobNextReconcileAt(context),
-          },
+          window,
           skippedOptionalResources,
-        );
-        const historicalPullReadiness =
-          requiresJunctionHistoricalPullReadiness(extendedHistoricalPolicy)
-          && timeseriesImport.fetchComplete
-            ? await readHistoricalPullReadiness(
-                context,
-                effectiveResource,
-                sourceProviderSlug,
-              )
-            : undefined;
-        if (
-          extendedHistoricalBackfill
-          && extendedHistoricalPolicy?.anchor === "current_day"
-          && sourceProviderSlug
-          && sourceLifecycleEpoch !== null
-          && await resolveJunctionCurrentSourceAdmission(
-            context,
-            sourceProviderSlug,
-            sourceLifecycleEpoch,
-          ) !== "admitted"
-        ) {
-          return {};
-        }
-        return finalizePreciseImportResult(
-          withJunctionHistoricalCoverageVerification(
-            context,
-            job,
-            window,
-            withJunctionExtendedTimeseriesBackfillFollowUp({
-              context,
-              historicalPullReadiness,
-              importResult: timeseriesImport,
-              job,
-              resource: effectiveResource,
-              result,
-              window,
-            }),
-          ),
+          completedWorkoutStreamIdentities,
+          inventory,
         );
       }
 
@@ -3457,7 +2714,7 @@ export function createJunctionDeviceSyncProvider(
       );
     }
 
-    const sourceProviders = await loadAndProjectSourceProviders();
+    const sourceProviders = await inventory.loadAndProjectSourceProviders();
     const preparedImport = await prepareJunctionImportSnapshot(
       context,
       summaries,
@@ -3486,6 +2743,848 @@ export function createJunctionDeviceSyncProvider(
           nextReconcileAt: clampWebhookJobNextReconcileAt(context),
         },
         skippedOptionalResources,
+      ),
+    );
+  }
+
+  async function executeCompanionHrvResourceJob(
+    context: ProviderJobContext,
+    job: DeviceSyncJobRecord,
+  ): Promise<ProviderJobResult> {
+    let observation;
+    let admissionId;
+    try {
+      observation = parseSerializedCompanionHrvRmssdObservation(
+        job.payload.companionObservationJson,
+      );
+      admissionId = parseCompanionHrvRmssdAdmissionId(
+        job.payload.companionAdmissionId,
+      );
+      const expectedAdmissionId = createHash("sha256")
+        .update(serializeCompanionHrvRmssdObservation(observation))
+        .digest("hex");
+      if (admissionId !== expectedAdmissionId) {
+        throw new TypeError("Companion HRV admission identity did not match its observation.");
+      }
+    } catch {
+      throw deviceSyncError({
+        code: JUNCTION_COMPANION_HRV_OBSERVATION_INVALID_CODE,
+        message: "Companion HRV observation payload was invalid.",
+        retryable: false,
+      });
+    }
+
+    if (!await isJunctionCompanionSourceCurrentlyAdmitted(
+      context,
+      JUNCTION_COMPANION_HRV_SOURCE_PROVIDER,
+    )) {
+      return {};
+    }
+    await context.importSnapshot({
+      provider: "junction",
+      accountId: buildJunctionImportAccountId(context.account.externalAccountId),
+      connectionId: context.account.id,
+      importedAt: context.now,
+      companionHrvRmssd: { admissionId, observation },
+    });
+    return {};
+  }
+
+  async function executeCompanionHealthMetadataResourceJob(
+    context: ProviderJobContext,
+    job: DeviceSyncJobRecord,
+  ): Promise<ProviderJobResult> {
+    const records = parseJunctionCompanionHealthMetadataJob(job);
+    if (!await isJunctionCompanionSourceCurrentlyAdmitted(
+      context,
+      JUNCTION_COMPANION_HEALTH_METADATA_SOURCE_PROVIDER,
+    )) {
+      return {};
+    }
+    await importJunctionCompanionHealthMetadataSnapshot(context, records);
+    return {
+      nextReconcileAt: clampWebhookJobNextReconcileAt(context),
+    };
+  }
+
+  async function executeSparseCalendarRefreshResourceJob(
+    context: ProviderJobContext,
+    job: DeviceSyncJobRecord,
+    resource: string | null,
+    sourceProviderSlug: string | null,
+    calendarRefreshDay: string,
+    skippedOptionalResources: JunctionSkippedOptionalResource[],
+    inventory: ReturnType<typeof createJobInventoryLoader>,
+  ): Promise<ProviderJobResult> {
+    if (
+      !resource
+      || !JUNCTION_SPARSE_CALENDAR_AGGREGATE_RESOURCE_SET.has(resource)
+      || !isConfiguredJunctionResource("timeseries", resource)
+    ) {
+      throw deviceSyncError({
+        code: JUNCTION_CALENDAR_REFRESH_JOB_INVALID_CODE,
+        message: "Junction calendar refresh job did not name an admitted sparse resource.",
+        retryable: false,
+      });
+    }
+    const queuedCalendarSourceIdentity = readJunctionSparseCalendarSourceIdentity(job);
+    const currentSources = context.listConnectionSources
+      ? await context.listConnectionSources()
+      : context.account.sources ?? [];
+    const accountSourceIdentity = resolveJunctionAccountSourceIdentity(
+      currentSources,
+      queuedCalendarSourceIdentity.sourceProviderSlug,
+      context.connectionSourceAdmissionMode !== "listed_only",
+    );
+    if (
+      !accountSourceIdentity
+      || !isJunctionSourceAdmittedForImport(
+        currentSources,
+        sourceProviderSlug,
+        context.connectionSourceAdmissionMode !== "listed_only",
+        "connected",
+      )
+    ) {
+      throw deviceSyncError({
+        code: "JUNCTION_CALENDAR_REFRESH_SOURCE_AUTHORITY_UNAVAILABLE",
+        message: "Junction calendar source authority is temporarily unavailable.",
+        retryable: true,
+      });
+    }
+    const sourceProviders = await inventory.loadAndProjectSourceProviders();
+    const calendarSourceIdentity = {
+      ...queuedCalendarSourceIdentity,
+      sourceProviderSlug: accountSourceIdentity.sourceProviderSlug,
+      ...(accountSourceIdentity.sourceInstanceId
+        ? { sourceInstanceId: accountSourceIdentity.sourceInstanceId }
+        : {}),
+    };
+    const calendarFetchSourceProviderSlug = resolveJunctionProviderRouteSlug(
+      queuedCalendarSourceIdentity.sourceProviderSlug,
+    );
+    const windowStart = `${calendarRefreshDay}T00:00:00.000Z`;
+    const dailyImport = await importTimeseriesDailyAggregateSnapshots(
+      context,
+      sourceProviders,
+      windowStart,
+      addMilliseconds(windowStart, TIMESERIES_CHUNK_MS),
+      skippedOptionalResources,
+      [resource],
+      calendarFetchSourceProviderSlug,
+      calendarSourceIdentity,
+    );
+    const expectedDailyAggregateResourceId = buildJunctionDailyTimeseriesAggregateResourceId({
+      dayKey: calendarRefreshDay,
+      resource,
+      ...calendarSourceIdentity,
+    });
+    if (
+      !dailyImport.yieldedAt
+      && !dailyImport.appliedDailyAggregateResourceIds?.includes(expectedDailyAggregateResourceId)
+    ) {
+      throw deviceSyncError({
+        code: "JUNCTION_CALENDAR_REFRESH_DAILY_STATE_NOT_APPLIED",
+        message: "Junction calendar refresh did not apply its owned daily state.",
+        retryable: true,
+      });
+    }
+    const followUp = dailyImport.yieldedAt
+      ? buildJunctionSparseCalendarRefreshJob({
+          dayKey: calendarRefreshDay,
+          priority: job.priority,
+          resource,
+          ...calendarSourceIdentity,
+        })
+      : null;
+    return withJunctionSkippedResourceMetadata(
+      context,
+      {
+        ...(followUp ? { scheduledJobs: [followUp] } : {}),
+        nextReconcileAt: clampWebhookJobNextReconcileAt(context),
+      },
+      skippedOptionalResources,
+    );
+  }
+
+  async function executeTemporalAuthorityResourceJob(
+    context: ProviderJobContext,
+    window: { windowStart: string; windowEnd: string },
+    temporalAuthorityJob: NonNullable<ReturnType<typeof readJunctionTemporalAuthorityJob>>,
+    skippedOptionalResources: JunctionSkippedOptionalResource[],
+    inventory: ReturnType<typeof createJobInventoryLoader>,
+  ): Promise<ProviderJobResult> {
+    if (context.shouldYield?.()) {
+      throw deviceSyncError({
+        code: "JUNCTION_TEMPORAL_AUTHORITY_JOB_YIELDED",
+        message: "Junction temporal catch-up yielded before collection.",
+        retryable: true,
+      });
+    }
+    if (!context.vaultTimeZone) {
+      throw deviceSyncError({
+        code: "JUNCTION_TEMPORAL_AUTHORITY_TIMEZONE_UNAVAILABLE",
+        message: "Junction temporal catch-up requires the vault timezone.",
+        retryable: true,
+      });
+    }
+    if (context.vaultTimeZone !== temporalAuthorityJob.timeZone) {
+      return {};
+    }
+    const expectedWindow = resolveVaultLocalDayWindow(
+      temporalAuthorityJob.dayKey,
+      temporalAuthorityJob.timeZone,
+    );
+    if (
+      !expectedWindow
+      || expectedWindow.windowStart !== window.windowStart
+      || expectedWindow.windowEnd !== window.windowEnd
+      || Date.parse(expectedWindow.windowEnd) + JUNCTION_TEMPORAL_AUTHORITY_LAG_MS
+        > Date.parse(context.now)
+    ) {
+      throw deviceSyncError({
+        code: "JUNCTION_TEMPORAL_AUTHORITY_JOB_INVALID",
+        message: "Junction temporal catch-up job did not describe an eligible complete local day.",
+        retryable: false,
+      });
+    }
+    const skippedResourceCountBeforeFetch = skippedOptionalResources.length;
+    const sourceProviders = await inventory.loadAndProjectSourceProviders();
+    await importJunctionTimeseriesResourceSnapshot({
+      authorizedLocalDay: {
+        dayKey: temporalAuthorityJob.dayKey,
+        timeZone: temporalAuthorityJob.timeZone,
+      },
+      context,
+      dateQueryFormat: "datetime",
+      resource: temporalAuthorityJob.resource,
+      skippedOptionalResources,
+      sourceProviders,
+      windowEnd: expectedWindow.windowEnd,
+      windowStart: expectedWindow.windowStart,
+    });
+    if (skippedOptionalResources.length > skippedResourceCountBeforeFetch) {
+      throw deviceSyncError({
+        code: "JUNCTION_TEMPORAL_AUTHORITY_RESOURCE_UNAVAILABLE",
+        message: "Junction temporal catch-up resource was unavailable.",
+        retryable: true,
+      });
+    }
+    return {
+      nextReconcileAt: clampWebhookJobNextReconcileAt(context),
+    };
+  }
+
+  async function executeDirectResourceJob(
+    context: ProviderJobContext,
+    job: DeviceSyncJobRecord,
+    directInput: JunctionDirectResourceJobInput,
+    inventory: ReturnType<typeof createJobInventoryLoader>,
+  ): Promise<ProviderJobResult> {
+    if (
+      !isJunctionSourceAdmittedForImport(
+        context.account.sources ?? [],
+        directInput.sourceProviderSlug,
+      )
+    ) {
+      return {};
+    }
+    // This lookup uses the stable provider-config authority, not the
+    // replaceable per-connection credential epoch. It resolves source
+    // provenance only; the accepted inline payload remains the data
+    // carrier and the floor remains the sole projection owner.
+    const sourceProviders = shouldLoadJunctionDirectResourceSourceProviders(directInput)
+      ? await inventory.loadSourceProviders()
+      : [];
+    const connectHistoricalWindow = buildConnectHistoricalBackfillWindow(
+      context.account,
+      summaryBackfillDays,
+    );
+    const importResult = await importJunctionDirectResourceSnapshot(
+      context,
+      sourceProviders,
+      directInput.windowStart,
+      directInput.windowEnd,
+      directInput.resource,
+      [directInput.record],
+      connectHistoricalWindow,
+    );
+    const directHistoricalWindow = readJunctionDirectHistoricalEvidenceWindow(
+      directInput,
+      connectHistoricalWindow,
+      importResult.normalizationEvidence,
+      providerFilter,
+    );
+    return withJunctionHistoricalCoverageVerification(
+      context,
+      job,
+      directHistoricalWindow,
+      withJunctionDirectHistoricalBackfillEvidence(
+        context,
+        job,
+        directInput,
+        directHistoricalWindow,
+        importResult,
+        { nextReconcileAt: clampWebhookJobNextReconcileAt(context) },
+      ),
+    );
+  }
+
+  async function executeTimeseriesResourceJob(
+    context: ProviderJobContext,
+    job: DeviceSyncJobRecord,
+    effectiveResource: string,
+    sourceProviderSlug: string | null,
+    window: { windowStart: string; windowEnd: string },
+    skippedOptionalResources: JunctionSkippedOptionalResource[],
+    completedWorkoutStreamIdentities: ReadonlySet<string>,
+    inventory: ReturnType<typeof createJobInventoryLoader>,
+  ): Promise<ProviderJobResult> {
+    const { loadSourceProviders, loadAndProjectSourceProviders } = inventory;
+    const extendedHistoricalBackfill =
+      isJunctionExtendedTimeseriesBackfillJob(job, effectiveResource);
+    const extendedHistoricalPolicy = extendedHistoricalBackfill
+      ? resolveJunctionExtendedTimeseriesBackfillPolicy(effectiveResource)
+      : null;
+    if (
+      extendedHistoricalPolicy
+      && !canCurrentRuntimeMutateJunctionExtendedTimeseriesHistoryBackfillCoverage(
+        context.account.metadata,
+        effectiveResource,
+        extendedHistoricalPolicy.version,
+      )
+    ) {
+      return {};
+    }
+    if (
+      extendedHistoricalPolicy
+      && sourceProviderSlug
+      && !canRepresentJunctionExtendedTimeseriesHistoryBackfillCoverage(
+        context.account.metadata,
+        sourceProviderSlug,
+        effectiveResource,
+        extendedHistoricalPolicy.version,
+      )
+    ) {
+      throw deviceSyncError({
+        code: "JUNCTION_EXTENDED_HISTORY_COVERAGE_UNREPRESENTABLE",
+        message: "Junction extended-history completion could not be retained exactly.",
+        retryable: false,
+      });
+    }
+    const sourceLifecycleEpoch = extendedHistoricalPolicy
+      ? readSafeInteger(job.payload.sourceLifecycleEpoch)
+      : null;
+    if (
+      extendedHistoricalPolicy
+      && (sourceLifecycleEpoch === null || sourceLifecycleEpoch < 1)
+    ) {
+      return {};
+    }
+    const historicalWindowStart =
+      toIsoTimestampIfValid(normalizeString(job.payload.historicalWindowStart))
+      ?? window.windowStart;
+    let sourceProviders: readonly JunctionProviderConnection[];
+    let sourceIdentityAuthority: readonly JunctionImportAdmissionSource[] | undefined;
+    let currentSourceAdmission: JunctionCurrentSourceAdmission = "admitted";
+    try {
+      if (
+        extendedHistoricalBackfill
+        && sourceProviderSlug
+        && sourceLifecycleEpoch !== null
+      ) {
+        currentSourceAdmission = resolveJunctionCurrentSourceAdmissionFromSources(
+          context.account.sources ?? [],
+          sourceProviderSlug,
+          context.connectionSourceAdmissionMode !== "listed_only",
+          sourceLifecycleEpoch,
+        );
+        if (currentSourceAdmission === "fenced") {
+          return {};
+        }
+      }
+      if (extendedHistoricalBackfill && sourceProviderSlug) {
+        sourceProviders = await loadSourceProviders();
+        sourceIdentityAuthority = await readJunctionImportSources(context);
+        // Projection only writes local source observations. Reuse its fresh
+        // authority for admission before the next provider request.
+        await projectJunctionSources(context, sourceProviders, {
+          admissionSources: sourceIdentityAuthority,
+        });
+        currentSourceAdmission = resolveJunctionCurrentSourceAdmissionFromSources(
+          sourceIdentityAuthority,
+          sourceProviderSlug,
+          context.connectionSourceAdmissionMode !== "listed_only",
+          sourceLifecycleEpoch ?? undefined,
+        );
+      } else {
+        sourceProviders = await loadAndProjectSourceProviders();
+      }
+    } catch (error) {
+      if (
+        extendedHistoricalBackfill
+        && (
+          job.payload.historicalProviderRecordsSeen === true
+          || job.payload.historicalRecordsSeen === true
+        )
+        && isRetryableDeviceSyncFailure(error)
+      ) {
+        return withJunctionExtendedTimeseriesBackfillFollowUp({
+          context,
+          importResult: buildUncollectedTimeseriesImportResult(false),
+          job,
+          resource: effectiveResource,
+          result: {
+            nextReconcileAt: clampWebhookJobNextReconcileAt(context),
+          },
+          window,
+        });
+      }
+      throw error;
+    }
+    if (currentSourceAdmission === "fenced") {
+      return {};
+    }
+    if (
+      extendedHistoricalBackfill
+      && (
+        currentSourceAdmission !== "admitted"
+        || !isJunctionSourceResourceCurrentlyAvailable({
+          connectionId: context.account.id,
+          providers: sourceProviders,
+          resource: effectiveResource,
+          sourceProviderSlug,
+        })
+      )
+    ) {
+      const result = {
+        nextReconcileAt: clampWebhookJobNextReconcileAt(context),
+      };
+      if (
+        job.payload.historicalProviderRecordsSeen !== true
+        && job.payload.historicalRecordsSeen !== true
+      ) {
+        return result;
+      }
+      return withJunctionExtendedTimeseriesBackfillFollowUp({
+        context,
+        importResult: buildUncollectedTimeseriesImportResult(false),
+        job,
+        resource: effectiveResource,
+        result,
+        window,
+      });
+    }
+    if (
+      requiresJunctionHistoricalPullReadiness(extendedHistoricalPolicy)
+      && window.windowStart === historicalWindowStart
+    ) {
+      const historicalPullReadiness = await readHistoricalPullReadiness(
+        context,
+        effectiveResource,
+        sourceProviderSlug,
+      );
+      if (historicalPullReadiness === "no_obligation") {
+        return withJunctionExtendedTimeseriesBackfillFollowUp({
+          context,
+          historicalPullReadiness,
+          importResult: buildUncollectedTimeseriesImportResult(true),
+          job,
+          resource: effectiveResource,
+          result: { nextReconcileAt: clampWebhookJobNextReconcileAt(context) },
+          window,
+        });
+      }
+      if (historicalPullReadiness === "pending") {
+        const retryDelayMs = EMPTY_HISTORICAL_BACKFILL_RETRY_DELAYS_MS.at(-1) ?? 0;
+        return {
+          nextReconcileAt: clampWebhookJobNextReconcileAt(context),
+          scheduledJobs: [buildExtendedTimeseriesBackfillFollowUp(job, {
+            availableAt: addMilliseconds(context.now, retryDelayMs),
+            windowEnd: window.windowEnd,
+            windowStart: window.windowStart,
+          })],
+        };
+      }
+      if (historicalPullReadiness === "terminal_failure") {
+        return { nextReconcileAt: clampWebhookJobNextReconcileAt(context) };
+      }
+    }
+    const timeseriesPolicy = resolveJunctionTimeseriesResourcePolicy(effectiveResource);
+    const historicalResourceJobWorkBudget =
+      createJunctionHistoricalResourceJobWorkBudget(job);
+    if (JUNCTION_DENSE_FIDELITY_RESOURCE_SET.has(effectiveResource)) {
+      const dailyImport = await importTimeseriesDailyAggregateSnapshots(
+        context,
+        sourceProviders,
+        window.windowStart,
+        window.windowEnd,
+        skippedOptionalResources,
+        [effectiveResource],
+        sourceProviderSlug,
+        undefined,
+        historicalResourceJobWorkBudget,
+      );
+      if (dailyImport.yieldedAt) {
+        return withJunctionSkippedResourceMetadata(
+          context,
+          buildYieldedJunctionJobResult({
+            context,
+            job,
+            windowEnd: window.windowEnd,
+            windowStart: dailyImport.yieldedAt,
+          }),
+          skippedOptionalResources,
+        );
+      }
+
+      return withJunctionHistoricalCoverageVerification(
+        context,
+        job,
+        window,
+        withJunctionSkippedResourceMetadata(
+          context,
+          { nextReconcileAt: clampWebhookJobNextReconcileAt(context) },
+          skippedOptionalResources,
+        ),
+      );
+    }
+    if (
+      timeseriesPolicy?.historyWindow === "dense_timeseries"
+      && (
+        timeseriesPolicy.enabledByDefault === false
+        || JUNCTION_CLOSED_DAY_TIMESERIES_RESOURCES.has(effectiveResource)
+      )
+    ) {
+      const dailyImport = await importTimeseriesDailySnapshots(
+        context,
+        sourceProviders,
+        window.windowStart,
+        window.windowEnd,
+        skippedOptionalResources,
+        effectiveResource,
+        sourceProviderSlug,
+        completedWorkoutStreamIdentities,
+        job.payload.workoutStreamEmptySeen === true,
+        historicalResourceJobWorkBudget,
+      );
+      const result = withJunctionSkippedResourceMetadata(
+        context,
+        dailyImport.yieldedAt
+          ? buildYieldedJunctionJobResult({
+              context,
+              job,
+              windowEnd: window.windowEnd,
+              windowStart: dailyImport.yieldedAt,
+              workoutStreamCursor: effectiveResource === "workout_stream"
+                ? dailyImport.workoutStreamCursor
+                : undefined,
+              workoutStreamEmptySeen: dailyImport.workoutStreamEmptySeen,
+            })
+          : { nextReconcileAt: clampWebhookJobNextReconcileAt(context) },
+        skippedOptionalResources,
+      );
+      return withJunctionWorkoutStreamEmptyReplay({
+        job,
+        now: context.now,
+        replayWindow: dailyImport.emptyWorkoutStreamReplayWindow,
+        result,
+        sourceProviderSlug,
+      });
+    }
+    if (
+      !extendedHistoricalBackfill
+      && timeseriesPolicy?.maxCanonicalRecordsPerWindow !== undefined
+    ) {
+      const [boundedWindow] = buildPreciseTimeseriesWindows(
+        window.windowStart,
+        window.windowEnd,
+      );
+      if (!boundedWindow) {
+        return withJunctionSkippedResourceMetadata(
+          context,
+          { nextReconcileAt: clampWebhookJobNextReconcileAt(context) },
+          skippedOptionalResources,
+        );
+      }
+      await importJunctionTimeseriesResourceSnapshot({
+        context,
+        dateQueryFormat: "datetime",
+        resource: effectiveResource,
+        skippedOptionalResources,
+        sourceProviderSlug,
+        sourceProviders,
+        windowEnd: boundedWindow.windowEnd,
+        windowStart: boundedWindow.windowStart,
+      });
+      return withJunctionSkippedResourceMetadata(
+        context,
+        Date.parse(boundedWindow.windowEnd) < Date.parse(window.windowEnd)
+          ? buildYieldedJunctionJobResult({
+              context,
+              job,
+              windowEnd: window.windowEnd,
+              windowStart: boundedWindow.windowEnd,
+            })
+          : { nextReconcileAt: clampWebhookJobNextReconcileAt(context) },
+        skippedOptionalResources,
+      );
+    }
+    const timeseriesImport = await importTimeseriesPreciseSnapshots(
+      context,
+      sourceProviders,
+      window.windowStart,
+      window.windowEnd,
+      skippedOptionalResources,
+      effectiveResource,
+      sourceProviderSlug,
+      {
+        dateQueryFormat: extendedHistoricalPolicy?.completion === "daily_aggregate"
+          ? "date"
+          : "datetime",
+        historicalProviderRecordsSeen:
+          job.payload.historicalProviderRecordsSeen === true,
+        preservePartialRetryableFailure: extendedHistoricalBackfill,
+        ...(sourceIdentityAuthority ? { sourceIdentityAuthority } : {}),
+        sourceLifecycleEpoch: extendedHistoricalBackfill
+          ? sourceLifecycleEpoch ?? undefined
+          : undefined,
+        sourceStatusRequirement: extendedHistoricalBackfill
+          ? "connected"
+          : undefined,
+      },
+      historicalResourceJobWorkBudget,
+    );
+    return completePreciseTimeseriesResourceJob({
+      context,
+      job,
+      effectiveResource,
+      sourceProviderSlug,
+      window,
+      skippedOptionalResources,
+      timeseriesImport,
+      extendedHistoricalBackfill,
+      extendedHistoricalPolicy,
+      sourceLifecycleEpoch,
+    });
+  }
+
+  function buildUncollectedTimeseriesImportResult(
+    fetchComplete: boolean,
+  ): JunctionPreciseTimeseriesImportResult {
+    return {
+      acceptedProviderRecordCount: 0,
+      canonicalProviderRecordIdentities: [],
+      canonicalEventCount: 0,
+      canonicalEventDayKeys: [],
+      canonicalSparseCalendarTargets: [],
+      fetchComplete,
+      providerRecordsExamined: false,
+      providerRecordCount: 0,
+      unresolvedProviderRecordIdentities: [],
+      unresolvedProviderRecordCount: 0,
+      unresolvedProviderRecordsWithoutStableIdentity: false,
+      yieldedAt: null,
+    };
+  }
+
+  async function completePreciseTimeseriesResourceJob(input: {
+    context: ProviderJobContext;
+    job: DeviceSyncJobRecord;
+    effectiveResource: string;
+    sourceProviderSlug: string | null;
+    window: { windowStart: string; windowEnd: string };
+    skippedOptionalResources: JunctionSkippedOptionalResource[];
+    timeseriesImport: JunctionPreciseTimeseriesImportResult;
+    extendedHistoricalBackfill: boolean;
+    extendedHistoricalPolicy: ReturnType<typeof resolveJunctionExtendedTimeseriesBackfillPolicy>;
+    sourceLifecycleEpoch: number | null;
+  }): Promise<ProviderJobResult> {
+    const {
+      context,
+      job,
+      effectiveResource,
+      sourceProviderSlug,
+      window,
+      skippedOptionalResources,
+      timeseriesImport,
+      extendedHistoricalBackfill,
+      extendedHistoricalPolicy,
+      sourceLifecycleEpoch,
+    } = input;
+    const dailyAggregateRetryAttempts = readHistoricalBackfillJobEmptyAttempts(job);
+    const calendarRefreshJobs =
+      JUNCTION_SPARSE_CALENDAR_AGGREGATE_RESOURCE_SET.has(effectiveResource)
+        ? buildJunctionSparseCalendarRefreshJobs({
+            asOf: context.now,
+            priority: job.priority,
+            resource: effectiveResource,
+            targets: timeseriesImport.canonicalSparseCalendarTargets,
+          })
+        : [];
+    const finalizePreciseImportResult = (
+      result: ProviderJobResult,
+    ): ProviderJobResult =>
+      calendarRefreshJobs.length === 0
+        ? result
+        : {
+            ...result,
+            scheduledJobs: [
+              ...(result.scheduledJobs ?? []),
+              ...calendarRefreshJobs,
+            ],
+          };
+    if (
+      extendedHistoricalBackfill
+      && timeseriesImport.postFetchSourceAdmission === "fenced"
+    ) {
+      return finalizePreciseImportResult({});
+    }
+    if (
+      extendedHistoricalBackfill
+      && timeseriesImport.postFetchSourceAdmission === "pending"
+      && job.payload.historicalProviderRecordsSeen !== true
+      && job.payload.historicalRecordsSeen !== true
+      && timeseriesImport.providerRecordCount === 0
+    ) {
+      return finalizePreciseImportResult(
+        withJunctionSkippedResourceMetadata(
+          context,
+          {
+            nextReconcileAt: clampWebhookJobNextReconcileAt(context),
+          },
+          skippedOptionalResources,
+        ),
+      );
+    }
+    const historicalRecordsSeen = extendedHistoricalBackfill
+      ? job.payload.historicalRecordsSeen === true
+        || timeseriesImport.canonicalEventCount > 0
+        || (
+          doesJunctionImportReceiptResolveDeliveredRows(effectiveResource)
+          && timeseriesImport.providerRecordsExamined
+        )
+      : undefined;
+    const dailyAggregateNeedsRetry =
+      extendedHistoricalPolicy?.completion === "daily_aggregate"
+      && timeseriesImport.providerRecordCount > 0
+      && timeseriesImport.acceptedProviderRecordCount < timeseriesImport.providerRecordCount
+      && dailyAggregateRetryAttempts < EMPTY_HISTORICAL_BACKFILL_RETRY_DELAYS_MS.length;
+    if (dailyAggregateNeedsRetry) {
+      const retryAttempts = dailyAggregateRetryAttempts + 1;
+      const retryDelayMs = EMPTY_HISTORICAL_BACKFILL_RETRY_DELAYS_MS[retryAttempts - 1] ?? 0;
+      return finalizePreciseImportResult(
+        withJunctionSkippedResourceMetadata(
+          context,
+          {
+            nextReconcileAt: clampWebhookJobNextReconcileAt(context),
+            scheduledJobs: [buildExtendedTimeseriesBackfillFollowUp(job, {
+              availableAt: addMilliseconds(context.now, retryDelayMs),
+              payload: {
+                emptyBackfillAttempts: retryAttempts,
+                historicalRecordsSeen,
+              },
+              windowEnd: window.windowEnd,
+              windowStart: window.windowStart,
+            })],
+          },
+          skippedOptionalResources,
+        ),
+      );
+    }
+    const historicalUnresolvedProviderRecords = extendedHistoricalBackfill
+      && extendedHistoricalPolicy?.completion !== "daily_aggregate"
+      ? isJunctionBodyTimeseriesResource(effectiveResource)
+          && timeseriesImport.fetchComplete
+          && timeseriesImport.unresolvedProviderRecordCount === 0
+        ? { identities: [], withoutStableIdentity: false }
+        : resolveJunctionHistoricalUnresolvedProviderRecords(
+            job,
+            timeseriesImport,
+          )
+      : undefined;
+    const historicalUnresolvedProviderRecordCount =
+      historicalUnresolvedProviderRecords === undefined
+        ? undefined
+        : countJunctionHistoricalUnresolvedProviderRecords(
+            historicalUnresolvedProviderRecords,
+          );
+    const historicalUnresolvedProviderRecordIdentitiesJson =
+      historicalUnresolvedProviderRecords === undefined
+        ? undefined
+        : encodeJunctionHistoricalUnresolvedProviderRecords(
+            historicalUnresolvedProviderRecords,
+          );
+    const historicalProviderRecordsSeen =
+      historicalUnresolvedProviderRecordCount === undefined
+        ? undefined
+        : historicalUnresolvedProviderRecordCount > 0;
+    if (timeseriesImport.yieldedAt) {
+      const yieldedResult = buildYieldedJunctionJobResult({
+        context,
+        emptyBackfillAttempts:
+          extendedHistoricalPolicy?.completion === "daily_aggregate"
+            ? 0
+            : undefined,
+        historicalProviderRecordsSeen,
+        historicalRecordsSeen,
+        historicalUnresolvedProviderRecordIdentitiesJson,
+        historicalUnresolvedProviderRecordCount,
+        job,
+        windowEnd: window.windowEnd,
+        windowStart: timeseriesImport.yieldedAt,
+      });
+      return finalizePreciseImportResult(
+        withJunctionSkippedResourceMetadata(
+          context,
+          yieldedResult,
+          skippedOptionalResources,
+        ),
+      );
+    }
+
+    const result = withJunctionSkippedResourceMetadata(
+      context,
+      {
+        nextReconcileAt: clampWebhookJobNextReconcileAt(context),
+      },
+      skippedOptionalResources,
+    );
+    const historicalPullReadiness =
+      requiresJunctionHistoricalPullReadiness(extendedHistoricalPolicy)
+      && timeseriesImport.fetchComplete
+        ? await readHistoricalPullReadiness(
+            context,
+            effectiveResource,
+            sourceProviderSlug,
+          )
+        : undefined;
+    if (
+      extendedHistoricalBackfill
+      && extendedHistoricalPolicy?.anchor === "current_day"
+      && sourceProviderSlug
+      && sourceLifecycleEpoch !== null
+      && await resolveJunctionCurrentSourceAdmission(
+        context,
+        sourceProviderSlug,
+        sourceLifecycleEpoch,
+      ) !== "admitted"
+    ) {
+      return {};
+    }
+    return finalizePreciseImportResult(
+      withJunctionHistoricalCoverageVerification(
+        context,
+        job,
+        window,
+        withJunctionExtendedTimeseriesBackfillFollowUp({
+          context,
+          historicalPullReadiness,
+          importResult: timeseriesImport,
+          job,
+          resource: effectiveResource,
+          result,
+          window,
+        }),
       ),
     );
   }


### PR DESCRIPTION
## Why and outcome

Junction resource execution mixed companion payloads, calendar repairs, temporal catch-up, direct inline imports, and historical timeseries completion in one function with cyclomatic complexity 143. Private phase handlers now expose those existing boundaries, reducing the dispatcher to 21 and changed-file complexity debt from 405 to 338 without changing import or retry behavior.

The timeseries collection and completion phases remain together in the existing provider factory, reusing its inventory, importer, and coverage owners. Three identical no-collection receipts now share one constructor.

## Product UX

- Effort: Not applicable — internal behavior-preserving refactor.
- Result: Not applicable.
- Walkthrough: Existing companion, inline webhook, calendar-repair, temporal catch-up, and history-recovery journeys retain their payload admission, effect ordering, error codes, cursors, and completion results.

## Evidence

- Direct: Device-syncd package regressions passed: 63 files, 1,424 tests in 225.79 seconds. The command was `pnpm --filter @murphai/device-syncd test -- test/junction-provider-resources.test.ts test/junction-provider-history.test.ts test/junction-provider-history-recovery.test.ts test/junction-provider-backfill.test.ts test/junction-provider-workout-stream.test.ts test/junction-provider-webhooks.test.ts test/junction-admission-source-reads.test.ts test/junction-blood-pressure-backfill.test.ts test/junction-provider-identity.test.ts test/junction-timeseries-source-reuse.test.ts`; the forwarded separator selected the full package.
- Coverage: Existing provider-shaped tests exercise malformed companion payloads, inline-import authority, disconnected and stale source epochs, strict calendar receipts, temporal eligibility, unavailable endpoints, historical retries, and workout continuation cursors. No implementation-mirroring tests were added.
- `pnpm --filter @murphai/device-syncd typecheck` passed.
- `git diff --check` passed. Whitespace-insensitive diff inspection confirmed preserved branch bodies and return wrappers.
- Parent candidate review, exact-head ReviewGPT, and all required CI checks passed on the reviewed head.

## Non-obvious affected surfaces

The resource executor serves hosted and local device ingestion. Provider calls remain in the same order, inline carriers retain credential-free authority, and precise sparse imports still retain calendar repair jobs before completion. Existing package regressions cover these paths.

## Architecture and reuse

- Existing systems reused: Junction's provider factory, per-job inventory loader, source admission checks, canonical import boundaries, receipt types, and coverage/follow-up builders.
- New logic: None; existing execution phases and no-collection receipt construction are named explicitly.
- New abstractions: Private companion, calendar, temporal, direct, timeseries collection, and precise completion helpers; one private no-collection receipt constructor. They introduce no public API or state owner.
- Complexity intentionally avoided: No generic dispatcher framework, cross-module dependency bag, queue, dependency, new policy, or parallel retry store.

## Complexity impact

- Guard: pass — `pnpm complexity:diff -- --base-ref ef746ba347a55316c6189b066fd6ff4fa8bf08fa -- packages/device-syncd/src/providers/junction.ts`; file debt 405 → 338 (-67), maximum 143 → 106 (-37).
- Hotspots: Changed phases are `executeResourceJob` 21 (was 143), `executeTimeseriesResourceJob` 56, and `completePreciseTimeseriesResourceJob` 39. Their remaining branches encode source admission, collection policy, and exact retry/receipt disposition; the smaller companion/calendar/temporal/direct helpers are below 20. Unchanged owners remain `executeJob` 106, `projectJunctionSources` 47, `executeFullJobTimeseriesContinuation` 46, `importTimeseriesPreciseSnapshots` 41, `withJunctionExtendedTimeseriesBackfillFollowUp` 40, `recordAcceptedJunctionFitbitCoverage` 35, `evaluateJunctionHistoricalBackfillCoverage` 35, `junctionTimeseriesRecordValueIdentity` 33, `importJunctionWorkoutStreamWindow` 32, `isBlockedJunctionSourceAvailabilityKey` 29, `buildJunctionWebhookWindow` 28, `importJunctionTimeseriesResourceSnapshot` 27, `importTimeseriesDailyAggregateSnapshots` 26, `selectJunctionElectrocardiogramRecordingCandidates` 26, `classifyClearOptionalJunctionResourceCode` 24, `extractJunctionWebhookSourceProviderSlugFallback` 24, and the existing record-filter callback 23.
- Agent judgment: The extraction makes distinct payload and completion authority reviewable while preserving existing gates. Further simplification should address one named policy owner with its own proof; splitting every remaining branch only to cross a numeric threshold would obscure the coupled retry decisions.

## Hot reply path impact

- Path status: Not applicable — device resource execution does not change foreground reply assembly or delivery.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: No new work; existing awaits remain in their original order inside private handlers.
- Before/after proof: Existing provider-call and import-receipt regressions pass; no latency change is claimed.

## Murph initial provider input impact

Not applicable for individual and group runtimes: no prompt, tool, schema, history, model, or provider-input assembly surface changes.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

## Deployment concerns

- Deployment: not applicable
- Reason: Private behavior-preserving function extraction changes no persisted representation, public protocol, runtime authority, or deployment ordering requirement. Existing and refactored code consume the same jobs and emit the same receipts and continuations.

## Change-shape breakdown

Classification rule: TypeScript implementation is Source; the completed execution plan is Docs. No binary, generated, dependency, test, or configuration changes. Most source additions/deletions are existing bodies moved and unindented.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 869 | 770 |
| Tests / fixtures | 0 | 0 |
| Docs | 55 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **924** | **770** |

## Changelog

- Changelog: not applicable
- Reason: Internal refactor preserves all member-visible import and recovery behavior.

ReviewGPT first-reviewed head: 19a69e9402a87e43abed657a56143f50e26914d4
ReviewGPT context sensitivity: sensitive
Classification reason: Refactors device import admission, retries, and canonical receipt handling.

## ReviewGPT result

- Round 1: PASS on 19a69e9402a87e43abed657a56143f50e26914d4.
- Model: GPT-6 Pro, verified by captured response metadata; guarded full snapshot and exact committed turn verified.
- No qualifying findings; no review remediation required. All required CI checks passed on this same head.
