### PR TITLE
refactor(assistant): simplify Codex attempt capability policy

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-complexity-codex-attempt-sep11.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-complexity-codex-attempt-sep11.md
@@ -1,0 +1,47 @@
+# Simplify Codex attempt capability construction
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal
+
+Reduce branching in the Codex attempt runner while preserving the complete provider request, attempt lifecycle, usage attribution, cancellation, and failure evidence.
+
+## Scope and owner
+
+The existing assistant-engine runner owns provider request construction and attempt outcomes. Keep the change inside that owner with private helpers and focused runner regressions. Planning, tool declarations, prompts, external protocols, and persisted state retain their existing owners.
+
+## Evidence and design
+
+The attempt function repeats the same restriction families across environment, hosted ports, network ports, permissions, and thread configuration. Derive those shared predicates once, keep precedence explicit, and separate request assembly from result/error handling. Do not add a policy framework or state owner.
+
+## Protected invariants
+
+- Preserve output-only, creative song, maintenance, read-only automation, group-email, and ordinary hosted/local capability differences, including overlapping conditions.
+- Preserve request order, service-tier deadlines, live callbacks, optional field presence, failed-attempt metadata, and accepted-input release.
+- Add no awaited work, provider calls, database reads, retries, or persistent state.
+- No deployment ordering or schema compatibility change; old and new code construct the same requests.
+
+## Tasks
+
+1. Consolidate capability policy and separate provider request construction from attempt lifecycle.
+2. Extend composed runner tests for overlap precedence and authority mismatches.
+3. Run focused runner tests, relevant typecheck, and complexity guard; inspect full diff and privacy.
+4. Close this implementation plan, commit, push, and open a draft PR for parent review and final gates.
+
+## Verification
+
+Use assistant-codex-final-coverage.test.ts for real runner construction and outcomes, plus focused contract checks where needed. Run assistant-engine typecheck and pnpm complexity:diff. Existing behavior and provider inputs must remain identical. Assess real-model proof after deterministic checks; this refactor changes no authored prompts, schemas, tool eligibility, or reply policy.
+
+## Results
+
+- Introduced private capability classification and ordered thread/permission selectors; derived the shared hosted, tool, and internet restrictions once.
+- Separated provider input assembly from the attempt lifecycle. Result and failure handling remains byte-identical to base.
+- Expanded output-only/follow-up overlap and all four maintenance-authority/follow-up combinations; existing ordinary, creative, memory, Habitat, onboarding, group email, Flex, usage, and diagnostics assertions remain.
+- Focused runner and authority suites: 33 tests passed on candidate and on the original runner with the same expanded assertions.
+- Assistant-engine typecheck passed with one checker. Diff whitespace and changed-line privacy inspection passed.
+- Complexity guard passed: executeAssistantCodexAttempt 132 to 24; file maximum 132 to 64; debt 112 to 49. Remaining hotspots are request assembly (64), attempt lifecycle (24), and capability classification (21). Further splitting would chiefly move optional-field defaults or the coupled attempt failure state rather than simplify policy.
+- No live-model run: composed provider inputs, prompt text, tool/schema declarations, and reply policy retain their existing semantics; deterministic runner proof directly covers the refactored boundary.
+- Internal refactor only, so no public changelog. Parent owns draft candidate review, ReviewGPT, and exact-head CI.
+Completed: 2026-09-11

--- a/packages/assistant-engine/src/assistant/codex-turn-runner.ts
+++ b/packages/assistant-engine/src/assistant/codex-turn-runner.ts
@@ -38,6 +38,7 @@ import type {
   AssistantProviderRequestOutcome,
   AssistantProviderUsage,
   AssistantProviderUsageDraft,
+  AssistantProviderTurnInput,
 } from './providers/types.js'
 import {
   resolveCodexAssistantProviderTokenPricingBasis,
@@ -448,7 +449,7 @@ function emitCodexPlanTraceEvent(input: {
   }
 }
 
-async function executeAssistantCodexAttempt(input: {
+type AssistantCodexAttemptInput = {
   analyzeVideoTurnState?: AnalyzeVideoTurnState | null
   attemptPlan: AssistantCodexAttemptPlan
   executionPlan: AssistantCodexTurnExecutionPlan
@@ -458,7 +459,11 @@ async function executeAssistantCodexAttempt(input: {
   } & AssistantProviderRequestStartTiming) => Promise<void> | void) | null
   providerRequestOrdinal: number | null
   providerStartCriticalPath?: AssistantProviderStartCriticalPathContext | null
-}): Promise<AssistantCodexAttemptOutcome> {
+}
+
+async function executeAssistantCodexAttempt(
+  input: AssistantCodexAttemptInput,
+): Promise<AssistantCodexAttemptOutcome> {
   const { attemptPlan, executionPlan } = input
   let attemptMetadata: AssistantProviderAttemptMetadata = {
     activityLabels: [] as readonly string[],
@@ -508,277 +513,9 @@ async function executeAssistantCodexAttempt(input: {
       executionPlan,
       hostedMemberId: executionPlan.executionContext?.hosted?.memberId ?? null,
     })
-    const serviceTier = resolveCodexAttemptServiceTier({
-      env: attemptEnv,
-      executionContext: executionPlan.executionContext,
-      requestedServiceTier: executionPlan.input.serviceTier ?? null,
-      routeModel: attemptPlan.route.providerOptions.model ?? null,
-      routeModelProvider: attemptPlan.route.providerOptions.modelProvider ?? null,
-    })
-    const voiceMemoDeliveryChannel =
-      attemptPlan.routePlan.voiceMemoDeliveryChannel ?? null
-    const assistantPreferredElevenLabsVoiceId =
-      attemptPlan.routePlan.assistantPreferredElevenLabsVoiceId ?? null
-    const outputOnlyTurn =
-      executionPlan.profile.toolProfile === 'output-only-turn'
-    const readOnlyAutomationTurn = isReadOnlyScheduledTurn(
-      executionPlan.input, attemptPlan.routePlan.followUpInvocation,
+    const attemptResult = await executeCodexAssistantTurnAttemptFromInput(
+      buildCodexAttemptProviderInput(input, reasoningEffort, usageAttribution),
     )
-    const hostedRuntimeCapabilitiesRestrictedTurn =
-      outputOnlyTurn ||
-      executionPlan.profile.promptProfile === 'creative-notification'
-    const nativeCapabilitiesRestrictedTurn =
-      hostedRuntimeCapabilitiesRestrictedTurn
-    const creativeNotificationSongTurn =
-      executionPlan.profile.promptProfile === 'creative-notification' &&
-      executionPlan.profile.toolProfile === 'provider-turn'
-    const systemNotificationTurn =
-      executionPlan.profile.promptProfile === 'system-notification' ||
-      executionPlan.profile.promptProfile === 'creative-notification'
-    const groupRoomModelMaintenanceTurn =
-      executionPlan.profile.toolProfile === 'maintenance-turn' &&
-      executionPlan.input.maintenanceProfile === 'group-room-model' &&
-      executionPlan.input.scheduledInvocationAuthority?.automationId ===
-        MURPH_GROUP_ROOM_MODEL_CONSOLIDATION_AUTOMATION_ID
-    const memberMemoryMaintenanceTurn =
-      executionPlan.profile.toolProfile === 'maintenance-turn' &&
-      executionPlan.input.maintenanceProfile === 'member-memory' &&
-      executionPlan.input.scheduledInvocationAuthority?.automationId ===
-        MURPH_OVERNIGHT_MEMORY_CONSOLIDATION_AUTOMATION_ID
-    const toolOnlyMaintenanceTurn =
-      groupRoomModelMaintenanceTurn || memberMemoryMaintenanceTurn
-    const habitatVoiceMaintenanceTurn =
-      executionPlan.profile.toolProfile === 'maintenance-turn' &&
-      executionPlan.input.maintenanceProfile === 'habitat-voice'
-    const restrictedOneShotTurn =
-      groupRoomModelMaintenanceTurn ||
-      memberMemoryMaintenanceTurn ||
-      readOnlyAutomationTurn
-    const audience = executionPlan.sharedPlan.conversationPolicy.audience
-    const groupConversation =
-      resolveAssistantConversationScope(audience) === 'group'
-    const groupEmailTurn =
-      audience.threadIsDirect === false &&
-      normalizeNullableString(audience.channel)?.toLowerCase() === 'email'
-    const ordinaryHostedWorkspaceTurn =
-      Boolean(executionPlan.executionContext?.hosted) &&
-      !restrictedOneShotTurn &&
-      !nativeCapabilitiesRestrictedTurn &&
-      !groupEmailTurn
-    const hostedLocalTestProviderTurn =
-      attemptPlan.route.providerOptions.modelProvider ===
-        HOSTED_LOCAL_TEST_CODEX_MODEL_PROVIDER_ID ||
-      attemptPlan.route.providerOptions.modelProvider ===
-        HOSTED_LOCAL_TEST_VENICE_CODEX_MODEL_PROVIDER_ID
-    const attemptResult = await executeCodexAssistantTurnAttemptFromInput({
-      providerConfig: {
-        approvalPolicy:
-          nativeCapabilitiesRestrictedTurn || readOnlyAutomationTurn
-          ? 'never'
-          : attemptPlan.route.providerOptions.approvalPolicy,
-        codexCommand:
-          attemptPlan.route.codexCommand ??
-          executionPlan.input.codexCommand ??
-          undefined,
-        codexHome: attemptPlan.route.providerOptions.codexHome,
-        model: attemptPlan.route.providerOptions.model,
-        modelProvider: attemptPlan.route.providerOptions.modelProvider,
-        oss: attemptPlan.route.providerOptions.oss,
-        profile: attemptPlan.route.providerOptions.profile,
-        provider: attemptPlan.route.provider,
-        reasoningEffort,
-        sandbox:
-          outputOnlyTurn
-            ? null
-            : creativeNotificationSongTurn ||
-                readOnlyAutomationTurn ||
-                groupEmailTurn
-              ? 'read-only'
-              : attemptPlan.route.providerOptions.sandbox,
-      },
-      turn: {
-        abortSignal: serviceTier
-          ? composeAssistantProviderFlexDeadlineSignal(executionPlan.input.abortSignal)
-          : executionPlan.input.abortSignal,
-        analyzeVideoTurnState: input.analyzeVideoTurnState ?? null,
-        activeTurnId: executionPlan.turnId,
-        activeTurnSteering: executionPlan.activeTurnSteering,
-        activeTurnSessionId: attemptPlan.session.sessionId,
-        allowFinishWithoutReply: executionPlan.allowFinishWithoutReply,
-        automationRelativeDateReferenceWindow:
-          resolveAssistantAcceptedTurnInputReferenceWindow(
-            executionPlan.acceptedInputItems ?? [],
-          ),
-        authorizeAcceptedMessageTarget:
-          executionPlan.authorizeAcceptedMessageTarget ?? null,
-        codexThreadConfig:
-          nativeCapabilitiesRestrictedTurn
-            ? ASSISTANT_NATIVE_CAPABILITIES_RESTRICTED_THREAD_CONFIG
-            : toolOnlyMaintenanceTurn
-              ? ASSISTANT_TOOL_ONLY_MAINTENANCE_THREAD_CONFIG
-              : readOnlyAutomationTurn
-                ? ASSISTANT_READ_ONLY_AUTOMATION_THREAD_CONFIG
-                : habitatVoiceMaintenanceTurn
-                  ? ASSISTANT_HABITAT_MAINTENANCE_THREAD_CONFIG
-                  : groupEmailTurn
-                    ? ASSISTANT_GROUP_EMAIL_THREAD_CONFIG
-                    : null,
-        conversationHistoryMessages:
-          attemptPlan.routePlan.conversationHistoryMessages,
-        developerInstructions: attemptPlan.routePlan.developerInstructions,
-        dynamicTools: outputOnlyTurn || readOnlyAutomationTurn
-          ? []
-          : attemptPlan.routePlan.dynamicTools,
-        environments:
-          nativeCapabilitiesRestrictedTurn ||
-          readOnlyAutomationTurn ||
-          toolOnlyMaintenanceTurn
-          ? []
-          : attemptPlan.routePlan.environments,
-        env: attemptEnv,
-        ...(creativeNotificationSongTurn
-          ? {
-              generateSongPolicy:
-                ASSISTANT_CREATIVE_NOTIFICATION_SONG_POLICY,
-            }
-          : {}),
-        followUpAttachmentAllowed: attemptPlan.routePlan.followUpAttachmentAllowed,
-        groupConversation,
-        groupRoomModelMaintenanceAuthorized: groupRoomModelMaintenanceTurn,
-        memberMemoryMaintenanceAuthorized: memberMemoryMaintenanceTurn,
-        hostedToolContext:
-          hostedRuntimeCapabilitiesRestrictedTurn ||
-          readOnlyAutomationTurn ||
-          toolOnlyMaintenanceTurn
-          ? null
-          : executionPlan.hostedToolContext ?? null,
-        materializeWorkspaceArtifacts:
-          hostedRuntimeCapabilitiesRestrictedTurn ||
-          readOnlyAutomationTurn ||
-          toolOnlyMaintenanceTurn
-          ? null
-          : executionPlan.executionContext?.hosted?.materializeWorkspaceArtifacts ?? null,
-        onboardingFirstReadCompletionTransitionAvailable:
-          attemptPlan.routePlan.onboardingGuidanceInjected &&
-          executionPlan.input.scheduledOccurrenceAt == null &&
-          executionPlan.input.scheduledInvocationAuthority == null,
-        onAdditionalUsage: executionPlan.executionContext.hosted?.usageRecorder
-          ? (additionalUsage) => recordAdditionalAssistantUsageEvents({
-              additionalUsages: [additionalUsage],
-              effectiveEnv: attemptEnv,
-              executionContext: executionPlan.executionContext,
-              providerRequestAcceptedInputIds:
-                (executionPlan.acceptedInputItems ?? []).map((item) => item.id),
-              providerResult: {
-                attemptCount: attemptPlan.attemptCount,
-                provider: attemptPlan.route.provider,
-                providerOptions: attemptPlan.route.providerOptions,
-                route: attemptPlan.route,
-                session: attemptPlan.session,
-                usageAttribution,
-              },
-              turnId: executionPlan.turnId,
-            })
-          : null,
-        onEvent: executionPlan.input.onProviderEvent ?? undefined,
-        onFinishWithoutReplyAccepted:
-          executionPlan.onFinishWithoutReplyAccepted ?? null,
-        onFinishWithoutReplyRecorded:
-          executionPlan.onFinishWithoutReplyRecorded ?? null,
-        onProviderRequestStarted: (event) => {
-          notifyProviderRequestStartedBestEffort({
-            event: {
-              ...event,
-              providerRequestOrdinal: input.providerRequestOrdinal,
-            },
-            hook: input.onProviderRequestStarted ?? null,
-          })
-        },
-        onTraceEvent: executionPlan.input.onTraceEvent,
-        productFeedbackRecorder: createAssistantProductFeedbackRecorder({
-          acceptedInputItems: executionPlan.acceptedInputItems ?? [],
-          ...(executionPlan.hostedToolContext
-              ?.currentProductFeedbackAcceptedInputIds
-            ? {
-                getAcceptedInputIds:
-                  executionPlan.hostedToolContext
-                    .currentProductFeedbackAcceptedInputIds,
-              }
-            : {}),
-          productFeedbackCandidateSink:
-            executionPlan.executionContext?.hosted?.productFeedbackCandidateSink ?? null,
-        }),
-        providerThreadEphemeral: systemNotificationTurn || restrictedOneShotTurn
-          ? true
-          : executionPlan.input.providerThreadEphemeral ?? null,
-        progressDelivery:
-          hostedRuntimeCapabilitiesRestrictedTurn ||
-          readOnlyAutomationTurn ||
-          toolOnlyMaintenanceTurn
-          ? null
-          : executionPlan.progressDelivery ?? null,
-        permissions:
-          groupRoomModelMaintenanceTurn
-            ? MURPH_GROUP_ROOM_MODEL_MAINTENANCE_PERMISSION_PROFILE
-            : readOnlyAutomationTurn && executionPlan.executionContext?.hosted
-              ? MURPH_MEMBER_READ_PERMISSION_PROFILE
-              : ordinaryHostedWorkspaceTurn
-                ? hostedLocalTestProviderTurn
-                  ? null
-                  : MURPH_MEMBER_WORKSPACE_PERMISSION_PROFILE
-                : null,
-        ...(restrictedOneShotTurn
-          ? { processLifetime: 'one-shot' as const }
-          : {}),
-        providerFetch:
-          outputOnlyTurn ||
-          readOnlyAutomationTurn
-          ? null
-          : executionPlan.executionContext?.hosted?.providerFetch ?? null,
-        providerRequestOrdinal: input.providerRequestOrdinal ?? null,
-        ...(input.providerStartCriticalPath
-          ? { providerStartCriticalPath: input.providerStartCriticalPath }
-          : {}),
-        publicInternetFetch:
-          outputOnlyTurn ||
-          readOnlyAutomationTurn ||
-          toolOnlyMaintenanceTurn
-          ? null
-          : executionPlan.executionContext?.hosted?.publicInternetFetch ?? null,
-        requireHostedPrivateImageDelivery:
-          !hostedRuntimeCapabilitiesRestrictedTurn &&
-          !readOnlyAutomationTurn &&
-          !toolOnlyMaintenanceTurn &&
-          Boolean(executionPlan.executionContext?.hosted),
-        runtimeWorkspaceRoots:
-          restrictedOneShotTurn || ordinaryHostedWorkspaceTurn
-          ? [attemptPlan.routePlan.workingDirectory]
-          : null,
-        resume: readOnlyAutomationTurn ? null : attemptPlan.routePlan.resume,
-        // Per-turn execution policy from the message input, not route identity.
-        serviceTier,
-        sessionContext: attemptPlan.routePlan.sessionContext
-          ? {
-              binding: attemptPlan.session.binding,
-            }
-          : undefined,
-        showThinkingTraces: executionPlan.input.showThinkingTraces ?? false,
-        systemPrompt: attemptPlan.routePlan.systemPrompt,
-        turnContextPrompt: attemptPlan.routePlan.turnContextPrompt,
-        trustedContextReferences:
-          executionPlan.input.trustedContextReferences ?? null,
-        usageAttribution,
-        vaultRoot: executionPlan.input.vault,
-        userMessageContent: resolveCodexRouteUserMessageContent({
-          route: attemptPlan.route,
-          userMessageContent: executionPlan.input.userMessageContent,
-        }),
-        userPrompt: executionPlan.input.prompt,
-        assistantPreferredElevenLabsVoiceId,
-        voiceMemoDeliveryChannel,
-        workingDirectory: attemptPlan.routePlan.workingDirectory,
-      },
-    })
     attemptMetadata = normalizeAssistantProviderAttemptMetadata(attemptResult.metadata)
     recordAssistantRuntimeIssueInputsBestEffort({
       issues: attemptMetadata.runtimeIssueInputs,
@@ -904,6 +641,313 @@ async function executeAssistantCodexAttempt(input: {
       additionalUsages: failedAttemptAdditionalUsages,
       usageAttribution,
     }
+  }
+}
+
+function resolveCodexAttemptCapabilities(
+  attemptPlan: AssistantCodexAttemptPlan,
+  executionPlan: AssistantCodexTurnExecutionPlan,
+) {
+  const outputOnlyTurn =
+    executionPlan.profile.toolProfile === 'output-only-turn'
+  const readOnlyAutomationTurn = isReadOnlyScheduledTurn(
+    executionPlan.input, attemptPlan.routePlan.followUpInvocation,
+  )
+  const nativeCapabilitiesRestrictedTurn =
+    outputOnlyTurn ||
+    executionPlan.profile.promptProfile === 'creative-notification'
+  const creativeNotificationSongTurn =
+    executionPlan.profile.promptProfile === 'creative-notification' &&
+    executionPlan.profile.toolProfile === 'provider-turn'
+  const systemNotificationTurn =
+    executionPlan.profile.promptProfile === 'system-notification' ||
+    executionPlan.profile.promptProfile === 'creative-notification'
+  const automationId =
+    executionPlan.input.scheduledInvocationAuthority?.automationId
+  const groupRoomModelMaintenanceTurn =
+    executionPlan.profile.toolProfile === 'maintenance-turn' &&
+    executionPlan.input.maintenanceProfile === 'group-room-model' &&
+    automationId === MURPH_GROUP_ROOM_MODEL_CONSOLIDATION_AUTOMATION_ID
+  const memberMemoryMaintenanceTurn =
+    executionPlan.profile.toolProfile === 'maintenance-turn' &&
+    executionPlan.input.maintenanceProfile === 'member-memory' &&
+    automationId === MURPH_OVERNIGHT_MEMORY_CONSOLIDATION_AUTOMATION_ID
+  const toolOnlyMaintenanceTurn =
+    groupRoomModelMaintenanceTurn || memberMemoryMaintenanceTurn
+  const habitatVoiceMaintenanceTurn =
+    executionPlan.profile.toolProfile === 'maintenance-turn' &&
+    executionPlan.input.maintenanceProfile === 'habitat-voice'
+  const restrictedOneShotTurn =
+    toolOnlyMaintenanceTurn || readOnlyAutomationTurn
+  const audience = executionPlan.sharedPlan.conversationPolicy.audience
+  const groupConversation =
+    resolveAssistantConversationScope(audience) === 'group'
+  const groupEmailTurn =
+    audience.threadIsDirect === false &&
+    normalizeNullableString(audience.channel)?.toLowerCase() === 'email'
+  const hostedCapabilitiesRestricted =
+    nativeCapabilitiesRestrictedTurn || restrictedOneShotTurn
+  const toolsRestricted = outputOnlyTurn || readOnlyAutomationTurn
+  const publicInternetRestricted = toolsRestricted || toolOnlyMaintenanceTurn
+  const ordinaryHostedWorkspaceTurn =
+    Boolean(executionPlan.executionContext?.hosted) &&
+    !hostedCapabilitiesRestricted &&
+    !groupEmailTurn
+  const hostedLocalTestProviderTurn =
+    attemptPlan.route.providerOptions.modelProvider ===
+      HOSTED_LOCAL_TEST_CODEX_MODEL_PROVIDER_ID ||
+    attemptPlan.route.providerOptions.modelProvider ===
+      HOSTED_LOCAL_TEST_VENICE_CODEX_MODEL_PROVIDER_ID
+  return {
+    outputOnlyTurn,
+    readOnlyAutomationTurn,
+    nativeCapabilitiesRestrictedTurn,
+    creativeNotificationSongTurn,
+    systemNotificationTurn,
+    groupRoomModelMaintenanceTurn,
+    memberMemoryMaintenanceTurn,
+    toolOnlyMaintenanceTurn,
+    habitatVoiceMaintenanceTurn,
+    restrictedOneShotTurn,
+    groupConversation,
+    groupEmailTurn,
+    ordinaryHostedWorkspaceTurn,
+    hostedLocalTestProviderTurn,
+    hostedCapabilitiesRestricted,
+    toolsRestricted,
+    publicInternetRestricted,
+  }
+}
+
+type CodexAttemptCapabilities = ReturnType<typeof resolveCodexAttemptCapabilities>
+
+function resolveCodexAttemptThreadConfig(
+  capabilities: CodexAttemptCapabilities,
+): AssistantProviderTurnInput['turn']['codexThreadConfig'] {
+  if (capabilities.nativeCapabilitiesRestrictedTurn) {
+    return ASSISTANT_NATIVE_CAPABILITIES_RESTRICTED_THREAD_CONFIG
+  }
+  if (capabilities.toolOnlyMaintenanceTurn) {
+    return ASSISTANT_TOOL_ONLY_MAINTENANCE_THREAD_CONFIG
+  }
+  if (capabilities.readOnlyAutomationTurn) {
+    return ASSISTANT_READ_ONLY_AUTOMATION_THREAD_CONFIG
+  }
+  if (capabilities.habitatVoiceMaintenanceTurn) {
+    return ASSISTANT_HABITAT_MAINTENANCE_THREAD_CONFIG
+  }
+  return capabilities.groupEmailTurn ? ASSISTANT_GROUP_EMAIL_THREAD_CONFIG : null
+}
+
+function resolveCodexAttemptPermissions(
+  capabilities: CodexAttemptCapabilities,
+  executionPlan: AssistantCodexTurnExecutionPlan,
+): AssistantProviderTurnInput['turn']['permissions'] {
+  if (capabilities.groupRoomModelMaintenanceTurn) {
+    return MURPH_GROUP_ROOM_MODEL_MAINTENANCE_PERMISSION_PROFILE
+  }
+  if (capabilities.readOnlyAutomationTurn && executionPlan.executionContext?.hosted) {
+    return MURPH_MEMBER_READ_PERMISSION_PROFILE
+  }
+  if (capabilities.ordinaryHostedWorkspaceTurn && !capabilities.hostedLocalTestProviderTurn) {
+    return MURPH_MEMBER_WORKSPACE_PERMISSION_PROFILE
+  }
+  return null
+}
+
+function buildCodexAttemptProviderInput(
+  input: AssistantCodexAttemptInput,
+  reasoningEffort: string,
+  usageAttribution: AssistantUsageAttribution | null,
+): AssistantProviderTurnInput {
+  const { attemptPlan, executionPlan } = input
+  const attemptEnv = attemptPlan.routePlan.cliEnv
+  const serviceTier = resolveCodexAttemptServiceTier({
+    env: attemptEnv,
+    executionContext: executionPlan.executionContext,
+    requestedServiceTier: executionPlan.input.serviceTier ?? null,
+    routeModel: attemptPlan.route.providerOptions.model ?? null,
+    routeModelProvider: attemptPlan.route.providerOptions.modelProvider ?? null,
+  })
+  const voiceMemoDeliveryChannel =
+    attemptPlan.routePlan.voiceMemoDeliveryChannel ?? null
+  const assistantPreferredElevenLabsVoiceId =
+    attemptPlan.routePlan.assistantPreferredElevenLabsVoiceId ?? null
+  const capabilities = resolveCodexAttemptCapabilities(attemptPlan, executionPlan)
+  return {
+    providerConfig: {
+      approvalPolicy:
+        capabilities.nativeCapabilitiesRestrictedTurn ||
+        capabilities.readOnlyAutomationTurn
+          ? 'never'
+          : attemptPlan.route.providerOptions.approvalPolicy,
+      codexCommand:
+        attemptPlan.route.codexCommand ??
+        executionPlan.input.codexCommand ??
+        undefined,
+      codexHome: attemptPlan.route.providerOptions.codexHome,
+      model: attemptPlan.route.providerOptions.model,
+      modelProvider: attemptPlan.route.providerOptions.modelProvider,
+      oss: attemptPlan.route.providerOptions.oss,
+      profile: attemptPlan.route.providerOptions.profile,
+      provider: attemptPlan.route.provider,
+      reasoningEffort,
+      sandbox:
+        capabilities.outputOnlyTurn
+          ? null
+          : capabilities.creativeNotificationSongTurn ||
+              capabilities.readOnlyAutomationTurn ||
+              capabilities.groupEmailTurn
+            ? 'read-only'
+            : attemptPlan.route.providerOptions.sandbox,
+    },
+    turn: {
+      abortSignal: serviceTier
+        ? composeAssistantProviderFlexDeadlineSignal(executionPlan.input.abortSignal)
+        : executionPlan.input.abortSignal,
+      analyzeVideoTurnState: input.analyzeVideoTurnState ?? null,
+      activeTurnId: executionPlan.turnId,
+      activeTurnSteering: executionPlan.activeTurnSteering,
+      activeTurnSessionId: attemptPlan.session.sessionId,
+      allowFinishWithoutReply: executionPlan.allowFinishWithoutReply,
+      automationRelativeDateReferenceWindow:
+        resolveAssistantAcceptedTurnInputReferenceWindow(
+          executionPlan.acceptedInputItems ?? [],
+        ),
+      authorizeAcceptedMessageTarget:
+        executionPlan.authorizeAcceptedMessageTarget ?? null,
+      codexThreadConfig: resolveCodexAttemptThreadConfig(capabilities),
+      conversationHistoryMessages:
+        attemptPlan.routePlan.conversationHistoryMessages,
+      developerInstructions: attemptPlan.routePlan.developerInstructions,
+      dynamicTools: capabilities.toolsRestricted
+        ? []
+        : attemptPlan.routePlan.dynamicTools,
+      environments: capabilities.hostedCapabilitiesRestricted
+        ? []
+        : attemptPlan.routePlan.environments,
+      env: attemptEnv,
+      ...(capabilities.creativeNotificationSongTurn
+        ? {
+            generateSongPolicy:
+              ASSISTANT_CREATIVE_NOTIFICATION_SONG_POLICY,
+          }
+        : {}),
+      followUpAttachmentAllowed: attemptPlan.routePlan.followUpAttachmentAllowed,
+      groupConversation: capabilities.groupConversation,
+      groupRoomModelMaintenanceAuthorized:
+        capabilities.groupRoomModelMaintenanceTurn,
+      memberMemoryMaintenanceAuthorized: capabilities.memberMemoryMaintenanceTurn,
+      hostedToolContext: capabilities.hostedCapabilitiesRestricted
+        ? null
+        : executionPlan.hostedToolContext ?? null,
+      materializeWorkspaceArtifacts: capabilities.hostedCapabilitiesRestricted
+        ? null
+        : executionPlan.executionContext?.hosted?.materializeWorkspaceArtifacts ?? null,
+      onboardingFirstReadCompletionTransitionAvailable:
+        attemptPlan.routePlan.onboardingGuidanceInjected &&
+        executionPlan.input.scheduledOccurrenceAt == null &&
+        executionPlan.input.scheduledInvocationAuthority == null,
+      onAdditionalUsage: executionPlan.executionContext.hosted?.usageRecorder
+        ? (additionalUsage) => recordAdditionalAssistantUsageEvents({
+            additionalUsages: [additionalUsage],
+            effectiveEnv: attemptEnv,
+            executionContext: executionPlan.executionContext,
+            providerRequestAcceptedInputIds:
+              (executionPlan.acceptedInputItems ?? []).map((item) => item.id),
+            providerResult: {
+              attemptCount: attemptPlan.attemptCount,
+              provider: attemptPlan.route.provider,
+              providerOptions: attemptPlan.route.providerOptions,
+              route: attemptPlan.route,
+              session: attemptPlan.session,
+              usageAttribution,
+            },
+            turnId: executionPlan.turnId,
+          })
+        : null,
+      onEvent: executionPlan.input.onProviderEvent ?? undefined,
+      onFinishWithoutReplyAccepted:
+        executionPlan.onFinishWithoutReplyAccepted ?? null,
+      onFinishWithoutReplyRecorded:
+        executionPlan.onFinishWithoutReplyRecorded ?? null,
+      onProviderRequestStarted: (event) => {
+        notifyProviderRequestStartedBestEffort({
+          event: {
+            ...event,
+            providerRequestOrdinal: input.providerRequestOrdinal,
+          },
+          hook: input.onProviderRequestStarted ?? null,
+        })
+      },
+      onTraceEvent: executionPlan.input.onTraceEvent,
+      productFeedbackRecorder: createAssistantProductFeedbackRecorder({
+        acceptedInputItems: executionPlan.acceptedInputItems ?? [],
+        ...(executionPlan.hostedToolContext
+            ?.currentProductFeedbackAcceptedInputIds
+          ? {
+              getAcceptedInputIds:
+                executionPlan.hostedToolContext
+                  .currentProductFeedbackAcceptedInputIds,
+            }
+          : {}),
+        productFeedbackCandidateSink:
+          executionPlan.executionContext?.hosted?.productFeedbackCandidateSink ?? null,
+      }),
+      providerThreadEphemeral:
+        capabilities.systemNotificationTurn || capabilities.restrictedOneShotTurn
+          ? true
+          : executionPlan.input.providerThreadEphemeral ?? null,
+      progressDelivery: capabilities.hostedCapabilitiesRestricted
+        ? null
+        : executionPlan.progressDelivery ?? null,
+      permissions: resolveCodexAttemptPermissions(capabilities, executionPlan),
+      ...(capabilities.restrictedOneShotTurn
+        ? { processLifetime: 'one-shot' as const }
+        : {}),
+      providerFetch: capabilities.toolsRestricted
+        ? null
+        : executionPlan.executionContext?.hosted?.providerFetch ?? null,
+      providerRequestOrdinal: input.providerRequestOrdinal ?? null,
+      ...(input.providerStartCriticalPath
+        ? { providerStartCriticalPath: input.providerStartCriticalPath }
+        : {}),
+      publicInternetFetch: capabilities.publicInternetRestricted
+        ? null
+        : executionPlan.executionContext?.hosted?.publicInternetFetch ?? null,
+      requireHostedPrivateImageDelivery:
+        !capabilities.hostedCapabilitiesRestricted &&
+        Boolean(executionPlan.executionContext?.hosted),
+      runtimeWorkspaceRoots:
+        capabilities.restrictedOneShotTurn || capabilities.ordinaryHostedWorkspaceTurn
+          ? [attemptPlan.routePlan.workingDirectory]
+          : null,
+      resume: capabilities.readOnlyAutomationTurn
+        ? null
+        : attemptPlan.routePlan.resume,
+      // Per-turn execution policy from the message input, not route identity.
+      serviceTier,
+      sessionContext: attemptPlan.routePlan.sessionContext
+        ? {
+            binding: attemptPlan.session.binding,
+          }
+        : undefined,
+      showThinkingTraces: executionPlan.input.showThinkingTraces ?? false,
+      systemPrompt: attemptPlan.routePlan.systemPrompt,
+      turnContextPrompt: attemptPlan.routePlan.turnContextPrompt,
+      trustedContextReferences:
+        executionPlan.input.trustedContextReferences ?? null,
+      usageAttribution,
+      vaultRoot: executionPlan.input.vault,
+      userMessageContent: resolveCodexRouteUserMessageContent({
+        route: attemptPlan.route,
+        userMessageContent: executionPlan.input.userMessageContent,
+      }),
+      userPrompt: executionPlan.input.prompt,
+      assistantPreferredElevenLabsVoiceId,
+      voiceMemoDeliveryChannel,
+      workingDirectory: attemptPlan.routePlan.workingDirectory,
+    },
   }
 }
 

--- a/packages/assistant-engine/test/assistant-codex-final-coverage.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-final-coverage.test.ts
@@ -801,7 +801,7 @@ describe('Codex model catalog', () => {
     })
   })
 
-  it('enforces the output-only boundary at provider execution', async () => {
+  it.each([false, true])('enforces output-only restrictions before follow-up configuration (follow-up=%s)', async (followUpInvocation) => {
     const route = createRoute()
     const session = createAssistantSession({
       providerOptions: route.providerOptions,
@@ -881,6 +881,7 @@ describe('Codex model catalog', () => {
           surface: null,
         },
         dynamicTools: unsafeDynamicTools,
+        followUpInvocation,
         environments: [{ PRIVATE_ENVIRONMENT: 'must-not-pass' }],
         onboardingGuidanceInjected: false,
         planningDiagnostics: createRoutePlanningDiagnostics(),
@@ -926,7 +927,11 @@ describe('Codex model catalog', () => {
       publicInternetFetch: null,
       requireHostedPrivateImageDelivery: false,
     })
-    expect(providerInput).not.toHaveProperty('processLifetime')
+    if (followUpInvocation) {
+      expect(providerInput).toHaveProperty('processLifetime', 'one-shot')
+    } else {
+      expect(providerInput).not.toHaveProperty('processLifetime')
+    }
     expect(unsafeDynamicTools).not.toEqual([])
     expect(unsafeProgressDelivery.send).not.toHaveBeenCalled()
   })
@@ -1298,7 +1303,15 @@ describe('Codex model catalog', () => {
     expect(unsafeProgressDelivery.send).not.toHaveBeenCalled()
   })
 
-  it('runs immutable room-model maintenance as a one-shot tool-only permission turn', async () => {
+  it.each([
+    { managedAuthority: true, followUpInvocation: false },
+    { managedAuthority: true, followUpInvocation: true },
+    { managedAuthority: false, followUpInvocation: false },
+    { managedAuthority: false, followUpInvocation: true },
+  ])('preserves room-model authority and follow-up precedence: %j', async ({
+    managedAuthority,
+    followUpInvocation,
+  }) => {
     const route = createRoute({
       providerOptions: {
         modelProvider: HOSTED_LOCAL_TEST_CODEX_MODEL_PROVIDER_ID,
@@ -1311,7 +1324,9 @@ describe('Codex model catalog', () => {
       maintenanceProfile: 'group-room-model' as const,
       prompt: 'Refresh the group room model.',
       scheduledInvocationAuthority: {
-        automationId: MURPH_GROUP_ROOM_MODEL_CONSOLIDATION_AUTOMATION_ID,
+        automationId: managedAuthority
+          ? MURPH_GROUP_ROOM_MODEL_CONSOLIDATION_AUTOMATION_ID
+          : 'unrelated-automation',
         occurrenceAt: '2026-07-25T08:00:00.000Z',
       },
       vault: '/vaults/group',
@@ -1366,6 +1381,7 @@ describe('Codex model catalog', () => {
           surface: 'linq',
         },
         dynamicTools: [MURPH_GROUP_ROOM_MODEL_TOOL],
+        followUpInvocation,
         onboardingGuidanceInjected: false,
         planningDiagnostics: createRoutePlanningDiagnostics(),
         promptCacheMetadata: null,
@@ -1394,21 +1410,39 @@ describe('Codex model catalog', () => {
     })
 
     expect(outcome.kind).toBe('succeeded')
-    expect(
+    expect(providerMocks.executeCodexAssistantTurnAttemptFromInput).toHaveBeenCalledOnce()
+    const providerInput =
       providerMocks.executeCodexAssistantTurnAttemptFromInput.mock.calls[0]?.[0]
-        ?.codexThreadConfig,
-    ).toEqual(EXPECTED_TOOL_ONLY_MAINTENANCE_THREAD_CONFIG)
-    expect(
-      providerMocks.executeCodexAssistantTurnAttemptFromInput,
-    ).toHaveBeenCalledWith(expect.objectContaining({
-      dynamicTools: [MURPH_GROUP_ROOM_MODEL_TOOL],
-      groupRoomModelMaintenanceAuthorized: true,
-      permissions:
-        MURPH_GROUP_ROOM_MODEL_MAINTENANCE_PERMISSION_PROFILE,
-      processLifetime: 'one-shot',
-      providerThreadEphemeral: true,
+    expect(providerInput.codexThreadConfig).toEqual(
+      managedAuthority
+        ? EXPECTED_TOOL_ONLY_MAINTENANCE_THREAD_CONFIG
+        : followUpInvocation
+          ? EXPECTED_READ_ONLY_AUTOMATION_THREAD_CONFIG
+          : null,
+    )
+    expect(providerInput).toMatchObject({
+      dynamicTools: followUpInvocation ? [] : [MURPH_GROUP_ROOM_MODEL_TOOL],
+      groupRoomModelMaintenanceAuthorized: managedAuthority,
+      memberMemoryMaintenanceAuthorized: false,
+      permissions: managedAuthority
+        ? MURPH_GROUP_ROOM_MODEL_MAINTENANCE_PERMISSION_PROFILE
+        : followUpInvocation ? MURPH_MEMBER_READ_PERMISSION_PROFILE : null,
+      providerThreadEphemeral: managedAuthority || followUpInvocation ? true : null,
       runtimeWorkspaceRoots: ['/vaults/group'],
-    }))
+    })
+    if (managedAuthority || followUpInvocation) {
+      expect(providerInput).toHaveProperty('processLifetime', 'one-shot')
+      expect(providerInput).toMatchObject({
+        environments: [],
+        hostedToolContext: null,
+        materializeWorkspaceArtifacts: null,
+        progressDelivery: null,
+        publicInternetFetch: null,
+        requireHostedPrivateImageDelivery: false,
+      })
+    } else {
+      expect(providerInput).not.toHaveProperty('processLifetime')
+    }
   })
 
   it('keeps memory maintenance one-shot and isolated from reminder tools', async () => {


### PR DESCRIPTION
## Why and outcome

Codex attempt execution mixed capability policy, provider request assembly, and failure handling in one function with cyclomatic complexity 132. Derive shared restriction families once and keep ordered thread/permission selection in private helpers, with request assembly separated from the attempt lifecycle.

The refactor preserves existing provider inputs and outcomes. Attempt complexity falls to 24, the file maximum to 64, and complexity debt from 112 to 49.

## Product UX

- Effort: Not applicable — internal behavior-preserving refactor.
- Result: Not applicable — no member-facing behavior or prose changes.
- Walkthrough: Existing ordinary hosted/local, group email, output-only notification, creative song, maintenance, onboarding check-in, and recovery boundaries remain covered. Expanded tests verify overlapping follow-up restrictions and exact maintenance authority.

## Evidence

- Direct: `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir packages/assistant-engine test test/assistant-codex-final-coverage.test.ts test/codex-authority-hard-cut.test.ts` — 33 tests passed on the candidate and on the original runner at `ef746ba347a55316c6189b066fd6ff4fa8bf08fa` with the same expanded tests.
- Coverage: Real runner calls captured provider requests; assertions cover capability denial/retention, permission precedence, process lifetime, Flex, rich input, additional usage, diagnostics, and terminal failure behavior. Result/failure handling is byte-identical to base.
- Typecheck: `MURPH_TSC_PACKAGE_CHECKERS=1 pnpm --dir packages/assistant-engine typecheck` — passed.
- Diff: `git diff --check` and changed-line privacy inspection passed.
- Live-model proof: Not run; this changes no prompt, schema, tool eligibility, reply policy, or composed provider-input semantics. Deterministic proof directly exercises the construction boundary.
- Parent candidate review, exact-head ReviewGPT, and all required CI checks passed on the reviewed head.

## Non-obvious affected surfaces

Maintenance and read-only follow-up can overlap. Thread configuration retains native-restriction, tool-only maintenance, read-only, Habitat, then group-email precedence; room-model permission retains priority over read-only permission. Creative song turns retain provider/internet fetch while denying hosted effect ports. Expanded tests cover the overlapping cases alongside existing creative and ordinary-turn assertions.

## Architecture and reuse

- Existing systems reused: The existing assistant-engine runner, execution/attempt plans, provider input contract, and focused runner fixtures.
- New logic: None; shared restriction predicates replace repeated equivalent expressions.
- New abstractions: Private input type, capability classifier, ordered thread/permission selectors, and provider-input builder. No public exports or persisted state.
- Complexity intentionally avoided: No policy registry, mutable capability state, compatibility layer, additional provider call, or retry mechanism.

## Complexity impact

- Guard: pass — `pnpm complexity:diff -- --base ef746ba347 -- packages/assistant-engine/src/assistant/codex-turn-runner.ts`; debt 112 → 49, maximum 132 → 64.
- Hotspots: `buildCodexAttemptProviderInput` 64, `executeAssistantCodexAttempt` 24, and `resolveCodexAttemptCapabilities` 21. Request-field defaults stay together; attempt failure evidence retains one owner; capability classification keeps its related policy facts explicit.
- Agent judgment: The repeated policy chains are removed. Further splitting would largely relocate optional-field defaults or fragment coupled failure-state handling without simplifying behavior.

## Hot reply path impact

- Path status: Touched — provider request construction is synchronous refactoring on the existing foreground path.
- Database calls: None added or moved.
- Network/provider calls: None added or moved; one existing provider attempt remains.
- Other awaited latency: None added or moved; cancellation, Flex deadline, failure recording, and accepted-input release ordering are unchanged.
- Before/after proof: The same 33 focused boundary tests pass against base and candidate; overlap cases assert exactly one provider call. No timing/retry/fallback policy changes or claimed latency measurement.

## Murph initial provider input impact

Not applicable to token measurement: request assembly was reorganized without changing provider-visible content or capability selection for either individual or group runtimes.

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |
| Group Murph | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable | Not applicable |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged; composed runner tests retain request and permission assertions.
- Measurement method: Not run — no provider-input content or behavior changed; no measured zero is claimed.

ReviewGPT first-reviewed head: be13257322e63efac7822aa6ef7c15469cc430c5
ReviewGPT context sensitivity: sensitive
Classification reason: Refactors hosted provider capability and permission construction.

## Deployment concerns

- Deployment: not applicable
- Reason: No schema, persisted state, external protocol, deployment configuration, or cross-version contract changes; the refactored runner builds the existing request shape and preserves all outcomes.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source, existing test changes are tests, and the completed execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 316 | 272 |
| Tests / fixtures | 51 | 17 |
| Docs | 47 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **414** | **289** |

## Changelog

- Changelog: not applicable
- Reason: Internal complexity reduction preserves existing member-visible behavior.

## ReviewGPT result

- Round 1: PASS on be13257322e63efac7822aa6ef7c15469cc430c5.
- Model: GPT-6 Pro, verified by captured response metadata; guarded full snapshot and exact committed turn verified.
- No qualifying findings; no review remediation required. All required CI checks passed on this same head.
