### PR TITLE
refactor(device-sync): simplify hosted account hydration

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-complexity-account-hydration.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-complexity-account-hydration.md
@@ -1,0 +1,56 @@
+# Simplify hosted account hydration
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Outcome and invariant
+
+Reduce the hosted hydration transaction's branching while preserving hosted-first
+identity, fail-closed legacy consolidation, independent connection/token revision
+fences, token clearing, setup fields, and job retirement/wake ordering.
+
+## Evidence and owner
+
+The existing store hydration callback has complexity 127 and file debt 115.
+The callback mixes identity resolution, revision acceptance, repeated field
+selection, and three-table persistence. Metadata sanitizers and cleared
+credential projection also duplicate existing logic. The SQLite store remains
+the sole local owner; no schema or persisted-state contract changes.
+
+## Implementation
+
+- Keep identity lookup/consolidation and all writes inside one immediate transaction.
+- Name identity and observation decisions; select the accepted connection once,
+  retaining the existing null fallback behavior for nullable connection fields.
+- Reuse identical metadata sanitization and existing credential projection.
+- Preserve SQL statements, write order, job effects, and public APIs.
+
+## Risk and proof
+
+Stale snapshots must not overwrite live revisions or credentials; nullable legacy
+fields retain their established fallback. Public store tests cover identities,
+privacy forks, stale/replayed versions, and reconnect effects. Add focused null
+fallback/accepted clearing regression coverage and prove it against the base.
+Run the full store suite, service hydration scenario, package typecheck, and
+complexity guard with bounded workers. Parent owns candidate review and final
+ReviewGPT/CI. Internal refactor only; no member-visible changelog.
+
+## Progress
+
+- Investigation and owner documentation complete.
+- Implementation complete: shared metadata sanitization and credential projection,
+  explicit identity/revision phases, and one connection selection.
+- Base regression proof: both new stale/replayed field tests pass against the
+  unmodified source. Candidate proof: 62 store/field tests and one focused
+  service hydration test pass with one worker per command.
+- `MURPH_TSC_PACKAGE_MODE=single-threaded pnpm --dir packages/device-syncd typecheck` passes.
+- `pnpm complexity:diff --base HEAD -- packages/device-syncd/src/store/hosted-account-hydration.ts`
+  passes: file debt 115 to 29, maximum 127 to 36, transaction callback 127 to 21.
+- Remaining hotspots keep cohesive identity consolidation (36), unchanged token
+  acceptance policy (28), observed revision projection (23), replay comparison
+  (21), and transactional persistence/job effects (21). Further splitting solely
+  for the threshold would obscure those decisions.
+- Candidate diff and privacy checked; no contract, schema, or deployment skew change.
+  Parent completion review, ReviewGPT, and exact-head CI remain separately owned.
+Completed: 2026-09-11

--- a/packages/device-syncd/src/store/hosted-account-hydration.ts
+++ b/packages/device-syncd/src/store/hosted-account-hydration.ts
@@ -94,26 +94,7 @@ function isRawHostedDeviceSyncIdentifierMetadataKey(normalizedKey: string): bool
     || normalizedKey.includes("clientuserid");
 }
 
-function sanitizeHostedConnectionMetadata(
-  value: Record<string, unknown> | null | undefined,
-): Record<string, unknown> {
-  const sanitized = sanitizeStoredDeviceSyncMetadata(value);
-
-  for (const key of Object.keys(sanitized)) {
-    const normalizedKey = normalizeMetadataKey(key);
-    if (
-      normalizedKey.includes("hmacsecret")
-      || normalizedKey.includes("webhooksecret")
-      || isRawHostedDeviceSyncIdentifierMetadataKey(normalizedKey)
-    ) {
-      delete sanitized[key];
-    }
-  }
-
-  return sanitized;
-}
-
-function sanitizeCredentialMetadata(
+function sanitizeHostedMetadata(
   value: Record<string, unknown> | null | undefined,
 ): Record<string, unknown> {
   const sanitized = sanitizeStoredDeviceSyncMetadata(value);
@@ -165,7 +146,7 @@ function sanitizeCredentialSubject(
 }
 
 function buildCredentialMetadata(credential: HostedAccountCredentialInput): Record<string, unknown> {
-  const metadata = sanitizeCredentialMetadata(credential.credentialMetadata ?? {});
+  const metadata = sanitizeHostedMetadata(credential.credentialMetadata ?? {});
 
   if (credential.kind !== "provider_config") {
     return metadata;
@@ -308,17 +289,6 @@ function buildCredentialColumnsFromExisting(
     };
   }
 
-  if (credentialKind === "none") {
-    return {
-      credentialKind,
-      providerConfigKey: null,
-      accessTokenEncrypted: null,
-      refreshTokenEncrypted: null,
-      accessTokenExpiresAt: null,
-      credentialMetadataJson,
-    };
-  }
-
   if (existing?.credential.kind === "oauth_tokens") {
     return {
       credentialKind: "oauth_tokens",
@@ -343,38 +313,13 @@ function buildCredentialColumnsFromExisting(
 function buildClearedCredentialColumnsFromExisting(
   existing: StoredDeviceSyncAccount | null,
 ): ResolvedHostedCredentialColumns {
-  const credentialKind = readStoredCredentialKind(existing);
-  const credentialMetadataJson = stringifyJson(readStoredCredentialMetadata(existing));
-
-  if (credentialKind === "provider_config") {
-    return {
-      credentialKind,
-      providerConfigKey: readStoredProviderConfigKey(existing),
-      accessTokenEncrypted: null,
-      refreshTokenEncrypted: null,
-      accessTokenExpiresAt: null,
-      credentialMetadataJson,
-    };
-  }
-
-  if (credentialKind === "none") {
-    return {
-      credentialKind,
-      providerConfigKey: null,
-      accessTokenEncrypted: null,
-      refreshTokenEncrypted: null,
-      accessTokenExpiresAt: null,
-      credentialMetadataJson,
-    };
-  }
-
+  const columns = buildCredentialColumnsFromExisting(existing);
   return {
-    credentialKind: "none",
-    providerConfigKey: null,
+    ...columns,
+    credentialKind: columns.credentialKind === "provider_config" ? "provider_config" : "none",
     accessTokenEncrypted: null,
     refreshTokenEncrypted: null,
     accessTokenExpiresAt: null,
-    credentialMetadataJson,
   };
 }
 
@@ -596,141 +541,210 @@ export function isReplayedHostedObservedTokenVersion(input: {
     && input.localTokenRevision !== input.hostedObservedTokenRevision;
 }
 
+function resolveHostedHydrationAccount(
+  database: DatabaseSync,
+  input: HostedAccountHydrationInput,
+  hostedConnectionId: string | null,
+): StoredDeviceSyncAccount | null {
+  const existingByHostedConnection = hostedConnectionId
+    ? getAccountByHostedConnectionId(database, hostedConnectionId)
+    : null;
+  const existingByExternalAccount = getAccountByExternalAccount(
+    database,
+    input.connection.provider,
+    input.connection.externalAccountId,
+  );
+  const terminalPrivacyScrub = isTerminalHostedPrivacyScrub(
+    input.connection,
+    hostedConnectionId,
+  );
+  const externalAccountHostedConnectionId = existingByExternalAccount
+    ? getHostedConnectionIdForAccountId(database, existingByExternalAccount.id)
+    : null;
+  const unboundEpochAccounts = terminalPrivacyScrub
+    ? listUnboundAccountsByConnectionEpoch(
+        database,
+        input.connection.provider,
+        input.connection.connectedAt,
+      )
+    : [];
+  if (
+    existingByHostedConnection
+    && existingByHostedConnection.provider !== input.connection.provider
+  ) {
+    throw new TypeError("Hosted device-sync connection cannot change providers.");
+  }
+  if (
+    hostedConnectionId
+    && externalAccountHostedConnectionId
+    && externalAccountHostedConnectionId !== hostedConnectionId
+  ) {
+    throw new TypeError(
+      "Hosted device-sync account is already bound to another hosted connection.",
+    );
+  }
+  const recognizedBoundTerminalFork = Boolean(
+    terminalPrivacyScrub
+    && existingByHostedConnection
+    && existingByExternalAccount
+    && existingByHostedConnection.id !== existingByExternalAccount.id
+    && unboundEpochAccounts.length === 1
+    && unboundEpochAccounts[0]?.id === existingByExternalAccount.id
+  );
+  if (
+    existingByHostedConnection
+    && existingByExternalAccount
+    && existingByHostedConnection.id !== existingByExternalAccount.id
+    && !recognizedBoundTerminalFork
+  ) {
+    throw new TypeError(
+      "Hosted device-sync connection identity conflicts with another local account.",
+    );
+  }
+  if (
+    recognizedBoundTerminalFork
+    && existingByHostedConnection
+    && existingByExternalAccount
+  ) {
+    consolidateLegacyHostedAccount(
+      database,
+      existingByHostedConnection.id,
+      existingByExternalAccount.id,
+    );
+  }
+  let existing = existingByHostedConnection ?? existingByExternalAccount;
+  if (!existing && terminalPrivacyScrub) {
+    if (
+      unboundEpochAccounts.length > 1
+      || unboundEpochAccounts[0]?.externalAccountId.startsWith("opaque:") === true
+    ) {
+      throw new TypeError("Hosted device-sync legacy connection identity is ambiguous.");
+    }
+    existing = unboundEpochAccounts[0] ?? null;
+  }
+  if (existing && terminalPrivacyScrub && !recognizedBoundTerminalFork) {
+    const legacySiblings = unboundEpochAccounts.filter(
+      (account) => account.id !== existing.id,
+    );
+    if (
+      legacySiblings.length > 1
+      || legacySiblings[0]?.externalAccountId.startsWith("opaque:") === true
+    ) {
+      throw new TypeError("Hosted device-sync legacy connection identity is ambiguous.");
+    }
+    if (legacySiblings[0]) {
+      consolidateLegacyHostedAccount(database, existing.id, legacySiblings[0].id);
+    }
+  }
+  return existing;
+}
+
+function planHostedAccountHydration(
+  existing: StoredDeviceSyncAccount | null,
+  input: HostedAccountHydrationInput,
+): ReturnType<typeof resolveHostedAccountHydrationPlan> {
+  const connectionStateStale = isStaleHostedObservedUpdatedAt(
+    existing?.hostedObservedUpdatedAt ?? null,
+    input.hostedObservedUpdatedAt ?? null,
+  );
+  const connectionStateReplayed = isReplayedHostedObservedUpdatedAt({
+    localConnectionRevision: existing?.localConnectionRevision ?? 0,
+    nextObservedUpdatedAt: input.hostedObservedUpdatedAt ?? null,
+    hostedObservedConnectionRevision: existing?.hostedObservedConnectionRevision ?? 0,
+    previousObservedUpdatedAt: existing?.hostedObservedUpdatedAt ?? null,
+  });
+  const tokenStateStale = isStaleHostedObservedTokenVersion(
+    existing?.hostedObservedTokenVersion ?? null,
+    input.hostedObservedTokenVersion ?? null,
+  );
+  const tokenStateReplayed = isReplayedHostedObservedTokenVersion({
+    hostedObservedTokenRevision: existing?.hostedObservedTokenRevision ?? 0,
+    localTokenRevision: existing?.localTokenRevision ?? 0,
+    nextObservedTokenVersion: input.hostedObservedTokenVersion ?? null,
+    previousObservedTokenVersion: existing?.hostedObservedTokenVersion ?? null,
+  });
+  return resolveHostedAccountHydrationPlan({
+    existing,
+    hydration: input,
+    connectionStateReplayed,
+    connectionStateStale,
+    tokenStateReplayed,
+    tokenStateStale,
+  });
+}
+
+function selectHydratedHostedConnection(
+  existing: StoredDeviceSyncAccount | null,
+  connection: HostedAccountHydrationInput["connection"],
+  connectionAccepted: boolean,
+): HostedAccountHydrationInput["connection"] {
+  if (connectionAccepted || !existing) {
+    return connection;
+  }
+
+  return {
+    ...existing,
+    displayName: existing.displayName ?? connection.displayName,
+    setupPhase: existing.setupPhase ?? connection.setupPhase ?? null,
+    setupExpiresAt: existing.setupExpiresAt ?? connection.setupExpiresAt ?? null,
+  };
+}
+
+function resolveHydratedObservationState(
+  existing: StoredDeviceSyncAccount | null,
+  input: HostedAccountHydrationInput,
+  hydrationPlan: ReturnType<typeof resolveHostedAccountHydrationPlan>,
+): Pick<StoredDeviceSyncAccount,
+  | "hostedObservedUpdatedAt"
+  | "hostedObservedConnectionRevision"
+  | "hostedObservedTokenVersion"
+  | "hostedObservedTokenRevision"
+> {
+  const shouldClearTokens = hydrationPlan.tokenPayloadAction === "clear";
+  const hostedObservedUpdatedAt = hydrationPlan.connectionAccepted
+    ? input.hostedObservedUpdatedAt ?? existing?.hostedObservedUpdatedAt ?? null
+    : existing?.hostedObservedUpdatedAt ?? null;
+  const hostedObservedConnectionRevision = hydrationPlan.connectionAccepted
+    && input.advanceHostedObservedConnectionRevision !== false
+    ? existing?.localConnectionRevision ?? 0
+    : existing?.hostedObservedConnectionRevision ?? 0;
+  const hostedObservedTokenVersion = shouldClearTokens
+    ? input.hostedObservedTokenVersion
+    : hydrationPlan.advanceTokenObservation
+      ? input.hostedObservedTokenVersion
+      : existing?.hostedObservedTokenVersion ?? null;
+  const hostedObservedTokenRevision = shouldClearTokens || hydrationPlan.advanceTokenObservation
+    ? existing?.localTokenRevision ?? 0
+    : existing?.hostedObservedTokenRevision ?? 0;
+  return {
+    hostedObservedUpdatedAt,
+    hostedObservedConnectionRevision,
+    hostedObservedTokenVersion,
+    hostedObservedTokenRevision,
+  };
+}
+
 export function hydrateHostedAccount(
   database: DatabaseSync,
   input: HostedAccountHydrationInput,
 ): StoredDeviceSyncAccount | null {
   return withImmediateTransaction(database, () => {
     const hostedConnectionId = normalizeHostedConnectionId(input.hostedConnectionId);
-    const existingByHostedConnection = hostedConnectionId
-      ? getAccountByHostedConnectionId(database, hostedConnectionId)
-      : null;
-    const existingByExternalAccount = getAccountByExternalAccount(
-      database,
-      input.connection.provider,
-      input.connection.externalAccountId,
-    );
-    const terminalPrivacyScrub = isTerminalHostedPrivacyScrub(
-      input.connection,
-      hostedConnectionId,
-    );
-    const externalAccountHostedConnectionId = existingByExternalAccount
-      ? getHostedConnectionIdForAccountId(database, existingByExternalAccount.id)
-      : null;
-    const unboundEpochAccounts = terminalPrivacyScrub
-      ? listUnboundAccountsByConnectionEpoch(
-          database,
-          input.connection.provider,
-          input.connection.connectedAt,
-        )
-      : [];
-    if (
-      existingByHostedConnection
-      && existingByHostedConnection.provider !== input.connection.provider
-    ) {
-      throw new TypeError("Hosted device-sync connection cannot change providers.");
-    }
-    if (
-      hostedConnectionId
-      && externalAccountHostedConnectionId
-      && externalAccountHostedConnectionId !== hostedConnectionId
-    ) {
-      throw new TypeError(
-        "Hosted device-sync account is already bound to another hosted connection.",
-      );
-    }
-    const recognizedBoundTerminalFork = Boolean(
-      terminalPrivacyScrub
-      && existingByHostedConnection
-      && existingByExternalAccount
-      && existingByHostedConnection.id !== existingByExternalAccount.id
-      && unboundEpochAccounts.length === 1
-      && unboundEpochAccounts[0]?.id === existingByExternalAccount.id
-    );
-    if (
-      existingByHostedConnection
-      && existingByExternalAccount
-      && existingByHostedConnection.id !== existingByExternalAccount.id
-      && !recognizedBoundTerminalFork
-    ) {
-      throw new TypeError(
-        "Hosted device-sync connection identity conflicts with another local account.",
-      );
-    }
-    if (
-      recognizedBoundTerminalFork
-      && existingByHostedConnection
-      && existingByExternalAccount
-    ) {
-      consolidateLegacyHostedAccount(
-        database,
-        existingByHostedConnection.id,
-        existingByExternalAccount.id,
-      );
-    }
-    let existing = existingByHostedConnection ?? existingByExternalAccount;
-    if (!existing && terminalPrivacyScrub) {
-      if (
-        unboundEpochAccounts.length > 1
-        || unboundEpochAccounts[0]?.externalAccountId.startsWith("opaque:") === true
-      ) {
-        throw new TypeError("Hosted device-sync legacy connection identity is ambiguous.");
-      }
-      existing = unboundEpochAccounts[0] ?? null;
-    }
-    if (existing && terminalPrivacyScrub && !recognizedBoundTerminalFork) {
-      const legacySiblings = unboundEpochAccounts.filter(
-        (account) => account.id !== existing.id,
-      );
-      if (
-        legacySiblings.length > 1
-        || legacySiblings[0]?.externalAccountId.startsWith("opaque:") === true
-      ) {
-        throw new TypeError("Hosted device-sync legacy connection identity is ambiguous.");
-      }
-      if (legacySiblings[0]) {
-        consolidateLegacyHostedAccount(database, existing.id, legacySiblings[0].id);
-      }
-    }
+    const existing = resolveHostedHydrationAccount(database, input, hostedConnectionId);
 
     if (!existing && getHostedHydrationTokenInput(input) === undefined && input.credential === undefined) {
       return null;
     }
 
-    const connectionStateStale = isStaleHostedObservedUpdatedAt(
-      existing?.hostedObservedUpdatedAt ?? null,
-      input.hostedObservedUpdatedAt ?? null,
-    );
-    const connectionStateReplayed = isReplayedHostedObservedUpdatedAt({
-      localConnectionRevision: existing?.localConnectionRevision ?? 0,
-      nextObservedUpdatedAt: input.hostedObservedUpdatedAt ?? null,
-      hostedObservedConnectionRevision: existing?.hostedObservedConnectionRevision ?? 0,
-      previousObservedUpdatedAt: existing?.hostedObservedUpdatedAt ?? null,
-    });
-    const tokenStateStale = isStaleHostedObservedTokenVersion(
-      existing?.hostedObservedTokenVersion ?? null,
-      input.hostedObservedTokenVersion ?? null,
-    );
-    const tokenStateReplayed = isReplayedHostedObservedTokenVersion({
-      hostedObservedTokenRevision: existing?.hostedObservedTokenRevision ?? 0,
-      localTokenRevision: existing?.localTokenRevision ?? 0,
-      nextObservedTokenVersion: input.hostedObservedTokenVersion ?? null,
-      previousObservedTokenVersion: existing?.hostedObservedTokenVersion ?? null,
-    });
-    const hydrationPlan = resolveHostedAccountHydrationPlan({
-      existing,
-      hydration: input,
-      connectionStateReplayed,
-      connectionStateStale,
-      tokenStateReplayed,
-      tokenStateStale,
-    });
+    const hydrationPlan = planHostedAccountHydration(existing, input);
     const shouldClearTokens = hydrationPlan.tokenPayloadAction === "clear";
-    const connectionUpdatedAt = hydrationPlan.connectionAccepted
-      ? input.connection.updatedAt
-      : existing?.updatedAt ?? input.connection.updatedAt;
-    const rowUpdatedAt = latestIsoTimestamp(existing?.updatedAt ?? null, connectionUpdatedAt)
-      ?? connectionUpdatedAt;
+    const connection = selectHydratedHostedConnection(
+      existing,
+      input.connection,
+      hydrationPlan.connectionAccepted,
+    );
+    const rowUpdatedAt = latestIsoTimestamp(existing?.updatedAt ?? null, connection.updatedAt)
+      ?? connection.updatedAt;
     const inputTokens = getHostedHydrationTokenInput(input);
     const credentialColumns = resolveHydratedHostedAccountCredential({
       acceptNonTokenCredential: hydrationPlan.acceptNonTokenCredential,
@@ -740,47 +754,16 @@ export function hydrateHostedAccount(
       hydration: input,
       inputTokens: hydrationPlan.tokenPayloadAction === "apply_bundle" ? inputTokens : undefined,
     });
-    const hostedObservedUpdatedAt = hydrationPlan.connectionAccepted
-      ? input.hostedObservedUpdatedAt ?? existing?.hostedObservedUpdatedAt ?? null
-      : existing?.hostedObservedUpdatedAt ?? null;
-    const hostedObservedConnectionRevision = hydrationPlan.connectionAccepted
-      && input.advanceHostedObservedConnectionRevision !== false
-      ? existing?.localConnectionRevision ?? 0
-      : existing?.hostedObservedConnectionRevision ?? 0;
-    const hostedObservedTokenVersion = shouldClearTokens
-      ? input.hostedObservedTokenVersion
-      : hydrationPlan.advanceTokenObservation
-        ? input.hostedObservedTokenVersion
-        : existing?.hostedObservedTokenVersion ?? null;
-    const hostedObservedTokenRevision = shouldClearTokens || hydrationPlan.advanceTokenObservation
-      ? existing?.localTokenRevision ?? 0
-      : existing?.hostedObservedTokenRevision ?? 0;
-    const displayName = hydrationPlan.connectionAccepted
-      ? input.connection.displayName
-      : existing?.displayName ?? input.connection.displayName;
-    const status = hydrationPlan.connectionAccepted
-      ? input.connection.status
-      : existing?.status ?? input.connection.status;
-    const setupPhase = hydrationPlan.connectionAccepted
-      ? input.connection.setupPhase ?? null
-      : existing?.setupPhase ?? input.connection.setupPhase ?? null;
-    const setupExpiresAt = hydrationPlan.connectionAccepted
-      ? input.connection.setupExpiresAt ?? null
-      : existing?.setupExpiresAt ?? input.connection.setupExpiresAt ?? null;
-    const scopes = hydrationPlan.connectionAccepted
-      ? input.connection.scopes
-      : existing?.scopes ?? input.connection.scopes;
-    const metadata = sanitizeHostedConnectionMetadata(
-      hydrationPlan.connectionAccepted
-        ? input.connection.metadata
-        : existing?.metadata ?? input.connection.metadata,
-    );
-    const connectedAt = hydrationPlan.connectionAccepted
-      ? input.connection.connectedAt
-      : existing?.connectedAt ?? input.connection.connectedAt;
-    const externalAccountId = hydrationPlan.connectionAccepted
-      ? input.connection.externalAccountId
-      : existing?.externalAccountId ?? input.connection.externalAccountId;
+    const {
+      hostedObservedUpdatedAt,
+      hostedObservedConnectionRevision,
+      hostedObservedTokenVersion,
+      hostedObservedTokenRevision,
+    } = resolveHydratedObservationState(existing, input, hydrationPlan);
+    const { displayName, status, scopes, connectedAt, externalAccountId } = connection;
+    const setupPhase = connection.setupPhase ?? null;
+    const setupExpiresAt = connection.setupExpiresAt ?? null;
+    const metadata = sanitizeHostedMetadata(connection.metadata);
     const disconnectGeneration = existing
       ? hydrationPlan.connectionAccepted && status === "disconnected" && existing.status !== "disconnected"
         ? existing.disconnectGeneration + 1

--- a/packages/device-syncd/test/hosted-account-hydration-fields.test.ts
+++ b/packages/device-syncd/test/hosted-account-hydration-fields.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { rm } from "node:fs/promises";
+import path from "node:path";
+
+import { test } from "vitest";
+
+import { SqliteDeviceSyncStore } from "../src/store.ts";
+import type { HostedAccountHydrationInput } from "../src/store/hosted-account-hydration.ts";
+import { makeTempDirectory } from "./helpers.ts";
+
+test.each(["stale", "replayed"] as const)(
+  "%s hosted connection preserves empty fields and legacy nullable fallbacks",
+  async (revision) => {
+    const tempDir = await makeTempDirectory("murph-hosted-hydration-fields");
+    const store = new SqliteDeviceSyncStore(path.join(tempDir, "state.sqlite"));
+    const input: HostedAccountHydrationInput = {
+      credential: { kind: "none" },
+      connection: {
+        connectedAt: "2026-09-01T00:00:00.000Z",
+        displayName: null,
+        externalAccountId: "synthetic-hydration-account",
+        metadata: {},
+        provider: "demo",
+        scopes: [],
+        setupExpiresAt: null,
+        setupPhase: null,
+        status: "active",
+        updatedAt: "2026-09-01T02:00:00.000Z",
+      },
+      hostedObservedTokenVersion: null,
+      hostedObservedUpdatedAt: "2026-09-01T02:00:00.000Z",
+      localState: {
+        lastErrorCode: null,
+        lastErrorMessage: null,
+        lastSyncCompletedAt: null,
+        lastSyncErrorAt: null,
+        lastSyncStartedAt: null,
+        lastWebhookAt: null,
+        nextReconcileAt: null,
+      },
+    };
+
+    try {
+      const initial = store.hydrateHostedAccount(input);
+      assert.ok(initial);
+      const current = revision === "replayed"
+        ? store.patchAccount(initial.id, { metadata: {} })
+        : initial;
+
+      const observedAt = revision === "stale"
+        ? "2026-09-01T01:00:00.000Z"
+        : input.hostedObservedUpdatedAt;
+      const rejected = store.hydrateHostedAccount({
+        ...input,
+        hostedObservedUpdatedAt: observedAt,
+        connection: {
+          ...input.connection,
+          connectedAt: "2026-09-01T01:00:00.000Z",
+          displayName: "Synthetic setup",
+          metadata: { incoming: true },
+          scopes: ["sleep"],
+          setupExpiresAt: "2026-09-01T04:00:00.000Z",
+          setupPhase: "pending_link",
+          status: "disconnected",
+          updatedAt: "2026-09-01T01:00:00.000Z",
+        },
+        localState: {
+          ...input.localState,
+          lastSyncCompletedAt: "2026-09-01T03:00:00.000Z",
+        },
+      });
+
+      assert.ok(rejected);
+      assert.equal(rejected.id, initial.id);
+      assert.equal(rejected.status, "active");
+      assert.equal(rejected.connectedAt, initial.connectedAt);
+      assert.equal(rejected.updatedAt, current.updatedAt);
+      assert.equal(rejected.disconnectGeneration, initial.disconnectGeneration);
+      assert.deepEqual(rejected.scopes, []);
+      assert.deepEqual(rejected.metadata, {});
+      assert.equal(rejected.displayName, "Synthetic setup");
+      assert.equal(rejected.setupPhase, "pending_link");
+      assert.equal(rejected.setupExpiresAt, "2026-09-01T04:00:00.000Z");
+      assert.equal(rejected.lastSyncCompletedAt, "2026-09-01T03:00:00.000Z");
+      assert.equal(rejected.hostedObservedUpdatedAt, initial.hostedObservedUpdatedAt);
+      assert.equal(rejected.hostedObservedConnectionRevision, initial.hostedObservedConnectionRevision);
+
+      const accepted = store.hydrateHostedAccount({
+        ...input,
+        hostedObservedUpdatedAt: "2026-09-01T05:00:00.000Z",
+        connection: {
+          ...input.connection,
+          updatedAt: "2026-09-01T05:00:00.000Z",
+        },
+      });
+      assert.ok(accepted);
+      assert.equal(accepted.displayName, null);
+      assert.equal(accepted.setupPhase, null);
+      assert.equal(accepted.setupExpiresAt, null);
+      assert.equal(accepted.hostedObservedConnectionRevision, accepted.localConnectionRevision);
+    } finally {
+      store.close();
+      await rm(tempDir, { force: true, recursive: true });
+    }
+  },
+);


### PR DESCRIPTION
## Why and outcome

Hosted account hydration combined identity reconciliation, revision acceptance, field selection, and persistence in one callback with cyclomatic complexity 127. This refactor gives identity and observation decisions named phases, selects connection state once, and reuses duplicate metadata and credential projection logic. Maximum function complexity falls to 36 and file debt falls from 115 to 29.

Hydration keeps its existing transaction, SQL ordering, credential/replay fences, privacy consolidation, and job lifecycle behavior. The new regression tests explicitly preserve the legacy nullable-field fallbacks for stale/replayed snapshots and clearing from a fresh accepted snapshot.

## Product UX

- Effort: Not applicable — internal behavior-preserving store refactor.
- Result: Not applicable.
- Walkthrough: Existing connection, reconnect, disconnect, and hydration semantics are covered by the store and service tests; no member interaction changes.

## Evidence

- Direct: `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir packages/device-syncd exec vitest run --config vitest.config.ts --no-coverage test/store.test.ts test/hosted-account-hydration-fields.test.ts` — 62 tests passed.
- Direct: `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir packages/device-syncd exec vitest run --config vitest.config.ts --no-coverage test/service.test.ts -t 'sqlite store hosted hydration replaces mirrored metadata and clears local tokens on disconnect'` — 1 test passed, 148 unrelated cases skipped.
- Direct: `MURPH_TSC_PACKAGE_MODE=single-threaded pnpm --dir packages/device-syncd typecheck` — passed.
- Coverage: Both new stale/replayed nullable-field regression cases also pass against the original source. Existing store tests cover hosted identity collisions, legacy privacy forks, independent token/connection revisions, disconnect clearing, and reconnect job effects.
- Parent candidate review, exact-head ReviewGPT, and all required CI checks passed on the reviewed head.

## Non-obvious affected surfaces

Credential metadata sanitization shares the identical existing sanitizer with connection metadata. Clearing reuses the existing credential-column projection while retaining provider-config credentials. Store/service regressions cover sanitization and credential transitions.

## Architecture and reuse

- Existing systems reused: The SQLite store, immediate transaction, identity/consolidation helpers, hydration acceptance policy, and existing job lifecycle owners.
- New logic: None; accepted state and persistence behavior are preserved.
- New abstractions: Four private helpers name identity resolution, replay planning, connection selection, and observed revision projection within the existing file.
- Complexity intentionally avoided: Duplicate sanitizers, repeated field-by-field acceptance branches, and duplicate credential projections were removed without adding a state owner, dependency, schema, or generalized framework.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base HEAD -- packages/device-syncd/src/store/hosted-account-hydration.ts` before commit; debt 115 → 29, maximum 127 → 36, transaction callback 127 → 21.
- Hotspots: `resolveHostedHydrationAccount` 36 keeps fail-closed identity/consolidation decisions together; unchanged `resolveHostedAccountHydrationPlan` 28 retains independent token policy; `resolveHydratedObservationState` 23 owns revision projection; `planHostedAccountHydration` 21 owns replay comparisons; transaction callback 21 owns ordered persistence and job effects.
- Agent judgment: The refactor removes real duplicated decisions and exposes coherent phases. Further splitting these remaining functions solely to reach the threshold would obscure their coupled invariants.

## Hot reply path impact

- Path status: Not applicable — this change refactors device account hydration and adds no foreground reply operations.
- Database calls: None added or moved; all existing reads, consolidation, and writes remain inside the same immediate transaction in the same order.
- Network/provider calls: None.
- Other awaited latency: None.
- Before/after proof: Store/service regression suites pass; source inspection confirms unchanged SQL and job-effect ordering.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: this change has no prompt, instruction, tool, schema, generated guidance, or provider-input surface.

ReviewGPT context sensitivity: sensitive
Classification reason: Behavior-preserving refactor of credential/revision state and privacy-sensitive account identity consolidation.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal refactor with unchanged stored schema, wire contracts, public API, and deployment ordering; no new compatibility or convergence requirement.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source, the new regression file is tests, and the archived execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 200 | 217 |
| Tests / fixtures | 106 | 0 |
| Docs | 56 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **362** | **217** |

## Changelog

- Changelog: not applicable
- Reason: Internal complexity reduction preserves all member-visible behavior.

ReviewGPT first-reviewed head: 8bb09b0d039c05c97255c2345a795b01718fa7a1

## ReviewGPT result

- Round 1: PASS on 8bb09b0d039c05c97255c2345a795b01718fa7a1.
- Model: GPT-6 Pro, verified by captured response metadata; guarded full snapshot and exact committed turn verified.
- No qualifying findings; no review remediation required. All required CI checks passed on this same head.
