### PR TITLE
refactor(web): simplify Linq member admission planning

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-complexity2-linq-planning-sep11.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-complexity2-linq-planning-sep11.md
@@ -1,0 +1,52 @@
+# Simplify Linq direct-member admission and signup planning
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal
+
+Reduce Linq planner complexity by isolating the existing direct-member admission boundary and sharing repeated fallback signup and first-contact admission plan construction. Preserve every accepted-message, consent, identity, routing, and delivery invariant.
+
+## Evidence and current owners
+
+The provider planner has complexity debt 278 and maximum 93. Direct-member admission currently combines exact mailbox dedupe, consent outcomes, failed preparation precedence, and routing revalidation within the outer planner. Initial fallback and fallback retry repeat the same inbound-count, invite, and response sequence; direct/group admission repeat the same result construction.
+
+The existing Web transaction, mailbox dedupe, member access, prepared routing and invite owners remain authoritative. Preflight and in-transaction reads are separate live checks and must not be collapsed.
+
+## Scope and constraints
+
+- In scope: private same-file phase and shared result construction in webhook-provider-linq.ts; focused proof if an evidence gap appears.
+- Out of scope: schema, public API, prompts, provider requests, line policy, group provisioning redesign, deployment and merging.
+- Preserve participant-before-chat-before-member locks, access reads, duplicate recovery before mutable policy, consent notice behavior and crypto failure precedence.
+- Preserve Family-before-group-before-billing handling, post-Family access rechecks, first-contact identity creation authority, invite ownership and inbound counting order.
+- No new database/provider calls, retries, dependencies, persisted state or framework.
+
+## Tasks
+
+1. Inspect current source, owner docs and composed coverage.
+2. Isolate direct-member admission and remove repeated fallback/admission construction.
+3. Run focused composed Web tests, Web typecheck and complexity guard; inspect the full diff and privacy.
+4. Close this plan with a scoped commit, push and create a complete draft PR. Parent owns candidate review, Ready, ReviewGPT and completion.
+
+## Risks and mitigation
+
+- A refactor could change which duplicate, consent or preparation failure wins. Keep the existing order and exercise the composed dispatch, idempotency and mailbox-preparation suites.
+- Sharing fallback work could move counting or invite issuance ahead of route authority. Invoke the shared sequence only at the original call sites after their unchanged authorization work.
+- No member-visible change or provider-input change is intended, so no changelog entry or model-input measurement is required.
+
+## Verification
+
+- Passed: `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir apps/web test:prepared test/hosted-onboarding-linq-dispatch.test.ts test/hosted-onboarding-linq-thread-route.test.ts test/hosted-onboarding-linq-mailbox-root-prewarm.test.ts test/hosted-onboarding-linq-read-receipt-authority.test.ts test/hosted-onboarding-webhook-idempotency.test.ts` — 433 tests in five files.
+- Passed: `pnpm --dir apps/web typecheck` with the shared two-checker profile.
+- Passed: `pnpm complexity:diff --base HEAD` against the unchanged task base. File debt 278 to 257; maximum 93 to 89. Outer planner 93 to 76; first-contact planner 76 to 72. Both added private helpers are below the threshold of 20.
+- Reviewed all nine remaining hotspots. Group planning, message-edit handling, thread preparation, Family acceptance and route policy retain their existing authority and transaction boundaries; further decomposition belongs in separately proven work.
+- Existing composed tests cover exact duplicate repair before mutable policy, withdrawn consent versus failed/null preparation, first-contact fallback/retry, group admission, prewarmed cryptography and receipt authority. No new test-only export or duplicated implementation test was needed.
+- Full source diff and privacy inspected; `git diff --check` passed. No added database or provider call, no changed live-read ordering, and no schema or provider-input change.
+
+## Outcome and handoff
+
+Existing direct-member admission now returns either its canonical terminal plan or its two admitted routing facts. Initial and retry fallback signup share one ordered count/invite/response sequence; direct and group first-contact admission share existing result and diagnostic construction. Removed the one-use duplicate-plan closure and redundant first-contact active-state alias.
+
+Implementation and focused proof are complete. The parent owns the draft candidate review, Ready transition, exact-head CI, ReviewGPT and merging. No changelog: this is internal, behavior-preserving planner maintenance.
+Completed: 2026-09-11

--- a/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
+++ b/apps/web/src/lib/hosted-onboarding/webhook-provider-linq.ts
@@ -1486,39 +1486,6 @@ export async function planHostedOnboardingLinqWebhook(
     existingMemberLookup,
     existingPendingLinqContactLookupPresent: Boolean(existingPendingLinqContactLookup),
   });
-  const buildExistingMemberDuplicatePlan = (duplicateInput: {
-    existingMemberActive: boolean;
-    mailboxItemId: string;
-    memberId: string;
-  }): HostedOnboardingLinqDirectPlan =>
-    logHostedLinqWebhookPlannerDecisionAndReturn(
-      buildActiveMemberDirectPlan({
-        desiredSideEffects: [],
-        postCommitGroupJoinConfirmationMemberIds: [duplicateInput.memberId],
-        response: {
-          duplicate: true,
-          ignored: true,
-          ok: true,
-          reason: "duplicate-webhook-event",
-        },
-        // No checkpoint on the duplicate read: this transaction did not run
-        // the append-path workspace upsert, so the retry keeps the legacy
-        // signal path that repairs a missing workspace row.
-        wakeHandoffs: [{
-          eventId: input.event.event_id,
-          mailboxItemId: duplicateInput.mailboxItemId,
-          source: "linq",
-          userId: duplicateInput.memberId,
-        }],
-      }),
-      buildHostedLinqWebhookPlannerDetails(input.event, context, {
-        duplicate: true,
-        existingMemberActive: duplicateInput.existingMemberActive,
-        existingMemberMatch,
-        reason: "duplicate-webhook-event",
-        routeStage: "active-member-duplicate",
-      }),
-    );
   const memberRouteBindingAuthority = resolveHostedLinqHomeLineRouteBindingAuthority({
     existingMemberMatch,
     participantContact,
@@ -1589,117 +1556,20 @@ export async function planHostedOnboardingLinqWebhook(
   }
 
   if (existingMember) {
-    if (!preparedDirectMailboxControlAuthority) {
-      await lockHostedMemberRow(input.prisma, existingMember.id);
-    }
-    const exactMemberAccess = await readHostedRuntimeAiAccessDecision({
-      memberId: existingMember.id,
-      noticeSeed: input.event.event_id,
-      now: new Date(occurredAt),
-      prisma: input.prisma,
+    const admission = await admitHostedLinqExistingDirectMemberTx({
+      context,
+      directMailboxPreparationFailureProvided,
+      directMailboxPreparationProvided,
+      existingMember,
+      existingMemberMatch,
+      input,
+      preparedDirectMailboxControlAuthority,
     });
-    existingMemberEffectiveActive = exactMemberAccess.allowed;
-    // The committed mailbox row is the canonical classification for this exact
-    // member/event pair. Repair its wake before mutable Family, group, quota, or
-    // routing state can reinterpret a provider redelivery.
-    const existingMailboxItem = await readHostedMailboxItemByDedupeKey({
-      dedupeKey: input.event.event_id,
-      prisma: input.prisma,
-      userId: existingMember.id,
-    });
-    if (existingMailboxItem) {
-      return buildExistingMemberDuplicatePlan({
-        existingMemberActive: existingMemberEffectiveActive,
-        mailboxItemId: existingMailboxItem.id,
-        memberId: existingMember.id,
-      });
+    if ("response" in admission) {
+      return admission;
     }
-    if (directMailboxPreparationFailureProvided) {
-      if (
-        !exactMemberAccess.allowed
-        && exactMemberAccess.reason !== "health_data_consent_withdrawn"
-      ) {
-        throw input.directMailboxPreparationFailure;
-      }
-    }
-    if (
-      !exactMemberAccess.allowed
-      && exactMemberAccess.reason === "health_data_consent_withdrawn"
-    ) {
-      if (
-        !isHostedLinqDirectChatAttested(messageEvent)
-        || !exactMemberAccess.userNotice
-      ) {
-        return buildHostedLinqIgnoredPlan(input.event, context, {
-          accessReason: exactMemberAccess.reason,
-          existingMemberActive: false,
-          existingMemberMatch,
-          reason: "health-data-consent-withdrawn",
-          routeStage: "health-data-consent-withdrawn",
-        });
-      }
-      return logHostedLinqWebhookPlannerDecisionAndReturn(
-        buildInactiveMemberAccessNoticeResponse({
-          chatId: summary.chatId,
-          memberId: existingMember.id,
-          message: exactMemberAccess.userNotice.message,
-          messageId: summary.messageId,
-          noticeCode: exactMemberAccess.userNotice.code,
-          occurredAt,
-          sourceEventId: input.event.event_id,
-        }),
-        buildHostedLinqWebhookPlannerDetails(input.event, context, {
-          accessReason: exactMemberAccess.reason,
-          existingMemberActive: false,
-          existingMemberMatch,
-          noticeCode: exactMemberAccess.userNotice.code,
-          reason: HOSTED_LINQ_INACTIVE_MEMBER_NOTICE_REASON[
-            exactMemberAccess.userNotice.code
-          ],
-          routeStage: "health-data-consent-withdrawn",
-        }),
-      );
-    }
-
-    if (
-      directMailboxPreparationProvided
-      && input.preparedDirectMailboxPayloadRoot === null
-    ) {
-      // Exact duplicate, withdrawn consent, suspension, and stable owner
-      // mismatch already terminated above. Any other existing member can still
-      // enter Family, group-reply, instant-start, signup, or route policy that
-      // reads or writes private routing, even while mailbox access is inactive.
-      throw hostedLinqDirectMailboxPreparationRequired("member");
-    }
-
-    if (directMailboxPreparationFailureProvided) {
-      // Exact duplicate and withdrawn consent are the only outcomes whose
-      // authority is complete without private routing. Quota, Family, group,
-      // and home-route decisions require the prepared state, so preserve the
-      // provider retry instead of partially reclassifying this event.
-      throw input.directMailboxPreparationFailure;
-    }
-
-    if (directMailboxPreparationProvided) {
-      if (!preparedDirectMailboxControlAuthority) {
-        throw hostedLinqDirectMailboxPreparationRequired("member");
-      }
-      if (
-        exactMemberAccess.allowed
-        && !preparedDirectMailboxControlAuthority.preparedIngressRoot
-        && preparedDirectMailboxControlAuthority.preparedFamilyInvite?.kind
-          !== "accepted_replay"
-      ) {
-        throw hostedLinqDirectMailboxPreparationRequired("ingress-root");
-      }
-      preparedDirectRoutingAuthority =
-        await revalidatePreparedHostedLinqDirectRoutingTx({
-          memberId: existingMember.id,
-          prepared: preparedDirectMailboxControlAuthority,
-          prisma: input.prisma,
-        });
-    }
-
+    existingMemberEffectiveActive = admission.existingMemberActive;
+    preparedDirectRoutingAuthority = admission.preparedRoutingAuthority;
   }
 
   const familyPlan = await planHostedLinqFamilyInviteWebhook({
@@ -1914,6 +1784,172 @@ export async function planHostedOnboardingLinqWebhook(
   });
 }
 
+async function admitHostedLinqExistingDirectMemberTx(admission: {
+  context: ReturnType<typeof resolveHostedOnboardingLinqMessageContext>;
+  directMailboxPreparationFailureProvided: boolean;
+  directMailboxPreparationProvided: boolean;
+  existingMember: HostedMemberCoreState;
+  existingMemberMatch: HostedLinqExistingMemberMatch;
+  input: HostedOnboardingLinqWebhookPlannerInput;
+  preparedDirectMailboxControlAuthority: PreparedHostedLinqDirectMailboxPayloadRoot | null;
+}): Promise<
+  | HostedOnboardingLinqDirectPlan
+  | {
+      existingMemberActive: boolean;
+      preparedRoutingAuthority: PreparedHostedLinqDirectMailboxPayloadRoot | null;
+    }
+> {
+  const {
+    context,
+    directMailboxPreparationFailureProvided,
+    directMailboxPreparationProvided,
+    existingMember,
+    existingMemberMatch,
+    input,
+    preparedDirectMailboxControlAuthority,
+  } = admission;
+  const { messageEvent, occurredAt, summary } = context;
+  let preparedDirectRoutingAuthority: PreparedHostedLinqDirectMailboxPayloadRoot | null = null;
+  if (!preparedDirectMailboxControlAuthority) {
+    await lockHostedMemberRow(input.prisma, existingMember.id);
+  }
+  const exactMemberAccess = await readHostedRuntimeAiAccessDecision({
+    memberId: existingMember.id,
+    noticeSeed: input.event.event_id,
+    now: new Date(occurredAt),
+    prisma: input.prisma,
+  });
+  const existingMemberEffectiveActive = exactMemberAccess.allowed;
+  // The committed mailbox row is the canonical classification for this exact
+  // member/event pair. Repair its wake before mutable Family, group, quota, or
+  // routing state can reinterpret a provider redelivery.
+  const existingMailboxItem = await readHostedMailboxItemByDedupeKey({
+    dedupeKey: input.event.event_id,
+    prisma: input.prisma,
+    userId: existingMember.id,
+  });
+  if (existingMailboxItem) {
+    return logHostedLinqWebhookPlannerDecisionAndReturn(
+      buildActiveMemberDirectPlan({
+        desiredSideEffects: [],
+        postCommitGroupJoinConfirmationMemberIds: [existingMember.id],
+        response: {
+          duplicate: true,
+          ignored: true,
+          ok: true,
+          reason: "duplicate-webhook-event",
+        },
+        // No checkpoint on the duplicate read: this transaction did not run
+        // the append-path workspace upsert, so the retry keeps the legacy
+        // signal path that repairs a missing workspace row.
+        wakeHandoffs: [{
+          eventId: input.event.event_id,
+          mailboxItemId: existingMailboxItem.id,
+          source: "linq",
+          userId: existingMember.id,
+        }],
+      }),
+      buildHostedLinqWebhookPlannerDetails(input.event, context, {
+        duplicate: true,
+        existingMemberActive: existingMemberEffectiveActive,
+        existingMemberMatch,
+        reason: "duplicate-webhook-event",
+        routeStage: "active-member-duplicate",
+      }),
+    );
+  }
+  if (directMailboxPreparationFailureProvided) {
+    if (
+      !exactMemberAccess.allowed
+      && exactMemberAccess.reason !== "health_data_consent_withdrawn"
+    ) {
+      throw input.directMailboxPreparationFailure;
+    }
+  }
+  if (
+    !exactMemberAccess.allowed
+    && exactMemberAccess.reason === "health_data_consent_withdrawn"
+  ) {
+    if (
+      !isHostedLinqDirectChatAttested(messageEvent)
+      || !exactMemberAccess.userNotice
+    ) {
+      return buildHostedLinqIgnoredPlan(input.event, context, {
+        accessReason: exactMemberAccess.reason,
+        existingMemberActive: false,
+        existingMemberMatch,
+        reason: "health-data-consent-withdrawn",
+        routeStage: "health-data-consent-withdrawn",
+      });
+    }
+    return logHostedLinqWebhookPlannerDecisionAndReturn(
+      buildInactiveMemberAccessNoticeResponse({
+        chatId: summary.chatId,
+        memberId: existingMember.id,
+        message: exactMemberAccess.userNotice.message,
+        messageId: summary.messageId,
+        noticeCode: exactMemberAccess.userNotice.code,
+        occurredAt,
+        sourceEventId: input.event.event_id,
+      }),
+      buildHostedLinqWebhookPlannerDetails(input.event, context, {
+        accessReason: exactMemberAccess.reason,
+        existingMemberActive: false,
+        existingMemberMatch,
+        noticeCode: exactMemberAccess.userNotice.code,
+        reason: HOSTED_LINQ_INACTIVE_MEMBER_NOTICE_REASON[
+          exactMemberAccess.userNotice.code
+        ],
+        routeStage: "health-data-consent-withdrawn",
+      }),
+    );
+  }
+
+  if (
+    directMailboxPreparationProvided
+    && input.preparedDirectMailboxPayloadRoot === null
+  ) {
+    // Exact duplicate, withdrawn consent, suspension, and stable owner
+    // mismatch already terminated above. Any other existing member can still
+    // enter Family, group-reply, instant-start, signup, or route policy that
+    // reads or writes private routing, even while mailbox access is inactive.
+    throw hostedLinqDirectMailboxPreparationRequired("member");
+  }
+
+  if (directMailboxPreparationFailureProvided) {
+    // Exact duplicate and withdrawn consent are the only outcomes whose
+    // authority is complete without private routing. Quota, Family, group,
+    // and home-route decisions require the prepared state, so preserve the
+    // provider retry instead of partially reclassifying this event.
+    throw input.directMailboxPreparationFailure;
+  }
+
+  if (directMailboxPreparationProvided) {
+    if (!preparedDirectMailboxControlAuthority) {
+      throw hostedLinqDirectMailboxPreparationRequired("member");
+    }
+    if (
+      exactMemberAccess.allowed
+      && !preparedDirectMailboxControlAuthority.preparedIngressRoot
+      && preparedDirectMailboxControlAuthority.preparedFamilyInvite?.kind
+        !== "accepted_replay"
+    ) {
+      throw hostedLinqDirectMailboxPreparationRequired("ingress-root");
+    }
+    preparedDirectRoutingAuthority =
+      await revalidatePreparedHostedLinqDirectRoutingTx({
+        memberId: existingMember.id,
+        prepared: preparedDirectMailboxControlAuthority,
+        prisma: input.prisma,
+      });
+  }
+
+  return {
+    existingMemberActive: existingMemberEffectiveActive,
+    preparedRoutingAuthority: preparedDirectRoutingAuthority,
+  };
+}
+
 async function planHostedLinqFirstContactWebhook(planner: {
   context: ReturnType<typeof resolveHostedOnboardingLinqMessageContext>;
   existingMember: HostedMemberCoreState | null;
@@ -1939,7 +1975,6 @@ async function planHostedLinqFirstContactWebhook(planner: {
     preparedDirectRoutingAuthority,
   } = planner;
   const { messageEvent, occurredAt, recipientPhoneNumber, summary } = context;
-  const existingMemberEffectiveActive = existingMemberActive;
   const buildUnassignableHomeLinePlan = (routeStage: string) =>
     buildHostedLinqUnassignableHomeLinePlan({
       context,
@@ -1981,7 +2016,7 @@ async function planHostedLinqFirstContactWebhook(planner: {
     participantContact,
   })) {
     return buildHostedLinqIgnoredPlan(input.event, context, {
-      existingMemberActive: existingMemberEffectiveActive,
+      existingMemberActive,
       existingMemberMatch,
       reason: "undeliverable-first-contact",
       routeStage: "ignored-undeliverable-first-contact",
@@ -1995,7 +2030,7 @@ async function planHostedLinqFirstContactWebhook(planner: {
     });
   if (firstContactContentDisposition === "contentless") {
     return buildHostedLinqIgnoredPlan(input.event, context, {
-      existingMemberActive: existingMemberEffectiveActive,
+      existingMemberActive,
       existingMemberMatch,
       reason: "contentless-first-contact",
       routeStage: "ignored-contentless-first-contact",
@@ -2004,7 +2039,7 @@ async function planHostedLinqFirstContactWebhook(planner: {
 
   if (firstContactContentDisposition === "blocked") {
     return buildHostedLinqIgnoredPlan(input.event, context, {
-      existingMemberActive: existingMemberEffectiveActive,
+      existingMemberActive,
       existingMemberMatch,
       reason: "blocked-first-contact-content",
       routeStage: "ignored-blocked-first-contact-content",
@@ -2037,22 +2072,13 @@ async function planHostedLinqFirstContactWebhook(planner: {
     && (input.requireFirstContactAdmission === true || instantStartCandidate)
     && input.firstContactAdmissionDecision?.kind !== "allow"
   ) {
-    return logHostedLinqWebhookPlannerDecisionAndReturn(
-      buildFirstContactAdmissionRequiredPlan({
-        participantContact,
-        request: buildHostedLinqFirstContactAdmissionRequest({
-          context,
-          event: input.event,
-          participantContact,
-        }),
-      }),
-      buildHostedLinqWebhookPlannerDetails(input.event, context, {
-        existingMemberActive: Boolean(existingMemberEffectiveActive),
-        existingMemberMatch,
-        reason: "first-contact-admission-required",
-        routeStage: "first-contact-admission-required",
-      }),
-    );
+    return buildFirstContactAdmissionRequiredPlan({
+      context,
+      event: input.event,
+      existingMemberActive: Boolean(existingMemberActive),
+      existingMemberMatch,
+      participantContact,
+    });
   }
 
   const existingDailyState = existingMember
@@ -2065,7 +2091,7 @@ async function planHostedLinqFirstContactWebhook(planner: {
 
   if (existingDailyState?.onboardingLinkSentAt && !groupJoinContext) {
     return buildHostedLinqIgnoredPlan(input.event, context, {
-      existingMemberActive: existingMemberEffectiveActive,
+      existingMemberActive,
       existingMemberMatch,
       reason: "signup-link-already-sent",
       routeStage: "first-contact-signup-already-sent",
@@ -2090,7 +2116,7 @@ async function planHostedLinqFirstContactWebhook(planner: {
   const retryableFallbackRecipientPhone =
     await readRetryableUnsentFallbackRecipientPhone({
       bindingResult,
-      existingMemberActive: Boolean(existingMemberEffectiveActive),
+      existingMemberActive: Boolean(existingMemberActive),
       memberId: existingMember?.id ?? null,
       onboardingLinkSentAt: existingDailyState?.onboardingLinkSentAt ?? null,
       prisma: input.prisma,
@@ -2103,39 +2129,12 @@ async function planHostedLinqFirstContactWebhook(planner: {
       return buildUnassignableHomeLinePlan("ignored-unassignable-home-line");
     }
 
-    const dailyState = await incrementHostedLinqInboundDailyState({
+    return planHostedLinqFallbackSignupTx({
+      assignedPhone: retryableFallbackRecipientPhone,
       memberId: existingMember.id,
-      occurredAt,
-      prisma: input.prisma,
+      planner,
+      routeStage: "first-contact-fallback-retry",
     });
-    const invite = await issueHostedInviteTx({
-      channel: "linq",
-      memberId: existingMember.id,
-      prisma: input.prisma,
-    });
-
-    return logHostedLinqWebhookPlannerDecisionAndReturn(
-      buildFallbackSignupLinkResponse({
-        assignedPhone: retryableFallbackRecipientPhone,
-        groupJoinCode: groupJoinContext?.joinCode,
-        groupJoinOutreachId: groupJoinContext?.outreachId,
-        inviteCode: invite.inviteCode,
-        inviteId: invite.id,
-        memberId: existingMember.id,
-        occurredAt,
-        participantContact,
-        sourceEventId: input.event.event_id,
-      }),
-      buildHostedLinqWebhookPlannerDetails(input.event, context, {
-        chatDirectAttested: isHostedLinqDirectChatAttested(messageEvent),
-        dailyInboundCount: dailyState.inboundCount,
-        existingMemberActive: existingMemberEffectiveActive,
-        existingMemberMatch,
-        fallbackLine: true,
-        reason: "sent-signup-link",
-        routeStage: "first-contact-fallback-retry",
-      }),
-    );
   }
   const blockedPlan = buildRouteBindingBlockedPlan(bindingResult, {
     capacityExhausted: "ignored-home-line-capacity-exhausted",
@@ -2253,39 +2252,12 @@ async function planHostedLinqFirstContactWebhook(planner: {
       });
     }
 
-    const dailyState = await incrementHostedLinqInboundDailyState({
+    return planHostedLinqFallbackSignupTx({
+      assignedPhone,
       memberId: member.id,
-      occurredAt,
-      prisma: input.prisma,
+      planner,
+      routeStage: "first-contact-signup-link",
     });
-    const invite = await issueHostedInviteTx({
-      channel: "linq",
-      memberId: member.id,
-      prisma: input.prisma,
-    });
-
-    return logHostedLinqWebhookPlannerDecisionAndReturn(
-      buildFallbackSignupLinkResponse({
-        assignedPhone,
-        groupJoinCode: groupJoinContext?.joinCode,
-        groupJoinOutreachId: groupJoinContext?.outreachId,
-        inviteCode: invite.inviteCode,
-        inviteId: invite.id,
-        memberId: member.id,
-        occurredAt,
-        participantContact,
-        sourceEventId: input.event.event_id,
-      }),
-      buildHostedLinqWebhookPlannerDetails(input.event, context, {
-        chatDirectAttested: isHostedLinqDirectChatAttested(messageEvent),
-        dailyInboundCount: dailyState.inboundCount,
-        existingMemberActive: existingMemberEffectiveActive,
-        existingMemberMatch,
-        fallbackLine: true,
-        reason: "sent-signup-link",
-        routeStage: "first-contact-signup-link",
-      }),
-    );
   }
 
   if (instantStartEligible) {
@@ -2323,7 +2295,7 @@ async function planHostedLinqFirstContactWebhook(planner: {
       },
       buildHostedLinqWebhookPlannerDetails(input.event, context, {
         chatDirectAttested: true,
-        existingMemberActive: existingMemberEffectiveActive,
+        existingMemberActive,
         existingMemberMatch,
         reason: "instant-start-enrollment-required",
         routeDecision: bindingResult.kind,
@@ -2345,7 +2317,7 @@ async function planHostedLinqFirstContactWebhook(planner: {
   if (dailyState.onboardingLinkSentAt && !groupJoinContext) {
     return buildHostedLinqIgnoredPlan(input.event, context, {
       dailyInboundCount: dailyState.inboundCount,
-      existingMemberActive: existingMemberEffectiveActive,
+      existingMemberActive,
       existingMemberMatch,
       reason: "signup-link-already-sent",
       routeStage: "first-contact-signup-already-sent",
@@ -2375,10 +2347,65 @@ async function planHostedLinqFirstContactWebhook(planner: {
     buildHostedLinqWebhookPlannerDetails(input.event, context, {
       chatDirectAttested: isHostedLinqDirectChatAttested(messageEvent),
       dailyInboundCount: dailyState.inboundCount,
-      existingMemberActive: existingMemberEffectiveActive,
+      existingMemberActive,
       existingMemberMatch,
       reason: "sent-signup-link",
       routeStage: "first-contact-signup-link",
+    }),
+  );
+}
+
+async function planHostedLinqFallbackSignupTx({
+  assignedPhone,
+  memberId,
+  planner,
+  routeStage,
+}: {
+  assignedPhone: string;
+  memberId: string;
+  planner: Parameters<typeof planHostedLinqFirstContactWebhook>[0];
+  routeStage: "first-contact-fallback-retry" | "first-contact-signup-link";
+}): Promise<HostedOnboardingLinqDirectPlan> {
+  const {
+    context,
+    existingMemberActive,
+    existingMemberMatch,
+    groupJoinContext,
+    participantContact,
+    plannerInput: input,
+  } = planner;
+  const { messageEvent, occurredAt } = context;
+  const dailyState = await incrementHostedLinqInboundDailyState({
+    memberId,
+    occurredAt,
+    prisma: input.prisma,
+  });
+  const invite = await issueHostedInviteTx({
+    channel: "linq",
+    memberId,
+    prisma: input.prisma,
+  });
+
+  return logHostedLinqWebhookPlannerDecisionAndReturn(
+    buildFallbackSignupLinkResponse({
+      assignedPhone,
+      groupJoinCode: groupJoinContext?.joinCode,
+      groupJoinOutreachId: groupJoinContext?.outreachId,
+      inviteCode: invite.inviteCode,
+      inviteId: invite.id,
+      memberId,
+      occurredAt,
+      participantContact,
+      sourceEventId: input.event.event_id,
+    }),
+    buildHostedLinqWebhookPlannerDetails(input.event, context, {
+      chatDirectAttested: isHostedLinqDirectChatAttested(messageEvent),
+      dailyInboundCount: dailyState.inboundCount,
+      existingMemberActive,
+      existingMemberMatch,
+      fallbackLine: true,
+      reason: "sent-signup-link",
+      routeStage,
     }),
   );
 }
@@ -4060,22 +4087,13 @@ async function planHostedLinqGroupChatWebhook(input: {
       && input.firstContactAdmissionDecision?.kind !== "allow"
     ) {
       return withNextRequiredPendingSetupCandidateId(
-        logHostedLinqWebhookPlannerDecisionAndReturn(
-          buildFirstContactAdmissionRequiredPlan({
-            participantContact,
-            request: buildHostedLinqFirstContactAdmissionRequest({
-              context: input.context,
-              event: input.event,
-              participantContact,
-            }),
-          }),
-          buildHostedLinqWebhookPlannerDetails(input.event, input.context, {
-            existingMemberActive: false,
-            existingMemberMatch: senderIdentityMatch,
-            reason: "first-contact-admission-required",
-            routeStage: "first-contact-admission-required",
-          }),
-        ),
+        buildFirstContactAdmissionRequiredPlan({
+          context: input.context,
+          event: input.event,
+          existingMemberActive: false,
+          existingMemberMatch: senderIdentityMatch,
+          participantContact,
+        }),
       );
     }
 
@@ -4203,21 +4221,32 @@ async function planHostedLinqDailyQuotaAdmissionDenied(input: {
 }
 
 function buildFirstContactAdmissionRequiredPlan(input: {
+  context: ReturnType<typeof resolveHostedOnboardingLinqMessageContext>;
+  event: HostedLinqWebhookEvent;
+  existingMemberActive: boolean;
+  existingMemberMatch: HostedLinqExistingMemberMatch;
   participantContact: HostedLinqParticipantContact;
-  request: HostedLinqFirstContactAdmissionRequest;
 }): HostedOnboardingLinqDirectPlan {
-  return {
-    ...buildActiveMemberDirectPlan({
-      desiredSideEffects: [],
-      response: {
-        ignored: true,
-        ok: true,
-        reason: "first-contact-admission-required",
-      },
+  return logHostedLinqWebhookPlannerDecisionAndReturn(
+    {
+      ...buildActiveMemberDirectPlan({
+        desiredSideEffects: [],
+        response: {
+          ignored: true,
+          ok: true,
+          reason: "first-contact-admission-required",
+        },
+      }),
+      firstContactAdmissionParticipantContact: input.participantContact,
+      firstContactAdmissionRequest: buildHostedLinqFirstContactAdmissionRequest(input),
+    },
+    buildHostedLinqWebhookPlannerDetails(input.event, input.context, {
+      existingMemberActive: input.existingMemberActive,
+      existingMemberMatch: input.existingMemberMatch,
+      reason: "first-contact-admission-required",
+      routeStage: "first-contact-admission-required",
     }),
-    firstContactAdmissionParticipantContact: input.participantContact,
-    firstContactAdmissionRequest: input.request,
-  };
+  );
 }
 
 export function buildHostedLinqFirstContactAdmissionRequest(input: {


### PR DESCRIPTION
## Why and outcome

Linq's direct-member planner combines exact-event duplicate recovery, consent, preparation failures and routing admission; initial and retry fallback signup also repeat the same count/invite/response sequence. Isolate the existing admission phase and share fallback signup and direct/group first-contact result construction while preserving policy, live authority reads and effect order.

## Product UX

- Effort: Not applicable — internal behavior-preserving planner refactor.
- Result: Not applicable.
- Walkthrough: Existing direct and group admission, signup fallback, duplicate recovery and consent outcomes remain unchanged; no UI or copy change.

## Evidence

- Direct: `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir apps/web test:prepared test/hosted-onboarding-linq-dispatch.test.ts test/hosted-onboarding-linq-thread-route.test.ts test/hosted-onboarding-linq-mailbox-root-prewarm.test.ts test/hosted-onboarding-linq-read-receipt-authority.test.ts test/hosted-onboarding-webhook-idempotency.test.ts` — 433 tests passed across five files.
- Coverage: Composed dispatch proves duplicate recovery before mutable policy, consent versus failed/null preparation, first-contact signup and retry, group admission and routing, prewarmed crypto and receipt authority. Existing proof covers the changed claim without test-only exports.
- Typecheck: `pnpm --dir apps/web typecheck` passed, shared two-checker profile.
- Diff: Full source and privacy reviewed; `git diff --check` passed. Parent candidate review, exact-head CI and ReviewGPT passed on this head.

## Non-obvious affected surfaces

Duplicate wakes retain their checkpoint-free recovery path and group-join confirmation IDs. Consent notices still precede routing failures where authorized; post-Family access rechecks and group-before-billing handling remain live. Dispatch, idempotency and prewarm suites exercise these boundaries.

## Architecture and reuse

- Existing systems reused: Web transaction, runtime-access, mailbox dedupe, prepared routing, invite and response-plan owners.
- New logic: None; existing branches and state transitions are preserved.
- New abstractions: Two private same-file helpers for direct-member admission and repeated fallback signup; expanded the existing first-contact admission result helper. The admission return reuses the existing plan type or returns two authority facts.
- Complexity intentionally avoided: Removed the one-use duplicate-result closure and redundant active-state alias. No new state owner, framework, dependency, query, retry or protocol.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base HEAD` on the dirty candidate against task base `3fcb0ab14d8137af4d4858ad030de8ab2c904970`. File debt 278 → 257 (-21); maximum 93 → 89 (-4). Outer planner 93 → 76; first-contact planner 76 → 72. Both new helpers are below 20.
- Hotspots: `planHostedLinqGroupChatWebhook` 89; `planHostedOnboardingLinqWebhook` 76; `planHostedLinqFirstContactWebhook` 72; `planHostedLinqMessageEditedWebhook` 56; `prepareHostedLinqThreadContainerAdmission` 40; `planHostedLinqFamilyInviteWebhook` 31; `planHostedLinqExplicitThreadRouteWebhook` 28; `resolveHostedLinqDirectPreparationMemberId` 23; `planHostedLinqActiveMemberDirectWebhook` 22.
- Agent judgment: All listed hotspots were inspected. This scope removes real duplicate construction and gives admission an explicit result boundary. Further group, edit, preparation and Family simplification warrants separate focused work because those branches protect distinct transaction and authority decisions; repeated live reads must remain.

## Hot reply path impact

- Path status: Touched — existing Linq ingress admission and recovery planning.
- Database calls: None added or moved onto the path. Existing locks, exact access and dedupe reads, routing revalidation, inbound count and invite calls retain their call sites and serial order; maximum call counts are unchanged.
- Network/provider calls: None added or moved onto the path. Existing effect plans and post-commit execution remain unchanged.
- Other awaited latency: No new I/O, timer or task. Existing awaited admission and fallback sequences now run inside private helpers; timeout, retry and fallback policy is unchanged. No measured latency claim.
- Before/after proof: Focused composed suites preserve dedupe read counts, no-mutation terminal cases, prewarm boundaries, routing side effects and fallback results; source comparison confirms all existing live reads and ordering remain.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no prompt, instruction, tool definition, schema, deferred metadata, generated guidance, history or provider request builder changes.

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed.

ReviewGPT context sensitivity: sensitive
Classification reason: Hosted ingress admission touches identity, consent, duplicate recovery and routing authority.
ReviewGPT first-reviewed head: 0d469a3c1ef18bc087e454f73facec38b2b9f686

## Deployment concerns

- Deployment: not applicable
- Reason: Private Web implementation changes only. No persisted schema, wire contract, configuration, cross-artifact protocol or rollout-order change.

## Change-shape breakdown

Classification rule: TypeScript runtime file is Source; the completed execution plan is Docs. No tests, configuration, generated output or binary changes.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 286 | 257 |
| Tests / fixtures | 0 | 0 |
| Docs | 52 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **338** | **257** |

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving planner maintenance; no member-visible behavior, copy, recovery policy or delivery change.

## ReviewGPT result

- Round 1: PASS on 0d469a3c1ef18bc087e454f73facec38b2b9f686.
- Model: GPT-6 Pro, verified by captured response metadata; guarded full snapshot and exact committed turn verified.
- No qualifying findings; no review remediation required. All required CI checks and routed Temporal compatibility passed on this same head.
