### PR TITLE
refactor(assistant): simplify Codex final-response reconciliation

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-complexity2-codex-events-sep11.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-complexity2-codex-events-sep11.md
@@ -1,0 +1,47 @@
+# Simplify Codex final-response reconciliation
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Outcome and owner
+
+Reduce branching in the existing assistant-engine App Server turn runner without changing delivered replies, quiet outcomes, transcripts, or event ordering. The runner remains the sole owner of mutable event state and process cleanup. Private synchronous helpers derive final-response selection and presentation from that state.
+
+## Evidence and design
+
+The runner has cyclomatic complexity 102 and mixes final-output reconciliation with process lifecycle. Current/trailing response selection uses overlapping boolean expressions; promoted and final responses repeat card/workout text and transcript rendering. Replace overlapping selection predicates with explicit ordered outcomes, reuse card rendering, and separate final required-output composition. Do not add a framework, public export, or persisted state.
+
+## Protected invariants
+
+- Preserve trailing-candidate promotion, earlier and latest no-reply precedence, delivery ordinals, targets, media, cards, context references, and follow-up ownership.
+- Preserve distinction between delivered text and semantic transcript, including tracking authority, card overflow recovery, calendar suffixes, approval URLs, and daylight-saving clarification order.
+- Leave live event mutation, pending-request settlement, cancellation, process cleanup, usage accounting, and resume authority in their current order.
+- No new awaited work, external calls, schemas, deployment ordering, or compatibility layers.
+
+## Product proof
+
+Outcome: Existing replies and silence remain identical while the code becomes easier to review.
+Reaches: Ordinary text/media/card replies, live-steered earlier answers, later acknowledgements, and required recovery output.
+Proof: Scripted provider-event suites assert exact output and suppression; one production-derived real-Codex acknowledgement journey checks preserved earlier reply and one later quiet action.
+
+## Tasks
+
+1. Introduce private final-selection and presentation helpers and remove duplicate rendering.
+2. Extend focused deterministic output assertions and the existing live acknowledgement journey.
+3. Run focused steering/events/recovery suites, assistant-engine typecheck, complexity guard, and focused live proof; inspect actual synthetic reply.
+4. Review privacy and full diff, close this implementation plan, commit, push, and open a complete draft PR for parent review and final gates.
+
+## Results
+
+Implemented private ordered trailing-response selection and shared card/final-output presentation. No public API or runtime state owner was added. The event/provider lifecycle span remains byte-identical to the baseline.
+
+- Complexity guard passes against base `3fcb0ab14d8137af4d4858ad030de8ab2c904970`: file debt 229 → 203 and maximum 102 → 76. The new private helpers remain below 20; other existing hotspots are unchanged. Total complexity is 1540 → 1541 because extracted function baselines count separately; this is a coherent boundary simplification, not a total-branch reduction claim.
+- Steering suite: 45 passing after strengthening text/card/oversized tracked-card assertions. Events and recovery suites: 79 passing. An initial expected tracking timestamp mismatch in the new assertion was corrected to recognize runtime-owned snapshot refresh while retaining the complete rendered response and tracking authority assertion.
+- Five focused scripted real-App-Server cases pass for DST clarification and exact calendar links/suffixes.
+- Five focused trailing-selection cases pass with the original source restored temporarily, confirming baseline behavior; candidate bytes were restored afterward.
+- Assistant-engine typecheck and diff whitespace checks pass.
+- Focused real-Codex acknowledgement journey passes with `gpt-5.6-terra`, local subscription: the earlier answer is preserved, exactly one quiet-finish action occurs with no other dynamic calls, and final reply, media, card, follow-up, and target remain absent. Actual synthetic output inspected: Ready. The journey was repeated only to recover direct-output evidence lost across context compaction; both invocations passed.
+
+Implementation handoff remains a draft PR. The parent owns candidate review, Ready, exact-head CI, ReviewGPT, and completion.
+Completed: 2026-09-11

--- a/packages/assistant-engine/src/assistant-codex.ts
+++ b/packages/assistant-engine/src/assistant-codex.ts
@@ -805,6 +805,111 @@ function appendRequiredAutomationLocalAtClarification(
     .join('\n\n')
 }
 
+type CodexTrailingResponseSelection = 'current' | 'retain' | 'promote' | 'suppress'
+
+function selectCodexTrailingResponse(input: {
+  candidate: CodexAppServerTrailingResponseCandidate | null
+  latestFinalAction: MurphDynamicToolFinalActionPatch | null
+  candidateFinalAction: MurphDynamicToolFinalActionPatch | null
+  currentMessage: string
+  currentMedia: readonly AssistantResponseMedia[]
+  currentCard: AssistantResponseCard | null
+  currentCardTextFallback: CompactTableWorkoutResponseCardV1 | null
+}): CodexTrailingResponseSelection {
+  if (input.candidate === null) {
+    return 'current'
+  }
+  // A later quiet acknowledgement must retain the earlier answer as a segment.
+  if (input.latestFinalAction?.kind === 'none') {
+    return 'promote'
+  }
+  if (input.latestFinalAction === null && input.candidateFinalAction?.kind === 'none') {
+    return 'suppress'
+  }
+  if (
+    normalizeNullableString(input.currentMessage) !== null ||
+    input.currentMedia.length > 0 ||
+    input.currentCard !== null ||
+    input.currentCardTextFallback !== null
+  ) {
+    return 'promote'
+  }
+  return 'retain'
+}
+
+function renderCodexResponseCardPresentation(input: {
+  card: AssistantResponseCard | null
+  cardTextFallback: CompactTableWorkoutResponseCardV1 | null
+  omitCardTracking: boolean
+}): { message: string; transcript: string } | null {
+  if (input.card) {
+    const message = renderAssistantResponseCardText(input.card)
+    return {
+      message,
+      transcript: input.omitCardTracking
+        ? message
+        : renderAssistantResponseCardTranscriptText(input.card),
+    }
+  }
+  if (input.cardTextFallback) {
+    return {
+      message: renderAssistantWorkoutResponseCardText(input.cardTextFallback),
+      transcript: renderAssistantWorkoutResponseCardTranscriptText(input.cardTextFallback),
+    }
+  }
+  return null
+}
+
+function buildCodexFinalResponsePresentation(input: {
+  modelMessage: string
+  media: readonly AssistantResponseMedia[]
+  card: AssistantResponseCard | null
+  cardTextFallback: CompactTableWorkoutResponseCardV1 | null
+  requiredClarifications: readonly RequiredAutomationLocalAtClarification[]
+  requiredApprovalUrls: readonly string[]
+  requiredSuffix: string | null
+  requiredFallback: string | null
+}): Pick<CodexAppServerTurnResult, 'finalMessage' | 'transcriptMessage' | 'responseCard'> {
+  const hasRequiredClarifications = input.requiredClarifications.length > 0
+  const renderedCard = renderCodexResponseCardPresentation({
+    card: input.card,
+    cardTextFallback: input.cardTextFallback,
+    omitCardTracking: hasRequiredClarifications,
+  })
+  const semanticMessage = renderedCard?.message ?? input.modelMessage
+  const requiredMessage =
+    normalizeNullableString(semanticMessage) ?? input.requiredFallback ?? semanticMessage
+  const finalMessage = appendRequiredFinalResponseSuffix(
+    appendRequiredVaultFileApprovalUrls(
+      appendRequiredAutomationLocalAtClarification(
+        requiredMessage,
+        input.requiredClarifications,
+      ),
+      input.requiredApprovalUrls,
+    ),
+    input.requiredSuffix,
+    input.requiredFallback,
+  )
+  const semanticTranscript = renderedCard?.transcript ??
+    normalizeNullableString(input.modelMessage) ??
+    (input.media.length > 0 ? '' : null)
+  const transcriptMessage = appendRequiredFinalResponseSuffix(
+    appendRequiredAutomationLocalAtClarification(
+      normalizeNullableString(semanticTranscript) ??
+        input.requiredFallback ??
+        semanticTranscript,
+      input.requiredClarifications,
+    ),
+    input.requiredSuffix,
+    input.requiredFallback,
+  )
+  return {
+    finalMessage,
+    transcriptMessage,
+    responseCard: hasRequiredClarifications ? null : input.card,
+  }
+}
+
 export async function executeCodexAppServerTurn(
   input: CodexAppServerTurnInput,
 ): Promise<CodexAppServerTurnResult> {
@@ -4088,20 +4193,13 @@ async function runCodexAppServerTurnOnProcess(
       return
     }
 
-    const response = trailingSteerCandidate.card
-      ? renderAssistantResponseCardText(trailingSteerCandidate.card)
-      : trailingSteerCandidate.cardTextFallback
-        ? renderAssistantWorkoutResponseCardText(
-            trailingSteerCandidate.cardTextFallback,
-          )
-        : trailingSteerCandidate.response
-    const transcriptResponse = trailingSteerCandidate.card
-      ? renderAssistantResponseCardTranscriptText(trailingSteerCandidate.card)
-      : trailingSteerCandidate.cardTextFallback
-        ? renderAssistantWorkoutResponseCardTranscriptText(
-            trailingSteerCandidate.cardTextFallback,
-          )
-        : response
+    const renderedCard = renderCodexResponseCardPresentation({
+      card: trailingSteerCandidate.card,
+      cardTextFallback: trailingSteerCandidate.cardTextFallback,
+      omitCardTracking: false,
+    })
+    const response = renderedCard?.message ?? trailingSteerCandidate.response
+    const transcriptResponse = renderedCard?.transcript ?? response
     precedingAgentMessageSegments.push({
       ...(trailingSteerCandidate.contextReferences === undefined
         ? {}
@@ -6199,41 +6297,28 @@ async function runCodexAppServerTurnOnProcess(
   const latestFinalActionPatch = resolveFinalActionPatch(
     latestDeliveryContextOrdinal,
   )
-  let finalTrailingSteerCandidate = readTrailingSteerCandidate()
-  const trailingSteerCandidateDeliveryContextOrdinal =
-    finalTrailingSteerCandidate?.deliveryContextOrdinal ?? null
-  const trailingSteerCandidateFinalActionPatch =
-    trailingSteerCandidateDeliveryContextOrdinal !== null
-      ? resolveFinalActionPatch(trailingSteerCandidateDeliveryContextOrdinal)
-      : null
-  const suppressTrailingSteerCandidateForEarlierNoReply =
-    latestFinalActionPatch === null &&
-    finalTrailingSteerCandidate !== null &&
-    trailingSteerCandidateFinalActionPatch?.kind === 'none'
-  const shouldPromoteTrailingSteerCandidate =
-    finalTrailingSteerCandidate !== null &&
-    (
-      latestFinalActionPatch?.kind === 'none' ||
-      (
-        !suppressTrailingSteerCandidateForEarlierNoReply &&
-        (
-          normalizeNullableString(extractedFinalMessage) !== null ||
-          responseMedia.length > 0 ||
-          responseCard !== null ||
-          responseCardTextFallback !== null
-        )
-      )
-    )
-  if (shouldPromoteTrailingSteerCandidate) {
+  const finalTrailingSteerCandidate = readTrailingSteerCandidate()
+  const trailingResponseSelection = selectCodexTrailingResponse({
+    candidate: finalTrailingSteerCandidate,
+    latestFinalAction: latestFinalActionPatch,
+    candidateFinalAction: finalTrailingSteerCandidate === null
+      ? null
+      : resolveFinalActionPatch(finalTrailingSteerCandidate.deliveryContextOrdinal),
+    currentMessage: extractedFinalMessage,
+    currentMedia: responseMedia,
+    currentCard: responseCard,
+    currentCardTextFallback: responseCardTextFallback,
+  })
+  if (trailingResponseSelection === 'promote') {
     promoteTrailingSteerCandidate()
-    finalTrailingSteerCandidate = null
   }
+  const suppressTrailingSteerCandidateForEarlierNoReply =
+    trailingResponseSelection === 'suppress'
+  const finalResponseCandidate = trailingResponseSelection === 'retain'
+    ? finalTrailingSteerCandidate
+    : null
   const selectedFinalMessage =
-    finalTrailingSteerCandidate?.response ?? extractedFinalMessage
-  // A latest-context no-reply already promoted and cleared the candidate above.
-  const finalResponseCandidate = suppressTrailingSteerCandidateForEarlierNoReply
-    ? null
-    : finalTrailingSteerCandidate
+    finalResponseCandidate?.response ?? extractedFinalMessage
   const finalResponseMedia = finalResponseCandidate?.media ?? responseMedia
   const finalResponseCard = finalResponseCandidate?.card ?? responseCard
   if (finalResponseCard !== null && finalResponseMedia.length > 0) {
@@ -6263,54 +6348,20 @@ async function runCodexAppServerTurnOnProcess(
     noReplySelected || suppressTrailingSteerCandidateForEarlierNoReply
       ? ''
       : selectedFinalMessage
-  const semanticFinalMessage = finalResponseCard
-    ? renderAssistantResponseCardText(finalResponseCard)
-    : finalResponseCardTextFallback
-      ? renderAssistantWorkoutResponseCardText(finalResponseCardTextFallback)
-      : modelFinalMessage
-  const normalizedSemanticFinalMessage =
-    normalizeNullableString(semanticFinalMessage)
-  const requiredSemanticFinalMessage =
-    normalizedSemanticFinalMessage ??
-    requiredFinalResponseFallback ??
-    semanticFinalMessage
-  const requiredAutomationLocalAtClarificationsInOrder =
-    [...requiredAutomationLocalAtClarifications.values()]
-  const deliveredFinalResponseCard =
-    requiredAutomationLocalAtClarificationsInOrder.length === 0
-      ? finalResponseCard
-      : null
-  const finalMessage = appendRequiredFinalResponseSuffix(
-    appendRequiredVaultFileApprovalUrls(
-      appendRequiredAutomationLocalAtClarification(
-        requiredSemanticFinalMessage,
-        requiredAutomationLocalAtClarificationsInOrder,
-      ),
-      requiredVaultFileApprovalUrls,
-    ),
-    requiredFinalResponseSuffix,
-    requiredFinalResponseFallback,
-  )
-  const semanticTranscriptMessage = finalResponseCard
-    ? requiredAutomationLocalAtClarificationsInOrder.length === 0
-      ? renderAssistantResponseCardTranscriptText(finalResponseCard)
-      : renderAssistantResponseCardText(finalResponseCard)
-    : finalResponseCardTextFallback
-      ? renderAssistantWorkoutResponseCardTranscriptText(
-          finalResponseCardTextFallback,
-        )
-      : normalizeNullableString(modelFinalMessage) ??
-        (finalResponseMedia.length > 0 ? '' : null)
-  const transcriptMessage = appendRequiredFinalResponseSuffix(
-    appendRequiredAutomationLocalAtClarification(
-      normalizeNullableString(semanticTranscriptMessage) ??
-      requiredFinalResponseFallback ??
-      semanticTranscriptMessage,
-      requiredAutomationLocalAtClarificationsInOrder,
-    ),
-    requiredFinalResponseSuffix,
-    requiredFinalResponseFallback,
-  )
+  const {
+    finalMessage,
+    transcriptMessage,
+    responseCard: deliveredFinalResponseCard,
+  } = buildCodexFinalResponsePresentation({
+    modelMessage: modelFinalMessage,
+    media: finalResponseMedia,
+    card: finalResponseCard,
+    cardTextFallback: finalResponseCardTextFallback,
+    requiredClarifications: [...requiredAutomationLocalAtClarifications.values()],
+    requiredApprovalUrls: requiredVaultFileApprovalUrls,
+    requiredSuffix: requiredFinalResponseSuffix,
+    requiredFallback: requiredFinalResponseFallback,
+  })
   if (
     noReplySelected &&
     normalizeNullableString(extractedFinalMessage) !== null
@@ -6340,8 +6391,7 @@ async function runCodexAppServerTurnOnProcess(
     acceptedNoReplyDeliveryContextOrdinals:
       acceptedNoReplyDeliveryContextOrdinals,
     finalAction,
-    finalActionExplicit:
-      finalActionPatch?.kind === 'none' && !requiredUserVisibleOutput,
+    finalActionExplicit: noReplySelected,
     finalMessage,
     providerAuthoredFinalMessage: modelFinalMessage,
     transcriptMessage,

--- a/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-real-e2e.test.ts
@@ -30198,6 +30198,8 @@ describeRealCodex('real Codex steered acknowledgement no-reply e2e', () => {
       expect(result.responseDeliveryContextOrdinal).toBe(1)
       expect(result.responseMedia).toEqual([])
       expect(result.responseCard).toBeNull()
+      expect(result.followUpRequest).toBeNull()
+      expect(result.targetInputId).toBeNull()
       expect(finishAttempts).toHaveLength(1)
       expect(readDynamicToolAttempts(result.jsonEvents)).toEqual(finishAttempts)
     } finally {

--- a/packages/assistant-engine/test/assistant-codex-runtime-steering.test.ts
+++ b/packages/assistant-engine/test/assistant-codex-runtime-steering.test.ts
@@ -18,9 +18,11 @@ import {
 } from "./assistant-codex-runtime.harness.ts";
 
 import path from 'node:path'
-import type {
-  AssistantResponseCard,
-  CompactTableWorkoutResponseCardV1,
+import {
+  renderAssistantResponseCardText,
+  renderAssistantWorkoutResponseCardText,
+  type AssistantResponseCard,
+  type CompactTableWorkoutResponseCardV1,
 } from '@murphai/operator-config/assistant-response-cards'
 import { VaultCliError } from '@murphai/operator-config/vault-cli-errors'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -2558,13 +2560,46 @@ describe('steered final segments', () => {
     expect(result.precedingAgentMessageSegments).toEqual([])
   })
 
-  it('accepts a later no-reply while preserving an earlier pending answer', async () => {
+  it.each([
+    {
+      label: 'text',
+      card: null,
+      toolResult: '',
+      response: 'Answer one.',
+      transcriptResponse: null,
+    },
+    {
+      label: 'response card',
+      card: DAILY_NUTRITION_RESPONSE_CARD,
+      toolResult: 'response card attached',
+      response: renderAssistantResponseCardText(DAILY_NUTRITION_RESPONSE_CARD),
+      transcriptResponse: null,
+    },
+    {
+      label: 'oversized tracked-card recovery',
+      card: OVERSIZED_TRACKED_WORKOUT_RESPONSE_CARD,
+      toolResult: 'workout card envelope too large; full text recovery selected',
+      response: renderAssistantWorkoutResponseCardText(OVERSIZED_TRACKED_WORKOUT_RESPONSE_CARD),
+      transcriptResponse: expect.stringContaining(
+        `${renderAssistantWorkoutResponseCardText(OVERSIZED_TRACKED_WORKOUT_RESPONSE_CARD)}\n\n` +
+        `[Murph tracked workout source: ${OVERSIZED_TRACKED_WORKOUT_RESPONSE_CARD.tracking.entityId}; snapshot: `,
+      ),
+    },
+  ])('preserves earlier $label when a later no-reply wins', async ({
+    card, toolResult, response, transcriptResponse,
+  }) => {
     const result = await runScriptedSteeredFinalSegmentsTurn([
       completedItemEvent({
         id: 'user-1',
         type: 'user_message',
         message: 'First question',
       }),
+      ...(card === null ? [] : [{
+        card,
+        expectedText: toolResult,
+        id: 73,
+        kind: 'attach-response-card' as const,
+      }]),
       completedItemEvent({
         id: 'assistant-1',
         type: 'assistant_message',
@@ -2580,16 +2615,22 @@ describe('steered final segments', () => {
         id: 74,
         expectedText: 'finished without reply',
       },
-    ])
+    ], { responseCardsAvailable: true })
 
     expect(result.acceptedNoReplyDeliveryContextOrdinals).toEqual([1])
     expect(result.finalMessage).toBe('')
+    expect(result.providerAuthoredFinalMessage).toBe('')
+    expect(result.transcriptMessage).toBeNull()
+    expect(result.responseCard).toBeNull()
+    expect(result.responseMedia).toEqual([])
+    expect(result.followUpRequest).toBeNull()
     expect(result.finalAction).toEqual({ kind: 'none' })
     expect(result.finalActionExplicit).toBe(true)
     expect(result.precedingAgentMessageSegments).toEqual([{
       deliveryContextOrdinal: 0,
       media: [],
-      response: 'Answer one.',
+      response,
+      ...(transcriptResponse === null ? {} : { transcriptResponse }),
     }])
   })
 


### PR DESCRIPTION
## Why and outcome

The Codex App Server turn runner mixes final-response reconciliation with lifecycle coordination, and repeats card/workout rendering for earlier and final replies. Introduce ordered trailing-response selection and private shared presentation helpers so reply precedence and required-output ordering can be reviewed together.

Preserves earlier-answer promotion, later quiet acknowledgements, card recovery, transcripts, and required clarification/link ordering. Event mutation and provider lifecycle code remain byte-identical to the base.

## Product UX

- Effort: Patch — internal behavior-preserving refactor.
- Result: Ready — focused real-Codex prose and effects inspected.
- Walkthrough: Covers ordinary replies, steered earlier answers, quiet acknowledgements, card overflow, DST clarification, and required calendar output. No prompt, tool-contract, or member-facing behavior change is intended; no plan deviation.

## Evidence

- Direct: `pnpm test:assistant:live -- --test "keeps the earlier answer and stays quiet for the later acknowledgement" --codex-home <AUTHENTICATED_CODEX_HOME>` with `gpt-5.6-terra`, local subscription. Pass: earlier answer preserved; exactly one quiet-finish action and no other dynamic-tool calls; no later message, media, card, follow-up, or target. Actual synthetic output inspected: Ready.
- Coverage: `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir packages/assistant-engine test test/assistant-codex-runtime-steering.test.ts` — 45 pass. Events and recovery suites — 79 pass; the steering suite covers runtime-owned tracking snapshot refresh.
- `MURPH_VITEST_MAX_WORKERS=1 pnpm --dir packages/assistant-engine test test/assistant-codex-scripted-runtime.test.ts --testNamePattern 'trusted DST|exact runtime-owned calendar link|exact calendar suffix'` — 5 pass through the real local App Server and scripted provider.
- Baseline parity: five focused trailing-selection tests pass with original source at `3fcb0ab14d8137af4d4858ad030de8ab2c904970`; candidate restored byte-for-byte afterward.
- `MURPH_TSC_PACKAGE_CHECKERS=1 pnpm --dir packages/assistant-engine typecheck` and `git diff --check` — pass. Parent review, ReviewGPT, and all required CI passed on this head.

## Non-obvious affected surfaces

Tracked-workout transcript authority and oversized-card recovery are covered by steering assertions; required DST clarification still suppresses attached cards, approval URLs remain display-only, and exact calendar suffixes retain their ordering. Recovery and scripted App Server suites exercise these adjacent policies.

## Architecture and reuse

- Existing systems reused: Existing card renderers, output appenders, delivery ordinals, and the runner's canonical mutable state.
- New logic: None; ordered selection represents existing precedence and shared rendering composes existing policies.
- New abstractions: Three private synchronous helpers and a private selection union; no public API or new state owner.
- Complexity intentionally avoided: No new transport layer, dispatch framework, dependency, persisted state, or asynchronous orchestration.

## Complexity impact

- Guard: Pass — `pnpm complexity:diff` (invoked with pnpm silent output): `pnpm --silent complexity:diff --base 3fcb0ab14d8137af4d4858ad030de8ab2c904970 --json -- packages/assistant-engine/src/assistant-codex.ts`. File debt 229 → 203; maximum and `runCodexAppServerTurnOnProcess` 102 → 76. New helpers are 11, 4, and 12. Total complexity is 1540 → 1541 because function baselines count separately; the claim is coherent responsibility separation and reduced hotspot debt.
- Hotspots: Runner 76 retains lifecycle ownership. Unchanged: accepted-event handler 63, accepted-server-request handler 50, dynamic-tool closure 49, result closure 40, serialized-tool classifier 30, parsed-message handler 25, transport-diagnostics builder 24, parsed-message callback 23, managed-account operation 22, resume-context assertion 21. Each was inspected; this PR leaves their event/policy boundaries intact.
- Agent judgment: Further reduction of the remaining runner and event handlers is justified as separate bounded work with lifecycle-specific proof. Expanding this output refactor into concurrent state mutation would combine independent risks.

## Hot reply path impact

- Path status: Touched — synchronous final-output reconciliation and promoted-segment rendering.
- Database calls: None added or moved.
- Network/provider calls: None added or moved; call counts, ordering, timeouts, retries, and fallback lifecycle are unchanged.
- Other awaited latency: None added or moved; private helpers are synchronous. No latency benchmark claimed.
- Before/after proof: Five original-source parity cases; 124 deterministic steering/events/recovery cases; five scripted App Server recovery cases. The event/provider lifecycle block remains byte-identical.

## Murph initial provider input impact

Not applicable for individual or group runtimes: the changes derive final output after provider execution and render promoted responses. Initial instructions, tool/schema/generated guidance, history, and provider request construction are unchanged. No provider-input measurement was run and no measured-zero claim is made.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal synchronous refactor; no schema, persisted representation, cross-service protocol, or supported-version contract changes.

## Change-shape breakdown

Classification rule: Source is the runner, tests are the two existing test files, and docs are the closed execution plan. No binary or generated output.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 146 | 96 |
| Tests / fixtures | 49 | 6 |
| Docs | 47 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **242** | **102** |

## Changelog

- Changelog: not applicable
- Reason: Internal behavior-preserving refactor with no intended member-visible change.

ReviewGPT first-reviewed head: 87a8749f314d2ba6e751fe71d87909e512ad0687
ReviewGPT context sensitivity: sensitive
Classification reason: Assistant reply reconciliation affects quiet outcomes, tracking transcripts, and required user-visible recovery output.

## ReviewGPT result

- Round 1: PASS on 87a8749f314d2ba6e751fe71d87909e512ad0687.
- Model: GPT-6 Pro, verified by captured response metadata; guarded full snapshot and exact committed turn verified.
- No qualifying findings; no review remediation required. All required CI checks and routed Temporal compatibility passed on this same head.

## Completion status

- Parent candidate review and verified GPT-6 Pro ReviewGPT passed on the head above.
- Billing, both CLI checks, and routed Temporal compatibility passed.
- Release CI passed after the interrupted jobs were resumed on the unchanged reviewed head. All required checks and routed Temporal compatibility are green.
