### PR TITLE
refactor(device-sync): simplify OAuth callback admission and cleanup

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-complexity2-public-ingress.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-complexity2-public-ingress.md
@@ -1,0 +1,57 @@
+# Simplify OAuth callback admission and cleanup
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Outcome and protected invariants
+
+Make callback state admission and cleanup precedence easier to review. Preserve
+provider/member binding before state consumption, consumed-state replay and
+recovery behavior, seeded connection epochs, source-scoped cleanup, credential
+policy, and persistence/hook ordering. No callback cookie or public API changes.
+
+## Evidence and owner
+
+The callback has cyclomatic complexity 96. It reconstructs the same redirect
+context four times, wraps three cleanup branches identically, and repeats failed
+provider-authority cleanup. DeviceSyncPublicIngress and its existing store/hooks
+remain the owners; no new persisted state, dependencies, or generic orchestration.
+
+## Scope and decisions
+
+- Give OAuth state consume/discard admission one private method and derive its
+  callback context once after provider/owner/state validation.
+- Consolidate identical cleanup and error wrapping while preserving source,
+  persisted connection, disconnect-guard, and seeded-account precedence.
+- Keep unresolved-claim recovery and its existing error behavior in place.
+- Leave prepared-webhook admission untouched; its authority decisions are separate.
+
+## Proof
+
+Run full public-ingress and Junction SDK sign-in tests with bounded workers, the
+package typecheck, and the complexity guard. The existing public tests cover
+replay/query tampering, owner/provider mismatches, seeded epoch/disconnect races,
+credential policy, source admission, and provider-revoke/cleanup ambiguity.
+Inspect the complete diff for effect ordering, privacy, and unjustified machinery.
+
+## Progress
+
+- Read-only investigation and owner review complete.
+- Implementation complete: one state-admission phase, one redirect-context
+  builder, one source-context projection, and consolidated cleanup branches.
+- Redirect-context construction stays at the selected outcome so persisted-return
+  sanitization keeps its original warning and error ordering.
+- `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir packages/device-syncd exec vitest run --config vitest.config.ts --no-coverage test/public-ingress.test.ts test/junction-sdk-sign-in.test.ts`
+  passes all 90 tests against the final source.
+- `MURPH_TSC_PACKAGE_MODE=single-threaded pnpm --dir packages/device-syncd typecheck` passes.
+- `pnpm complexity:diff --base HEAD -- packages/device-syncd/src/public-ingress.ts`
+  passes: callback/max 96 to 71; file debt 144 to 119. Callback 71 retains its
+  effect and cleanup sequence; unchanged webhook 71 and connection start 37 are
+  separate authority boundaries. Further extraction would require unnecessary
+  mutable callback context or a broader task.
+- Full diff, privacy, and effect/error precedence reviewed. Existing public
+  regression coverage is sufficient; no implementation-mirroring tests added.
+- Parent owns candidate review, Ready, ReviewGPT, CI, and merge.
+- Internal behavior-preserving refactor; no changelog entry required.
+Completed: 2026-09-11

--- a/packages/device-syncd/src/public-ingress.ts
+++ b/packages/device-syncd/src/public-ingress.ts
@@ -53,6 +53,7 @@ import type {
   HandleWebhookResult,
   MarkPublicDeviceSyncConnectionSetupFailedResult,
   OAuthStateConsumeClaim,
+  OAuthStateRecord,
   ProviderConnectionResult,
   ProviderBeginConnectionResult,
   PublicDeviceSyncAccount,
@@ -1031,16 +1032,23 @@ export class DeviceSyncPublicIngress {
     );
   }
 
-  private async handleConnectionCallbackForProvider(
+  private buildConnectionCallbackContext(provider: string, stateRecord: OAuthStateRecord) {
+    return {
+      connectSourceId: readConnectSourceId(stateRecord.metadata),
+      connectTarget: readConnectTarget(stateRecord.metadata),
+      provider,
+      returnTo: this.sanitizeStoredReturnTo(stateRecord.returnTo ?? null),
+    };
+  }
+
+  private async claimConnectionCallback(
     provider: DeviceSyncProvider,
     input: HandleConnectionCallbackInput,
     callback: ReturnType<typeof prepareConnectionCallback>,
-  ): Promise<CompleteConnectionResult> {
+  ) {
     const now = callback.receivedAt;
-    const descriptor = this.describeProvider(provider);
     const callbackQuery = callback.query;
     const state = callback.state;
-
     const expectedOwnerId = normalizeString(input.expectedOwnerId);
     const preProviderError = resolveDefinitivePreProviderOAuthCallbackError(
       provider,
@@ -1100,12 +1108,7 @@ export class DeviceSyncPublicIngress {
           retryable: false,
           httpStatus: 409,
         }),
-        {
-          connectSourceId: readConnectSourceId(stateResult.record.metadata),
-          connectTarget: readConnectTarget(stateResult.record.metadata),
-          provider: provider.provider,
-          returnTo: this.sanitizeStoredReturnTo(stateResult.record.returnTo ?? null),
-        },
+        this.buildConnectionCallbackContext(provider.provider, stateResult.record),
       );
     }
 
@@ -1117,12 +1120,7 @@ export class DeviceSyncPublicIngress {
           retryable: false,
           httpStatus: 409,
         }),
-        {
-          connectSourceId: readConnectSourceId(stateResult.record.metadata),
-          connectTarget: readConnectTarget(stateResult.record.metadata),
-          provider: provider.provider,
-          returnTo: this.sanitizeStoredReturnTo(stateResult.record.returnTo ?? null),
-        },
+        this.buildConnectionCallbackContext(provider.provider, stateResult.record),
       );
     }
 
@@ -1134,30 +1132,42 @@ export class DeviceSyncPublicIngress {
           callbackError,
         });
       }
-      throw attachOAuthCallbackContext(preProviderError!, {
-        connectSourceId: readConnectSourceId(stateResult.record.metadata),
-        connectTarget: readConnectTarget(stateResult.record.metadata),
-        provider: provider.provider,
-        returnTo: this.sanitizeStoredReturnTo(stateResult.record.returnTo ?? null),
-      });
+      throw attachOAuthCallbackContext(
+        preProviderError!,
+        this.buildConnectionCallbackContext(provider.provider, stateResult.record),
+      );
     }
 
+    return {
+      stateResult,
+      callbackContext: this.buildConnectionCallbackContext(provider.provider, stateResult.record),
+    };
+  }
+
+  private async handleConnectionCallbackForProvider(
+    provider: DeviceSyncProvider,
+    input: HandleConnectionCallbackInput,
+    callback: ReturnType<typeof prepareConnectionCallback>,
+  ): Promise<CompleteConnectionResult> {
+    const now = callback.receivedAt;
+    const descriptor = this.describeProvider(provider);
+    const callbackQuery = callback.query;
+    const state = callback.state;
+
+    const { stateResult, callbackContext } = await this.claimConnectionCallback(provider, input, callback);
     const stateRecord = stateResult.record;
-    const returnTo = this.sanitizeStoredReturnTo(stateRecord.returnTo ?? null);
+    const { connectSourceId, connectTarget, returnTo } = callbackContext;
     const seededAccountId = readSeededConnectionAccountId(stateRecord.metadata);
     let seededExternalAccountId = readSeededConnectionExternalAccountId(stateRecord.metadata);
     const seededSetupExpiresAt = readSeededConnectionSetupExpiresAt(stateRecord.metadata);
     const seededConnectedAt = seededAccountId
       ? readSeededConnectionConnectedAt(stateRecord.metadata) ?? stateRecord.createdAt
       : null;
-    const connectSourceId = readConnectSourceId(stateRecord.metadata);
-    const connectTarget = readConnectTarget(stateRecord.metadata);
     const sourceProviderSlug = readSourceProviderSlug(stateRecord.metadata);
-    const callbackContext = {
-      connectSourceId,
-      connectTarget,
-      provider: provider.provider,
-      returnTo,
+    const connectionSourceContext = {
+      ...(connectSourceId ? { connectSourceId } : {}),
+      ...(connectTarget ? { connectTarget } : {}),
+      ...(sourceProviderSlug ? { sourceProviderSlug } : {}),
     };
     let connection: ProviderConnectionResult | null = null;
     let account: PublicDeviceSyncAccount | null = null;
@@ -1169,66 +1179,29 @@ export class DeviceSyncPublicIngress {
     try {
       seededAccount = seededAccountId ? await this.store.getConnectionById(seededAccountId) : null;
 
-    if (seededAccount && seededAccount.provider !== provider.provider) {
-      throw attachOAuthCallbackContext(
-        deviceSyncError({
-          code: "CONNECTION_SEEDED_ACCOUNT_MISMATCH",
-          message: "Device sync connection callback referenced a seeded account for another provider.",
-          retryable: false,
-          httpStatus: 400,
-        }),
-        callbackContext,
-      );
-    }
+      if (seededAccount && seededAccount.provider !== provider.provider) {
+        throw attachOAuthCallbackContext(
+          deviceSyncError({
+            code: "CONNECTION_SEEDED_ACCOUNT_MISMATCH",
+            message: "Device sync connection callback referenced a seeded account for another provider.",
+            retryable: false,
+            httpStatus: 400,
+          }),
+          callbackContext,
+        );
+      }
 
-    if (seededAccountId && !seededAccount) {
-      throw attachOAuthCallbackContext(
-        deviceSyncError({
-          code: "CONNECTION_SEEDED_ACCOUNT_MISMATCH",
-          message: "Device sync connection callback referenced an unexpected seeded account.",
-          retryable: false,
-          httpStatus: 400,
-        }),
-        callbackContext,
-      );
-    }
-
-    if (seededAccount?.status === "disconnected") {
-      throw attachOAuthCallbackContext(
-        deviceSyncError({
-          code: "CONNECTION_ALREADY_DISCONNECTED",
-          message: "Device sync connection callback was received after the seeded account was disconnected.",
-          retryable: false,
-          httpStatus: 409,
-        }),
-        callbackContext,
-      );
-    }
-
-    if (seededAccount && seededAccount.connectedAt !== seededConnectedAt) {
-      throw attachOAuthCallbackContext(
-        deviceSyncError({
-          code: "CONNECTION_SEEDED_ACCOUNT_CHANGED",
-          message: "Device sync connection changed after this connection flow started.",
-          retryable: false,
-          httpStatus: 409,
-        }),
-        callbackContext,
-      );
-    }
-
-    seededExternalAccountId = seededAccount?.externalAccountId ?? seededExternalAccountId ?? null;
-    reusedEstablishedJunctionAccount =
-      provider.provider === "junction"
-      && sourceProviderSlug !== null
-      && seededAccount !== null
-      && isEstablishedDeviceSyncConnection(seededAccount);
-
-    if (seededExternalAccountId) {
-      seededAccount ??= await this.store.getConnectionByExternalAccount(
-        provider.provider,
-        seededExternalAccountId,
-      );
+      if (seededAccountId && !seededAccount) {
+        throw attachOAuthCallbackContext(
+          deviceSyncError({
+            code: "CONNECTION_SEEDED_ACCOUNT_MISMATCH",
+            message: "Device sync connection callback referenced an unexpected seeded account.",
+            retryable: false,
+            httpStatus: 400,
+          }),
+          callbackContext,
+        );
+      }
 
       if (seededAccount?.status === "disconnected") {
         throw attachOAuthCallbackContext(
@@ -1241,7 +1214,44 @@ export class DeviceSyncPublicIngress {
           callbackContext,
         );
       }
-    }
+
+      if (seededAccount && seededAccount.connectedAt !== seededConnectedAt) {
+        throw attachOAuthCallbackContext(
+          deviceSyncError({
+            code: "CONNECTION_SEEDED_ACCOUNT_CHANGED",
+            message: "Device sync connection changed after this connection flow started.",
+            retryable: false,
+            httpStatus: 409,
+          }),
+          callbackContext,
+        );
+      }
+
+      seededExternalAccountId = seededAccount?.externalAccountId ?? seededExternalAccountId ?? null;
+      reusedEstablishedJunctionAccount =
+        provider.provider === "junction"
+        && sourceProviderSlug !== null
+        && seededAccount !== null
+        && isEstablishedDeviceSyncConnection(seededAccount);
+
+      if (seededExternalAccountId) {
+        seededAccount ??= await this.store.getConnectionByExternalAccount(
+          provider.provider,
+          seededExternalAccountId,
+        );
+
+        if (seededAccount?.status === "disconnected") {
+          throw attachOAuthCallbackContext(
+            deviceSyncError({
+              code: "CONNECTION_ALREADY_DISCONNECTED",
+              message: "Device sync connection callback was received after the seeded account was disconnected.",
+              retryable: false,
+              httpStatus: 409,
+            }),
+            callbackContext,
+          );
+        }
+      }
 
       if (!descriptor.callbackUrl && connectionFlowRequiresCallbackUrl(descriptor.connectionKind)) {
         throw deviceSyncError({
@@ -1249,14 +1259,6 @@ export class DeviceSyncPublicIngress {
           message: `Device sync provider ${provider.provider} requires a connection callback URL but does not define a callback path.`,
           retryable: false,
           httpStatus: 500,
-        });
-      }
-
-      const callbackError = normalizeString(callbackQuery.get("error"));
-      if (callbackError && resolveDeviceProviderConnectionDescriptor(provider.descriptor).kind === "oauth2") {
-        this.logger.warn?.("OAuth callback was rejected by the provider.", {
-          provider: provider.provider,
-          callbackError,
         });
       }
 
@@ -1336,9 +1338,7 @@ export class DeviceSyncPublicIngress {
       const establishment = await this.hooks.onConnectionEstablished?.({
         account,
         connectionStartedAt: stateRecord.createdAt,
-        ...(connectSourceId ? { connectSourceId } : {}),
-        ...(connectTarget ? { connectTarget } : {}),
-        ...(sourceProviderSlug ? { sourceProviderSlug } : {}),
+        ...connectionSourceContext,
         connection: {
           ...connection,
           ...(initialJobs ? { initialJobs } : {}),
@@ -1366,21 +1366,19 @@ export class DeviceSyncPublicIngress {
       return {
         account,
         returnTo,
-        ...(connectSourceId ? { connectSourceId } : {}),
-        ...(connectTarget ? { connectTarget } : {}),
-        ...(sourceProviderSlug ? { sourceProviderSlug } : {}),
+        ...connectionSourceContext,
       };
     } catch (error) {
-      if (reusedEstablishedJunctionAccount) {
-        // Never apply account-wide cleanup to a source-scoped Link attempt.
-        // Provider completion precedes hosted source admission, so a rejected
-        // obsolete Link can have recreated the exact provider registration.
-        // The hosted hook owns source-epoch-aware target cleanup; it is the
-        // only safe place to remove that registration without touching the
-        // established parent or a newer accepted source epoch.
-        const cleanupAccount = account ?? seededAccount;
-        if (connection && cleanupAccount && sourceProviderSlug) {
-          try {
+      try {
+        if (reusedEstablishedJunctionAccount) {
+          // Never apply account-wide cleanup to a source-scoped Link attempt.
+          // Provider completion precedes hosted source admission, so a rejected
+          // obsolete Link can have recreated the exact provider registration.
+          // The hosted hook owns source-epoch-aware target cleanup; it is the
+          // only safe place to remove that registration without touching the
+          // established parent or a newer accepted source epoch.
+          const cleanupAccount = account ?? seededAccount;
+          if (connection && cleanupAccount && sourceProviderSlug) {
             await this.hooks.onConnectionSourceAdmissionRejected?.({
               account: cleanupAccount,
               connectionStartedAt: stateRecord.createdAt,
@@ -1388,70 +1386,39 @@ export class DeviceSyncPublicIngress {
               provider,
               now,
             });
-          } catch (cleanupError) {
-            throw attachOAuthCallbackContext(cleanupError, callbackContext);
           }
-        }
-      } else if (connection) {
-        try {
-          if (connectionPersisted && account) {
-            await this.cleanupPersistedOAuthConnection(
-              provider,
-              account,
-              connection,
-              now,
-              error,
-            );
-          } else if (isSeededAccountDisconnectedGuardError(error)) {
-            if (!await this.ensureFailedOAuthConnectionCleanupOwnership(
-              provider,
-              connection,
-              stateRecord.ownerId ?? null,
-              now,
-              { state, consumedAt: stateResult.consumedAt },
-            )) {
-              throw createOAuthSetupCleanupOwnershipError(error);
-            }
-          } else if (seededAccountId) {
-            await this.markSeededConnectionSetupFailed(
-              provider,
-              seededAccountId,
-              seededConnectedAt,
-              connection,
-              stateRecord.ownerId ?? null,
-              now,
-              error,
-              { state, consumedAt: stateResult.consumedAt },
-            );
-          } else {
-            if (!await this.ensureFailedOAuthConnectionCleanupOwnership(
-              provider,
-              connection,
-              stateRecord.ownerId ?? null,
-              now,
-              { state, consumedAt: stateResult.consumedAt },
-            )) {
-              throw createOAuthSetupCleanupOwnershipError(error);
-            }
+        } else if (connection && connectionPersisted && account) {
+          await this.cleanupPersistedOAuthConnection(
+            provider,
+            account,
+            connection,
+            now,
+            error,
+          );
+        } else if (connection && (isSeededAccountDisconnectedGuardError(error) || !seededAccountId)) {
+          if (!await this.ensureFailedOAuthConnectionCleanupOwnership(
+            provider,
+            connection,
+            stateRecord.ownerId ?? null,
+            now,
+            { state, consumedAt: stateResult.consumedAt },
+          )) {
+            throw createOAuthSetupCleanupOwnershipError(error);
           }
-        } catch (cleanupError) {
-          throw attachOAuthCallbackContext(cleanupError, callbackContext);
-        }
-      } else if (seededAccountId) {
-        try {
+        } else if (seededAccountId) {
           await this.markSeededConnectionSetupFailed(
             provider,
             seededAccountId,
             seededConnectedAt,
-            null,
+            connection,
             stateRecord.ownerId ?? null,
             now,
             error,
             { state, consumedAt: stateResult.consumedAt },
           );
-        } catch (cleanupError) {
-          throw attachOAuthCallbackContext(cleanupError, callbackContext);
         }
+      } catch (cleanupError) {
+        throw attachOAuthCallbackContext(cleanupError, callbackContext);
       }
 
       if (


### PR DESCRIPTION
## Why and outcome

OAuth callback admission and cleanup repeated redirect-context construction, source-result projection, cleanup-owner calls, and error wrapping inside one high-complexity callback. This refactor isolates state consume/discard admission, reuses those projections, and consolidates equivalent cleanup branches. Callback complexity falls from 96 to 71 and file complexity debt from 144 to 119, with 33 fewer source lines.

Provider/member binding, replay and recovery results, seeded connection epochs, credential policy, source-scoped cleanup, persistence, and hook ordering retain their existing behavior. Context sanitization stays at the selected outcome, preserving its warning/error ordering.

## Product UX

- Effort: Not applicable — internal behavior-preserving callback refactor.
- Result: Not applicable.
- Walkthrough: Existing OAuth success, denial, replay, ownership mismatch, seeded reconnect/disconnect races, and cleanup recovery paths remain covered by the public ingress tests. No browser interaction or cookie changes.

## Evidence

- Direct: `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir packages/device-syncd exec vitest run --config vitest.config.ts --no-coverage test/public-ingress.test.ts test/junction-sdk-sign-in.test.ts` — 90 tests passed on the final source.
- Direct: `MURPH_TSC_PACKAGE_MODE=single-threaded pnpm --dir packages/device-syncd typecheck` — passed.
- Coverage: Existing public tests exercise consumed callback replay with modified query fields, provider/member mismatch without consuming valid state, ambiguous provider exchange and lease recovery, seeded epoch/disconnect races, credential policy, source admission, post-persistence failure, refresh-lease ownership, and failed provider-revoke cleanup. Junction tests use the real provider implementation with synthetic responses.
- Exact-head CI and final ReviewGPT passed on this head.

## Non-obvious affected surfaces

Failure handling continues to prefer source-scoped cleanup, then persisted-account cleanup, then disconnected/unseeded provider ownership, then seeded setup failure. Unresolved-claim recovery remains outside the cleanup error wrapper so its existing error behavior is preserved. Existing focused tests cover each authority boundary.

## Architecture and reuse

- Existing systems reused: DeviceSyncPublicIngress, the public ingress store, OAuth state claims, credential-policy validation, and the existing cleanup/source-admission hooks.
- New logic: None; existing callback behavior is preserved.
- New abstractions: Two private methods name state admission and callback-context construction within the existing class.
- Complexity intentionally avoided: Removed repeated cleanup bodies and projections without introducing a mutable callback context, new persisted state, generic orchestration, or dependency.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base HEAD -- packages/device-syncd/src/public-ingress.ts` before commit; debt 144 → 119 and maximum 96 → 71.
- Hotspots: `handleConnectionCallbackForProvider` 71 retains the coupled provider/persistence/cleanup sequence; unchanged `handlePreparedWebhook` 71 and `startConnectionForProvider` 37 are separate authority boundaries outside this callback refactor.
- Agent judgment: The change removes actual duplicated decisions and cleanup calls. Further extraction would require a broader task or an unnecessary mutable callback context; the current scoped change preserves explicit effect ownership.

## Hot reply path impact

- Path status: Not applicable — this change affects device connection callbacks, not foreground conversation reply processing.
- Database calls: None added or moved; existing consume/discard, connection, claim-recovery, and cleanup calls retain their ordering and conditions.
- Network/provider calls: None added; completion and cleanup/revoke behavior are preserved.
- Other awaited latency: No external work added; state admission is awaited through one private method.
- Before/after proof: Full focused public-ingress/Junction suites pass; complete diff review confirms effect and error precedence.

## Murph initial provider input impact

Not applicable for individual and group Murph: no prompts, instructions, tools, schemas, generated guidance, or provider-input builders change.

ReviewGPT context sensitivity: sensitive
Classification reason: OAuth state ownership, credential cleanup, and callback authority boundaries.
ReviewGPT first-reviewed head: ecda159216faede457c434c4170165798cf42cab

## Deployment concerns

- Deployment: not applicable
- Reason: Internal refactor with unchanged public API, stored state, provider contracts, and browser cookies; no schema migration, deployment ordering, or compatibility-window change.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source and the completed execution plan is docs. Existing tests are reused unchanged. No binaries or generated output.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 133 | 166 |
| Tests / fixtures | 0 | 0 |
| Docs | 57 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **190** | **166** |

## Changelog

- Changelog: not applicable
- Reason: Internal complexity reduction preserves member-visible behavior.

## ReviewGPT result

- Round 1: PASS on ecda159216faede457c434c4170165798cf42cab.
- Model: GPT-6 Pro, verified by captured response metadata; guarded full snapshot and exact committed turn verified.
- No qualifying findings; no review remediation required. All required CI checks and routed Temporal compatibility passed on this same head.
