### PR TITLE
refactor(assistant): unify local turn settlement

### DIFF
--- a/agent-docs/exec-plans/completed/2026-09-11-complexity2-local-service.md
+++ b/agent-docs/exec-plans/completed/2026-09-11-complexity2-local-service.md
@@ -1,0 +1,39 @@
+# Collapse assistant terminal settlement duplication
+
+Status: completed
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal and protected invariants
+
+Reduce local-service terminal-settlement complexity while preserving each returned result, transcript, delivery, usage record, and failure outcome. The turn lock and active-input controller remain the lifecycle owners; preserve registration, drain, commit-authority, resume, cancellation, and cleanup ordering.
+
+## Evidence and design
+
+The current source duplicates delivery-outcome result construction in ordinary completion, accepted-no-reply failure recovery, and deterministic audience-safety completion. Provider success and terminal failure also duplicate usage ordinal allocation and recording. Transcript projection occupies the lifecycle function despite depending only on already-resolved turn facts. Keep focused helpers in the same owner; add no mutable lifecycle object, new persistence, retry, or external work.
+
+## Scope
+
+- Local-service result/usage settlement and preceding/final response projection.
+- Focused existing local-service tests, relevant package typecheck, complexity guard, and one production-derived real-Codex journey.
+- Parent owns candidate review, Ready, exact-head CI, final ReviewGPT, and merge.
+
+## Tasks
+
+1. Collapse repeated result and usage construction without moving effects.
+2. Isolate transcript projection at its existing call position.
+3. Verify authority, failure, delivery, steering, typing, and session regression suites plus typecheck and guard.
+4. Inspect live reply, privacy and final diff; close the implementation plan and open a complete draft PR.
+
+## Verification
+
+- `pnpm --filter @murphai/assistant-engine typecheck` passed.
+- `pnpm complexity:diff --base HEAD -- packages/assistant-engine/src/assistant/local-service.ts` passed against creation base `85c157e01432a45d694732c93934998fc50df059`: file debt 143 to 108, maximum 128 to 109; `runCurrentProviderRequest` 55 to 39.
+- Remaining hotspots are the turn lifecycle owner (`run`, 109) and provider request owner (`runCurrentProviderRequest`, 39). Further splitting their mutable authority, steering, and recovery transitions would exceed this focused settlement change.
+- Focused local-service failures, delivery, live-input, typing-input, and session suites passed: 5 files, 108 tests, with one worker.
+- Existing focused real-Codex journey `answers once from an early detail retained across sixty committed messages` passed with `gpt-5.6-terra`, local subscription auth: 60 committed messages, one provider request, one user/assistant transcript pair, and the correct concise recall reply. Reply review: Ready.
+- Full source diff reviewed by the parent. Confirmed that null transcript input returns before media inspection and that the four-case delivery union preserves intent projection. No source changes were requested.
+- Privacy and final diff checks passed. No new Frog entry was needed; relevant existing friction records were inspected.
+- Implementation complete; parent retains final candidate/head review, Ready, exact-head CI, ReviewGPT, and merge ownership.
+- Provider inputs, tool declarations, persisted schemas, and deployment contracts are unchanged; initial provider input measurement is not applicable.
+Completed: 2026-09-11

--- a/packages/assistant-engine/src/assistant/local-service.ts
+++ b/packages/assistant-engine/src/assistant/local-service.ts
@@ -508,6 +508,33 @@ function resolveUnverifiedExternalAudienceResponse(prompt: string): string {
     : UNVERIFIED_EXTERNAL_AUDIENCE_RESPONSE
 }
 
+function buildCompletedAssistantAskResult(input: {
+  outcome: AssistantDeliveryOutcome
+  prompt: string
+  response: string
+  responseDisposition?: 'none'
+  vault: string
+}): AssistantAskResult {
+  const { outcome } = input
+  return normalizeAssistantAskResultForReturn({
+    vault: redactAssistantDisplayPath(input.vault),
+    status: 'completed',
+    prompt: input.prompt,
+    response: input.response,
+    ...(input.responseDisposition === 'none'
+      ? { responseDisposition: 'none' as const }
+      : {}),
+    media: outcome.media,
+    session: outcome.session,
+    delivery: outcome.kind === 'sent' ? outcome.delivery : null,
+    deliveryDeferred: outcome.kind === 'queued',
+    deliveryIntentId: outcome.kind === 'not-requested' ? null : outcome.intentId,
+    deliveryError: outcome.kind === 'queued' || outcome.kind === 'failed'
+      ? outcome.error
+      : null,
+  })
+}
+
 async function completeUnverifiedExternalAudienceTurn(input: {
   message: AssistantMessageInput
   plan: AssistantTurnSharedPlan
@@ -565,23 +592,11 @@ async function completeUnverifiedExternalAudienceTurn(input: {
 
   return {
     outcome,
-    result: normalizeAssistantAskResultForReturn({
-      delivery: outcome.kind === 'sent' ? outcome.delivery : null,
-      deliveryDeferred: outcome.kind === 'queued',
-      deliveryError:
-        outcome.kind === 'queued' || outcome.kind === 'failed'
-          ? outcome.error
-          : null,
-      deliveryIntentId:
-        outcome.kind === 'sent' || outcome.kind === 'queued' || outcome.kind === 'failed'
-          ? outcome.intentId
-          : null,
-      media: outcome.media,
+    result: buildCompletedAssistantAskResult({
+      outcome,
       prompt: input.message.prompt,
       response: input.response,
-      session: outcome.session,
-      status: 'completed',
-      vault: redactAssistantDisplayPath(input.message.vault),
+      vault: input.message.vault,
     }),
   }
 }
@@ -1643,6 +1658,52 @@ export async function sendAssistantMessageLocal(
                 : precedingReplyDeliveryContextOrdinal,
           })
         }
+        const recordCurrentProviderUsage = async (usageInput: {
+          providerResult: Parameters<typeof recordAssistantUsageEvent>[0]['providerResult']
+          additionalUsages: Parameters<typeof recordAdditionalAssistantUsageEvents>[0]['additionalUsages']
+          providerRequestOutcome?: Parameters<typeof recordAssistantUsageEvent>[0]['providerRequestOutcome']
+        }): Promise<void> => {
+          const usageRecordStartedAt = Date.now()
+          const primaryUsageRecordOrdinal = nextUsageRecordOrdinal
+          nextUsageRecordOrdinal += 1
+          await recordAssistantUsageEvent({
+            executionContext,
+            ...(providerRequestStartedAtMs === null
+              ? {}
+              : { occurredAt: new Date(providerRequestStartedAtMs).toISOString() }),
+            providerRequestAcceptedInputIds,
+            providerRequestOrdinal: primaryUsageRecordOrdinal,
+            ...(usageInput.providerRequestOutcome === undefined
+              ? {}
+              : { providerRequestOutcome: usageInput.providerRequestOutcome }),
+            providerResult: usageInput.providerResult,
+            turnId: currentUserTurn.turnId,
+          })
+          emitTurnTiming({
+            elapsedMs: elapsedSince(turnTimingStartedAt),
+            providerRequestOrdinal,
+            sinceProviderResultMs: providerResultReturnedAt === null
+              ? null
+              : elapsedSince(providerResultReturnedAt),
+            stage: 'usage-recorded',
+            stepElapsedMs: elapsedSince(usageRecordStartedAt),
+          })
+          const additionalUsages = usageInput.additionalUsages?.map(
+            (usageDraft) => ({
+              ...usageDraft,
+              providerRequestOrdinal: nextUsageRecordOrdinal++,
+            }),
+          )
+          await recordAdditionalAssistantUsageEvents({
+            additionalUsages,
+            effectiveEnv: currentInput.turnEnvironment?.env ?? process.env,
+            executionContext,
+            providerRequestAcceptedInputIds,
+            providerResult: usageInput.providerResult,
+            turnId: currentUserTurn.turnId,
+          })
+        }
+
         type CurrentProviderRequestResult =
           | {
               kind: 'completed'
@@ -1859,42 +1920,10 @@ export async function sendAssistantMessageLocal(
                 sessionId: providerOutcome.session.sessionId,
               })
             }
-            const usageRecordStartedAt = Date.now()
-            const primaryUsageRecordOrdinal = nextUsageRecordOrdinal
-            nextUsageRecordOrdinal += 1
-            await recordAssistantUsageEvent({
-              executionContext,
-              ...(providerRequestStartedAtMs === null
-                ? {}
-                : { occurredAt: new Date(providerRequestStartedAtMs).toISOString() }),
-              providerRequestAcceptedInputIds,
-              providerRequestOrdinal: primaryUsageRecordOrdinal,
+            await recordCurrentProviderUsage({
+              providerResult: failedProviderResult,
+              additionalUsages: providerOutcome.additionalUsages,
               providerRequestOutcome: providerOutcome.providerRequestOutcome,
-              providerResult: failedProviderResult,
-              turnId: currentUserTurn.turnId,
-            })
-            emitTurnTiming({
-              elapsedMs: elapsedSince(turnTimingStartedAt),
-              providerRequestOrdinal,
-              sinceProviderResultMs: providerResultReturnedAt === null
-                ? null
-                : elapsedSince(providerResultReturnedAt),
-              stage: 'usage-recorded',
-              stepElapsedMs: elapsedSince(usageRecordStartedAt),
-            })
-            const additionalUsages = providerOutcome.additionalUsages?.map(
-              (usageDraft) => ({
-                ...usageDraft,
-                providerRequestOrdinal: nextUsageRecordOrdinal++,
-              }),
-            )
-            await recordAdditionalAssistantUsageEvents({
-              additionalUsages,
-              effectiveEnv: currentInput.turnEnvironment?.env ?? process.env,
-              executionContext,
-              providerRequestAcceptedInputIds,
-              providerResult: failedProviderResult,
-              turnId: currentUserTurn.turnId,
             })
             if (
               requestInput.allowFailedNoReplyRecovery &&
@@ -2045,30 +2074,12 @@ export async function sendAssistantMessageLocal(
                 turnId: currentUserTurn.turnId,
                 vault: input.vault,
               })
-              const result = normalizeAssistantAskResultForReturn({
-                vault: redactAssistantDisplayPath(input.vault),
-                status: 'completed',
+              const result = buildCompletedAssistantAskResult({
+                outcome: finalDeliveryOutcome,
                 prompt: currentInput.prompt,
                 response: '',
-                responseDisposition: 'none' as const,
-                media: finalDeliveryOutcome.media,
-                session: finalDeliveryOutcome.session,
-                delivery:
-                  finalDeliveryOutcome.kind === 'sent'
-                    ? finalDeliveryOutcome.delivery
-                    : null,
-                deliveryDeferred: finalDeliveryOutcome.kind === 'queued',
-                deliveryIntentId:
-                  finalDeliveryOutcome.kind === 'sent' ||
-                  finalDeliveryOutcome.kind === 'queued' ||
-                  finalDeliveryOutcome.kind === 'failed'
-                    ? finalDeliveryOutcome.intentId
-                    : null,
-                deliveryError:
-                  finalDeliveryOutcome.kind === 'queued' ||
-                  finalDeliveryOutcome.kind === 'failed'
-                    ? finalDeliveryOutcome.error
-                    : null,
+                responseDisposition: 'none',
+                vault: input.vault,
               })
               turnInputController.complete(result)
               return {
@@ -2099,41 +2110,9 @@ export async function sendAssistantMessageLocal(
               sharedPlan,
             })
           }
-          const usageRecordStartedAt = Date.now()
-          const primaryUsageRecordOrdinal = nextUsageRecordOrdinal
-          nextUsageRecordOrdinal += 1
-          await recordAssistantUsageEvent({
-            executionContext,
-            ...(providerRequestStartedAtMs === null
-              ? {}
-              : { occurredAt: new Date(providerRequestStartedAtMs).toISOString() }),
-            providerRequestAcceptedInputIds,
-            providerRequestOrdinal: primaryUsageRecordOrdinal,
+          await recordCurrentProviderUsage({
             providerResult: currentProviderResult,
-            turnId: currentUserTurn.turnId,
-          })
-          emitTurnTiming({
-            elapsedMs: elapsedSince(turnTimingStartedAt),
-            providerRequestOrdinal,
-            sinceProviderResultMs: providerResultReturnedAt === null
-              ? null
-              : elapsedSince(providerResultReturnedAt),
-            stage: 'usage-recorded',
-            stepElapsedMs: elapsedSince(usageRecordStartedAt),
-          })
-          const additionalUsages = currentProviderResult.additionalUsages?.map(
-            (usageDraft) => ({
-              ...usageDraft,
-              providerRequestOrdinal: nextUsageRecordOrdinal++,
-            }),
-          )
-          await recordAdditionalAssistantUsageEvents({
-            additionalUsages,
-            effectiveEnv: currentInput.turnEnvironment?.env ?? process.env,
-            executionContext,
-            providerRequestAcceptedInputIds,
-            providerResult: currentProviderResult,
-            turnId: currentUserTurn.turnId,
+            additionalUsages: currentProviderResult.additionalUsages,
           })
 
           return {
@@ -2293,28 +2272,10 @@ export async function sendAssistantMessageLocal(
               )
               continue
             }
-            precedingResponseSegments.push({
-              followUpRequest: segment.followUpRequest,
-              ...(segment.contextReferences === undefined
-                ? {}
-                : {
-                    contextReferences: segment.contextReferences?.map(
-                      (reference) => ({ ...reference }),
-                    ) ?? null,
-                  }),
+            precedingResponseSegments.push(buildAssistantPrecedingReplySegment({
+              segment,
               deliveryContext: resolvedDeliveryContext.context,
-              response: segment.response,
-              ...(segment.transcriptResponse === undefined
-                ? {}
-                : { transcriptResponse: segment.transcriptResponse }),
-              media: segment.media ?? [],
-              ...(segment.targetInputId
-                ? {
-                    deliveryContextOrdinal: segment.deliveryContextOrdinal,
-                    targetInputId: segment.targetInputId,
-                  }
-                : {}),
-            })
+            }))
         }
         const precedingResponses = precedingResponseSegments.map((segment) => {
           const response = resolveAssistantPersistedReplyText({
@@ -2347,38 +2308,13 @@ export async function sendAssistantMessageLocal(
             vault: input.vault,
           })
         }
-        const noReplySelected = providerResult.finalAction?.kind === 'none'
-        const rawFinalResponseText = noReplySelected
-          ? null
-          : resolveAssistantProviderFinalResponseText(providerResult)
-        const finalResponseText =
-          rawFinalResponseText === null
-            ? null
-            : resolveAssistantPersistedReplyText({
-                messageInput: finalReplyInput,
-                rawResponse: rawFinalResponseText,
-                session: currentSession,
-                sharedPlan,
-              })
-        const rawTranscriptResponseText = noReplySelected
-          ? null
-          : providerResult.transcriptResponse ??
-            (providerResult.responseCard
-              ? renderAssistantResponseCardTranscriptText(providerResult.responseCard)
-              : null)
-        const transcriptResponseText =
-          rawTranscriptResponseText === null
-            ? null
-            : resolveAssistantPersistedReplyText({
-                messageInput: finalReplyInput,
-                rawResponse: rawTranscriptResponseText,
-                session: currentSession,
-                sharedPlan,
-              })
-        const assistantTranscriptText = resolveAssistantProviderTranscriptText({
-          media: providerResult.responseMedia,
-          response: transcriptResponseText,
-        })
+        const { rawFinalResponseText, finalResponseText, assistantTranscriptText } =
+          resolveAssistantFinalReplyContent({
+            providerResult,
+            finalReplyInput,
+            currentSession,
+            sharedPlan,
+          })
         const turnArtifactsStartedAt = Date.now()
         const session = await finalizeAssistantTurnArtifacts({
           assistantTranscriptText,
@@ -2649,28 +2585,14 @@ export async function sendAssistantMessageLocal(
           vault: input.vault,
         })
 
-        const result = normalizeAssistantAskResultForReturn({
-          vault: redactAssistantDisplayPath(input.vault),
-          status: 'completed',
+        const result = buildCompletedAssistantAskResult({
+          outcome: finalDeliveryOutcome,
           prompt: currentInput.prompt,
           response: finalResponse,
           ...(finalResponseDisposition === 'none'
             ? { responseDisposition: 'none' as const }
             : {}),
-          media: finalDeliveryOutcome.media,
-          session: finalDeliveryOutcome.session,
-          delivery: finalDeliveryOutcome.kind === 'sent' ? finalDeliveryOutcome.delivery : null,
-          deliveryDeferred: finalDeliveryOutcome.kind === 'queued',
-          deliveryIntentId:
-            finalDeliveryOutcome.kind === 'sent' ||
-            finalDeliveryOutcome.kind === 'queued' ||
-            finalDeliveryOutcome.kind === 'failed'
-              ? finalDeliveryOutcome.intentId
-              : null,
-          deliveryError:
-            finalDeliveryOutcome.kind === 'queued' || finalDeliveryOutcome.kind === 'failed'
-              ? finalDeliveryOutcome.error
-              : null,
+          vault: input.vault,
         })
         turnInputController.complete(result)
         const productFeedbackCandidate =
@@ -3151,6 +3073,81 @@ function isManualAssistantTurnTrigger(
 
 function elapsedSince(startedAt: number): number {
   return Math.max(0, Date.now() - startedAt)
+}
+
+function buildAssistantPrecedingReplySegment({
+  segment,
+  deliveryContext,
+}: {
+  segment: NonNullable<ExecutedAssistantProviderTurnResult['precedingResponseSegments']>[number]
+  deliveryContext: AssistantReplyDeliveryContext | null
+}): AssistantPrecedingReplySegment {
+  return {
+    followUpRequest: segment.followUpRequest,
+    ...(segment.contextReferences === undefined
+      ? {}
+      : {
+          contextReferences: segment.contextReferences?.map(
+            (reference) => ({ ...reference }),
+          ) ?? null,
+        }),
+    deliveryContext,
+    response: segment.response,
+    ...(segment.transcriptResponse === undefined
+      ? {}
+      : { transcriptResponse: segment.transcriptResponse }),
+    media: segment.media ?? [],
+    ...(segment.targetInputId
+      ? {
+          deliveryContextOrdinal: segment.deliveryContextOrdinal,
+          targetInputId: segment.targetInputId,
+        }
+      : {}),
+  }
+}
+
+function resolveAssistantFinalReplyContent({
+  providerResult,
+  finalReplyInput,
+  currentSession,
+  sharedPlan,
+}: {
+  providerResult: ExecutedAssistantProviderTurnResult
+  finalReplyInput: AssistantMessageInput
+  currentSession: AssistantSession
+  sharedPlan: AssistantTurnSharedPlan
+}) {
+  if (providerResult.finalAction?.kind === 'none') {
+    return {
+      rawFinalResponseText: null,
+      finalResponseText: null,
+      assistantTranscriptText: null,
+    }
+  }
+  const rawFinalResponseText = resolveAssistantProviderFinalResponseText(providerResult)
+  const finalResponseText = resolveAssistantPersistedReplyText({
+    messageInput: finalReplyInput,
+    rawResponse: rawFinalResponseText,
+    session: currentSession,
+    sharedPlan,
+  })
+  const rawTranscriptResponseText = providerResult.transcriptResponse ??
+    (providerResult.responseCard
+      ? renderAssistantResponseCardTranscriptText(providerResult.responseCard)
+      : null)
+  const transcriptResponseText = rawTranscriptResponseText === null
+    ? null
+    : resolveAssistantPersistedReplyText({
+        messageInput: finalReplyInput,
+        rawResponse: rawTranscriptResponseText,
+        session: currentSession,
+        sharedPlan,
+      })
+  const assistantTranscriptText = resolveAssistantProviderTranscriptText({
+    media: providerResult.responseMedia,
+    response: transcriptResponseText,
+  })
+  return { rawFinalResponseText, finalResponseText, assistantTranscriptText }
 }
 
 function resolveAssistantProviderFinalResponseText(


### PR DESCRIPTION
## Why and outcome

Local assistant completion repeated usage bookkeeping and delivery result construction across ordinary completion, accepted-no-reply recovery, and audience-safety completion. Share these transformations within the existing service so its lifecycle branches stay shorter while preserving returned results, transcripts, delivery, and usage attribution.

## Product UX

- Effort: Patch — internal refactor with unchanged member behavior.
- Result: Ready
- Walkthrough: Existing individual completion, group reconsideration, quiet recovery, queued/failed delivery, typing, and session behavior retain their existing contracts.

## Evidence

- Direct: `pnpm test:assistant:live -- --test "answers once from an early detail retained across sixty committed messages" --codex-home <authenticated-local-home>`; **passed**, `gpt-5.6-terra`, local subscription auth; 60 committed messages, exactly one provider request, one user/assistant transcript pair, and correct concise recall. Reply review: **Ready**; no duplicate action or unsupported claim.
- Coverage: `pnpm exec vitest run --config packages/assistant-engine/vitest.config.ts --maxWorkers 1` with `assistant-local-service-failures.test.ts`, `assistant-local-service-delivery.test.ts`, `assistant-local-service-live-input.test.ts`, `assistant-local-service-typing-input.test.ts`, and `assistant-local-service-session.test.ts`: **5 suites, 108 tests passed**.
- `pnpm --filter @murphai/assistant-engine typecheck`: passed.
- `git diff --check`: passed. Full source diff reviewed by the parent before final head review.

## Non-obvious affected surfaces

- Provider usage: success and terminal failure now share primary/additional usage recording. Existing group tests retain primary ordinals `[0, 3]` and additional ordinals `[[1, 2], [4]]`; failure tests assert the failed outcome and original error identity.
- Quiet completion: accepted-no-reply failure recovery retains reactions, acknowledged-input drain, and suppression. The existing transcript helper returns null before reading media when its response is null; the new early return preserves that behavior.
- Transcript and delivery projection: existing tests cover cards, media, preceding segments, delivery context, and all four delivery outcomes. The closed outcome union retains the same intent/error fields.
- Authority and cleanup: lock/controller registration, drain, commit checks, resume state, finalization, cancellation, and cleanup remain at their existing call positions; focused tests include superseded results and live steering.

## Architecture and reuse

- Existing systems reused: local-service lifecycle ownership, existing usage writers, delivery finalization, reply normalization, and result serialization.
- New logic: None; existing terminal result and reply-content transformations are shared.
- New abstractions: Four file-local helpers for completed result construction, usage recording, preceding-segment projection, and final reply content. No exported API or new state owner.
- Complexity intentionally avoided: No mutable lifecycle framework, new persistence, retries, configuration, or dependency.

## Complexity impact

- Guard: pass — `pnpm complexity:diff --base HEAD -- packages/assistant-engine/src/assistant/local-service.ts`, run before commit against creation base `85c157e01432a45d694732c93934998fc50df059`.
- File debt: **143 → 108 (−35)**; maximum: **128 → 109 (−19)**.
- Hotspots: `run` **128 → 109** and `runCurrentProviderRequest` **55 → 39**. Both retain mutable lifecycle/authority orchestration; the new helpers stay below threshold 20.
- Agent judgment: The change removes repeated terminal construction and isolates pure projections. Further splitting the remaining control flow would require a separate treatment of steering and recovery ownership.

## Hot reply path impact

- Path status: Touched — settlement after provider execution.
- Database calls: None added or moved onto the path.
- Network/provider calls: None added or moved onto the path.
- Other awaited latency: No new I/O. The usage helper wraps the existing sequence: one primary usage call, timing emission, then one additional-usage batch call per provider request. Its caller awaits completion at the existing success/failure positions. Timeouts, retries, and fallbacks are unchanged.
- Before/after proof: Full diff retains effect order and focused suites assert usage attribution, delivery/finalization counts, original-error preservation, and post-delivery maintenance. No latency improvement is claimed or measured.

## Murph initial provider input impact

Not applicable: this refactor changes local terminal settlement and projection after provider execution. It changes no assembled instructions, tool/schema/generated guidance, request wrapper, or conversation history for either runtime.

| Runtime | Base input tokens | Head input tokens | Delta | Percent | Base bytes | Head bytes | Byte delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Individual Murph | N/A | N/A | N/A | N/A | N/A | N/A | N/A |
| Group Murph | N/A | N/A | N/A | N/A | N/A | N/A | N/A |

- Assembled instructions: Unchanged.
- Tool/schema/generated guidance: Unchanged.
- Other provider-visible input: Unchanged.
- Measurement method: Not run — no provider-input surface changed; no measured-zero claim.

## Deployment concerns

- Deployment: not applicable
- Reason: Internal refactor with unchanged persisted schemas, runtime protocol, environment, and rollout contracts.

## Change-shape breakdown

Classification rule: Production TypeScript is source; the completed execution plan is docs. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 173 | 176 |
| Tests / fixtures | 0 | 0 |
| Docs | 39 | 0 |
| Config / tooling | 0 | 0 |
| Generated / other | 0 | 0 |
| **Total** | **212** | **176** |

## Changelog

- Changelog: not applicable
- Reason: Internal complexity reduction with unchanged member-visible behavior.

ReviewGPT first-reviewed head: d52915856a5abd74395a21f63108836c1afd89b8
ReviewGPT context sensitivity: sensitive
Classification reason: Assistant terminal settlement touches usage attribution, transcript/delivery projection, and lifecycle authority boundaries.

## ReviewGPT result

- Round 1: PASS on d52915856a5abd74395a21f63108836c1afd89b8.
- Model: GPT-6 Pro, verified by captured response metadata; guarded full snapshot and exact committed turn verified.
- No qualifying findings; no review remediation required. All required CI checks and routed Temporal compatibility passed on this same head.
