### PR TITLE
Share Junction daily and temporal aggregation primitives

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-complexity2-junction-aggregates.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-complexity2-junction-aggregates.md
@@ -1,0 +1,44 @@
+# Simplify Junction daily and temporal aggregation
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal
+
+Reduce repeated source/day identity and accumulation logic in Junction daily normalization while preserving canonical facts, temporal facets, and accepted-provider-record receipts.
+
+## Success criteria
+
+- Shared source/day keys, aggregate initialization, and count/sum/clock accumulation have one private implementation.
+- Provider-day facts and authorized vault-day temporal facets retain their separate authority, bounds, and publication behavior.
+- Focused Junction importer regressions, importer typecheck, and complexity guard pass with lower debt and maximum complexity.
+
+## Scope
+
+Only the importer Junction daily-aggregation seam and focused proof. Device provider execution, Core writes, schema, policy, dependencies, and persisted state remain unchanged.
+
+## Protected invariants
+
+Preserve source/provider instance identity, normalization and diagnostic precedence, units, floating and explicit clocks, dense revision selection, sparse selected-row admission, dedupe counts, provider day versus vault day, stable receipts, authoritative empty sets, input/output caps, and ordinary-empty no-tombstone behavior. The accepted-provider-record counter must continue using the same parser as canonical daily facts.
+
+## Design
+
+Derive dense/sparse resource classification once. Reuse one source/day key, aggregate seed, and sample count/sum/clock updater; retain daily sum-square and extrema behavior and temporal extrema semantics explicitly. Give temporal accumulation and capped publication named private boundaries within the same owner. Do not introduce a generic aggregation framework or shared mutable policy state.
+
+## Verification
+
+Run the focused Junction importer suites with one worker, importer typecheck, and cyclomatic diff against the task base. Existing core-backed tests cover replay, offset and floating day ownership, strict source-day rejection, exact duplicates, stable revisions, sparse corrections, temporal caps, and canonical output. Also run scenario-manifest integrity; exact-head integration CI remains parent-owned.
+
+## Completion
+
+Implemented shared source/day identity, aggregate seed, and count/sum/clock accumulation, with resource classification derived once. Temporal collection and capped publication retain their original owner and order. Daily initial sums and extrema remain distinct from temporal extrema to preserve numeric behavior. An over-cap throw cannot expose partial accumulators because both maps remain local until post-loop publication.
+
+- Focused Junction normalization, activity-resource, missing-resource, and snapshot-validation suites pass with one worker.
+- Importer typecheck passes.
+- Scenario integrity passes: 205 scenarios, 12 sample inputs, and 29 golden-output directories.
+- Cyclomatic diff passes against task base: file debt 153 to 129; maximum/function complexity 98 to 74. All added helpers are at or below 20. Remaining normalization/revision branches and unrelated resource hotspots retain their established owners; further broad decomposition is outside this shared-aggregation seam.
+- Diff whitespace and privacy inspection pass. No new dependency, public API, persisted representation, or product behavior.
+
+Parent owns final candidate review, Ready admission, required CI, ReviewGPT, and merge.
+Completed: 2026-09-11

--- a/packages/importers/src/device-providers/junction.ts
+++ b/packages/importers/src/device-providers/junction.ts
@@ -3933,20 +3933,21 @@ function buildJunctionDailyTimeseriesAggregates(input: {
     ? groupedTimeseriesResourceEntries(input.payload).filter(({ entry }) =>
         !Array.isArray(entry.data) || entry.data.length > 0)
     : timeseriesResourceEntries(input.payload);
-  const fidelityResource = isJunctionDenseFidelityResource(input.resource)
-    ? input.resource
-    : isJunctionSparseIntervalResource(input.resource)
-      ? input.resource
-      : undefined;
+  const denseResource = isJunctionDenseFidelityResource(input.resource) ? input.resource : undefined;
+  const sparseResource = isJunctionSparseIntervalResource(input.resource) ? input.resource : undefined;
+  const fidelityResource = denseResource ?? sparseResource;
+  const timestampPaths = sparseResource
+    ? JUNCTION_INTERVAL_START_TIMESTAMP_PATHS
+    : JUNCTION_INTERVAL_START_OWNED_TIMESTAMP_PATHS;
   if (fidelityResource) {
     assertJunctionTimeseriesResponseBound(fidelityResource, entries.length);
   }
-  const selectedDenseRecordKeys = isJunctionDenseFidelityResource(input.resource)
+  const selectedDenseRecordKeys = denseResource
     ? selectJunctionDenseFidelityRecordKeys({
         context: input.context,
         entries,
         normalizeValue: input.normalizeValue,
-        resource: input.resource,
+        resource: denseResource,
         resourceSlug: input.resourceSlug,
         valuePaths: input.valuePaths,
       })
@@ -3954,9 +3955,6 @@ function buildJunctionDailyTimeseriesAggregates(input: {
   const seenFidelityRecords = new Set<string>();
 
   for (const [index, { entry, originFallback }] of entries.entries()) {
-    const timestampPaths = isJunctionSparseIntervalResource(input.resource)
-      ? JUNCTION_INTERVAL_START_TIMESTAMP_PATHS
-      : JUNCTION_INTERVAL_START_OWNED_TIMESTAMP_PATHS;
     const providerTimestamp = firstStringFromPaths(entry, timestampPaths)
       ?? firstValueFromPaths(entry, timestampPaths);
     const rowDiagnostic = {
@@ -3994,7 +3992,7 @@ function buildJunctionDailyTimeseriesAggregates(input: {
     const providerValue = firstValueFromPaths(entry, input.valuePaths);
     const numericProviderValue = firstNumberFromPaths(entry, input.valuePaths);
     const value = input.normalizeValue(numericProviderValue, entry);
-    const sparseStartRaw = isJunctionSparseIntervalResource(input.resource)
+    const sparseStartRaw = sparseResource
       ? firstStringFromPaths(entry, JUNCTION_INTERVAL_START_TIMESTAMP_PATHS)
       : undefined;
     const timestamp = sparseStartRaw
@@ -4064,14 +4062,10 @@ function buildJunctionDailyTimeseriesAggregates(input: {
       continue;
     }
 
-    const key = [
-      resourceContext.externalRefResourceType,
-      resourceContext.origin.sourceType ?? "",
-      resourceContext.origin.sourceInstanceId ?? "",
-      dayKey,
-    ].join("\u0000");
+    const key = junctionTimeseriesSourceDayKey(resourceContext, dayKey);
     const existing = aggregates.get(key);
     const recordedAt = timestamp.recordedAt ?? sampleAt;
+    const sample: JunctionDailyTimeseriesSample = { entry, resourceContext, timestamp, recordedAt, value };
     const timeZone = input.requireExplicitTimestamp
       ? "UTC"
       : firstStringFromPaths(entry, ["timeZone", "timezone", "time_zone"]);
@@ -4089,8 +4083,8 @@ function buildJunctionDailyTimeseriesAggregates(input: {
           timestamp,
         })
       : undefined;
-    const denseStableIdentity = isJunctionDenseFidelityResource(input.resource)
-      ? buildJunctionDenseFidelityStableIdentity(input.resource, entry, resourceContext)
+    const denseStableIdentity = denseResource
+      ? buildJunctionDenseFidelityStableIdentity(denseResource, entry, resourceContext)
       : undefined;
     const denseSelection = denseStableIdentity
       ? selectedDenseRecordKeys?.get(denseStableIdentity)
@@ -4106,7 +4100,7 @@ function buildJunctionDailyTimeseriesAggregates(input: {
       ? input.selectedSparseRecords?.get(fidelityRecordKey)
       : undefined;
     if (
-      isJunctionSparseIntervalResource(input.resource)
+      sparseResource
       && entry.authoritativeEmptyCalendarSet !== true
       && fidelityRecordKey
       && input.selectedSparseRecords
@@ -4123,11 +4117,11 @@ function buildJunctionDailyTimeseriesAggregates(input: {
     if (fidelityRecordKey) {
       seenFidelityRecords.add(fidelityRecordKey);
     }
-    const fidelitySample = isJunctionDenseFidelityResource(input.resource)
+    const fidelitySample = denseResource
       ? buildJunctionTimeseriesFidelityPoint({
           defaultTimeZone: input.context.defaultTimeZone,
           entry,
-          resource: input.resource,
+          resource: denseResource,
           sampleAt,
           timestamp,
           value,
@@ -4139,31 +4133,21 @@ function buildJunctionDailyTimeseriesAggregates(input: {
     }
 
     if (!existing) {
-      aggregates.set(key, {
-        authoritativeEmptyCalendarSet: entry.authoritativeEmptyCalendarSet === true,
-        dayKey,
-        duplicateSampleCount: 0,
-        entry,
-        fidelitySamples: fidelitySample ? [fidelitySample] : [],
-        firstSampleAt: sampleAt,
-        lastRecordedAt: recordedAt,
-        lastSampleAt: sampleAt,
-        legacyDayKeys,
-        maxValue: value,
-        minValue: value,
-        evidencePartRole,
-        resourceContext,
-        sampleCount: 1,
-        sum: value,
-        sumSquares: value * value,
-        timestamp,
-        timeZone,
-      });
+      const aggregate = createJunctionTimeseriesAggregate(
+        sample, dayKey, sampleAt, evidencePartRole, timeZone,
+      );
+      aggregate.authoritativeEmptyCalendarSet = entry.authoritativeEmptyCalendarSet === true;
+      aggregate.fidelitySamples = fidelitySample ? [fidelitySample] : [];
+      aggregate.legacyDayKeys = legacyDayKeys;
+      aggregate.sampleCount = 1;
+      aggregate.sum = value;
+      aggregate.sumSquares = value * value;
+      aggregates.set(key, aggregate);
       if (fidelityResource) {
         assertJunctionTimeseriesSourceDayBound(fidelityResource, 1);
       }
     } else {
-      existing.sampleCount += 1;
+      appendJunctionTimeseriesSample(existing, sample, sampleAt);
       existing.authoritativeEmptyCalendarSet ||= entry.authoritativeEmptyCalendarSet === true;
       if (fidelitySample) {
         existing.fidelitySamples.push(fidelitySample);
@@ -4171,18 +4155,7 @@ function buildJunctionDailyTimeseriesAggregates(input: {
       if (fidelityResource) {
         assertJunctionTimeseriesSourceDayBound(fidelityResource, existing.sampleCount);
       }
-      existing.sum += value;
       existing.sumSquares += value * value;
-      if (sampleAt < existing.firstSampleAt) {
-        existing.firstSampleAt = sampleAt;
-      }
-
-      if (sampleAt >= existing.lastSampleAt) {
-        existing.lastSampleAt = sampleAt;
-        existing.lastRecordedAt = recordedAt;
-        existing.timestamp = timestamp;
-      }
-
       if (value < existing.minValue) {
         existing.minValue = value;
       }
@@ -4195,129 +4168,17 @@ function buildJunctionDailyTimeseriesAggregates(input: {
     const temporalSourceDay = ownsTemporalFeatures
       ? input.context.temporalFeatureSourceDay
       : undefined;
-    const temporalSampleAt = temporalSourceDay
-      ? resolveJunctionTemporalFeatureInstant(
-          timestamp,
-          temporalSourceDay.timeZone,
-          resolvedRowDiagnostic,
-        )
-      : null;
-    if (!temporalSourceDay || temporalSampleAt === null) continue;
-
-    const sourceDay = temporalSourceDay;
-    const vaultDayKey = toLocalDayKey(temporalSampleAt, sourceDay.timeZone);
-    if (vaultDayKey !== sourceDay.dayKey) {
-      // The provider fetched the exact authorized window, so a row that
-      // normalizes outside the target vault day (for example a fallback
-      // timestamp) is a lossy normalization, not out-of-scope data.
-      throw junctionCalendarRefreshNormalizationError(
-        "source_day.outside_authorized_day",
-        resolvedRowDiagnostic,
+    if (temporalSourceDay) {
+      appendJunctionTemporalSourceDaySample(
+        temporalAggregates, temporalSourceDay, sample, input.resourceSlug, resolvedRowDiagnostic,
       );
-    }
-    const temporalKey = [
-      resourceContext.externalRefResourceType,
-      resourceContext.origin.sourceType ?? "",
-      resourceContext.origin.sourceInstanceId ?? "",
-      sourceDay.dayKey,
-    ].join("\u0000");
-    let temporalAggregate = temporalAggregates.get(temporalKey);
-    if (!temporalAggregate) {
-      const sourceFacet = shortHash([
-        resourceContext.sourceProviderSlug,
-        resourceContext.origin.sourceType ?? "",
-        resourceContext.origin.sourceInstanceId ?? "",
-      ]);
-      temporalAggregate = {
-        authoritativeEmptyCalendarSet: false,
-        dayKey: sourceDay.dayKey,
-        duplicateSampleCount: 0,
-        entry,
-        fidelitySamples: [],
-        firstSampleAt: temporalSampleAt,
-        lastRecordedAt: recordedAt,
-        lastSampleAt: temporalSampleAt,
-        legacyDayKeys: new Set(),
-        maxValue: value,
-        minValue: value,
-        evidencePartRole:
-          `junction-timeseries-temporal-${input.resourceSlug}:${sourceDay.dayKey}:${sourceFacet}`,
-        resourceContext,
-        sampleCount: 0,
-        sum: 0,
-        sumSquares: 0,
-        timestamp,
-        timeZone: sourceDay.timeZone,
-      };
-      temporalAggregates.set(temporalKey, temporalAggregate);
-    }
-    temporalAggregate.sampleCount += 1;
-    temporalAggregate.sum += value;
-    if (temporalSampleAt < temporalAggregate.firstSampleAt) {
-      temporalAggregate.firstSampleAt = temporalSampleAt;
-    }
-    if (temporalSampleAt >= temporalAggregate.lastSampleAt) {
-      temporalAggregate.lastSampleAt = temporalSampleAt;
-      temporalAggregate.lastRecordedAt = recordedAt;
-      temporalAggregate.timestamp = timestamp;
-    }
-    temporalAggregate.minValue = Math.min(temporalAggregate.minValue, value);
-    temporalAggregate.maxValue = Math.max(temporalAggregate.maxValue, value);
-    const temporalFeatureSamples = temporalAggregate.temporalFeatureSamples ?? [];
-    if (temporalFeatureSamples.length >= JUNCTION_TEMPORAL_FEATURE_MAX_SAMPLES_PER_DAY) {
-      temporalAggregate.temporalFeatureInputSuppressed = true;
-      delete temporalAggregate.temporalFeatureSamples;
-    } else {
-      temporalFeatureSamples.push(stripUndefined({
-        recordedAt: temporalSampleAt,
-        value,
-        localMinuteOfDay: resolveJunctionTemporalFeatureVaultLocalMinuteOfDay(
-          temporalSampleAt,
-          sourceDay.timeZone,
-        ),
-      }));
-      temporalAggregate.temporalFeatureSamples = temporalFeatureSamples;
     }
   }
 
   if (ownsTemporalFeatures) {
-    for (const aggregate of [...temporalAggregates.values()].sort(
-      compareJunctionDailyTimeseriesAggregates,
-    )) {
-      const result: JunctionTemporalFeatureResult =
-        aggregate.temporalFeatureInputSuppressed
-          ? { observations: [], status: "suppressed_input_cap" }
-          : buildJunctionTemporalFeatures({
-            resource: temporalFeatureResource,
-            samples: aggregate.temporalFeatureSamples ?? [],
-          });
-      const existingObservationCount = input.context.temporalFeatureObservationCountsByDay.get(
-        aggregate.dayKey,
-      ) ?? 0;
-      if (
-        result.status === "complete"
-        && existingObservationCount + result.observations.length
-          > JUNCTION_TEMPORAL_FEATURE_MAX_OBSERVATIONS_PER_DAY
-      ) {
-        aggregate.temporalFeatureResult = {
-          observations: [],
-          status: "suppressed_output_cap",
-        };
-      } else {
-        aggregate.temporalFeatureResult = result;
-        input.context.temporalFeatureObservationCountsByDay.set(
-          aggregate.dayKey,
-          existingObservationCount + result.observations.length,
-        );
-      }
-      pushJunctionTemporalFeatureArtifact(input.context, input.resource, aggregate);
-      if (aggregate.temporalFeatureResult?.status === "complete") {
-        for (const observation of aggregate.temporalFeatureResult.observations) {
-          pushJunctionDailyTimeseriesObservation(input.context, aggregate, observation);
-        }
-      }
-      delete aggregate.temporalFeatureSamples;
-    }
+    publishJunctionTemporalAggregates(
+      input.context, input.resource, temporalFeatureResource, temporalAggregates,
+    );
 
     // A complete-source-day import owns only temporal facets. Its vault-window
     // samples cover partial provider days, so emitting ordinary observations,
@@ -4334,6 +4195,173 @@ function buildJunctionDailyTimeseriesAggregates(input: {
 
   pushJunctionDailyTimeseriesAggregateArtifacts(input.context, input.resource, sortedAggregates);
   return sortedAggregates;
+}
+
+interface JunctionDailyTimeseriesSample {
+  entry: PlainObject;
+  resourceContext: ResourceContext;
+  timestamp: ReturnType<typeof resolveRecordTimestamp>;
+  recordedAt: string;
+  value: number;
+}
+
+function junctionTimeseriesSourceDayKey(resourceContext: ResourceContext, dayKey: string): string {
+  return [
+    resourceContext.externalRefResourceType,
+    resourceContext.origin.sourceType ?? "",
+    resourceContext.origin.sourceInstanceId ?? "",
+    dayKey,
+  ].join("\u0000");
+}
+
+function createJunctionTimeseriesAggregate(
+  sample: JunctionDailyTimeseriesSample,
+  dayKey: string,
+  sampleAt: string,
+  evidencePartRole: string,
+  timeZone: string | undefined,
+): JunctionDailyTimeseriesAggregate {
+  return {
+    authoritativeEmptyCalendarSet: false,
+    dayKey,
+    duplicateSampleCount: 0,
+    entry: sample.entry,
+    fidelitySamples: [],
+    firstSampleAt: sampleAt,
+    lastRecordedAt: sample.recordedAt,
+    lastSampleAt: sampleAt,
+    legacyDayKeys: new Set(),
+    maxValue: sample.value,
+    minValue: sample.value,
+    evidencePartRole,
+    resourceContext: sample.resourceContext,
+    sampleCount: 0,
+    sum: 0,
+    sumSquares: 0,
+    timestamp: sample.timestamp,
+    timeZone,
+  };
+}
+
+function appendJunctionTimeseriesSample(
+  aggregate: JunctionDailyTimeseriesAggregate,
+  sample: JunctionDailyTimeseriesSample,
+  sampleAt: string,
+): void {
+  aggregate.sampleCount += 1;
+  aggregate.sum += sample.value;
+  if (sampleAt < aggregate.firstSampleAt) {
+    aggregate.firstSampleAt = sampleAt;
+  }
+  if (sampleAt >= aggregate.lastSampleAt) {
+    aggregate.lastSampleAt = sampleAt;
+    aggregate.lastRecordedAt = sample.recordedAt;
+    aggregate.timestamp = sample.timestamp;
+  }
+}
+
+function appendJunctionTemporalSourceDaySample(
+  temporalAggregates: Map<string, JunctionDailyTimeseriesAggregate>,
+  sourceDay: NonNullable<NormalizationContext["temporalFeatureSourceDay"]>,
+  sample: JunctionDailyTimeseriesSample,
+  resourceSlug: string,
+  resolvedRowDiagnostic: Omit<JunctionCalendarRefreshNormalizationDiagnostic, "reason">,
+): void {
+  const { resourceContext, timestamp, value } = sample;
+  const temporalSampleAt = resolveJunctionTemporalFeatureInstant(
+    timestamp, sourceDay.timeZone, resolvedRowDiagnostic,
+  );
+  if (temporalSampleAt === null) return;
+  const vaultDayKey = toLocalDayKey(temporalSampleAt, sourceDay.timeZone);
+  if (vaultDayKey !== sourceDay.dayKey) {
+    // The provider fetched the exact authorized window, so a row that
+    // normalizes outside the target vault day (for example a fallback
+    // timestamp) is a lossy normalization, not out-of-scope data.
+    throw junctionCalendarRefreshNormalizationError(
+      "source_day.outside_authorized_day",
+      resolvedRowDiagnostic,
+    );
+  }
+  const temporalKey = junctionTimeseriesSourceDayKey(resourceContext, sourceDay.dayKey);
+  let temporalAggregate = temporalAggregates.get(temporalKey);
+  if (!temporalAggregate) {
+    const sourceFacet = shortHash([
+      resourceContext.sourceProviderSlug,
+      resourceContext.origin.sourceType ?? "",
+      resourceContext.origin.sourceInstanceId ?? "",
+    ]);
+    temporalAggregate = createJunctionTimeseriesAggregate(
+      sample,
+      sourceDay.dayKey,
+      temporalSampleAt,
+      `junction-timeseries-temporal-${resourceSlug}:${sourceDay.dayKey}:${sourceFacet}`,
+      sourceDay.timeZone,
+    );
+    temporalAggregates.set(temporalKey, temporalAggregate);
+  }
+  appendJunctionTimeseriesSample(temporalAggregate, sample, temporalSampleAt);
+  temporalAggregate.minValue = Math.min(temporalAggregate.minValue, value);
+  temporalAggregate.maxValue = Math.max(temporalAggregate.maxValue, value);
+  const temporalFeatureSamples = temporalAggregate.temporalFeatureSamples ?? [];
+  if (temporalFeatureSamples.length >= JUNCTION_TEMPORAL_FEATURE_MAX_SAMPLES_PER_DAY) {
+    temporalAggregate.temporalFeatureInputSuppressed = true;
+    delete temporalAggregate.temporalFeatureSamples;
+  } else {
+    temporalFeatureSamples.push(stripUndefined({
+      recordedAt: temporalSampleAt,
+      value,
+      localMinuteOfDay: resolveJunctionTemporalFeatureVaultLocalMinuteOfDay(
+        temporalSampleAt,
+        sourceDay.timeZone,
+      ),
+    }));
+    temporalAggregate.temporalFeatureSamples = temporalFeatureSamples;
+  }
+}
+
+function publishJunctionTemporalAggregates(
+  context: NormalizationContext,
+  resource: string,
+  temporalFeatureResource: Parameters<typeof buildJunctionTemporalFeatures>[0]["resource"],
+  temporalAggregates: ReadonlyMap<string, JunctionDailyTimeseriesAggregate>,
+): void {
+  for (const aggregate of [...temporalAggregates.values()].sort(
+    compareJunctionDailyTimeseriesAggregates,
+  )) {
+    const result: JunctionTemporalFeatureResult =
+      aggregate.temporalFeatureInputSuppressed
+        ? { observations: [], status: "suppressed_input_cap" }
+        : buildJunctionTemporalFeatures({
+          resource: temporalFeatureResource,
+          samples: aggregate.temporalFeatureSamples ?? [],
+        });
+    const existingObservationCount = context.temporalFeatureObservationCountsByDay.get(
+      aggregate.dayKey,
+    ) ?? 0;
+    if (
+      result.status === "complete"
+      && existingObservationCount + result.observations.length
+        > JUNCTION_TEMPORAL_FEATURE_MAX_OBSERVATIONS_PER_DAY
+    ) {
+      aggregate.temporalFeatureResult = {
+        observations: [],
+        status: "suppressed_output_cap",
+      };
+    } else {
+      aggregate.temporalFeatureResult = result;
+      context.temporalFeatureObservationCountsByDay.set(
+        aggregate.dayKey,
+        existingObservationCount + result.observations.length,
+      );
+    }
+    pushJunctionTemporalFeatureArtifact(context, resource, aggregate);
+    if (aggregate.temporalFeatureResult?.status === "complete") {
+      for (const observation of aggregate.temporalFeatureResult.observations) {
+        pushJunctionDailyTimeseriesObservation(context, aggregate, observation);
+      }
+    }
+    delete aggregate.temporalFeatureSamples;
+  }
 }
 
 function pushJunctionEmptyDailyTimeseriesAggregateArtifact(


### PR DESCRIPTION
## Why and outcome

Junction daily normalization repeated source/day identity, aggregate initialization, and count/sum/clock accumulation across provider-day facts and authorized vault-day temporal facets. Share those primitives and derive resource classification once while preserving normalization, revision selection, canonical output, and accepted-provider-record receipts.

## Product UX

- Effort: Not applicable — internal importer refactor.
- Result: Not applicable.
- Walkthrough: Existing device import and replay behavior is preserved; no member-facing surface changes.

## Evidence

- Direct: Focused Junction normalization, activity-resource, missing-resource, and snapshot-validation suites pass with one worker (280 tests across 4 files): `MURPH_VITEST_MAX_WORKERS=1 pnpm --filter @murphai/importers exec vitest run --config vitest.config.ts --no-coverage test/device-providers-junction.test.ts test/device-providers-junction-activity-resources.test.ts test/device-providers-junction-missing-resources.test.ts test/device-provider-snapshot-validation.test.ts`.
- Coverage: Existing core-backed fixtures exercise duplicate and stable-revision selection, source identity, floating and offset day boundaries, canonical replay, sparse corrections and empties, strict source-day rejection, temporal facets and caps.
- `pnpm --filter @murphai/importers typecheck` passes.
- `pnpm test:scenario-integrity` passes: 205 scenarios, 12 sample inputs, 29 golden-output directories.
- `git diff --check` passes. Parent review, ReviewGPT, and all required CI passed on this head.

## Non-obvious affected surfaces

The accepted-provider-record receipt counter uses the same daily parser. Provider-day facts and vault-day temporal facets continue to use distinct day authority and publication paths. Daily initial sum and extrema semantics remain distinct from temporal extrema. Per-day cap failure cannot expose partial accumulators because both maps stay local until post-loop publication.

## Architecture and reuse

- Existing systems reused: Existing Junction resource policies, normalization, fidelity admission, aggregate representation, temporal feature builder, and canonical publishers.
- New logic: None; preserve existing validation, dedupe, authority, limits, ordering, and output.
- New abstractions: A private normalized-sample type and shared source/day key, aggregate seed, and sample accumulator; private temporal collection and publication boundaries inside the same owner.
- Complexity intentionally avoided: No generic aggregation framework, additional state owner, public API, dependency, or compatibility layer.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff -- --base-ref 3fcb0ab14d8137af4d4858ad030de8ab2c904970 -- packages/importers/src/device-providers/junction.ts`. Debt 153 → 129; maximum 98 → 74.
- Hotspots: Changed `buildJunctionDailyTimeseriesAggregates` is 74 and retains row normalization/diagnostic precedence and revision admission. Added helpers are at or below 20. Unchanged hotspots: `pushJunctionWorkoutStreamFeature` 33, `resolveJunctionSparseTimeseriesTimestamp` 32, `pushMenstrualCycleSummary` 31, `parseJunctionSparseTimeseriesRecord` 29, `assertJunctionSparseCalendarRepairRowsValid` 27, `buildRawResourcePayload` 27, `pushJunctionSparseTimeseriesRecords` 26, `pushJunctionSparseIntervalReadings` 25, `normalizeDistanceKilometers` 23, `pushJunctionDailyTimeseriesAggregateArtifacts` 22.
- Agent judgment: Shared accumulation removes real duplication. Further broad decomposition of independent normalization and resource policies would exceed this seam; retaining their decision order makes the authority boundaries reviewable.

## Hot reply path impact

- Path status: Not applicable — background device normalization only.
- Database calls: None added or moved.
- Network/provider calls: None added or moved.
- Other awaited latency: None added or moved.
- Before/after proof: The changed functions remain synchronous normalization and publication helpers.

## Murph initial provider input impact

Not applicable for both individual and group Murph: no prompt, message assembly, tool/schema, generated guidance, or other provider-input surface changed. Measurement not run.

## Deployment concerns

- Deployment: not applicable
- Reason: Private in-process refactor with unchanged exported API, wire format, stored representation, and deployment boundaries.

## Change-shape breakdown

Classification rule: Junction TypeScript is source; the completed execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 200 | 172 |
| Tests / fixtures | 0 | 0 |
| Docs | 44 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **244** | **172** |

## Changelog

- Changelog: not applicable
- Reason: Internal refactor preserving member-visible behavior.

ReviewGPT first-reviewed head: 54cf828da28132d11f63c568c82ff05403a0f158
ReviewGPT context sensitivity: sensitive
Classification reason: Health-data normalization, source-day authority, canonical receipt counting, and temporal replacement boundaries.

## ReviewGPT result

- Round 1: PASS on 54cf828da28132d11f63c568c82ff05403a0f158.
- Model: GPT-6 Pro, verified by captured response metadata; guarded full snapshot and exact committed turn verified.
- No qualifying findings; no review remediation required. All required CI checks and routed Temporal compatibility passed on this same head.

## Completion status

- Parent candidate review and verified GPT-6 Pro ReviewGPT passed on the head above.
- Billing, both CLI checks, and routed Temporal compatibility passed.
- Release CI passed after the interrupted jobs were resumed on the unchanged reviewed head. All required checks and routed Temporal compatibility are green.
