### PR TITLE
refactor(web): simplify hosted device runtime apply derivation

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-complexity-hosted-device-authority.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-complexity-hosted-device-authority.md
@@ -1,0 +1,57 @@
+# Simplify hosted device runtime apply derivation
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal
+
+- Simplify canonical hosted device runtime apply without changing authorization, token versions, source ownership, or persistence results.
+
+## Success criteria
+
+- Remove identity-only credential helpers and duplicated token derivation; replace correlated persistence flags with a typed credential plan.
+- Reduce callback complexity and file debt while focused authority/route, bounded PostgreSQL, typecheck, and guard proof passes.
+
+## Scope
+
+- In scope: private derivation and source-admission helpers in hosted-runtime-authority, focused regression proof.
+- Out of scope: authentication policy, persistence schemas, provider I/O, runtime protocols, source lifecycle semantics, or additional database queries.
+
+## Constraints
+
+- Technical constraints: preserve pre-BEGIN secret preparation, every live secret/root/connection/token/source epoch fence, one transaction at a time, and existing write/notice ordering.
+- Product/process constraints: Web remains the canonical control owner; no persisted state or public behavior changes.
+
+## Risks and mitigations
+
+1. A refactor could conflate missing, clear, and unchanged credentials or bypass live authority. Keep validation and fencing in place and prove token clear/replacement/no-op, authority drift, and maximum-cardinality composition through public owners.
+
+## Tasks
+
+1. Trace preparation, lock admission, pure derivation, persistence, and notices.
+2. Remove redundant helpers and consolidate credential and patch derivation without moving I/O or fences.
+3. Run focused authority/route and PostgreSQL cardinality proof, Web typecheck, and complexity guard.
+4. Review privacy and full diff, close implementation plan, commit/push a draft PR for parent-owned final review.
+
+## Decisions
+
+- Existing canonical connection/source/token records remain authoritative. A credential plan exists only within one callback and cannot authorize persistence independently of the existing live fences.
+- Private derivation helpers reuse existing token-version, metadata, lifecycle, and source comparison owners; no framework or package boundary is added.
+
+## Verification
+
+- Commands: focused hosted runtime authority and internal apply route tests; two isolated real-PostgreSQL maximum-cardinality apply cases; hosted-web typecheck; complexity diff.
+- Expected outcomes: equivalent public results and transaction counts, no external work in locked transactions, lower cyclomatic debt. Parent owns exact-head CI and ReviewGPT completion.
+
+## Implementation evidence
+
+- Authority and internal apply route suites: 90 tests passed, including five new cases covering current/pending/absent Google source authority and dirty-work blocking of Fitbit terminal projection.
+- Isolated real-PostgreSQL proof: both the 100-update no-op apply with concurrent foreground reads and the maximum Junction source-collection apply passed; six unrelated incident cases were excluded. The task database applied all 221 current migrations before testing.
+- Existing authority tests also prove 100 token preparations occur outside BEGIN and 100-by-64 source updates remain bounded to 6,400 serial source writes.
+- Hosted Web typecheck and diff whitespace checks passed. The full typecheck initially caught a grouped setup-phase enum assignment; preserving its dedicated assignment resolved it, and the final prepared Web check passed.
+- Complexity guard passed: callback 113 to 73; file debt 136 to 96. All added helpers remain at or below 20. The unchanged source-update resolver (44) and snapshot reader (39) are independent seams.
+- Removed two redundant credential helpers, shared token derivation, replaced correlated persistence flags, and grouped optional patch fields. Fitbit terminal source classification now computes successor presence once and reuses the selected set for dirty filtering.
+- Full diff review preserved every live authority fence, SQL call and serial transaction, credential validation order, prepared-token match assertion, and post-commit notice scheduling.
+- Implementation is complete; parent owns candidate review, Ready transition, final ReviewGPT, and exact-head CI.
+Completed: 2026-09-11

--- a/apps/web/src/lib/device-sync/hosted-runtime-authority.ts
+++ b/apps/web/src/lib/device-sync/hosted-runtime-authority.ts
@@ -428,26 +428,18 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
           provider: record.provider,
           updates: update.sources ?? [],
         });
-        const pendingDirtyBlocksFitbitTerminalProjection =
-          resolvedSourceUpdates.toApply.some((source) =>
-            isHostedRuntimeFitbitMigrationTerminalSourceUpdate({
-              currentSources: sources,
-              pendingSourceUpdates: resolvedSourceUpdates.toApply,
-              provider: record.provider,
-              source,
-            })
-          )
+        const fitbitTerminalSourceUpdates = findHostedRuntimeFitbitTerminalSourceUpdates({
+          currentSources: sources,
+          pendingSourceUpdates: resolvedSourceUpdates.toApply,
+          provider: record.provider,
+        });
+        const pendingDirtyBlocksFitbitTerminalProjection = fitbitTerminalSourceUpdates.size > 0
           && await controlPlane.store.hasPendingDirtyConnection(record.id, tx);
         const sourceUpdates = pendingDirtyBlocksFitbitTerminalProjection
           ? {
               ...resolvedSourceUpdates,
               toApply: resolvedSourceUpdates.toApply.filter((source) =>
-                !isHostedRuntimeFitbitMigrationTerminalSourceUpdate({
-                  currentSources: sources,
-                  pendingSourceUpdates: resolvedSourceUpdates.toApply,
-                  provider: record.provider,
-                  source,
-                })
+                !fitbitTerminalSourceUpdates.has(source)
               ),
             }
           : resolvedSourceUpdates;
@@ -477,9 +469,9 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
         const connectionEpochMismatch = connectionWriteRequested
           && baseline.connection.connectedAt !== update.observedConnectedAt;
         const baselineTokenVersion = getHostedRuntimeOAuthTokenBundle(baseline.credential)?.tokenVersion ?? null;
-        const tokenVersionMismatch = hostedRuntimeCredentialMutationRequiresTokenFence(update)
+        const tokenVersionMismatch = credentialMutationRequested
           && baselineTokenVersion !== update.observedTokenVersion;
-        const tokenRefreshLeaseConflict = hostedRuntimeCredentialMutationRequiresTokenFence(update)
+        const tokenRefreshLeaseConflict = credentialMutationRequested
           && hasHostedRuntimeRefreshLeaseForTokenVersion(record, baselineTokenVersion);
         const preparedTokenWriteMissing = update.credential?.kind === "oauth_tokens"
           && !preparedConnection.tokenWrite;
@@ -496,9 +488,7 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
           || (stateMutationRequested && sourceVersionMismatch)
           || historicalMetadataResolution?.rejected === true
           || historicalResetStateMismatch;
-        const credentialUpdate = update.credential === undefined
-          ? undefined
-          : resolveHostedRuntimeCredentialUpdate(update.credential);
+        const credentialUpdate = update.credential;
         if (
           credentialUpdate
           && (credentialUpdate.kind !== "oauth_tokens" || secretAuthorityCurrent)
@@ -510,91 +500,18 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
           });
         }
         const nextAccount = buildPublicConnectionFromRuntimeSnapshot(baseline);
-        let tokenBundleToPersist: HostedExecutionDeviceSyncRuntimeTokenBundle | null | undefined;
-        let tokenBundlePersistenceRequested = false;
-        let credentialToPersist:
-          | Exclude<
-            HostedExecutionDeviceSyncRuntimeCredentialSnapshot,
-            { kind: "oauth_tokens" } | { kind: "oauth_tokens_redacted" }
-          >
-          | undefined;
-
-        if (!versionMismatch && update.connection) {
-          if (Object.prototype.hasOwnProperty.call(update.connection, "displayName")) {
-            nextAccount.displayName = update.connection.displayName ?? null;
-          }
-          if (Object.prototype.hasOwnProperty.call(update.connection, "metadata")) {
-            nextAccount.metadata = historicalMetadataResolution?.metadata
-              ?? sanitizeStoredDeviceSyncMetadata(update.connection.metadata ?? {});
-          }
-          if (Object.prototype.hasOwnProperty.call(update.connection, "scopes")) {
-            nextAccount.scopes = [...(update.connection.scopes ?? [])];
-          }
-          if (Object.prototype.hasOwnProperty.call(update.connection, "status") && update.connection.status) {
-            nextAccount.status = normalizeHostedDeviceSyncLifecycleStatus(update.connection.status);
-          }
-          if (Object.prototype.hasOwnProperty.call(update.connection, "setupExpiresAt")) {
-            nextAccount.setupExpiresAt = update.connection.setupExpiresAt ?? null;
-          }
-          if (Object.prototype.hasOwnProperty.call(update.connection, "setupPhase")) {
-            nextAccount.setupPhase = update.connection.setupPhase ?? null;
-          }
+        if (!versionMismatch) {
+          applyHostedRuntimeAccountPatch(nextAccount, update, historicalMetadataResolution?.metadata);
         }
-
-        if (!versionMismatch && update.localState) {
-          if (update.localState.clearError) {
-            nextAccount.lastErrorCode = null;
-            nextAccount.lastErrorMessage = null;
-          }
-
-          for (const field of [
-            "lastErrorCode",
-            "lastErrorMessage",
-            "lastSyncCompletedAt",
-            "lastSyncErrorAt",
-            "lastSyncStartedAt",
-            "lastWebhookAt",
-            "nextReconcileAt",
-          ] as const) {
-            if (Object.prototype.hasOwnProperty.call(update.localState, field)) {
-              nextAccount[field] = update.localState[field] ?? null;
-            }
-          }
-        }
-
-        let tokenUpdate: HostedExecutionDeviceSyncRuntimeApplyEntry["tokenUpdate"];
-        if (versionMismatch && update.credential !== undefined) {
-          tokenUpdate = "skipped_version_mismatch";
-        } else if (update.credential !== undefined) {
-          if (!credentialUpdate) {
-            throw new TypeError("Hosted device-sync runtime credential update was not parsed.");
-          }
-
-          if (credentialUpdate.kind === "oauth_tokens") {
-            if ("clearTokens" in credentialUpdate) {
-              tokenBundleToPersist = null;
-              tokenBundlePersistenceRequested = true;
-              nextAccount.accessTokenExpiresAt = null;
-              tokenUpdate = getHostedRuntimeOAuthTokenBundle(baseline.credential) ? "cleared" : "missing";
-            } else {
-              tokenBundleToPersist = {
-                ...credentialUpdate.tokenBundle,
-                tokenVersion: computeNextHostedTokenVersion(
-                  getHostedRuntimeOAuthTokenBundle(baseline.credential),
-                  credentialUpdate.tokenBundle,
-                ),
-              };
-              tokenBundlePersistenceRequested = true;
-              nextAccount.accessTokenExpiresAt = tokenBundleToPersist.accessTokenExpiresAt;
-              tokenUpdate = "applied";
-            }
-          } else {
-            credentialToPersist = credentialUpdate;
-            nextAccount.accessTokenExpiresAt = null;
-            tokenUpdate = getHostedRuntimeOAuthTokenBundle(baseline.credential) ? "cleared" : "missing";
-          }
-        } else {
-          tokenUpdate = getHostedRuntimeOAuthTokenBundle(baseline.credential) ? "unchanged" : "missing";
+        const credentialPlan = planHostedRuntimeCredentialWrite({
+          baseline: baseline.credential,
+          credential: credentialUpdate,
+          versionMismatch,
+        });
+        if (credentialPlan.write) {
+          nextAccount.accessTokenExpiresAt = credentialPlan.write.kind === "oauth_tokens"
+            ? credentialPlan.write.tokenBundle?.accessTokenExpiresAt ?? null
+            : null;
         }
 
         const writeUpdate: HostedExecutionDeviceSyncRuntimeApplyEntry["writeUpdate"] =
@@ -613,50 +530,26 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
           for (const source of sourceUpdates.toApply) {
             await controlPlane.store.upsertConnectionSource({
               connectionId: update.connectionId,
-              sourceInstanceKey: source.sourceInstanceKey,
-              sourceProviderSlug: source.sourceProviderSlug,
-              ...(Object.prototype.hasOwnProperty.call(source, "displayName")
-                ? { displayName: source.displayName ?? null }
-                : {}),
-              status: source.status,
-              ...(source.lifecycleEpoch === undefined
-                ? {}
-                : { lifecycleEpoch: source.lifecycleEpoch }),
-              ...(Object.prototype.hasOwnProperty.call(source, "resourceAvailabilitySummary")
-                ? { resourceAvailabilitySummary: source.resourceAvailabilitySummary ?? null }
-                : {}),
-              ...(Object.prototype.hasOwnProperty.call(source, "lastErrorCode")
-                ? { lastErrorCode: source.lastErrorCode ?? null }
-                : {}),
-              ...(Object.prototype.hasOwnProperty.call(source, "lastErrorMessage")
-                ? { lastErrorMessage: source.lastErrorMessage ?? null }
-                : {}),
-              ...(Object.prototype.hasOwnProperty.call(source, "firstSeenAt")
-                ? { firstSeenAt: source.firstSeenAt ?? null }
-                : {}),
-              ...(Object.prototype.hasOwnProperty.call(source, "lastDataAt")
-                ? { lastDataAt: source.lastDataAt ?? null }
-                : {}),
-              lastSeenAt: source.lastSeenAt,
+              ...buildHostedRuntimeSourceWrite(source),
               tx,
             });
           }
         }
 
-        if (!versionMismatch && credentialToPersist) {
+        if (credentialPlan.write && credentialPlan.write.kind !== "oauth_tokens") {
           writtenRecord = await persistHostedRuntimeCredentialSnapshot({
             connectionId: update.connectionId,
-            credential: credentialToPersist,
+            credential: credentialPlan.write,
             tx,
           });
-        } else if (!versionMismatch && tokenBundlePersistenceRequested) {
+        } else if (credentialPlan.write?.kind === "oauth_tokens") {
           const preparedTokenWrite = preparedConnection.tokenWrite;
           if (!preparedTokenWrite) {
             throw new TypeError("Hosted device-sync runtime apply token write was not prepared.");
           }
           assertHostedRuntimePreparedTokenWriteMatches({
             prepared: preparedTokenWrite,
-            tokenBundle: tokenBundleToPersist ?? null,
+            tokenBundle: credentialPlan.write.tokenBundle,
           });
           writtenRecord = await controlPlane.store.persistPreparedRuntimeApplyTokenWrite({
             prepared: preparedTokenWrite,
@@ -678,7 +571,7 @@ export async function applyHostedDeviceSyncRuntimeResult(input: {
             ).connection,
             connectionId: update.connectionId,
             status: "updated",
-            tokenUpdate,
+            tokenUpdate: credentialPlan.tokenUpdate,
             writeUpdate,
           } satisfies HostedExecutionDeviceSyncRuntimeApplyEntry,
           noticeCandidates: resolveHostedRuntimeSourceDeliveryStallNoticeCandidates({
@@ -797,24 +690,16 @@ async function prepareHostedRuntimeApplyConnections(input: {
         [],
         { includeCredentialMaterial: true },
       );
-      const credential = resolveHostedRuntimeCredentialUpdate(update.credential);
-      if (credential.kind !== "oauth_tokens") {
-        throw new TypeError("Hosted device-sync runtime apply token preparation received a non-token credential.");
-      }
+      const credential = update.credential;
       validateHostedRuntimeCredentialMutation({
         baseline,
         credential,
         provider: connection.record.provider,
       });
-      const tokenBundle = "clearTokens" in credential
-        ? null
-        : {
-            ...credential.tokenBundle,
-            tokenVersion: computeNextHostedTokenVersion(
-              getHostedRuntimeOAuthTokenBundle(baseline.credential),
-              credential.tokenBundle,
-            ),
-          };
+      const tokenBundle = resolveHostedRuntimeNextTokenBundle(
+        getHostedRuntimeOAuthTokenBundle(baseline.credential),
+        credential,
+      );
       return [{
         externalAccountId: connection.secretMaterial.externalAccountId,
         record: connection.record,
@@ -1489,20 +1374,47 @@ function omitHostedRuntimeSourceFirstSeenAt(
   return next;
 }
 
-function isHostedRuntimeFitbitMigrationTerminalSourceUpdate(input: {
+function findHostedRuntimeFitbitTerminalSourceUpdates(input: {
   currentSources: readonly HostedDeviceConnectionSource[];
-  pendingSourceUpdates: readonly HostedExecutionDeviceSyncRuntimeConnectionSourceUpdate[];
+  pendingSourceUpdates: readonly HostedRuntimeConnectionSourceWrite[];
   provider: string;
-  source: HostedExecutionDeviceSyncRuntimeConnectionSourceUpdate;
-}): boolean {
-  return input.provider.trim().toLowerCase() === "junction"
-    && normalizeJunctionProviderSlug(input.source.sourceProviderSlug)
-      === JUNCTION_FITBIT_LEGACY_PROVIDER_SLUG
-    && isGoogleHealthFitbitMigrationLegacyTerminal(input.source)
-    && [...input.currentSources, ...input.pendingSourceUpdates].some((source) =>
-      normalizeJunctionProviderSlug(source.sourceProviderSlug)
-        === JUNCTION_GOOGLE_HEALTH_PROVIDER_SLUG
-    );
+}): ReadonlySet<HostedRuntimeConnectionSourceWrite> {
+  if (
+    input.provider.trim().toLowerCase() !== "junction"
+    || ![...input.currentSources, ...input.pendingSourceUpdates].some((source) =>
+      normalizeJunctionProviderSlug(source.sourceProviderSlug) === JUNCTION_GOOGLE_HEALTH_PROVIDER_SLUG
+    )
+  ) {
+    return new Set();
+  }
+  return new Set(input.pendingSourceUpdates.filter((source) =>
+    normalizeJunctionProviderSlug(source.sourceProviderSlug) === JUNCTION_FITBIT_LEGACY_PROVIDER_SLUG
+    && isGoogleHealthFitbitMigrationLegacyTerminal(source)
+  ));
+}
+
+function buildHostedRuntimeSourceWrite(source: HostedRuntimeConnectionSourceWrite) {
+  const optionalFields: Pick<HostedRuntimeConnectionSourceWrite,
+    "displayName" | "lastErrorCode" | "lastErrorMessage" | "firstSeenAt" | "lastDataAt"
+  > = {};
+  for (const field of [
+    "displayName", "lastErrorCode", "lastErrorMessage", "firstSeenAt", "lastDataAt",
+  ] as const) {
+    if (Object.prototype.hasOwnProperty.call(source, field)) {
+      optionalFields[field] = source[field] ?? null;
+    }
+  }
+  return {
+    sourceInstanceKey: source.sourceInstanceKey,
+    sourceProviderSlug: source.sourceProviderSlug,
+    status: source.status,
+    ...optionalFields,
+    ...(source.lifecycleEpoch === undefined ? {} : { lifecycleEpoch: source.lifecycleEpoch }),
+    ...(Object.prototype.hasOwnProperty.call(source, "resourceAvailabilitySummary")
+      ? { resourceAvailabilitySummary: source.resourceAvailabilitySummary ?? null }
+      : {}),
+    lastSeenAt: source.lastSeenAt,
+  };
 }
 
 function normalizeHostedRuntimeSourceUpdateForProvider(input: {
@@ -1713,20 +1625,95 @@ function getHostedRuntimeOAuthTokenBundle(
   return credential.kind === "oauth_tokens" ? credential.tokenBundle : null;
 }
 
-function hostedRuntimeCredentialMutationRequiresTokenFence(
-  update: HostedExecutionDeviceSyncRuntimeConnectionUpdate,
-): boolean {
-  return update.credential !== undefined;
+function resolveHostedRuntimeNextTokenBundle(
+  current: HostedExecutionDeviceSyncRuntimeTokenBundle | null,
+  credential: Extract<HostedExecutionDeviceSyncRuntimeCredentialUpdate, { kind: "oauth_tokens" }>,
+): HostedExecutionDeviceSyncRuntimeTokenBundle | null {
+  if ("clearTokens" in credential) {
+    return null;
+  }
+  return {
+    ...credential.tokenBundle,
+    tokenVersion: computeNextHostedTokenVersion(current, credential.tokenBundle),
+  };
 }
 
-function resolveHostedRuntimeCredentialUpdate(
-  credential: HostedExecutionDeviceSyncRuntimeCredentialUpdate,
-): HostedExecutionDeviceSyncRuntimeCredentialUpdate {
-  if (credential.kind === "oauth_tokens" && "clearTokens" in credential) {
-    return credential;
+// This plan only derives a write after the existing live authority fences pass.
+// A missing write means no mutation; an OAuth write with a null bundle clears it.
+function planHostedRuntimeCredentialWrite(input: {
+  baseline: HostedExecutionDeviceSyncRuntimeCredentialSnapshot;
+  credential: HostedExecutionDeviceSyncRuntimeCredentialUpdate | undefined;
+  versionMismatch: boolean;
+}): {
+  tokenUpdate: HostedExecutionDeviceSyncRuntimeApplyEntry["tokenUpdate"];
+  write?:
+    | Exclude<HostedExecutionDeviceSyncRuntimeCredentialSnapshot, { kind: "oauth_tokens" | "oauth_tokens_redacted" }>
+    | { kind: "oauth_tokens"; tokenBundle: HostedExecutionDeviceSyncRuntimeTokenBundle | null };
+} {
+  const current = getHostedRuntimeOAuthTokenBundle(input.baseline);
+  const { credential } = input;
+  if (!credential) {
+    return { tokenUpdate: current ? "unchanged" : "missing" };
   }
+  if (input.versionMismatch) {
+    return { tokenUpdate: "skipped_version_mismatch" };
+  }
+  if (credential.kind !== "oauth_tokens") {
+    return { tokenUpdate: current ? "cleared" : "missing", write: credential };
+  }
+  const tokenBundle = resolveHostedRuntimeNextTokenBundle(current, credential);
+  return {
+    tokenUpdate: tokenBundle ? "applied" : current ? "cleared" : "missing",
+    write: { kind: "oauth_tokens", tokenBundle },
+  };
+}
 
-  return credential;
+function applyHostedRuntimeAccountPatch(
+  account: PublicDeviceSyncAccount,
+  update: HostedExecutionDeviceSyncRuntimeConnectionUpdate,
+  historicalMetadata: Record<string, unknown> | undefined,
+): void {
+  const { connection, localState } = update;
+  if (connection) {
+    for (const field of ["displayName", "setupExpiresAt"] as const) {
+      if (Object.prototype.hasOwnProperty.call(connection, field)) {
+        account[field] = connection[field] ?? null;
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(connection, "metadata")) {
+      account.metadata = historicalMetadata
+        ?? sanitizeStoredDeviceSyncMetadata(connection.metadata ?? {});
+    }
+    if (Object.prototype.hasOwnProperty.call(connection, "scopes")) {
+      account.scopes = [...(connection.scopes ?? [])];
+    }
+    if (Object.prototype.hasOwnProperty.call(connection, "status") && connection.status) {
+      account.status = normalizeHostedDeviceSyncLifecycleStatus(connection.status);
+    }
+    if (Object.prototype.hasOwnProperty.call(connection, "setupPhase")) {
+      account.setupPhase = connection.setupPhase ?? null;
+    }
+  }
+  if (!localState) {
+    return;
+  }
+  if (localState.clearError) {
+    account.lastErrorCode = null;
+    account.lastErrorMessage = null;
+  }
+  for (const field of [
+    "lastErrorCode",
+    "lastErrorMessage",
+    "lastSyncCompletedAt",
+    "lastSyncErrorAt",
+    "lastSyncStartedAt",
+    "lastWebhookAt",
+    "nextReconcileAt",
+  ] as const) {
+    if (Object.prototype.hasOwnProperty.call(localState, field)) {
+      account[field] = localState[field] ?? null;
+    }
+  }
 }
 
 function validateHostedRuntimeCredentialMutation(input: {

--- a/apps/web/test/device-sync-hosted-runtime-authority.test.ts
+++ b/apps/web/test/device-sync-hosted-runtime-authority.test.ts
@@ -482,6 +482,7 @@ function createAuthorityHarness(input: {
         externalAccountId: currentRecord.externalAccountId ?? "acct_123",
       })),
     getStoredConnectionAccountForUser: vi.fn(async () => currentStoredAccount),
+    hasPendingDirtyConnection: vi.fn(async () => false),
     listConnectionSources: vi.fn(async () => connectionSources),
     listConnectionSourcesForConnections: vi.fn(async (connectionIds: readonly string[]) =>
       connectionSources.filter((source) => connectionIds.includes(source.connectionId))
@@ -2468,6 +2469,67 @@ describe("applyHostedDeviceSyncRuntimeResult", () => {
     expect(harness.upsertConnectionSource).not.toHaveBeenCalledWith(
       expect.objectContaining({ sourceInstanceKey: canonicalSourceInstanceKey }),
     );
+  });
+
+  it.each([
+    { google: "current", dirty: true, fitbitWrites: 0 },
+    { google: "current", dirty: false, fitbitWrites: 1 },
+    { google: "pending", dirty: true, fitbitWrites: 0 },
+    { google: "pending", dirty: false, fitbitWrites: 1 },
+    { google: "absent", dirty: true, fitbitWrites: 1 },
+  ])("checks dirty work once for a Fitbit terminal projection with $google Google authority and dirty=$dirty", async ({
+    google, dirty, fitbitWrites,
+  }) => {
+    const harness = createAuthorityHarness({
+      record: buildHostedRecord({ provider: "junction" }),
+      connectionSources: [
+        { sourceInstanceKey: "fitbit", sourceProviderSlug: "fitbit" },
+        ...(google === "current"
+          ? [{ sourceInstanceKey: "google_health", sourceProviderSlug: "google_health" }]
+          : []),
+      ],
+    });
+    harness.store.hasPendingDirtyConnection.mockResolvedValue(dirty);
+    const { applyHostedDeviceSyncRuntimeResult } = await import(
+      "@/src/lib/device-sync/hosted-runtime-authority"
+    );
+    const response = await applyHostedDeviceSyncRuntimeResult({
+      request: new Request("https://example.test/device-sync/runtime/apply", {
+        method: "POST",
+        body: JSON.stringify({
+          userId: "user_123",
+          updates: [{
+            connectionId: "conn_123",
+            observedConnectedAt: "2026-04-06T09:00:00.000Z",
+            observedUpdatedAt: "2026-04-06T10:00:00.000Z",
+            sources: [
+              {
+                sourceInstanceKey: "fitbit",
+                sourceProviderSlug: "fitbit",
+                observedLastSeenAt: "2026-04-06T10:00:00.000Z",
+                lastSeenAt: "2026-04-06T10:05:00.000Z",
+                status: "disconnected",
+              },
+              ...(google === "pending" ? [{
+                sourceInstanceKey: "google_health",
+                sourceProviderSlug: "google_health",
+                observedLastSeenAt: null,
+                lastSeenAt: "2026-04-06T10:05:00.000Z",
+                status: "connected",
+              }] : []),
+            ],
+          }],
+        }),
+      }),
+      trustedUserId: "user_123",
+    });
+
+    expect(harness.store.hasPendingDirtyConnection).toHaveBeenCalledTimes(google === "absent" ? 0 : 1);
+    const writes = harness.upsertConnectionSource.mock.calls.map(([write]) => write);
+    expect(writes.filter((write) => write.sourceProviderSlug === "fitbit")).toHaveLength(fitbitWrites);
+    expect(writes.filter((write) => write.sourceProviderSlug === "google_health")).toHaveLength(google === "pending" ? 1 : 0);
+    expect(harness.syncDurableConnectionState).not.toHaveBeenCalled();
+    expect(response.updates[0]?.writeUpdate).toBe(writes.length > 0 ? "applied" : "unchanged");
   });
 
   it("persists runtime source availability updates without rewriting connection state", async () => {


### PR DESCRIPTION
## Why and outcome

Hosted device runtime apply repeated credential decisions and token-version derivation while carrying three correlated persistence flags through its locked callback. Replace those flags with one typed credential write plan, share token derivation with pre-transaction preparation, and group optional account/source patch fields. The callback's cyclomatic complexity falls from 113 to 73 and file debt from 136 to 96.

Fitbit terminal source projections now classify successor presence once and reuse that result when dirty work blocks terminal writes. All live authorization fences, credential validation, serial database writes, and post-commit notice scheduling retain their existing order and behavior.

## Product UX

- Effort: Not applicable — internal behavior-preserving refactor of signed runtime callbacks.
- Result: Not applicable — no UI, user-facing action, or product policy changed.
- Walkthrough: Existing authority tests cover missing/stale/reconnected credentials, refresh leases, secret/root drift, provider-policy rejection, source lifecycle fences, and accepted writes. New composed cases verify dirty work blocks Fitbit terminal projection while an accompanying Google source update can still apply.

## Evidence

- Direct: `pnpm exec vitest run --config apps/web/vitest.config.ts --no-coverage apps/web/test/device-sync-hosted-runtime-authority.test.ts apps/web/test/device-sync-internal-runtime-apply-route.test.ts --maxWorkers=2` — 90 passed.
- Direct: `DATABASE_URL="$LOCAL_TEST_DB_URL" MURPH_TEST_POSTGRES_CONCURRENCY=1 pnpm exec vitest run --config apps/web/vitest.config.ts --no-coverage apps/web/test/device-sync-db-spike-resilience-postgres.test.ts -t '100-update no-op apply|maximum Junction runtime apply' --maxWorkers=1` — two real PostgreSQL cases passed; six unrelated incident cases skipped. The isolated loopback database applied all 221 current migrations first.
- Direct: Hosted Web generated prerequisites completed; `pnpm --dir apps/web typecheck:prepared` and `git diff --check` passed on the final source and tests.
- Coverage: The authority suite proves 100 token preparations stay outside BEGIN and 100-by-64 source updates remain 6,400 serial source writes. PostgreSQL proves the no-op apply remains serviceable on a two-connection pool and the maximum Junction apply reuses its source collection read. Five new cases cover current, incoming, and absent Google source authority with and without pending dirty work.
- Exact-head CI and final ReviewGPT passed on this head.

## Non-obvious affected surfaces

Credential clearing and re-tokenization share the same derivation used before and inside the transaction; existing public authority tests verify durable account binding, token versions, root revalidation, and prepared-token matching. Fitbit terminal filtering preserves the existing dirty-work read condition and leaves nonterminal incoming source writes intact.

## Architecture and reuse

- Existing systems reused: Canonical Web device control store, per-connection mutation lock, snapshot/secret preparation, token-version comparator, provider credential policy, and source lifecycle owners.
- New logic: None; redundant identity/fence helpers and unreachable checks were removed, and existing decisions now derive one explicit credential plan.
- New abstractions: Private token, credential-plan, account-patch, and source-patch helpers; the existing Fitbit classification helper now returns the selected source set. These hold only request-local derivations and cannot independently authorize persistence.
- Complexity intentionally avoided: No new state owner, policy registry, service, query, concurrency mechanism, dependency, schema, or public API. Shared derivation removes duplicate token calculations and repeated source classification.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base HEAD^ --head HEAD`; debt 136 → 96 and maximum 113 → 73.
- Hotspots: The changed callback inside `applyHostedDeviceSyncRuntimeResult` remains 73. Unchanged `resolveHostedRuntimeSourceUpdatesToApply` remains 44 and `readHostedDeviceSyncRuntimeState` remains 39. All added helpers are at or below 20.
- Agent judgment: The change removes repeated decisions and correlated state while leaving live authority visibly owned by the locked callback. The unchanged source-admission and snapshot-reader hotspots are independent contracts; further extraction is outside this bounded derivation refactor.

## Hot reply path impact

- Path status: Not applicable — this is device-control runtime write-back, with no conversation admission, provider input, or delivery-path changes.
- Database calls: None added or moved. Request limit stays 100 distinct updates; transactions remain serial with at most one active per request. No-op proof retains one preparation set-read and 100 live connection/source read pairs. Maximum source mutation remains 6,400 serial source-write calls across 100 transactions.
- Network/provider calls: None added or moved. Secret opening and token sealing remain before BEGIN; no provider/KMS work was moved under the connection lock.
- Other awaited latency: None added or moved. Dirty-work checks retain the same eligibility condition and at most one call per connection.
- Before/after proof: Exact live fences and persistence call ordering are unchanged in the diff; public maximum-cardinality assertions and isolated PostgreSQL tests passed.

## Murph initial provider input impact

Not applicable for both individual and group runtimes: no prompts, tools, generated guidance, conversation context, or initial provider request surfaces changed. No token measurement was needed.

ReviewGPT first-reviewed head: a6098847c2a7a48b1952a696e242535ac2c0105c
ReviewGPT context sensitivity: sensitive
Classification reason: Canonical hosted device authority and credential persistence refactor.

## Deployment concerns

- Deployment: not applicable
- Reason: Private Web implementation refactor preserves request/response contracts, persisted schemas, source/token epochs, and existing accepted/stale behavior. No coordinated rollout, migration, or new rollback floor is introduced.

## Change-shape breakdown

Classification rule: Runtime TypeScript is source, the public authority regression is tests, and the completed execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 156 | 169 |
| Tests / fixtures | 62 | 0 |
| Docs | 57 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **275** | **169** |

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving device-authority refactor; no member-visible feature or behavior change.

## ReviewGPT result

- Round 1: PASS on a6098847c2a7a48b1952a696e242535ac2c0105c.
- Model: GPT-6 Pro, verified by captured response metadata; guarded full snapshot and exact committed turn verified.
- No qualifying findings; no review remediation required. All required CI checks and routed Temporal compatibility passed on this same head.
