### PR TITLE
perf(cloudflare): retire idle runner assignments before the next message

### DIFF
--- a/.agents/friction-log/20260911184822-documented-changelog-test/friction.md
+++ b/.agents/friction-log/20260911184822-documented-changelog-test/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Documented changelog test command misses repository-root discovery and generated input'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The focused command documented in the changelog README and authoring skill should load and test authored fragments in a fresh installed worktree.
+
+## Current Behavior
+
+Running Vitest from apps/web finds no tests because the config includes repository-relative paths. Running the same config from the repository root then fails if the generated changelog module has not been prepared.
+
+## Possible Solution
+
+Document a focused command through the existing prepared test entrypoint or explicitly generate changelog fragments before invoking Vitest from the repository root.
+
+## Minimal Reproducible Example
+
+In a fresh installed worktree, run `pnpm --dir apps/web exec vitest run --config vitest.config.ts --no-coverage test/changelog-page.test.tsx`. Then run `pnpm exec vitest run --config apps/web/vitest.config.ts --no-coverage apps/web/test/changelog-page.test.tsx` before changelog generation.
+
+## Context
+
+Both commands block the documented content-only changelog verification. Existing test-filter separator friction covers a different argument parsing failure.

--- a/agent-docs/exec-plans/active/2026-09-11-runner-retirement-latency.md
+++ b/agent-docs/exec-plans/active/2026-09-11-runner-retirement-latency.md
@@ -67,4 +67,13 @@ interpretation or reply behavior; this change targets pre-execution allocation.
 
 - Isolated task checkout created; no other task checkout is being reused.
 - Existing production timing and exact deployed source inspected read-only.
-- Frozen workspace dependency installation running.
+- Frozen workspace dependencies installed.
+- Implemented post-stop durable retirement and verified background assignment clear.
+- Remote verification stays outside the consent/admission lock; only the local
+  conditional clear is serialized with new admission.
+- Six focused suites passed (584 tests); ten retirement-focused tests also pass,
+  including a message admitted while old-slot proof is delayed.
+- Cloudflare typecheck and complexity guard pass. Existing complexity debt is
+  unchanged; no modified function exceeds the threshold.
+- PR #3338 opened as a draft. Changelog entry added; final ReviewGPT and CI pending.
+- Production optimization is not deployed or benchmarked yet.

--- a/agent-docs/exec-plans/active/2026-09-11-runner-retirement-latency.md
+++ b/agent-docs/exec-plans/active/2026-09-11-runner-retirement-latency.md
@@ -1,0 +1,70 @@
+# Remove retired runner reconciliation from fresh message admission
+
+Status: active
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal
+
+Complete normal container retirement and clear its exact user-runner assignment
+before the next message, eliminating the old-target RPC from ordinary fresh
+admission. Preserve exact-member execution fences and recovery from uncertain
+or interrupted shutdown.
+
+## Success criteria
+
+- A fully stopped and retired idle target leaves no pending target for the next
+  admission; a synthetic delayed old-target RPC is never invoked on that path.
+- Warm retained targets remain reusable. Active fences, changed assignments,
+  failed native stops, delayed callbacks, and missed notifications stay safe.
+- Focused lifecycle, state, admission, and type checks pass. ReviewGPT audits the
+  complete candidate with the retirement race and compatibility boundaries.
+- Distinguish deterministic proof from any production latency measurement.
+
+## Scope and owners
+
+Cloudflare RunnerContainer owns native shutdown and immutable slot retirement.
+UserRunner owns the exact pending assignment and execution fence. Reuse those
+owners and existing state; add no scheduler, queue, or durable state table.
+Container sizing, standby inventory, prompts, and model behavior are unchanged.
+
+## Product UX
+
+Outcome: shorter waits before a fresh conversation starts after idle shutdown.
+Reaches: ordinary inbound messages, warm reuse, concurrent arrival during stop,
+and shutdown recovery.
+Proof: composed synthetic lifecycle-to-admission tests with a deliberately slow
+old-target lookup, plus wrong-target, active-fence, and failed-stop cases.
+
+## Investigation
+
+Normal lifecycle cleanup currently destroys the native container but leaves its
+slot binding and the user-runner pending assignment. Fresh admission therefore
+contacts the old slot, resolves native liveness, retires it, and clears the
+assignment before claiming prepared inventory. Existing per-phase telemetry
+separates reconciliation from claim and binding, but does not split the old-slot
+RPC internally.
+
+## Approach and risks
+
+1. Confirm stop ownership, retirement fencing, and completion callback ordering.
+2. Retire only after a proven, generation-matched normal lifecycle stop.
+3. Notify the existing user owner outside the lifecycle lock; clear only the
+   exact retired target without deleting an active fence or replacement target.
+4. Preserve existing next-admission reconciliation as recovery when notification
+   is unavailable, delayed, rejected, or lost.
+5. Add deterministic proofs, review the candidate, and run the requested final
+   ReviewGPT audit alongside exact-head CI.
+
+## Verification
+
+Planned: focused Cloudflare lifecycle and user-runner admission tests, state-store
+race tests, Cloudflare typecheck, documentation checks, and ReviewGPT review.
+No live-model test is needed unless the implementation expands into assistant
+interpretation or reply behavior; this change targets pre-execution allocation.
+
+## Progress
+
+- Isolated task checkout created; no other task checkout is being reused.
+- Existing production timing and exact deployed source inspected read-only.
+- Frozen workspace dependency installation running.

--- a/agent-docs/exec-plans/completed/2026-09-11-runner-retirement-latency.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-runner-retirement-latency.md
@@ -1,6 +1,6 @@
 # Remove retired runner reconciliation from fresh message admission
 
-Status: active
+Status: completed
 Created: 2026-09-11
 Updated: 2026-09-11
 
@@ -77,3 +77,18 @@ interpretation or reply behavior; this change targets pre-execution allocation.
   unchanged; no modified function exceeds the threshold.
 - PR #3338 opened as a draft. Changelog entry added; final ReviewGPT and CI pending.
 - Production optimization is not deployed or benchmarked yet.
+
+## Review and handoff
+
+- Final ReviewGPT round 1 passed on `6a3c4002567cfddda1b651273b2d7a9bf53c6b80`.
+- Full guarded snapshot; model attestation identifies GPT-6 Pro; response hash,
+  exact accepted turn and completion marker verified. Review exceeded three minutes.
+- Source-and-test review confirmed stop authority, generation checks, lock ordering,
+  replacement assignment protection, and backward-compatible retirement fallback.
+- No accepted findings remain. Local implementation and focused verification are complete.
+- Changelog archive verification passed (10 tests). The documented invocation issue
+  is recorded in the task Frog entry.
+- Required CI, merge, publication, and production timing remain pending operations
+  owned by the original task session; this completed implementation plan does not
+  claim a production deployment or measured latency improvement.
+Completed: 2026-09-11

--- a/agent-docs/references/hosted-runtime-protocol.md
+++ b/agent-docs/references/hosted-runtime-protocol.md
@@ -1877,6 +1877,20 @@ before fence or readiness work so a later caller-budget exit remains
 diagnosable without adding member or container identifiers. Failed, retried, or
 superseded starts do not emit an accepted attribution.
 
+Normal idle or completed-invocation cleanup retires the immutable member slot
+only after native destruction succeeds and the interaction generation remains
+unchanged. It then sends a best-effort retirement notification to the existing
+user owner without awaiting that owner from the slot lifecycle lock. The user
+owner reads the exact slot's durable retired binding outside its admission lock,
+then conditionally clears only the matching pending target under that lock. An
+active write fence or replacement target prevents the clear. No retirement hint
+alone grants authority, and the notification adds no remote wait under the
+foreground admission lock. A missed notification retains ordinary next-admission
+reconciliation; the already-retired slot can answer without another native
+liveness or destroy request. Warm reuse and uncertain stops retain their existing
+ownership and recovery behavior. This uses existing slot states and bindings and
+requires no Web, Temporal, or container-image wire change.
+
 Fresh allocation records `runnerTargetReconcileElapsedMs`, `standbyClaimElapsedMs`,
 and `runnerTargetBindElapsedMs` separately within the existing orchestration
 phase. Steps that were not needed record zero. `standbyAllocationElapsedMs` remains

--- a/apps/cloudflare/src/runner-container.ts
+++ b/apps/cloudflare/src/runner-container.ts
@@ -2074,6 +2074,45 @@ export class RunnerContainer extends Container {
       || this.containerInteractionGeneration !== input.expectedInteractionGeneration
     ) {
       renewActivityTimeout("cleanup-retained");
+      return;
+    }
+    this.retireStoppedMemberSlot();
+  }
+
+  private retireStoppedMemberSlot(): void {
+    const binding = this.readRunnerSlotBindingOptional();
+    if (binding?.state !== "bound") return;
+    // The caller holds the lifecycle lock and has proved native destruction
+    // without a newer interaction. Fence late admissions before notifying the
+    // user owner; this immutable target can never be restarted or rebound.
+    const store = this.requireRunnerSlotStore();
+    store.beginRetirement({ claimId: binding.claimId });
+    store.finishRetirement();
+    // Never await the user owner's consent lock from the slot lifecycle lock:
+    // an arriving ensure may already hold it while reading this exact slot.
+    this.ctx.waitUntil(this.notifyMemberSlotRetired(binding));
+  }
+
+  private async notifyMemberSlotRetired(
+    binding: Extract<HostedStandbySlotBinding, { state: "bound" }>,
+  ): Promise<void> {
+    try {
+      const namespace = readRunnerContainerMetadataRecordProperty(this.environment.USER_RUNNER);
+      if (typeof namespace.getByName !== "function") return;
+      const runner = readRunnerContainerMetadataRecordProperty(namespace.getByName(binding.userId));
+      if (typeof runner.recordRunnerContainerRetired !== "function") return;
+      await runner.recordRunnerContainerRetired({
+        runnerContainerName: binding.slotName,
+        userId: binding.userId,
+      });
+    } catch {
+      emitHostedExecutionStructuredLog({
+        component: "container",
+        level: "warn",
+        message: "Hosted runner retirement notification failed; preserving admission reconciliation fallback.",
+        phase: "container.ready",
+        userId: binding.userId,
+      });
     }
   }
 

--- a/apps/cloudflare/src/user-runner/hosted-user-runner.ts
+++ b/apps/cloudflare/src/user-runner/hosted-user-runner.ts
@@ -497,6 +497,15 @@ export class HostedUserRunner {
     return await this.hostedMediaRetention.delete(input);
   }
 
+  async recordRunnerContainerRetired(
+    input: Parameters<RuntimeProcessingController["verifyRetiredRunnerContainer"]>[0],
+  ): Promise<{ cleared: boolean }> {
+    if (!await this.runtimeProcessing.verifyRetiredRunnerContainer(input)) return { cleared: false };
+    return this.withRuntimeConsentMutationLock(async () => ({
+      cleared: await this.stateStore.clearStoppedRunnerContainerForUserControl(input),
+    }));
+  }
+
   async recordRuntimeCompletionFromContainer(
     input: Parameters<RuntimeInvocationService["recordRuntimeCompletionFromContainer"]>[0],
   ): ReturnType<RuntimeInvocationService["recordRuntimeCompletionFromContainer"]> {

--- a/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
+++ b/apps/cloudflare/src/user-runner/runtime-processing-controller.ts
@@ -301,6 +301,31 @@ export class RuntimeProcessingController {
     });
   }
 
+  async verifyRetiredRunnerContainer(input: {
+    runnerContainerName: string;
+    userId: string;
+  }): Promise<boolean> {
+    if (!isHostedRunnerTargetName(input.runnerContainerName) || !this.input.runnerContainerNamespace) {
+      return false;
+    }
+    const record = await this.input.stateStore.readState();
+    if (record.userId !== input.userId || record.writeFence
+      || record.pendingRunnerContainerName !== input.runnerContainerName) return false;
+    // The notification is only a hint. Read the slot's durable retirement proof
+    // before clearing its exact pending assignment under the user-owner lock.
+    // This bounded remote read itself never holds that foreground admission lock.
+    const proof = await settleStandbyOperationWithinBudget(
+      () => this.runnerSlot(input.runnerContainerName).readStandbySlotBinding(),
+      { deadlineAtMs: Date.now() + this.input.env.webControlTimeoutMs },
+      this.input.env.webControlTimeoutMs,
+    );
+    if (proof.kind !== "completed" || !hostedRunnerSlotBindingMatchesTarget(proof.value, input.runnerContainerName)
+      || proof.value.state !== "retired" || proof.value.userId !== null || proof.value.claimId !== null) {
+      return false;
+    }
+    return true;
+  }
+
   async ensureForUser(
     input: RuntimeProcessingInput,
     diagnostics: RuntimeProcessingDiagnostics = { stage: "state_bind", details: {} },

--- a/apps/cloudflare/src/worker-contracts.ts
+++ b/apps/cloudflare/src/worker-contracts.ts
@@ -143,6 +143,10 @@ export interface WorkerRunnerContainerNamespaceLike<
 }
 
 export interface WorkerUserRunnerStubLike {
+  recordRunnerContainerRetired?(input: {
+    runnerContainerName: string;
+    userId: string;
+  }): Promise<{ cleared: boolean }>;
   bindUser?(userId: string): Promise<{ userId: string }>;
   deleteHostedUserData?(userId: string): Promise<unknown>;
   reconcileRuntimeHealthDataConsentForUser?(userId: string): Promise<unknown>;

--- a/apps/cloudflare/src/worker/user-runner-durable-object.ts
+++ b/apps/cloudflare/src/worker/user-runner-durable-object.ts
@@ -133,6 +133,12 @@ export class UserRunnerDurableObject extends DurableObject implements UserRunner
     return this.runner.revokeActiveRuntimePlatformAiUsage(input);
   }
 
+  async recordRunnerContainerRetired(
+    input: Parameters<HostedUserRunner["recordRunnerContainerRetired"]>[0],
+  ): ReturnType<HostedUserRunner["recordRunnerContainerRetired"]> {
+    return this.runner.recordRunnerContainerRetired(input);
+  }
+
   async recordRuntimeCompletionFromContainer(
     input: Parameters<HostedUserRunner["recordRuntimeCompletionFromContainer"]>[0],
   ): ReturnType<HostedUserRunner["recordRuntimeCompletionFromContainer"]> {

--- a/apps/cloudflare/test/standby-runner.test.ts
+++ b/apps/cloudflare/test/standby-runner.test.ts
@@ -325,6 +325,61 @@ describe("RunnerContainer slot lifecycle", () => {
     expect(harness.destroy).not.toHaveBeenCalled();
   });
 
+  it("retires a stopped member slot before asynchronously clearing its assignment", async () => {
+    const notification = createDeferred<{ cleared: boolean }>();
+    const recordRunnerContainerRetired = vi.fn(() => notification.promise);
+    const h = createStandbyContainerHarness({ environment: {
+      USER_RUNNER: { getByName: vi.fn(() => ({ recordRunnerContainerRetired })) },
+    } });
+    const input = { claimId: createHostedStandbyClaimId(), releaseId: RELEASE_ID,
+      region: HOSTED_RUNNER_REGION, slotName: h.slotName, userId: "member_123" };
+    await h.container.bindStandbySlot(input);
+
+    // An unresolved callback must not hold the slot lifecycle lock.
+    await h.container.onActivityExpired();
+    expect(h.destroy).toHaveBeenCalledOnce();
+    await expect(h.container.readStandbySlotBinding()).resolves.toMatchObject({
+      state: "retired", userId: null, claimId: null,
+    });
+    expect(recordRunnerContainerRetired).toHaveBeenCalledWith({
+      runnerContainerName: h.slotName, userId: "member_123",
+    });
+    await expect(h.container.bindStandbySlot(input)).rejects.toThrow("cannot be rebound");
+    notification.resolve({ cleared: true });
+    await h.flushWaitUntil();
+  });
+
+  it("keeps stopped-slot recovery cheap when the retirement notification fails", async () => {
+    const recordRunnerContainerRetired = vi.fn(async () => { throw new Error("unavailable"); });
+    const h = createStandbyContainerHarness({ environment: {
+      USER_RUNNER: { getByName: () => ({ recordRunnerContainerRetired }) },
+    } });
+    await h.container.bindStandbySlot({ claimId: createHostedStandbyClaimId(), releaseId: RELEASE_ID,
+      region: HOSTED_RUNNER_REGION, slotName: h.slotName, userId: "member_123" });
+    await h.container.onActivityExpired();
+    await h.flushWaitUntil();
+    const nativeRead = vi.spyOn(h.container, "getState").mockClear().mockRejectedValue(new Error("slow native lookup"));
+    await expect(h.container.resolveRetainedStandbySlot({ currentReleaseId: RELEASE_ID,
+      region: HOSTED_RUNNER_REGION, slotName: h.slotName, userId: "member_123" }))
+      .resolves.toMatchObject({ state: "retired" });
+    expect(nativeRead).not.toHaveBeenCalled();
+    expect(h.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("does not publish retirement after an unconfirmed native stop", async () => {
+    const recordRunnerContainerRetired = vi.fn(async () => ({ cleared: true }));
+    const h = createStandbyContainerHarness({
+      destroy: async () => { throw new Error("platform unavailable"); },
+      environment: { USER_RUNNER: { getByName: () => ({ recordRunnerContainerRetired }) } },
+    });
+    await h.container.bindStandbySlot({ claimId: createHostedStandbyClaimId(), releaseId: RELEASE_ID,
+      region: HOSTED_RUNNER_REGION, slotName: h.slotName, userId: "member_123" });
+    await h.container.onActivityExpired();
+    await h.flushWaitUntil();
+    expect(recordRunnerContainerRetired).not.toHaveBeenCalled();
+    await expect(h.container.readStandbySlotBinding()).resolves.toMatchObject({ state: "bound" });
+  });
+
   it("keeps retryable unbound retirement member-free", async () => {
     const destroy = vi.fn()
       .mockRejectedValueOnce(new Error("platform unavailable"))
@@ -1266,7 +1321,8 @@ function createStandbyContainerHarness(input: {
   preflightReady?: boolean;
 } = {}) {
   const db = new DatabaseSync(":memory:");
-  const state = createDurableObjectState(db, []);
+  const pending: Promise<unknown>[] = [];
+  const state = createDurableObjectState(db, pending);
   let preflightReady = input.preflightReady ?? false;
   let nativeStatus = input.nativeStatus ?? "running";
   const codexPreflight = vi.fn(async () => {
@@ -1320,6 +1376,7 @@ function createStandbyContainerHarness(input: {
     startAndWaitForPorts,
   });
   return {
+    async flushWaitUntil() { await Promise.all(pending.splice(0)); },
     codexPreflight,
     container,
     environment,

--- a/apps/cloudflare/test/stubs/cloudflare-containers.ts
+++ b/apps/cloudflare/test/stubs/cloudflare-containers.ts
@@ -5,6 +5,7 @@ interface TestContainerStorage {
 }
 
 interface TestContainerContext {
+  waitUntil(promise: Promise<unknown>): void;
   container?: {
     readonly running: boolean;
   };
@@ -72,10 +73,12 @@ export class Container {
   sleepAfter: string | number = "10m";
 
   constructor(ctx?: {
+    waitUntil?(promise: Promise<unknown>): void;
     container?: TestContainerContext["container"];
     storage?: TestContainerStorage;
   }) {
     this.ctx = {
+      waitUntil: (promise) => { if (ctx?.waitUntil) ctx.waitUntil(promise); else void promise.catch(() => undefined); },
       ...(ctx?.container ? { container: ctx.container } : {}),
       storage: ctx?.storage ?? createMemoryStorage(),
     };

--- a/apps/cloudflare/test/user-runner-alarm.test.ts
+++ b/apps/cloudflare/test/user-runner-alarm.test.ts
@@ -1201,6 +1201,112 @@ describe("HostedUserRunner execution coordination", () => {
     expect(harness.invoke).toHaveBeenCalledOnce();
   });
 
+  it("clears a proven retirement before the next message without an old-target RPC", async () => {
+    const oldTarget = `runner--v-release_1--${"c".repeat(32)}`;
+    const retired: HostedStandbySlotBinding = { slotName: oldTarget, releaseId: "release_1",
+      region: "GLOBAL", state: "retired", claimId: null, userId: null };
+    const readProof = vi.fn(async () => retired);
+    const slowReconcile = vi.fn(async () => {
+      await new Promise(resolve => setTimeout(resolve, 900));
+      return retired;
+    });
+    const h = createRunnerHarness({
+      runnerRuntimeEnvSource: { ...TEST_RUNNER_RUNTIME_ENV_SOURCE, CF_VERSION_METADATA: { id: "release_1" } },
+      runnerContainerStubForName(name, stub) {
+        if (name === oldTarget) {
+          stub.readStandbySlotBinding = readProof;
+          stub.resolveRetainedStandbySlot = slowReconcile;
+        }
+        return stub;
+      },
+    });
+    await h.runner.bindUser(TEST_USER_ID);
+    h.sql.exec("UPDATE runner_meta SET active_runner_container_name = ? WHERE singleton = 1", oldTarget);
+    await expect(h.runner.recordRunnerContainerRetired({ runnerContainerName: oldTarget, userId: TEST_USER_ID }))
+      .resolves.toEqual({ cleared: true });
+    expect(readProof).toHaveBeenCalledOnce();
+    expect(readActiveRunnerContainerNameForTest(h.sql)).toBeNull();
+    h.runnerContainerNames.length = 0;
+    await expect(h.runner.ensureRuntimeProcessingForUser({ userId: TEST_USER_ID,
+      orchestrationAttemptId: "fresh-after-retirement" })).resolves.toMatchObject({ kind: "runtime_processing_accepted" });
+    await h.flushWaitUntil();
+    expect(h.invoke).toHaveBeenCalledOnce();
+    expect(slowReconcile).not.toHaveBeenCalled();
+    expect(h.runnerContainerNames).not.toContain(oldTarget);
+  });
+
+  it("admits a message while retirement proof is delayed and preserves the replacement", async () => {
+    const oldTarget = `runner--v-release_1--${"c".repeat(32)}`;
+    const retired: HostedStandbySlotBinding = { slotName: oldTarget, releaseId: "release_1",
+      region: "GLOBAL", state: "retired", claimId: null, userId: null };
+    const started = createDeferred<void>();
+    const proof = createDeferred<HostedStandbySlotBinding>();
+    const h = createRunnerHarness({
+      runnerRuntimeEnvSource: { ...TEST_RUNNER_RUNTIME_ENV_SOURCE, CF_VERSION_METADATA: { id: "release_1" } },
+      runnerContainerStubForName(name, stub) {
+        if (name === oldTarget) {
+          stub.readStandbySlotBinding = async () => { started.resolve(); return proof.promise; };
+          stub.resolveRetainedStandbySlot = async () => retired;
+        }
+        return stub;
+      },
+    });
+    await h.runner.bindUser(TEST_USER_ID);
+    h.sql.exec("UPDATE runner_meta SET active_runner_container_name = ? WHERE singleton = 1", oldTarget);
+    const notification = h.runner.recordRunnerContainerRetired({ runnerContainerName: oldTarget, userId: TEST_USER_ID });
+    await started.promise;
+    await expect(h.runner.ensureRuntimeProcessingForUser({ userId: TEST_USER_ID,
+      orchestrationAttemptId: "message-during-retirement-proof" })).resolves.toMatchObject({ kind: "runtime_processing_accepted" });
+    const replacement = readActiveRunnerContainerNameForTest(h.sql);
+    expect(replacement).not.toBeNull();
+    expect(replacement).not.toBe(oldTarget);
+    proof.resolve(retired);
+    await expect(notification).resolves.toEqual({ cleared: false });
+    expect(readActiveRunnerContainerNameForTest(h.sql)).toBe(replacement);
+    await h.flushWaitUntil();
+  });
+
+  it.each(["bound", "retiring", "wrong-slot", "unavailable"])(
+    "preserves the pending assignment when retirement proof is %s", async mode => {
+      const oldTarget = `runner--v-release_1--${"c".repeat(32)}`;
+      const h = createRunnerHarness({ runnerContainerStubForName(_name, stub) {
+        stub.readStandbySlotBinding = async () => {
+          if (mode === "unavailable") throw new Error("unavailable");
+          if (mode === "bound") return { slotName: oldTarget, releaseId: "release_1", region: "GLOBAL",
+            state: "bound", userId: TEST_USER_ID, claimId: "standby-claim-12345678-1234-4123-8123-123456789abc" };
+          return { slotName: mode === "wrong-slot" ? `runner--v-release_1--${"d".repeat(32)}` : oldTarget,
+            releaseId: "release_1", region: "GLOBAL", state: mode === "retiring" ? "retiring" : "retired",
+            claimId: null, userId: null };
+        };
+        return stub;
+      } });
+      await h.runner.bindUser(TEST_USER_ID);
+      h.sql.exec("UPDATE runner_meta SET active_runner_container_name = ? WHERE singleton = 1", oldTarget);
+      await expect(h.runner.recordRunnerContainerRetired({ runnerContainerName: oldTarget, userId: TEST_USER_ID }))
+        .resolves.toEqual({ cleared: false });
+      expect(readActiveRunnerContainerNameForTest(h.sql)).toBe(oldTarget);
+    },
+  );
+
+  it.each(["wrong-user", "replacement", "active-fence"])(
+    "ignores a retirement notification with %s without contacting the slot", async mode => {
+      const target = `runner--v-release_1--${"c".repeat(32)}`;
+      const replacement = `runner--v-release_1--${"d".repeat(32)}`;
+      const h = createRunnerHarness();
+      await h.runner.bindUser(TEST_USER_ID);
+      h.sql.exec("UPDATE runner_meta SET active_runner_container_name = ? WHERE singleton = 1",
+        mode === "replacement" ? replacement : target);
+      if (mode === "active-fence") {
+        h.sql.exec("UPDATE runner_meta SET active_attempt_id = ?, active_kind = 'runtime', active_started_at = ? WHERE singleton = 1", "active-synthetic", FIXED_NOW);
+      }
+      await expect(h.runner.recordRunnerContainerRetired({ runnerContainerName: target,
+        userId: mode === "wrong-user" ? "other-member" : TEST_USER_ID })).resolves.toEqual({ cleared: false });
+      expect(h.runnerContainerNames).toEqual([]);
+      expect(readActiveRunnerContainerNameForTest(h.sql)).toBe(mode === "replacement" ? replacement : target);
+      if (mode === "active-fence") expect(readRunnerMeta(h.sql).active_attempt_id).toBe("active-synthetic");
+    },
+  );
+
   it("releases consent withdrawal after retained standby resolution exhausts the command budget", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(FIXED_NOW));

--- a/apps/web/changelog/entries/2026-09-11/faster-replies-after-idle.json
+++ b/apps/web/changelog/entries/2026-09-11/faster-replies-after-idle.json
@@ -1,0 +1,19 @@
+{
+  "publishedOn": "2026-09-11",
+  "order": 100,
+  "item": {
+    "id": "faster-replies-after-idle",
+    "kind": "improvement",
+    "priority": 2,
+    "title": "Faster starts after a quiet stretch",
+    "summary": "Murph now finishes session cleanup before your next message arrives, reducing the wait to start a fresh reply.",
+    "details": "Your saved context is still restored before Murph responds. Recovery checks remain in place when a session has not shut down cleanly.",
+    "relevanceTags": [
+      "messaging",
+      "replies"
+    ],
+    "sourcePullRequests": [
+      3338
+    ]
+  }
+}


### PR DESCRIPTION
## Why and outcome

Normal idle cleanup stopped the native container but left its immutable slot and pending user assignment for the next message to reconcile. Retire the slot after a proven stop and notify the existing user owner so an ordinary later message can allocate without contacting the old container.

## Product UX

- Effort: Patch.
- Result: Ready; production timing remains unmeasured.
- Walkthrough: Fresh admission after idle skips old-target reconciliation. Warm reuse remains supported. Failed stops, missed notifications, active fences, and changed targets preserve the existing recovery path.

## Evidence

- Direct: Six Cloudflare test files passed, 584 tests total, covering lifecycle, standby, completion callbacks, runner identity, admission and write fences. The final focused retirement run passed 10 tests, including delayed-proof concurrency.
- Coverage: A synthetic slow old-target resolver is never invoked after verified retirement. A message can start while background proof is pending; the late clear preserves its replacement. Unavailable or non-retired proofs preserve the pending assignment.
- Typecheck: `pnpm --dir apps/cloudflare typecheck` passed.
- Changelog: fragment generation and focused archive test passed (10 tests).
- ReviewGPT: PASS on `6a3c4002567cfddda1b651273b2d7a9bf53c6b80`; full snapshot, GPT-6 Pro attested, completion marker and exact response hash verified; no accepted findings. The final follow-up only archives the implementation plan and records this evidence; runtime source, tests, and contracts are identical to the reviewed head. All required CI and the fresh Temporal compatibility proof passed on `609df8ff68b25ea4c7c79ef6e9d1196b18b78085`. Current-base merge-tree proof is clean.

## Non-obvious affected surfaces

The internal UserRunner RPC gains an optional retirement notification. The Container test double forwards Durable Object background work. Existing slot states and persisted schemas are reused.

## Architecture and reuse

- Existing systems reused: RunnerContainer lifecycle lock, immutable slot retirement, UserRunner consent lock, conditional pending-target clear, bounded slot RPC settlement.
- New logic: Post-stop retirement and a verified background notification.
- New abstractions: None; one internal RPC extends the existing user owner.
- Complexity intentionally avoided: No timer, queue, durable receipt table, polling loop, or additional execution owner.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`.
- Hotspots: Existing container functions above 20 are unchanged; no new complexity debt.
- Agent judgment: The slot owns native-stop proof; the user owner verifies durable retirement outside its admission lock and performs only the conditional clear under that lock.

## Hot reply path impact

- Path status: Touched through removal of pending old-target work after normal shutdown.
- Database calls: No new database calls on admission. Existing local SQLite writes perform background retirement and the conditional clear.
- Network/provider calls: Ordinary post-retirement admission avoids the old-slot RPC. Background cleanup sends one UserRunner notification and reads one exact slot binding; the read uses the existing web-control timeout with no retry and stays outside the foreground lock.
- Other awaited latency: No new network wait under the admission lock. A missed notification retains existing next-admission reconciliation; an already retired slot skips native liveness and destruction.
- Before/after proof: The focused test installs a delayed old-target resolver and verifies zero calls after retirement, plus a fresh successful invocation. This is deterministic call-path proof, not a production percentile claim.

## Murph initial provider input impact

- Assembled instructions: Unchanged for individual and group runtimes.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run because no provider-input surface changed; all changes are in container allocation and retirement before execution.

## Deployment concerns

- Deployment: applicable
- Supported skew: Existing retired slot states are readable by old Workers. Missing notification receivers fall back to ordinary next-admission reconciliation. No Web, Temporal, or container-image wire change.
- Safe order: Publish the Worker containing both internal RPC ends; existing runtime images can remain serving.
- Rollback floor: Existing small-runner namespace reader floor remains unchanged; any rollback requires separate authorization.
- Expected exposure: New cleanup applies to member slots stopped by the updated Worker; already pending targets use the existing fallback.
- Reversibility: A later Worker can stop sending notifications without invalidating persisted slot state.
- Convergence proof: Exact Worker publication and deployed endpoint smoke.
- Post-deploy checks: Inspect normal fresh-admission reconciliation timings and bounded lifecycle errors without exposing member identities.

## Change-shape breakdown

Classification rule: Runtime source, test paths, and authored documentation/content (including the changelog); no binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 83 | 0 |
| Tests / fixtures | 167 | 1 |
| Docs | 151 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **401** | **1** |

## Changelog

- Changelog: updated
- Items: 2026-09-11 · faster-replies-after-idle

ReviewGPT context sensitivity: sensitive
Classification reason: Internal runtime ownership, retirement ordering, and foreground admission concurrency.
ReviewGPT first-reviewed head: 6a3c4002567cfddda1b651273b2d7a9bf53c6b80

## Production deployment proof

Worker-only production deployment succeeded on 2026-09-12 at 05:46 UTC, using this PR merge commit `9a37ac9a58e7c4e019816fe415caaa2d28e3c825`. All predeployment gates, deployed endpoint smoke, and live Cloudflare state verification passed. Published Worker version: `e8290862-030c-4744-be1c-9361d92a5162`. Existing member runner images and capacity were retained.

No post-deployment member wakeup timing has been captured for the investigated case; the deterministic proof establishes zero old-target reconciliation calls after verified normal retirement.
