### PR TITLE
Require live Web protocol proof before hosted activation

### DIFF
--- a/.agents/friction-log/20260911194130-hosted-release-proof/friction.md
+++ b/.agents/friction-log/20260911194130-hosted-release-proof/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Hosted release proof deadline includes runner queue time'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+A protected release proof should distinguish waiting for a GitHub runner from executing its bounded checks, while keeping credential expiry, cancellation settlement, and total resource use bounded.
+
+## Current Behavior
+
+The compatibility controller starts one forty-minute private-run deadline immediately after dispatch. The private production proof then queues setup jobs, two builds, reader checks, and scenario jobs. Queue time can consume the proof window and cause the controller to cancel correctly running scenarios before they produce a result. The caller reports a timeout without distinguishing time spent queued from a test failure. A token lifetime budget is separate but does not extend the private-run deadline.
+
+## Possible Solution
+
+Inspect the existing admission and execution budget owners together. Preserve exact candidate identity and fail-closed proof, report phase-specific delay, and ensure the admitted work has a bounded feasible execution window. Do not add an unbounded retry or weaken required scenarios.
+
+## Minimal Reproducible Example
+
+Use an injected clock and mocked GitHub responses with the existing controller: dispatch one accepted private run, return queued jobs for most of the run budget, then return running scenario jobs whose individual timeouts have not expired. Advance the clock to the controller deadline. Observe cancellation before a scenario verdict even though no job has failed. Cover token expiry and cancellation settlement independently.
+
+## Context
+
+This release-tooling behavior can delay a necessary consumer-first rollout and force operators to interrupt unrelated CI to obtain runner capacity. The report uses a synthetic scheduling sequence and contains no production records.

--- a/agent-docs/exec-plans/active/2026-09-11-release-compatibility-safeguards.md
+++ b/agent-docs/exec-plans/active/2026-09-11-release-compatibility-safeguards.md
@@ -1,0 +1,168 @@
+# Verify incident recovery and enforce cross-plane release compatibility
+
+Status: active
+Created: 2026-09-11
+Updated: 2026-09-11
+
+## Goal
+
+- Restore the affected scheduled-delivery and runtime-log paths, verify the actual
+  production outcome, and prevent independently deployed components from activating
+  an incompatible protocol pair.
+- Explain the causal chain and the gaps in test, release, and recovery coverage in
+  a thorough retrospective after recovery is verified.
+
+## Success criteria
+
+- The canonical production Web and runner releases satisfy their declared protocol
+  dependencies; managed-container smoke and live release verification pass.
+- Fresh natural production observations establish whether the two incident symptoms
+  have stopped and whether the affected delivery/logging paths complete successfully.
+- Synthetic composed proof reproduces the incompatible old/new pair and demonstrates
+  that the chosen safeguard rejects it before activation while admitting supported pairs.
+- Prevention has focused verification, parent review, required external review, and
+  final-head CI. Any temporarily interrupted unrelated CI is restored or superseded
+  by valid current-head proof.
+
+## Scope
+
+- In scope: authorized canonical recovery rollout; remaining causes of the incident;
+  deployment compatibility and release-admission owners; causal retrospective;
+  narrowly scoped systemic prevention and its tests/documentation.
+- Out of scope: a new deployment platform, incident tracker, compatibility state
+  database, guessed route audience, automatic message replay, unrelated product work,
+  and device-provider investigation.
+
+## Constraints
+
+- Web owns audience and accepted runtime-log contracts; the Worker and runner consume
+  those contracts. Private Murph Cloud owns protected production deployment.
+- Reuse existing release metadata, signed admission/smoke boundaries, and test owners.
+  Prefer enforcing ordering or deriving evidence to adding another authority.
+- Do not relax production authentication, current-member authority, write fences,
+  required release proof, or rollback floors to make a deploy pass.
+- Keep private incident evidence outside public source and fixtures. Use synthetic
+  examples for code, tests, plans, and public review packets.
+- One original task owns recovery and completion. Preserve other worktrees and PRs.
+
+## Risks and mitigations
+
+1. A new runtime reaches an older Web consumer.
+   Mitigation: verify the real production Web dependency before runtime activation;
+   preserve the passed candidate checks while holding its production job if necessary.
+2. CI proves only components built from the same revision.
+   Mitigation: exercise the real deployed/candidate boundary and every supported
+   mixed-version pair relevant to the changed contract.
+3. Queueing consumes a release proof's bounded execution window.
+   Mitigation: distinguish queue, build, test, token, and settlement budgets in the
+   retrospective; prove the smallest correction at the existing controller owner.
+4. A universal compatibility layer introduces more state or blocks safe rollouts.
+   Mitigation: inspect existing owners first; require concrete reproduction and
+   successful supported-pair tests before choosing a mechanism.
+
+## Tasks
+
+1. Complete recovery through the protected workflows and verify live versions,
+   telemetry ingestion, and scheduled-delivery outcomes. Continue remediation if
+   the deployment does not resolve the established symptoms.
+2. Preserve a sanitized chronology, producer/consumer source evidence, exact gate
+   behavior, and the distinction between proximate cause and contributing conditions.
+3. Inspect the current deployment admission, smoke, and cross-repository proof
+   mechanisms. Identify why they allowed the incompatible pair and why recovery stalled.
+4. Propose the smallest owner-level safeguard and reproduce its absent behavior with
+   synthetic data before implementation. Use ReviewGPT for substantive implementation.
+5. Implement the accepted prevention, meaningful regression proof, and durable owner
+   documentation. Prepare the retrospective without publishing private evidence.
+6. Complete focused checks, scoped commits, parent review, final ReviewGPT and CI;
+   restore interrupted CI and verify the final authorized rollout where applicable.
+
+## Decisions
+
+- Existing prose already requires consumer-first deployment and mixed-version proof.
+  Additional prose alone cannot close a missing executable release gate.
+- Existing source-extraction checks reproduce an older Web authority response without
+  audience scope and an older strict log reader rejecting a new event value. The
+  correction must preserve the canonical audience owner rather than invent a fallback.
+- A successful Worker release receipt proves that execution-plane release, not the
+  compatibility of the independently served Web revision.
+- The prevention candidate adds signed, bounded evidence from the served Web's
+  actual log parser and audience-response builder at the existing deployment
+  activation seams. It preserves independent source revisions and canonical
+  audience authority. The additive Web endpoint must ship before the new CLI.
+- The introducing audience change explicitly tested an absent field as a retryable
+  scheduling failure; the Worker adapter separately accepted the legacy response.
+  These are valid local contracts but do not prove availability of the composed
+  deployed pair. Its rollout instructions already required Web before consumers.
+- The new diagnostic event was likewise documented as rejected by an older Web
+  reader. Keeping processing independent of logging avoided a processing failure,
+  but did not make the observation path compatible or verify its ingestion.
+- The production-core release suite selects Linq delivery/reminders, browser smoke,
+  and two foreground partitions. The full private manifest's `telegram` alias
+  resolves to first-contact proof; it does not select the separately registered
+  Telegram scheduled-reminder scenario. Ordinary Cloudflare Node suites exclude
+  E2E files. Adding a scenario to the public registry alone is not CI ownership.
+- A synthetic clock against the real compatibility controller reproduces recovery
+  cancellation: twenty minutes queued followed by twenty minutes executing exhausts
+  the forty-minute total deadline, even when a bounded twenty-five-minute execution
+  would finish inside the separate token budget. No network or production mutation
+  is needed for this proof.
+- Parent inspection caught forbidden cross-application test imports and a
+  header-case typing error in the initial protocol candidate. Remediation keeps
+  proof at each application owner and joins them through public contracts and
+  synthetic wire shapes. The resulting candidate passes 72 Cloudflare tests,
+  14 Web tests, both application typechecks, the shared package build, and
+  workspace boundary verification.
+- The timeout implementation derives usable proof time from the existing token
+  boundary minus settlement reserve, and carries the absolute deadline through
+  finalization and cancellation. Parent source review and all 75 controller tests
+  pass under the repository's Node runtime, including queue-heavy successful
+  execution, late finalization, and bounded cancellation settlement.
+
+## Causal retrospective
+
+- **Trigger:** independently deployed producers began requiring or emitting wire
+  values that the serving Web consumer did not yet supply or accept. The runtime
+  correctly refused to guess audience scope, while the strict log reader
+  correctly rejected an unknown event. Their combination caused unavailable
+  scheduled delivery and missing diagnostic ingestion.
+- **Why component tests passed:** the authority tests deliberately proved that a
+  missing audience defers work, and parser tests proved strict validation. Those
+  local guarantees are necessary, but neither guarantees that a release will
+  reach a consumer that satisfies the new obligation. Tests built from one
+  checkout also cannot establish the behavior of an older deployed Web.
+- **Why release checks missed the pair:** consumer-first guidance existed, but
+  the Worker activation owner did not require executable evidence from the
+  serving Web. Artifact smoke and container convergence attested a different
+  boundary. Temporal mixed-reader checks were present, but cover orchestration
+  facts rather than these runtime callbacks. Passing one compatibility proof
+  must not be treated as universal compatibility.
+- **Why journey coverage was incomplete:** the Telegram first-contact alias did
+  not include the registered scheduled-reminder scenario. A test file and a
+  public scenario registry entry are not proof that protected CI runs the journey.
+  Required cross-repository coverage and its selected manifest must agree.
+- **Why recovery took longer:** a fixed proof timeout charged queue and build
+  time against execution despite a larger existing credential budget. Separately,
+  requiring a new public scenario before its private manifest update blocked
+  newer proof, and private-head movement correctly invalidated a prior pinned
+  proof. A subsequent exact-candidate admission passed in GitHub while its
+  imported Vercel check remained running; a check retry remained queued. The
+  vendor synchronization cause is unproven. These delayed recovery; they did
+  not cause the original wire mismatch.
+- **Prevention:** enforce a live consumer prerequisite at activation, test
+  supported and rejected mixed-version wire shapes at their real owners, retain
+  positive downstream delivery and log-ingestion evidence, and keep proof plus
+  cancellation inside one explicit credential budget. Scenario prerequisites
+  must be deployed in consumer-first order across repositories too.
+- **Limits:** bounded live samples do not establish global atomic deployment or
+  prevent a later independent rollback. The audience and event witnesses do not
+  certify every opposite-direction Web-to-runtime contract. Preserve their
+  specific rollout floors and report missing natural-traffic proof honestly.
+
+## Verification
+
+- Recovery: protected workflow job receipts, canonical production alias/deployment
+  metadata, exact live Worker/container provenance, bounded fresh failure searches,
+  and positive completion/ingestion observations.
+- Prevention: focused tests invoking production admission/parser owners with synthetic
+  old/new combinations, applicable typechecks, complexity and document guards, then
+  required CI and independent review. Select exact commands after locating the owner.

--- a/apps/cloudflare/DEPLOY.md
+++ b/apps/cloudflare/DEPLOY.md
@@ -32,6 +32,75 @@ additional deploy-smoke slot. The unused member application stays at zero.
 The scaffold declares the budget on `RunnerContainer`; staging moves that budget
 to `NextRunnerContainer` when the live release selects that namespace.
 
+### Live Web protocol admission
+
+`deploy-worker-version.cli.ts` admits the **served** `HOSTED_WEB_BASE_URL` before
+release work and again before each namespace bootstrap, native retirement or
+application admission, compatibility activation, and final promotion. Each
+boundary then rechecks the current Worker identity. Uploading an inactive version
+is not admission; artifact/fleet smoke and native convergence receipts remain
+required and do not attest Web compatibility. Retries and worker-only releases
+must obtain fresh admission; there is no persisted compatibility receipt or skip
+flag.
+
+The signed, bodyless GET `/api/internal/hosted-runtime/protocol-admission` uses
+existing Web callback signature verification and replay protection, with its own
+system nonce owner (not the Temporal binding-admission contract). The request
+binds the protocol version and a fresh nonce in the signed query. The no-store
+reply echoes that nonce and contains executable evidence from two existing owners:
+
+- The Web runtime-log reader parses synthetic entries for its actual event-code
+  enum. The candidate requires its declared producer vocabulary to be a subset
+  of the reader's; a future reader's extra codes are allowed. The actual log route and
+  probe use the same parser, including `runner.processing_finished`.
+- The normal thread-route authority handler and probe share their response
+  builder. The candidate uses the actual Worker response parser on both direct
+  and group witnesses, requiring explicit `true` and `false`. Denial, malformed
+  audience and inverted direct/group semantics fail closed. The Worker parser
+  still accepts legacy authorized responses for callers that do not need an
+  audience; the runtime's scheduled-delivery boolean requirement and independent
+  callback reauthorization are unchanged.
+
+Worker-only releases run both checks too: retaining an image does not prove that
+it lacks the audience requirement. Without an attested contract for that retained
+artifact, mode alone cannot safely lower the consumer floor. The declared log
+vocabulary is conservative (not pruned to call-site reachability); a legacy Web
+must gain the compatible reader/response encoding before this CLI can activate it.
+Old callers remain compatible with the additive Web response. Neither check
+requires equal or monotonically ordered source revisions.
+
+Each admission requires three successful samples, one second apart. Any failed
+sample ends the attempt, rather than retrying until a compatible replica happens
+to answer. Every sample has a ten-second end-to-end deadline and a 16 KiB streamed
+response limit. Only HTTPS origin requests, non-redirected HTTP 200, JSON, no-store
+and absent/zero Age are admitted. Authentication failures, unavailable Web,
+unknown protocol versions, stale nonce, malformed evidence and missing contracts
+fail closed. Diagnostics contain fixed reason codes or locally owned event codes,
+not remote response bodies, URLs, signatures or deployment identities.
+
+**Bootstrap:** deploy the additive Web endpoint and compatible readers to the
+actual serving Web origin first and finish propagation before deploying this
+CLI. A Web revision with no admission endpoint returns 404 and is deliberately
+not admitted, even when otherwise compatible. Backport the endpoint with evidence
+from that revision's real owners when retaining an older compatible Web; do not
+copy a newer revision's claimed evidence. Missing or incorrect callback signing
+configuration must be repaired through the existing protected deployment path.
+An already-incompatible live pair still needs a compatible Web forward fix; this
+guard prevents the next mutation, not damage already in progress.
+
+This is a bounded directed-contract check, not a Git SHA ordering rule or a claim
+of global atomic rollout. Three observations cannot prove every Web replica has
+converged, nor prevent an independent Web rollback after the check. Keep the
+serving alias stable and preserve the required reader floor throughout activation
+and subsequent operation. Admission tests event-code parsing and the authority
+response encoding, not database route correctness, every log field, or all
+Web-to-runtime features. In particular, selected custom-inference revisions flow
+in the opposite direction: the **Custom Inference Activation** procedure below
+still owns flag enablement, selected-state migration and the runtime rollback
+floor. This GET neither reads member selection nor authorizes that feature's
+activation. New wire obligations need narrowly derived executable witnesses at
+their actual owners, not labels in a general capability registry.
+
 ### Selected-account size experiment
 
 `SmallRunnerContainer` has a ten-instance ceiling outside the regular fleet

--- a/apps/cloudflare/scripts/deploy-web-protocol.ts
+++ b/apps/cloudflare/scripts/deploy-web-protocol.ts
@@ -1,0 +1,144 @@
+import { setTimeout as sleep } from "node:timers/promises";
+
+import { normalizeHostedExecutionBaseUrl } from "@murphai/hosted-execution/env";
+import { assertHostedRuntimeWebProtocolAdmission } from "@murphai/hosted-execution/parsers";
+import {
+  HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_MAX_BYTES,
+  HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_PATH,
+  HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_VERSION,
+} from "@murphai/hosted-execution/runtime-control";
+import {
+  createHostedWebCallbackSignatureHeaders,
+  readHostedWebCallbackSigningEnvironment,
+} from "../src/web-callback-auth.ts";
+
+type EnvSource = Readonly<Record<string, string | undefined>>;
+export const HOSTED_WEB_PROTOCOL_PROBE_TIMEOUT_MS = 10_000;
+const SAMPLE_COUNT = 3;
+const SAMPLE_INTERVAL_MS = 1_000;
+
+// Every boundary gets fresh, spaced observations. A failing sample stops this
+// attempt; we never retry an incompatible response until a lucky replica passes.
+export async function assertHostedWebProtocolAdmission(
+  source: EnvSource,
+  options: {
+    fetchImpl?: typeof fetch;
+    sleep?: (ms: number) => Promise<unknown>;
+  } = {},
+): Promise<void> {
+  let origin: string | null;
+  try {
+    origin = normalizeHostedExecutionBaseUrl(source.HOSTED_WEB_BASE_URL, { requireOriginOnly: true });
+  } catch {
+    throw admissionFailure("web_origin");
+  }
+  if (!origin) throw admissionFailure("web_origin");
+  for (let sample = 0; sample < SAMPLE_COUNT; sample += 1) {
+    if (sample > 0) await (options.sleep ?? sleep)(SAMPLE_INTERVAL_MS);
+    await probeWithDeadline(new URL(HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_PATH, origin), source, options);
+  }
+}
+
+async function probeWithDeadline(
+  url: URL,
+  source: EnvSource,
+  options: { fetchImpl?: typeof fetch },
+): Promise<void> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(admissionFailure("timeout"));
+    }, HOSTED_WEB_PROTOCOL_PROBE_TIMEOUT_MS);
+  });
+  try {
+    await Promise.race([probe(url, source, options, controller.signal), deadline]);
+  } finally {
+    clearTimeout(timer);
+    controller.abort();
+  }
+}
+
+async function probe(
+  url: URL,
+  source: EnvSource,
+  options: { fetchImpl?: typeof fetch },
+  signal: AbortSignal,
+): Promise<void> {
+  const nonce = crypto.randomUUID();
+  url.searchParams.set("schemaVersion", String(HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_VERSION));
+  url.searchParams.set("nonce", nonce);
+  let headers: Record<string, string>;
+  try {
+    headers = await createHostedWebCallbackSignatureHeaders({
+      environment: readHostedWebCallbackSigningEnvironment(source),
+      method: "GET", path: url.pathname, search: url.search, nonce, payload: "",
+    });
+  } catch {
+    throw admissionFailure("signing_configuration");
+  }
+  let response: Response;
+  try {
+    response = await (options.fetchImpl ?? fetch)(url, {
+      method: "GET", redirect: "manual", cache: "no-store", credentials: "omit", signal,
+      headers: { ...headers, accept: "application/json", "cache-control": "no-store", pragma: "no-cache" },
+    });
+  } catch {
+    throw admissionFailure("unavailable");
+  }
+  try {
+    if (response.status !== 200 || response.redirected) throw admissionFailure(`http_${response.status}`);
+    if (!/(?:^|,)\s*no-store\s*(?:,|$)/iu.test(response.headers.get("cache-control") ?? "")
+      || (response.headers.has("age") && response.headers.get("age") !== "0")
+      || response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() !== "application/json") {
+      throw admissionFailure("uncached_json_required");
+    }
+    const value = await readBoundedJson(response, signal);
+    assertHostedRuntimeWebProtocolAdmission(value, nonce);
+  } finally {
+    // Do not await cancellation: a broken remote stream must not extend the deadline.
+    if (!response.body?.locked) void response.body?.cancel().catch(() => {});
+  }
+}
+
+async function readBoundedJson(response: Response, signal: AbortSignal): Promise<unknown> {
+  const length = response.headers.get("content-length");
+  if (length !== null && (!/^\d+$/u.test(length) || Number(length) > HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_MAX_BYTES)) {
+    throw admissionFailure("response_size");
+  }
+  if (!response.body) throw admissionFailure("response_body");
+  const reader = response.body.getReader();
+  const cancel = () => { void reader.cancel().catch(() => {}); };
+  signal.addEventListener("abort", cancel, { once: true });
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      signal.throwIfAborted();
+      const { done, value } = await reader.read().catch(() => {
+        throw admissionFailure("response_read");
+      });
+      if (done) break;
+      size += value.byteLength;
+      if (size > HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_MAX_BYTES) throw admissionFailure("response_size");
+      chunks.push(value);
+    }
+  } finally {
+    signal.removeEventListener("abort", cancel);
+    cancel();
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength; }
+  try {
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  } catch {
+    throw admissionFailure("invalid_json");
+  }
+}
+
+function admissionFailure(reason: string): Error {
+  return new Error(`Hosted Web protocol admission failed: ${reason}. No further activation is permitted; finish the compatible Web rollout and retry.`);
+}

--- a/apps/cloudflare/scripts/deploy-worker-version.cli.ts
+++ b/apps/cloudflare/scripts/deploy-worker-version.cli.ts
@@ -13,6 +13,7 @@ import {
   requireConfiguredString,
 } from "./deploy-automation/shared.ts";
 import { assertHostedDeployEnvironmentAsync } from "./deploy-preflight.js";
+import { assertHostedWebProtocolAdmission } from "./deploy-web-protocol.ts";
 import { resolveDeployWorkerCliPaths } from "./deploy-worker-version-paths.js";
 import { prepareSmallRunnerNamespaceBootstrap, stageHostedRunnerRelease } from "./stage-runner-release.ts";
 import { createRunnerReleaseProvider } from "./runner-release-provider.ts";
@@ -59,6 +60,15 @@ export async function runDeployWorkerVersionCli(
     dependencies: {
       async deployDirect(input) {
         const retainServingRunner = input.containerRolloutMode === "worker-only";
+        // Retaining an image does not attest an older protocol requirement.
+        // Worker-only deployments must preserve the same Web consumer floor.
+        const admitWeb = () => assertHostedWebProtocolAdmission(env);
+        const assertActivationAllowed = async (expectedLiveVersion: string): Promise<void> => {
+          await admitWeb();
+          // Recheck Worker identity after the bounded Web I/O, not before it.
+          await assertLiveVersion(input.workerName, input.configPath, expectedLiveVersion);
+        };
+        await admitWeb();
         const containerProvider = createCloudflareContainerProvider({
           accountId: requireConfiguredString(env.CLOUDFLARE_ACCOUNT_ID, "CLOUDFLARE_ACCOUNT_ID"),
           apiToken: requireConfiguredString(env.CLOUDFLARE_API_TOKEN, "CLOUDFLARE_API_TOKEN"),
@@ -80,7 +90,7 @@ export async function runDeployWorkerVersionCli(
           const before = await readCloudflareContainerApplicationIdentities(
             retainedContainers, containerProvider.listApplications, "before", containerProvider.readRollout,
           );
-          await assertLiveVersion(input.workerName, input.configPath, currentVersionId);
+          await assertActivationAllowed(currentVersionId);
           const output = await runWranglerLoggedCaptured([
             "deploy", "--config", bootstrapPath, "--name", input.workerName, "--containers-rollout=none",
             ...(input.includeSecrets ? ["--secrets-file", input.secretsFilePath] : []),
@@ -119,7 +129,7 @@ export async function runDeployWorkerVersionCli(
           return parseWranglerWorkerVersionId(`${output.stdout}\n${output.stderr}`);
         };
         const activateVersion = async (configPath: string, versionId: string, expectedLiveVersion: string): Promise<void> => {
-          await assertLiveVersion(input.workerName, input.configPath, expectedLiveVersion);
+          await assertActivationAllowed(expectedLiveVersion);
           await runWranglerLogged([
             "versions", "deploy", `${versionId}@100%`, "--yes", "--config", configPath,
             "--name", input.workerName, "--message", input.deploymentMessage,
@@ -132,7 +142,7 @@ export async function runDeployWorkerVersionCli(
         // serving ceiling. Never refill the retired application on a retry.
         for (const retirement of staged.retirements) {
           await releaseProvider.assertDrained(retirement.applicationId);
-          await assertLiveVersion(input.workerName, input.configPath, currentVersionId);
+          await assertActivationAllowed(currentVersionId);
           await releaseProvider.retireApplication(retirement);
         }
         const before = await readCloudflareContainerApplicationIdentities(
@@ -144,7 +154,7 @@ export async function runDeployWorkerVersionCli(
         });
         // Prove the isolated artifact before making the compatibility reader live.
         for (const application of staged.applications.filter(application => application.className === "DeploySmokeRunnerContainer")) {
-          await assertLiveVersion(input.workerName, input.configPath, currentVersionId);
+          await assertActivationAllowed(currentVersionId);
           await releaseProvider.admitApplication(application);
           await releaseProvider.assertApplicationReady({ ...application, listApplications: containerProvider.listApplications });
         }
@@ -162,7 +172,7 @@ export async function runDeployWorkerVersionCli(
               HOSTED_EXECUTION_SMOKE_RUNNER_MANIFEST_PATH: path.join(runnerBundleDir, ".murph-runner-bundle-manifest.json"),
             },
           });
-          await assertLiveVersion(input.workerName, input.configPath, stageVersionId);
+          await assertActivationAllowed(stageVersionId);
           const rolloutSteps = input.containerRolloutMode === "gradual"
             ? [10, 25, 50, 100].slice(-Math.min(serving.specification.max_instances, 4)) : [100];
           await releaseProvider.admitApplication({ ...serving,
@@ -174,10 +184,10 @@ export async function runDeployWorkerVersionCli(
         // Small runners carry member work: their old image needs the same
         // compatibility reader before native mutation as the normal fleet.
         for (const application of staged.applications.filter(application => application.className === "SmallRunnerContainer")) {
-          await assertLiveVersion(input.workerName, input.configPath, stageVersionId);
           if (application.applicationId) await releaseProvider.assertCapacity({
             applicationId: application.applicationId, specification: application.specification,
           });
+          await assertActivationAllowed(stageVersionId);
           await releaseProvider.admitApplication({ ...application, rolloutStepPercentage: 100 });
           await releaseProvider.assertApplicationReady({ ...application, listApplications: containerProvider.listApplications });
         }

--- a/apps/cloudflare/src/runtime-platform/effects-port.ts
+++ b/apps/cloudflare/src/runtime-platform/effects-port.ts
@@ -8,6 +8,7 @@ import type {
 import {
   parseHostedOperatorTaskControlResponse,
 } from "@murphai/hosted-execution";
+import { parseHostedExternalThreadRouteAuthorityResponse } from "@murphai/hosted-execution/parsers";
 import {
   parseHostedExecutionResolvedLinqDeliveryRoute,
   HOSTED_RUNTIME_LINQ_DELIVERY_BLOCK_CODES,
@@ -284,35 +285,7 @@ export function createCloudflareEffectsPort(input: {
               timeoutMs: input.timeoutMs,
               transport: webControlTransport,
             });
-            const assistantAskFallbackRequired =
-              (payload as { assistantAskFallbackRequired?: unknown } | null)
-                ?.assistantAskFallbackRequired;
-            const threadIsDirect =
-              (payload as { threadIsDirect?: unknown } | null)?.threadIsDirect;
-            if (
-              !payload
-              || typeof payload !== "object"
-              || Array.isArray(payload)
-              || (payload as { authorized?: unknown }).authorized !== true
-              || (
-                assistantAskFallbackRequired !== undefined
-                && typeof assistantAskFallbackRequired !== "boolean"
-              )
-              || (threadIsDirect !== undefined && typeof threadIsDirect !== "boolean")
-            ) {
-              throw new TypeError(
-                "Hosted external thread route authority response is invalid.",
-              );
-            }
-            if (threadIsDirect === undefined && assistantAskFallbackRequired === undefined) {
-              return;
-            }
-            return {
-              ...(typeof assistantAskFallbackRequired === "boolean"
-                ? { assistantAskFallbackRequired }
-                : {}),
-              ...(typeof threadIsDirect === "boolean" ? { threadIsDirect } : {}),
-            };
+            return parseHostedExternalThreadRouteAuthorityResponse(payload);
           },
           async controlOperatorTask(request, context) {
             return parseHostedOperatorTaskControlResponse(

--- a/apps/cloudflare/test/deploy-web-protocol.test.ts
+++ b/apps/cloudflare/test/deploy-web-protocol.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { encodeHostedExecutionSignedRequestPayload, readHostedExecutionSignatureHeaders } from "@murphai/hosted-execution/auth";
+import { HOSTED_EXECUTION_USER_ID_HEADER } from "@murphai/hosted-execution/contracts";
+import { assertHostedRuntimeWebProtocolAdmission, parseHostedRuntimeLogRequest } from "@murphai/hosted-execution/parsers";
+import { HOSTED_RUNTIME_LOG_EVENT_CODES, HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_MAX_BYTES } from "@murphai/hosted-execution/runtime-control";
+import { buildRuntimeProcessingSummaryEntry } from "../src/user-runner/diagnostics";
+import { syntheticHostedWebProtocolAdmission } from "./helpers/hosted-web-protocol";
+import { assertHostedWebProtocolAdmission, HOSTED_WEB_PROTOCOL_PROBE_TIMEOUT_MS } from "../scripts/deploy-web-protocol";
+
+let source: Record<string, string>;
+let publicKey: CryptoKey;
+beforeEach(async () => {
+  const keys = await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, ["sign", "verify"]);
+  publicKey = keys.publicKey;
+  source = { HOSTED_WEB_BASE_URL: "https://web.example.test", HOSTED_WEB_CALLBACK_SIGNING_PRIVATE_JWK: JSON.stringify(await crypto.subtle.exportKey("jwk", keys.privateKey)) };
+});
+afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); });
+const headers = { "cache-control": "no-store", "content-type": "application/json" };
+const noSleep = async () => {};
+const nonceFrom = (input: RequestInfo | URL) => new URL(input instanceof Request ? input.url : String(input)).searchParams.get("nonce")!;
+const reply = (input: RequestInfo | URL) => Response.json(syntheticHostedWebProtocolAdmission(nonceFrom(input)), { headers });
+
+it("signs fresh spaced samples using the public wire contract, without caching admission", async () => {
+  const nonces = new Set<string>();
+  const sleep = vi.fn(noSleep);
+  const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+    expect(init).toMatchObject({ method: "GET", redirect: "manual", cache: "no-store", credentials: "omit" });
+    const nonce = nonceFrom(input);
+    expect(nonces.has(nonce)).toBe(false);
+    nonces.add(nonce);
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+    const signed = readHostedExecutionSignatureHeaders(request.headers);
+    expect(signed).toMatchObject({ keyId: "v1", nonce });
+    expect(request.headers.get(HOSTED_EXECUTION_USER_ID_HEADER)).toBeNull();
+    if (!signed.signature || !signed.timestamp) throw new Error("Missing synthetic request signature.");
+    expect(await crypto.subtle.verify(
+      { name: "ECDSA", hash: "SHA-256" }, publicKey,
+      Uint8Array.from(Buffer.from(signed.signature, "base64url")).buffer,
+      encodeHostedExecutionSignedRequestPayload({
+        method: request.method, path: url.pathname, search: url.search,
+        nonce: signed.nonce, timestamp: signed.timestamp, payload: "", userId: null,
+      }),
+    )).toBe(true);
+    return reply(input);
+  });
+  for (let attempt = 0; attempt < 2; attempt += 1) await assertHostedWebProtocolAdmission(source, { fetchImpl, sleep });
+  expect(fetchImpl).toHaveBeenCalledTimes(6);
+  expect(sleep.mock.calls).toEqual([[1000], [1000], [1000], [1000]]);
+});
+
+it("parses the actual processing-summary producer payload and rejects it with an older strict reader", () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2000-01-01T00:00:00.000Z"));
+  const entry = buildRuntimeProcessingSummaryEntry({ stage: "admission", details: {} }, undefined, Date.now());
+  // The same synthetic wire shape is sent through Web's real log route in its
+  // owner test. No application imports another application's private sources.
+  expect(entry).toEqual({
+    at: "2000-01-01T00:00:00.000Z", component: "runner", eventCode: "runner.processing_finished",
+    level: "warn", phase: "invoke",
+    redactedJson: { runtimeProcessingStage: "admission", runtimeProcessingOutcome: "threw", runtimeProcessingElapsedMs: 0 },
+  });
+  expect(parseHostedRuntimeLogRequest({ entries: [entry] }).entries).toEqual([entry]);
+  const includes = HOSTED_RUNTIME_LOG_EVENT_CODES.includes.bind(HOSTED_RUNTIME_LOG_EVENT_CODES);
+  vi.spyOn(HOSTED_RUNTIME_LOG_EVENT_CODES, "includes").mockImplementation(code => code !== entry.eventCode && includes(code));
+  expect(() => parseHostedRuntimeLogRequest({ entries: [entry] })).toThrow();
+});
+
+it("accepts reader supersets, but not missing audience or emitted log codes", () => {
+  const evidence = syntheticHostedWebProtocolAdmission("synthetic-nonce");
+  expect(() => assertHostedRuntimeWebProtocolAdmission({ ...evidence, runtimeLogEventCodes: [...evidence.runtimeLogEventCodes, "future.synthetic"] }, evidence.nonce)).not.toThrow();
+  const legacy = { ...evidence, threadRouteAuthority: { direct: { authorized: true }, group: { authorized: true } } };
+  expect(() => assertHostedRuntimeWebProtocolAdmission(legacy, evidence.nonce)).toThrow("thread_route_audience");
+  const olderReader = { ...evidence, runtimeLogEventCodes: evidence.runtimeLogEventCodes.filter(code => code !== "runner.processing_finished") };
+  expect(() => assertHostedRuntimeWebProtocolAdmission(olderReader, evidence.nonce)).toThrow("runtime_log_event:runner.processing_finished");
+});
+
+it.each([
+  { schemaVersion: 2 }, { nonce: "stale" }, { kind: "unrelated" }, { runtimeLogEventCodes: [42] },
+  { threadRouteAuthority: { direct: { authorized: false }, group: { authorized: true } } },
+  { threadRouteAuthority: { direct: { authorized: true, threadIsDirect: false }, group: { authorized: true, threadIsDirect: true } } },
+  { threadRouteAuthority: { direct: { authorized: true, threadIsDirect: "true" }, group: { authorized: true } } },
+])("fails malformed, denied or unknown evidence closed: %j", change => {
+  const evidence = { ...syntheticHostedWebProtocolAdmission("synthetic-nonce"), ...change };
+  expect(() => assertHostedRuntimeWebProtocolAdmission(evidence, "synthetic-nonce")).toThrow();
+});
+
+it("stops on an incompatible sample during propagation instead of retrying until lucky", async () => {
+  let calls = 0;
+  await expect(assertHostedWebProtocolAdmission(source, { sleep: noSleep, fetchImpl: async input => {
+    calls += 1;
+    return calls === 2 ? new Response(null, { status: 404 }) : reply(input);
+  } })).rejects.toThrow("http_404");
+  expect(calls).toBe(2);
+});
+
+it.each([301, 302, 307, 308, 401, 403, 404, 500, 503])("rejects status %s without reading or forwarding credentials", async status => {
+  const fetchImpl = vi.fn<typeof fetch>(async () => new Response("synthetic remote detail", { status, headers: { location: "https://other.example.test" } }));
+  await expect(assertHostedWebProtocolAdmission(source, { sleep: noSleep, fetchImpl })).rejects.toThrow(`http_${status}`);
+  expect(fetchImpl).toHaveBeenCalledOnce();
+});
+
+const invalidResponseHeaders: ReadonlyArray<Record<string, string>> = [
+  { "cache-control": "public, max-age=60" }, { age: "1" }, { "content-type": "text/html" },
+  { "content-length": String(HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_MAX_BYTES + 1) },
+];
+it.each(invalidResponseHeaders)("rejects cached, wrong MIME or oversize metadata %j", overrides => {
+  return expect(assertHostedWebProtocolAdmission(source, { sleep: noSleep,
+    fetchImpl: async input => Response.json(syntheticHostedWebProtocolAdmission(nonceFrom(input)), { headers: { ...headers, ...overrides } }),
+  })).rejects.toThrow("Hosted Web protocol admission failed");
+});
+
+it("bounds streamed bytes and redacts transport and body read failures", async () => {
+  const factories: Array<() => Promise<Response>> = [
+    async () => new Response("x".repeat(HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_MAX_BYTES + 1), { headers }),
+    async () => new Response("not JSON: synthetic remote detail", { headers }),
+    async () => { throw new Error("synthetic remote detail"); },
+    async () => new Response(new ReadableStream({ start(controller) { controller.error(new Error("synthetic remote detail")); } }), { headers }),
+  ];
+  for (const fetchImpl of factories) {
+    const failure = await assertHostedWebProtocolAdmission(source, { sleep: noSleep, fetchImpl }).catch(error => error);
+    expect(failure).toBeInstanceOf(Error);
+    expect(failure.message).toContain("Hosted Web protocol admission failed");
+    expect(failure.message).not.toContain("synthetic remote detail");
+  }
+});
+
+it.each(["fetch", "body"])("bounds a stalled %s, including fetch implementations that ignore cancellation", async phase => {
+  vi.useFakeTimers();
+  const cancel = vi.fn();
+  const fetchImpl = vi.fn<typeof fetch>(async () => phase === "fetch" ? new Promise<Response>(() => {})
+    : new Response(new ReadableStream({ cancel }), { headers }));
+  const failure = assertHostedWebProtocolAdmission(source, { fetchImpl, sleep: noSleep }).catch(error => error);
+  await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledOnce());
+  await vi.advanceTimersByTimeAsync(HOSTED_WEB_PROTOCOL_PROBE_TIMEOUT_MS);
+  expect((await failure).message).toContain("timeout");
+  if (phase === "body") expect(cancel).toHaveBeenCalledOnce();
+});

--- a/apps/cloudflare/test/deploy-worker-version-cli.test.ts
+++ b/apps/cloudflare/test/deploy-worker-version-cli.test.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { syntheticHostedWebProtocolAdmission } from "./helpers/hosted-web-protocol";
+
+const webProtocolMocks = vi.hoisted(() => ({ admit: vi.fn() }));
+vi.mock("../scripts/deploy-web-protocol.ts", () => ({ assertHostedWebProtocolAdmission: webProtocolMocks.admit }));
 
 const fileMocks = vi.hoisted(() => ({ readFile: vi.fn(async () => "{}"), writeFile: vi.fn(async () => {}) }));
 vi.mock("node:fs/promises", async () => ({
@@ -56,6 +60,74 @@ vi.mock("../scripts/container-release-receipt.js", () => ({
 import { runDeployWorkerVersionCli } from "../scripts/deploy-worker-version.cli.js";
 
 describe("runDeployWorkerVersionCli", () => {
+  it.each(["old-reader", "old-audience", "unavailable", "denied", "malformed", "unknown-version"])("rejects %s before bootstrap, image work, or native mutation", async shape => {
+    releaseMocks.prepareSmallRunnerNamespaceBootstrap.mockResolvedValue("synthetic-bootstrap.jsonc");
+    await useRealWebAdmission(shape);
+    await expect(syntheticDeployment()).rejects.toThrow("Hosted Web protocol admission failed");
+    expect(imageMocks.prepareHostedContainerDeployImage).not.toHaveBeenCalled();
+    expect(wranglerMocks.runWranglerLoggedCaptured).not.toHaveBeenCalled();
+    expect(wranglerMocks.runWranglerLogged).not.toHaveBeenCalled();
+    expect(releaseMocks.admitApplication).not.toHaveBeenCalled();
+    expect(releaseMocks.retireApplication).not.toHaveBeenCalled();
+  });
+
+  it.each(["immediate", "worker-only"] as const)("admits current Web for %s without revision equality", async mode => {
+    await useRealWebAdmission("current");
+    if (mode === "worker-only") releaseMocks.stageHostedRunnerRelease.mockImplementation(async ({ configPath }) => ({
+      configPath, promotionConfigPath: configPath, activeApplicationName: "serving", workerOnly: true, applications: [], retirements: [],
+    }));
+    await syntheticDeployment(mode);
+    expect(wranglerMocks.runWranglerLogged).toHaveBeenCalled();
+    expect(webProtocolMocks.admit).toHaveBeenCalledWith(expect.anything());
+  });
+
+  it("does not mistake retaining the runner for proof that legacy audience is sufficient", async () => {
+    await useRealWebAdmission("old-audience");
+    releaseMocks.stageHostedRunnerRelease.mockImplementation(async ({ configPath }) => ({
+      configPath, promotionConfigPath: configPath, activeApplicationName: "serving", workerOnly: true, applications: [], retirements: [],
+    }));
+    await expect(syntheticDeployment("worker-only")).rejects.toThrow("thread_route_audience");
+    expect(wranglerMocks.runWranglerLogged).not.toHaveBeenCalled();
+    expect(releaseMocks.admitApplication).not.toHaveBeenCalled();
+  });
+
+  it.each(["bootstrap", "retirement", "smoke-application", "compatibility", "serving", "small", "promotion"])("rechecks Web immediately before %s", async boundary => {
+    const trace: string[] = [];
+    const serving = { name: renderedContainers[0]!.applicationName, className: "RunnerContainer", applicationId: "synthetic-serving", namespaceId: "synthetic-namespace", specification: {} };
+    releaseMocks.stageHostedRunnerRelease.mockImplementation(async ({ configPath }) => ({
+      configPath, promotionConfigPath: `${configPath}.promote`, activeApplicationName: serving.name, workerOnly: false,
+      applications: boundary === "serving" ? [serving] : boundary === "small" ? [{ ...serving, name: "synthetic-small", className: "SmallRunnerContainer" }]
+        : boundary === "smoke-application" ? [{ ...serving, name: "synthetic-smoke", className: "DeploySmokeRunnerContainer" }] : [],
+      retirements: boundary === "retirement" ? [{ name: "synthetic-retired", applicationId: "synthetic-retired", namespaceId: "synthetic-retired" }] : [],
+    }));
+    if (boundary === "bootstrap") releaseMocks.prepareSmallRunnerNamespaceBootstrap.mockResolvedValue("synthetic-bootstrap.jsonc");
+    const failAt = ["serving", "small", "promotion"].includes(boundary) ? 3 : 2;
+    await useRealWebAdmission(check => check === failAt ? "old-reader" : "current", () => trace.push("web"));
+    wranglerMocks.runWranglerJson.mockImplementation(async () => {
+      trace.push("identity");
+      return JSON.stringify({ versions: [{ percentage: 100, version_id: "version-direct" }] });
+    });
+    wranglerMocks.runWranglerLogged.mockImplementation(async args => { if (args[0] === "versions") trace.push("activation"); });
+    await expect(syntheticDeployment()).rejects.toThrow("runtime_log_event:runner.processing_finished");
+    expect(trace.at(-1)).toBe("web");
+    for (let i = 0; i < trace.length; i += 1) {
+      if (trace[i] === "activation") expect(trace.slice(i - 2, i)).toEqual(["web", "identity"]);
+    }
+    expect(trace.filter(event => event === "activation")).toHaveLength(failAt === 3 ? 1 : 0);
+    expect(releaseMocks.admitApplication).not.toHaveBeenCalled();
+    expect(releaseMocks.retireApplication).not.toHaveBeenCalled();
+    if (boundary === "bootstrap") expect(wranglerMocks.runWranglerLoggedCaptured).not.toHaveBeenCalled();
+  });
+
+  it("does not reuse admission after a previously successful deployment", async () => {
+    await useRealWebAdmission("current");
+    await syntheticDeployment();
+    const activations = wranglerMocks.runWranglerLogged.mock.calls.length;
+    await useRealWebAdmission("old-reader");
+    await expect(syntheticDeployment()).rejects.toThrow("runtime_log_event:runner.processing_finished");
+    expect(wranglerMocks.runWranglerLogged.mock.calls).toHaveLength(activations);
+  });
+
   it("publishes the retained namespace bootstrap before staging and stops if its receipts change", async () => {
     const trace: string[] = [];
     releaseMocks.prepareSmallRunnerNamespaceBootstrap.mockResolvedValue("/tmp/bootstrap.jsonc");
@@ -154,6 +226,7 @@ describe("runDeployWorkerVersionCli", () => {
   });
 
   beforeEach(() => {
+    webProtocolMocks.admit.mockReset().mockResolvedValue(undefined);
     releaseMocks.prepareSmallRunnerNamespaceBootstrap.mockReset();
     releaseMocks.prepareSmallRunnerNamespaceBootstrap.mockResolvedValue(null);
     releaseMocks.stageHostedRunnerRelease.mockReset();
@@ -718,5 +791,28 @@ async function syntheticDeployment(containerRolloutMode: "gradual" | "immediate"
       await dependencies.deployDirect({ configPath: "/tmp/config.jsonc", containerRolloutMode, deploymentMessage: "synthetic", includeSecrets: false, secretsFilePath: "/tmp/secrets.json", versionTag: "synthetic", workerName: "hosted-worker" });
       return createDeploymentResult();
     },
+  });
+}
+
+async function useRealWebAdmission(shape: string | ((check: number) => string), onCheck?: () => void) {
+  const { assertHostedWebProtocolAdmission } = await vi.importActual<typeof import("../scripts/deploy-web-protocol.ts")>("../scripts/deploy-web-protocol.ts");
+  const keys = await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, ["sign", "verify"]);
+  const signingKey = JSON.stringify(await crypto.subtle.exportKey("jwk", keys.privateKey));
+  let checks = 0;
+  webProtocolMocks.admit.mockImplementation(env => {
+    const responseShape = typeof shape === "function" ? shape(++checks) : shape;
+    onCheck?.();
+    return assertHostedWebProtocolAdmission({
+      ...env, HOSTED_WEB_BASE_URL: "https://web.example.test", HOSTED_WEB_CALLBACK_SIGNING_PRIVATE_JWK: signingKey,
+    }, { sleep: async () => {}, fetchImpl: async input => {
+      if (responseShape === "unavailable") return new Response(null, { status: 503 });
+      if (responseShape === "malformed") return new Response("not JSON", { headers: { "cache-control": "no-store", "content-type": "application/json" } });
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      const evidence = syntheticHostedWebProtocolAdmission(url.searchParams.get("nonce")!);
+      if (responseShape === "old-reader") evidence.runtimeLogEventCodes = evidence.runtimeLogEventCodes.filter(code => code !== "runner.processing_finished");
+      if (responseShape === "old-audience") evidence.threadRouteAuthority = { direct: { authorized: true }, group: { authorized: true } };
+      if (responseShape === "denied") evidence.threadRouteAuthority = { direct: { authorized: false }, group: { authorized: true, threadIsDirect: false } };
+      return Response.json(responseShape === "unknown-version" ? { ...evidence, schemaVersion: 2 } : evidence, { headers: { "cache-control": "no-store" } });
+    } });
   });
 }

--- a/apps/cloudflare/test/helpers/hosted-web-protocol.ts
+++ b/apps/cloudflare/test/helpers/hosted-web-protocol.ts
@@ -1,0 +1,22 @@
+import {
+  HOSTED_RUNTIME_LOG_EVENT_CODES,
+  HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_KIND,
+  HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_VERSION,
+  type HostedRuntimeWebProtocolAdmission,
+} from "@murphai/hosted-execution/runtime-control";
+
+// Synthetic wire evidence for the deployment consumer, not the Web implementation.
+// Web's own tests prove that its authenticated handler derives this evidence from
+// the real log parser and authority response owner.
+export function syntheticHostedWebProtocolAdmission(nonce: string): HostedRuntimeWebProtocolAdmission {
+  return {
+    kind: HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_KIND,
+    schemaVersion: HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_VERSION,
+    nonce,
+    runtimeLogEventCodes: [...HOSTED_RUNTIME_LOG_EVENT_CODES],
+    threadRouteAuthority: {
+      direct: { authorized: true, threadIsDirect: true },
+      group: { authorized: true, threadIsDirect: false },
+    },
+  };
+}

--- a/apps/web/app/api/internal/hosted-runtime/protocol-admission/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/protocol-admission/route.ts
@@ -1,0 +1,28 @@
+import { HOSTED_EXECUTION_NONCE_HEADER } from "@murphai/hosted-execution/contracts";
+import { HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_VERSION } from "@murphai/hosted-execution/runtime-control";
+
+import { requireHostedCloudflareSystemCallbackRequest } from "@/src/lib/hosted-execution/cloudflare-callback-auth";
+import { buildHostedRuntimeWebProtocolAdmission } from "@/src/lib/hosted-execution/runtime-protocol";
+import { hostedOnboardingError } from "@/src/lib/hosted-onboarding/errors";
+import { jsonOk, withJsonError } from "@/src/lib/hosted-onboarding/http";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withJsonError(async (request: Request) => {
+  await requireHostedCloudflareSystemCallbackRequest(request, {
+    maxBodyBytes: 0,
+    nonceOwner: "system:hosted-runtime-protocol-admission",
+  });
+  const query = new URL(request.url).searchParams;
+  const nonce = request.headers.get(HOSTED_EXECUTION_NONCE_HEADER);
+  if (!nonce || query.size !== 2 || query.get("nonce") !== nonce
+    || query.get("schemaVersion") !== String(HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_VERSION)) {
+    throw hostedOnboardingError({
+      code: "HOSTED_RUNTIME_PROTOCOL_PROBE_INVALID",
+      httpStatus: 400,
+      message: "Hosted runtime protocol probe is invalid.",
+      retryable: false,
+    });
+  }
+  return jsonOk(buildHostedRuntimeWebProtocolAdmission(nonce));
+});

--- a/apps/web/app/api/internal/hosted-runtime/thread-route/authority/route.ts
+++ b/apps/web/app/api/internal/hosted-runtime/thread-route/authority/route.ts
@@ -6,6 +6,7 @@ import {
 import {
   requireHostedCloudflareCallbackRequest,
 } from "@/src/lib/hosted-execution/cloudflare-callback-auth";
+import { buildHostedThreadRouteAuthorityResponse } from "@/src/lib/hosted-execution/runtime-protocol";
 import {
   hostedOnboardingError,
 } from "@/src/lib/hosted-onboarding/errors";
@@ -99,13 +100,10 @@ export const POST = withJsonError(async (request: Request) => {
       : undefined;
     return { threadIsDirect, assertion };
   });
-  return jsonOk({
-    authorized: true,
-    threadIsDirect: result.threadIsDirect,
-    ...(result.assertion?.assistantAskFallbackRequired
-      ? { assistantAskFallbackRequired: true }
-      : {}),
-  });
+  return jsonOk(buildHostedThreadRouteAuthorityResponse(
+    result.threadIsDirect,
+    result.assertion?.assistantAskFallbackRequired,
+  ));
 });
 
 interface AssistantAskCompletionAuthority {

--- a/apps/web/src/lib/hosted-execution/cloudflare-callback-auth.ts
+++ b/apps/web/src/lib/hosted-execution/cloudflare-callback-auth.ts
@@ -68,14 +68,14 @@ export async function requireHostedCloudflareCallbackRequest(
 
 export async function requireHostedCloudflareSystemCallbackRequest(
   request: Request,
-  options: HostedCloudflareCallbackRequestOptions,
+  options: HostedCloudflareCallbackRequestOptions & { nonceOwner?: string },
 ): Promise<string> {
   if (request.headers.has(HOSTED_EXECUTION_USER_ID_HEADER)) {
     throw unauthorizedCloudflareCallbackError();
   }
 
   return requireHostedCloudflareSignedRequest(request, options, {
-    nonceOwner: HOSTED_TEMPORAL_WORKER_BINDING_ADMISSION_NONCE_OWNER,
+    nonceOwner: options.nonceOwner ?? HOSTED_TEMPORAL_WORKER_BINDING_ADMISSION_NONCE_OWNER,
     signatureUserId: null,
   });
 }

--- a/apps/web/src/lib/hosted-execution/runtime-protocol.ts
+++ b/apps/web/src/lib/hosted-execution/runtime-protocol.ts
@@ -1,0 +1,35 @@
+import { parseHostedRuntimeLogRequest } from "@murphai/hosted-execution/parsers";
+import {
+  buildHostedRuntimeLogProtocolProbe,
+  HOSTED_RUNTIME_LOG_EVENT_CODES,
+  HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_KIND,
+  HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_VERSION,
+  type HostedRuntimeWebProtocolAdmission,
+} from "@murphai/hosted-execution/runtime-control";
+
+export function buildHostedThreadRouteAuthorityResponse(
+  threadIsDirect: boolean,
+  assistantAskFallbackRequired?: boolean,
+) {
+  return {
+    authorized: true,
+    threadIsDirect,
+    ...(assistantAskFallbackRequired ? { assistantAskFallbackRequired: true } : {}),
+  };
+}
+
+export function buildHostedRuntimeWebProtocolAdmission(nonce: string): HostedRuntimeWebProtocolAdmission {
+  return {
+    kind: HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_KIND,
+    schemaVersion: HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_VERSION,
+    nonce,
+    // This is the same parser imported by the real /hosted-runtime/log route.
+    // No log is persisted and no member, provider or runner is accessed.
+    runtimeLogEventCodes: HOSTED_RUNTIME_LOG_EVENT_CODES.map(eventCode =>
+      parseHostedRuntimeLogRequest(buildHostedRuntimeLogProtocolProbe(eventCode)).entries[0]!.eventCode),
+    threadRouteAuthority: {
+      direct: buildHostedThreadRouteAuthorityResponse(true),
+      group: buildHostedThreadRouteAuthorityResponse(false),
+    },
+  };
+}

--- a/apps/web/test/hosted-runtime-protocol-admission.test.ts
+++ b/apps/web/test/hosted-runtime-protocol-admission.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assertHostedRuntimeWebProtocolAdmission,
+  parseHostedExternalThreadRouteAuthorityResponse,
+} from "@murphai/hosted-execution/parsers";
+import {
+  buildHostedRuntimeLogProtocolProbe,
+  HOSTED_RUNTIME_LOG_EVENT_CODES,
+  HOSTED_RUNTIME_LOG_REQUEST_MAX_ENTRIES,
+  HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_PATH,
+  type HostedRuntimeLogRequest,
+} from "@murphai/hosted-execution/runtime-control";
+import {
+  HOSTED_EXECUTION_NONCE_HEADER,
+  HOSTED_EXECUTION_SIGNATURE_HEADER,
+  HOSTED_EXECUTION_SIGNING_KEY_ID_HEADER,
+  HOSTED_EXECUTION_TIMESTAMP_HEADER,
+  HOSTED_EXECUTION_USER_ID_HEADER,
+} from "@murphai/hosted-execution/contracts";
+import { encodeHostedExecutionSignedRequestPayload } from "@murphai/hosted-execution/auth";
+
+const edges = vi.hoisted(() => ({ consume: vi.fn(), write: vi.fn() }));
+vi.mock("@/src/lib/prisma", () => ({ getPrisma: () => ({}) }));
+vi.mock("@/src/lib/hosted-execution/internal-request-nonces", () => ({
+  PrismaHostedCallbackRequestNonceStore: class {
+    consumeHostedCallbackRequestNonce = edges.consume;
+  },
+}));
+vi.mock("@/src/lib/hosted-runtime-log/write", () => ({ writeHostedRuntimeLogs: edges.write }));
+vi.mock("@/src/lib/hosted-workspace/store", () => ({ claimHostedAcceptedAttemptFailureRecheck: async () => false }));
+vi.mock("@/src/lib/hosted-orchestration/signal-runtime", () => ({ signalHostedRuntimeRecheckRuntime: vi.fn() }));
+vi.mock("@/src/lib/hosted-runtime-log/personal-patterns-run-alert", () => ({
+  hasHostedPersonalPatternsRunAlert: () => false, reportHostedPersonalPatternsRunAlerts: vi.fn(),
+}));
+
+import { GET } from "../app/api/internal/hosted-runtime/protocol-admission/route";
+import { POST as log } from "../app/api/internal/hosted-runtime/log/route";
+
+// Synthetic boundary payload; the Cloudflare owner test checks the actual
+// processing-summary producer against this shape using the public log parser.
+const processingSummary = { entries: [{
+  at: "2000-01-01T00:00:00.000Z", component: "runner", eventCode: "runner.processing_finished",
+  level: "warn", phase: "invoke",
+  redactedJson: { runtimeProcessingStage: "admission", runtimeProcessingOutcome: "threw", runtimeProcessingElapsedMs: 0 },
+}] } satisfies HostedRuntimeLogRequest;
+
+let privateKey: CryptoKey;
+beforeEach(async () => {
+  const keys = await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, ["sign", "verify"]);
+  const publicJwk = await crypto.subtle.exportKey("jwk", keys.publicKey);
+  privateKey = keys.privateKey;
+  vi.stubEnv("HOSTED_WEB_CALLBACK_SIGNING_KEY_ID", "v1");
+  vi.stubEnv("HOSTED_WEB_CALLBACK_SIGNING_PUBLIC_JWK", JSON.stringify(publicJwk));
+  vi.stubEnv("HOSTED_WEB_CALLBACK_SIGNING_PUBLIC_KEYRING_JSON", JSON.stringify({ v1: publicJwk }));
+  const seen = new Set<string>();
+  edges.consume.mockReset().mockImplementation(async ({ nonceHash }: { nonceHash: string }) => {
+    if (seen.has(nonceHash)) return false;
+    seen.add(nonceHash);
+    return true;
+  });
+  edges.write.mockReset().mockImplementation(async ({ entries }: { entries: unknown[] }) => entries.length);
+});
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllEnvs(); });
+
+async function request(options: { version?: string; payload?: unknown; userId?: string } = {}) {
+  const nonce = crypto.randomUUID();
+  const method = options.payload === undefined ? "GET" : "POST";
+  const url = new URL(method === "GET" ? HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_PATH : "/api/internal/hosted-runtime/log", "https://web.example.test");
+  if (method === "GET") {
+    url.searchParams.set("schemaVersion", options.version ?? "1");
+    url.searchParams.set("nonce", nonce);
+  }
+  const payload = options.payload === undefined ? "" : JSON.stringify(options.payload);
+  // Same public payload encoder and WebCrypto signer pattern as Web's auth tests.
+  const timestamp = new Date().toISOString();
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" }, privateKey,
+    encodeHostedExecutionSignedRequestPayload({
+      method, path: url.pathname, search: url.search, nonce, payload, timestamp, userId: options.userId,
+    }),
+  );
+  const headers = new Headers({
+    "content-type": "application/json",
+    [HOSTED_EXECUTION_NONCE_HEADER]: nonce,
+    [HOSTED_EXECUTION_SIGNING_KEY_ID_HEADER]: "v1",
+    [HOSTED_EXECUTION_SIGNATURE_HEADER]: Buffer.from(signature).toString("base64url"),
+    [HOSTED_EXECUTION_TIMESTAMP_HEADER]: timestamp,
+  });
+  if (options.userId) headers.set(HOSTED_EXECUTION_USER_ID_HEADER, options.userId);
+  return new Request(url, { method, headers, ...(method === "POST" ? { body: payload } : {}) });
+}
+
+describe("served Web protocol admission", () => {
+  it("composes a signed wire request, real GET authentication, live parser evidence and public candidate validator", async () => {
+    const probe = await request();
+    const response = await GET(probe);
+    expect(response.status).toBe(200);
+    const evidence = await response.json();
+    expect(() => assertHostedRuntimeWebProtocolAdmission(evidence, probe.headers.get(HOSTED_EXECUTION_NONCE_HEADER)!)).not.toThrow();
+    expect(edges.consume).toHaveBeenCalledOnce();
+    expect(edges.consume).toHaveBeenCalledWith(expect.objectContaining({ userId: "system:hosted-runtime-protocol-admission" }));
+    expect(edges.write).not.toHaveBeenCalled();
+  });
+
+  it("binds evidence to a signed nonce, disallows member identity, and rejects replay and version changes", async () => {
+    const probe = await request();
+    const response = await GET(probe.clone());
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    const evidence = await response.json();
+    expect(() => assertHostedRuntimeWebProtocolAdmission(evidence, probe.headers.get(HOSTED_EXECUTION_NONCE_HEADER)!)).not.toThrow();
+    expect((await GET(probe.clone())).status).toBe(401);
+    expect((await GET(await request({ userId: "synthetic-member" }))).status).toBe(401);
+    expect((await GET(await request({ version: "2" }))).status).toBe(400);
+    const tampered = await request();
+    const url = new URL(tampered.url);
+    url.searchParams.set("nonce", crypto.randomUUID());
+    expect((await GET(new Request(url, tampered))).status).toBe(401);
+    const unsigned = await GET(new Request(probe.url));
+    expect(unsigned.status).toBe(401);
+    expect(unsigned.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("passes every advertised event through the actual Web log handler before persistence", async () => {
+    const evidence = await (await GET(await request())).json();
+    expect(evidence.runtimeLogEventCodes).toEqual(HOSTED_RUNTIME_LOG_EVENT_CODES);
+    for (let start = 0; start < HOSTED_RUNTIME_LOG_EVENT_CODES.length; start += HOSTED_RUNTIME_LOG_REQUEST_MAX_ENTRIES) {
+      const entries = HOSTED_RUNTIME_LOG_EVENT_CODES.slice(start, start + HOSTED_RUNTIME_LOG_REQUEST_MAX_ENTRIES)
+        .flatMap(code => buildHostedRuntimeLogProtocolProbe(code).entries);
+      const response = await log(await request({ payload: { entries }, userId: "synthetic-member" }));
+      expect(response.status).toBe(200);
+      expect(edges.write).toHaveBeenLastCalledWith({ entries, userId: "synthetic-member" });
+    }
+    expect((await log(await request({ payload: processingSummary, userId: "synthetic-member" }))).status).toBe(200);
+    expect(edges.write).toHaveBeenLastCalledWith({ entries: processingSummary.entries, userId: "synthetic-member" });
+  });
+
+  it("cannot advertise a newly produced event when the real strict reader still rejects it", async () => {
+    // Synthetic older enum membership, not a mocked parser or handler. Keep the
+    // advertised source enum unchanged to prove the witness cannot silently drift.
+    const includes = HOSTED_RUNTIME_LOG_EVENT_CODES.includes.bind(HOSTED_RUNTIME_LOG_EVENT_CODES);
+    vi.spyOn(HOSTED_RUNTIME_LOG_EVENT_CODES, "includes").mockImplementation(code => code !== "runner.processing_finished" && includes(code));
+    expect((await log(await request({ payload: processingSummary, userId: "synthetic-member" }))).status).toBe(400);
+    expect((await GET(await request())).status).not.toBe(200);
+    expect(edges.write).not.toHaveBeenCalled();
+    const oldEntry = buildHostedRuntimeLogProtocolProbe("runner.started");
+    expect((await log(await request({ payload: oldEntry, userId: "synthetic-member" }))).status).toBe(200);
+  });
+
+  it("retains legacy authority semantics without manufacturing audience", () => {
+    expect(parseHostedExternalThreadRouteAuthorityResponse({ authorized: true })).toBeUndefined();
+    for (const threadIsDirect of [true, false]) {
+      expect(parseHostedExternalThreadRouteAuthorityResponse({ authorized: true, threadIsDirect })).toEqual({ threadIsDirect });
+    }
+    for (const value of [{ authorized: false }, { authorized: true, threadIsDirect: null }, { authorized: true, assistantAskFallbackRequired: "yes" }]) {
+      expect(() => parseHostedExternalThreadRouteAuthorityResponse(value)).toThrow();
+    }
+  });
+});

--- a/apps/web/test/hosted-runtime-thread-route-authority-route.test.ts
+++ b/apps/web/test/hosted-runtime-thread-route-authority-route.test.ts
@@ -37,6 +37,9 @@ vi.mock("@/src/lib/hosted-orchestration/mailbox-wake", () => ({
   handoffHostedMailboxWake: mocks.handoffHostedMailboxWake,
 }));
 
+import { buildHostedRuntimeWebProtocolAdmission } from "../src/lib/hosted-execution/runtime-protocol";
+import { parseHostedExternalThreadRouteAuthorityResponse } from "@murphai/hosted-execution/parsers";
+
 import { POST } from "../app/api/internal/hosted-runtime/thread-route/authority/route";
 
 describe("hosted runtime thread route authority route", () => {
@@ -311,7 +314,10 @@ describe("hosted runtime thread route authority route", () => {
     ));
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ authorized: true, threadIsDirect });
+    const payload = await response.json();
+    const witness = buildHostedRuntimeWebProtocolAdmission("synthetic-nonce").threadRouteAuthority;
+    expect(payload).toEqual(threadIsDirect ? witness.direct : witness.group);
+    expect(parseHostedExternalThreadRouteAuthorityResponse(payload)).toEqual({ threadIsDirect });
     expect(
       mocks.assertHostedAssistantNotificationRouteAuthority,
     ).toHaveBeenCalledWith({

--- a/packages/hosted-execution/src/parsers.ts
+++ b/packages/hosted-execution/src/parsers.ts
@@ -231,6 +231,10 @@ export {
   parseHostedWorkspaceState,
 } from "./parsers/runtime-control.ts";
 export {
+  assertHostedRuntimeWebProtocolAdmission,
+  parseHostedExternalThreadRouteAuthorityResponse,
+} from "./parsers/runtime-protocol.ts";
+export {
   parseHostedRuntimeLogEntry,
   parseHostedRuntimeRedactedJson,
   parseHostedRuntimeLogRequest,

--- a/packages/hosted-execution/src/parsers/runtime-protocol.ts
+++ b/packages/hosted-execution/src/parsers/runtime-protocol.ts
@@ -1,0 +1,62 @@
+import {
+  HOSTED_RUNTIME_LOG_EVENT_CODES,
+  HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_KIND,
+  HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_VERSION,
+} from "../runtime-control.ts";
+import { requireObject } from "./assertions.ts";
+
+// Preserve the legacy response for callers which do not need an audience.
+// Scheduled delivery still independently requires the live owner's boolean.
+export function parseHostedExternalThreadRouteAuthorityResponse(
+  value: unknown,
+): { assistantAskFallbackRequired?: boolean; threadIsDirect?: boolean } | void {
+  const record = requireObject(value, "Hosted external thread route authority response");
+  const { authorized, assistantAskFallbackRequired, threadIsDirect } = record;
+  if (
+    authorized !== true
+    || (assistantAskFallbackRequired !== undefined && typeof assistantAskFallbackRequired !== "boolean")
+    || (threadIsDirect !== undefined && typeof threadIsDirect !== "boolean")
+  ) {
+    throw new TypeError("Hosted external thread route authority response is invalid.");
+  }
+  if (threadIsDirect === undefined && assistantAskFallbackRequired === undefined) return;
+  return {
+    ...(typeof assistantAskFallbackRequired === "boolean" ? { assistantAskFallbackRequired } : {}),
+    ...(typeof threadIsDirect === "boolean" ? { threadIsDirect } : {}),
+  };
+}
+
+export function assertHostedRuntimeWebProtocolAdmission(
+  value: unknown,
+  nonce: string,
+): void {
+  const record = requireObject(value, "Hosted Web protocol admission");
+  if (record.kind !== HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_KIND
+    || record.schemaVersion !== HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_VERSION
+    || record.nonce !== nonce) {
+    throw new Error("Hosted Web protocol admission failed: version_or_nonce.");
+  }
+  const codes = record.runtimeLogEventCodes;
+  if (!Array.isArray(codes) || codes.some(code => typeof code !== "string")) {
+    throw new Error("Hosted Web protocol admission failed: runtime_log_evidence.");
+  }
+  // A newer reader's superset is valid; source revision ordering is irrelevant.
+  for (const required of HOSTED_RUNTIME_LOG_EVENT_CODES) {
+    if (!codes.includes(required)) {
+      // Only locally owned enum values enter diagnostics, never response text.
+      throw new Error(`Hosted Web protocol admission failed: runtime_log_event:${required}.`);
+    }
+  }
+  let direct: ReturnType<typeof parseHostedExternalThreadRouteAuthorityResponse>;
+  let group: ReturnType<typeof parseHostedExternalThreadRouteAuthorityResponse>;
+  try {
+    const routes = requireObject(record.threadRouteAuthority, "Thread route evidence");
+    direct = parseHostedExternalThreadRouteAuthorityResponse(routes.direct);
+    group = parseHostedExternalThreadRouteAuthorityResponse(routes.group);
+  } catch {
+    throw new Error("Hosted Web protocol admission failed: thread_route_audience.");
+  }
+  if (direct?.threadIsDirect !== true || group?.threadIsDirect !== false) {
+    throw new Error("Hosted Web protocol admission failed: thread_route_audience.");
+  }
+}

--- a/packages/hosted-execution/src/runtime-control.ts
+++ b/packages/hosted-execution/src/runtime-control.ts
@@ -3620,6 +3620,37 @@ export interface HostedBrowserVaultReplicaPublishResponse {
   workspace: HostedWorkspaceState | null;
 }
 
+export const HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_PATH =
+  "/api/internal/hosted-runtime/protocol-admission";
+export const HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_KIND =
+  "hosted_runtime_web_protocol_admission";
+export const HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_VERSION = 1;
+export const HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_MAX_BYTES = 16 * 1024;
+
+export interface HostedRuntimeWebProtocolAdmission {
+  kind: typeof HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_KIND;
+  schemaVersion: typeof HOSTED_RUNTIME_WEB_PROTOCOL_ADMISSION_VERSION;
+  nonce: string;
+  runtimeLogEventCodes: readonly string[];
+  threadRouteAuthority: { direct: unknown; group: unknown };
+}
+
+// A synthetic wire message, not a log write. Exercise every producer enum value
+// through the deployed consumer's actual parser rather than a capability label.
+export function buildHostedRuntimeLogProtocolProbe(
+  eventCode: HostedRuntimeLogEventCode,
+): HostedRuntimeLogRequest {
+  return { entries: [{
+    at: "2000-01-01T00:00:00.000Z",
+    component: "runner",
+    errorCode: "SYNTHETIC_PROTOCOL_PROBE",
+    redactedJson: { safeErrorMessage: "Synthetic protocol admission probe." },
+    eventCode,
+    level: "info",
+    phase: "invoke",
+  }] };
+}
+
 export const HOSTED_RUNTIME_LOG_LEVELS = [
   "debug",
   "info",

--- a/scripts/hosted-orchestration-compatibility.mjs
+++ b/scripts/hosted-orchestration-compatibility.mjs
@@ -26,7 +26,6 @@ const PRODUCTION_CORE_LANES = [
 const GITHUB_API_VERSION = "2026-03-10";
 const HTTP_TIMEOUT_MS = 30_000;
 export const TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS = 58 * 60_000;
-export const TEMPORAL_COMPATIBILITY_RUN_TIMEOUT_MS = 40 * 60_000;
 const CANCEL_GRACE_MS = 2 * 60_000;
 export const TEMPORAL_COMPATIBILITY_SETTLEMENT_RESERVE_MS = 6 * 60_000;
 const POLL_MS = 15_000;
@@ -557,19 +556,21 @@ export function inspectJobPage(raw) {
   return raw.jobs;
 }
 
-export async function listAllRunJobs({ runId, token }) {
+export async function listAllRunJobs({ runId, token, ...timing }) {
   return inspectJobPage(await fetchJson(
     `https://api.github.com/repos/${TEMPORAL_COMPATIBILITY_PRIVATE_REPOSITORY}/actions/runs/${runId}/jobs?filter=latest&per_page=${PAGE_SIZE}&page=1`,
     { headers: githubHeaders(token) },
     "private compatibility job lookup",
+    timing,
   ));
 }
 
-async function resolvePrivateMain({ encodedPrivateRepository, token }) {
+async function resolvePrivateMain({ encodedPrivateRepository, token, ...timing }) {
   return inspectPrivateMainRef(await fetchJson(
     `https://api.github.com/repos/${encodedPrivateRepository}/git/ref/heads/${TEMPORAL_COMPATIBILITY_PRIVATE_BRANCH}`,
     { headers: githubHeaders(token) },
     "private main lookup",
+    timing,
   ));
 }
 
@@ -611,15 +612,22 @@ export async function runTemporalCompatibility({
     throw new Error("Pull request number must be a positive integer.");
   }
   const tokenDeadline = now() + TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS;
+  // Queue, setup and execution share the remaining credential budget. Reserve
+  // six minutes for either final proof reads (at most four 30-second calls) or
+  // cancellation (two 30-second calls plus two two-minute terminal waits).
+  const deadline = tokenDeadline - TEMPORAL_COMPATIBILITY_SETTLEMENT_RESERVE_MS;
+  const timing = { deadline: tokenDeadline, now };
   const encodedPrivateRepository = encodeRepository(TEMPORAL_COMPATIBILITY_PRIVATE_REPOSITORY);
   const privateSha = await resolvePrivateMain({
     encodedPrivateRepository,
     token: privateToken,
+    ...timing,
   });
   const workflowId = inspectPrivateWorkflow(await fetchJson(
     `https://api.github.com/repos/${encodedPrivateRepository}/actions/workflows/${encodeURIComponent(TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW)}`,
     { headers: githubHeaders(privateToken) },
     "private compatibility workflow lookup",
+    timing,
   ));
   const encodedPublicRepository = encodeRepository(publicRepository);
   const revalidatePublicTarget = async () => {
@@ -628,12 +636,14 @@ export async function runTemporalCompatibility({
         `https://api.github.com/repos/${encodedPublicRepository}/git/ref/heads/${expectedBaseRef.split("/").map(encodeURIComponent).join("/")}`,
         { headers: githubHeaders(publicToken) },
         "public deployment branch revalidation",
+        timing,
       ), expectedBaseRef);
       if (currentSha !== publicSha) {
         inspectPublicCandidateAncestry(await fetchJson(
           `https://api.github.com/repos/${encodedPublicRepository}/compare/${publicSha}...${currentSha}`,
           { headers: githubHeaders(publicToken) },
           "public deployment candidate ancestry",
+          timing,
         ), publicSha);
       }
       return;
@@ -642,6 +652,7 @@ export async function runTemporalCompatibility({
       `https://api.github.com/repos/${encodedPublicRepository}/pulls/${prNumber}`,
       { headers: githubHeaders(publicToken) },
       "public pull request revalidation",
+      timing,
     ), {
       expectedBaseRef,
       expectedSha: publicSha,
@@ -651,7 +662,7 @@ export async function runTemporalCompatibility({
   };
   await revalidatePublicTarget();
 
-  if (now() >= tokenDeadline - TEMPORAL_COMPATIBILITY_SETTLEMENT_RESERVE_MS - HTTP_TIMEOUT_MS) {
+  if (now() >= deadline - HTTP_TIMEOUT_MS) {
     throw new Error("Private GitHub token budget was exhausted before dispatch.");
   }
 
@@ -675,15 +686,12 @@ export async function runTemporalCompatibility({
       method: "POST",
     },
     "private compatibility workflow dispatch",
+    timing,
   ));
 
   let terminal = false;
   let runVisible = false;
   try {
-    const deadline = Math.min(
-      now() + TEMPORAL_COMPATIBILITY_RUN_TIMEOUT_MS,
-      tokenDeadline - TEMPORAL_COMPATIBILITY_SETTLEMENT_RESERVE_MS,
-    );
     while (now() < deadline) {
       const run = inspectPrivateRun(await readPrivateRun(runId, privateToken, {
         deadline,
@@ -701,7 +709,7 @@ export async function runTemporalCompatibility({
         if (run.conclusion !== "success") {
           throw new Error(`Private compatibility run completed with ${run.conclusion || "no conclusion"}.`);
         }
-        const proof = inspectAttestationJobs(await listAllRunJobs({ runId, token: privateToken }), {
+        const proof = inspectAttestationJobs(await listAllRunJobs({ runId, token: privateToken, ...timing }), {
           expectedTemporalTargetDigest,
           releaseScope,
           privateSha,
@@ -714,10 +722,12 @@ export async function runTemporalCompatibility({
         const currentPrivateSha = await resolvePrivateMain({
           encodedPrivateRepository,
           token: privateToken,
+          ...timing,
         });
         if (currentPrivateSha !== privateSha) {
           throw new Error("Private main changed during Temporal compatibility proof.");
         }
+        remainingHttpTimeout(timing, "private compatibility finalization");
         console.log(`::notice::temporal-compatibility result=success readers=${proof.readerCount} digest=${proof.digest}`);
         return proof;
       }
@@ -729,6 +739,7 @@ export async function runTemporalCompatibility({
     if (!terminal) {
       try {
         await cancelAcceptedRun({
+          deadline: tokenDeadline,
           privateSha,
           now,
           runId,
@@ -750,6 +761,7 @@ export async function runTemporalCompatibility({
 export async function cancelAcceptedRun({
   privateSha,
   now = Date.now,
+  deadline = now() + TEMPORAL_COMPATIBILITY_SETTLEMENT_RESERVE_MS,
   runId,
   sleepFn = sleep,
   token,
@@ -762,11 +774,13 @@ export async function cancelAcceptedRun({
       runId,
       "cancel",
       token,
+      { deadline, now },
     );
   } catch {
     ordinaryCancelFailed = true;
   }
   if (!ordinaryCancelFailed && await waitForTerminal({
+    deadline,
     privateSha,
     now,
     runId,
@@ -780,8 +794,10 @@ export async function cancelAcceptedRun({
     runId,
     "force-cancel",
     token,
+    { deadline, now },
   );
   if (!await waitForTerminal({
+    deadline,
     privateSha,
     now,
     runId,
@@ -795,6 +811,7 @@ export async function cancelAcceptedRun({
 }
 
 async function waitForTerminal({
+  deadline: tokenDeadline,
   privateSha,
   now,
   runId,
@@ -803,7 +820,7 @@ async function waitForTerminal({
   token,
   workflowId,
 }) {
-  const deadline = now() + timeoutMs;
+  const deadline = Math.min(tokenDeadline, now() + timeoutMs);
   while (now() < deadline) {
     let run;
     try {
@@ -840,7 +857,7 @@ async function readPrivateRun(runId, token, {
         `https://api.github.com/repos/${TEMPORAL_COMPATIBILITY_PRIVATE_REPOSITORY}/actions/runs/${runId}`,
         { headers: githubHeaders(token) },
         "private compatibility run lookup",
-        Math.min(HTTP_TIMEOUT_MS, remainingMs),
+        { deadline, now },
       );
     } catch (error) {
       if (
@@ -856,14 +873,14 @@ async function readPrivateRun(runId, token, {
   throw new Error("Private compatibility run visibility retry was exhausted.");
 }
 
-async function postRunControl(repository, runId, operation, token) {
+async function postRunControl(repository, runId, operation, token, timing) {
   const encodedRepository = encodeRepository(repository);
   const response = await fetch(
     `https://api.github.com/repos/${encodedRepository}/actions/runs/${runId}/${operation}`,
     {
       headers: githubHeaders(token),
       method: "POST",
-      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+      signal: AbortSignal.timeout(remainingHttpTimeout(timing, `private compatibility ${operation}`)),
     },
   );
   if (response.status !== 202 && response.status !== 409) {
@@ -871,6 +888,7 @@ async function postRunControl(repository, runId, operation, token) {
     throw new Error(`Private compatibility ${operation} failed with HTTP ${response.status}.`);
   }
   await response.body?.cancel().catch(() => undefined);
+  remainingHttpTimeout(timing, `private compatibility ${operation}`);
 }
 
 async function runSelectCommand() {
@@ -947,17 +965,31 @@ async function main(argv) {
   throw new Error("Expected select, run, or run-main.");
 }
 
-async function fetchJson(url, init, label, timeoutMs = HTTP_TIMEOUT_MS) {
-  const response = await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+function remainingHttpTimeout({ deadline = Number.POSITIVE_INFINITY, now = Date.now } = {}, label) {
+  const remainingMs = deadline - now();
+  if (remainingMs <= 0) throw new Error(`${label} exceeded its timing budget.`);
+  return Math.min(HTTP_TIMEOUT_MS, remainingMs);
+}
+
+async function fetchJson(url, init, label, timing) {
+  const response = await fetch(url, {
+    ...init,
+    signal: AbortSignal.timeout(remainingHttpTimeout(timing, label)),
+  });
   if (!response.ok) {
     await response.body?.cancel().catch(() => undefined);
     throw new HttpStatusError(label, response.status);
   }
+  let body;
   try {
-    return await response.json();
+    body = await response.json();
   } catch {
     throw new Error(`${label} returned invalid JSON.`);
   }
+  // Include body consumption and reject a late result even if an abort timer
+  // could not run promptly (for example, while the process was suspended).
+  remainingHttpTimeout(timing, label);
+  return body;
 }
 
 class HttpStatusError extends Error {

--- a/scripts/hosted-orchestration-compatibility.test.mjs
+++ b/scripts/hosted-orchestration-compatibility.test.mjs
@@ -15,7 +15,6 @@ import {
   TEMPORAL_COMPATIBILITY_PRIVATE_REPOSITORY,
   TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW_NAME,
   TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW_PATH,
-  TEMPORAL_COMPATIBILITY_RUN_TIMEOUT_MS,
   TEMPORAL_COMPATIBILITY_SETTLEMENT_RESERVE_MS,
   TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS,
   buildAttestationJobName,
@@ -866,54 +865,98 @@ test("controller dispatches main only after exact private-head, workflow, and pu
   }));
 });
 
-test("controller finalizes a last-admitted success before the private token safety boundary", async () => {
-  let nowMs = 0;
-  let dispatchFinishedAt = null;
-  let privateMainReads = 0;
-  await withCompatibilityEnv(async () => withFetch(async (url) => {
-    nowMs += 30_000;
-    if (url.endsWith(`/git/ref/heads/${TEMPORAL_COMPATIBILITY_PRIVATE_BRANCH}`)) {
-      privateMainReads += 1;
-      return jsonResponse(privateMainRef());
-    }
-    if (url.includes("/actions/workflows/") && !url.endsWith("/dispatches")) {
-      return jsonResponse({
-        id: WORKFLOW_ID,
-        name: TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW_NAME,
-        path: TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW_PATH,
-        state: "active",
-      });
-    }
-    if (url.endsWith("/pulls/42")) return jsonResponse(pullRequest());
-    if (url.endsWith("/dispatches")) {
-      dispatchFinishedAt = nowMs;
-      return jsonResponse({ workflow_run_id: RUN_ID });
-    }
-    if (url.endsWith(`/actions/runs/${RUN_ID}`)) {
-      assert.notEqual(dispatchFinishedAt, null);
-      nowMs = dispatchFinishedAt + TEMPORAL_COMPATIBILITY_RUN_TIMEOUT_MS;
-      return jsonResponse(privateRun());
-    }
-    if (url.includes(`/actions/runs/${RUN_ID}/jobs`)) {
-      return jsonResponse({ jobs: proofJobs(), total_count: 4 });
-    }
-    throw new Error(`unexpected URL ${url}`);
-  }, async () => {
-    const proof = await runTemporalCompatibility(compatibilityArgs({
-      now: () => nowMs,
-      sleepFn: async (duration) => {
-        nowMs += duration;
+for (const releaseScope of [HOSTED_RELEASE_SCOPE_NONE, HOSTED_RELEASE_SCOPE_PRODUCTION_CORE]) {
+  test(`controller completes ${releaseScope} after twenty queued and twenty-five executing minutes`, async () => {
+    let dispatchedAt;
+    const observedStatuses = new Set();
+    await withTimedController({
+      releaseScope,
+      respond: ({ kind }, clock) => {
+        if (kind === "dispatch") dispatchedAt = clock.ms;
+        if (kind !== "run") return;
+        const elapsed = clock.ms - dispatchedAt;
+        const status = elapsed < 20 * 60_000 ? "queued"
+          : elapsed < 45 * 60_000 ? "in_progress" : "completed";
+        observedStatuses.add(status);
+        return jsonResponse(privateRun({
+          status,
+          conclusion: status === "completed" ? "success" : null,
+        }));
       },
-    }));
-    assert.equal(proof.readerCount, 3);
-  }));
-  assert.equal(privateMainReads, 2);
-  assert.ok(nowMs < TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS);
-  assert.ok(
-    TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS - nowMs
-      > TEMPORAL_COMPATIBILITY_SETTLEMENT_RESERVE_MS,
-  );
-});
+    }, async ({ clock, run }) => {
+      const proof = await run();
+      assert.equal(proof.releaseScope, releaseScope);
+      assert.deepEqual([...observedStatuses], ["queued", "in_progress", "completed"]);
+      assert.equal(clock.ms - dispatchedAt, 45 * 60_000);
+      assert.ok(clock.ms < TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS);
+      assert.equal(clock.calls.filter(({ kind }) => kind === "jobs").length, 1);
+      assert.equal(clock.calls.filter(({ kind }) => kind === "cancel" || kind === "force-cancel").length, 0);
+    });
+  });
+}
+
+for (const lateKind of ["run", "jobs", "public", "ancestry", "private"]) {
+  test(`controller rejects ${lateKind} response bodies arriving at the credential boundary`, async () => {
+    let deliveredLate = false;
+    await withTimedController({
+      releaseScope: HOSTED_RELEASE_SCOPE_PRODUCTION_CORE,
+      respond: ({ kind, occurrence }, clock, response) => {
+        // Exercise the optional protected-main ancestry read during finalization.
+        if (kind === "public" && occurrence === 2) response = jsonResponse(publicMainRef(MOVED_PRIVATE_SHA));
+        const finalRead = (kind !== "public" && kind !== "private") || occurrence === 2;
+        if (kind === lateKind && finalRead) {
+          const json = response.json.bind(response);
+          response.json = async () => {
+            const body = await json();
+            clock.ms = TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS;
+            deliveredLate = true;
+            return body;
+          };
+        }
+        return response;
+      },
+    }, async ({ clock, run }) => {
+      await assert.rejects(run);
+      assert.equal(deliveredLate, true);
+      assert.equal(clock.calls.at(-1).kind, lateKind);
+      assert.ok(clock.calls.every(({ at }) => at < TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS));
+    });
+  });
+}
+
+for (const releaseScope of [HOSTED_RELEASE_SCOPE_NONE, HOSTED_RELEASE_SCOPE_PRODUCTION_CORE]) {
+  test(`controller finalizes a last-admitted ${releaseScope} success within the reserve`, async () => {
+    const deadline = TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS - TEMPORAL_COMPATIBILITY_SETTLEMENT_RESERVE_MS;
+    let observedSuccessAt;
+    await withTimedController({
+      releaseScope,
+      respond: ({ kind, occurrence }, clock) => {
+        if (kind === "run") {
+          if (clock.ms < deadline - 15_000) {
+            return jsonResponse(privateRun({ status: "in_progress", conclusion: null }));
+          }
+          // A final status read takes just under its remaining 15-second budget.
+          clock.ms = deadline - 1;
+          observedSuccessAt = clock.ms;
+        } else {
+          clock.ms += 30_000;
+        }
+        if (releaseScope !== HOSTED_RELEASE_SCOPE_NONE && kind === "public" && occurrence === 2) {
+          return jsonResponse(publicMainRef(MOVED_PRIVATE_SHA));
+        }
+      },
+    }, async ({ clock, run }) => {
+      const proof = await run();
+      assert.equal(proof.releaseScope, releaseScope);
+      assert.equal(observedSuccessAt, deadline - 1);
+      const finalReads = clock.calls.filter(({ at }) => at >= observedSuccessAt);
+      assert.deepEqual(finalReads.map(({ kind }) => kind), releaseScope === HOSTED_RELEASE_SCOPE_NONE
+        ? ["jobs", "public", "private"] : ["jobs", "public", "ancestry", "private"]);
+      assert.equal(clock.ms, observedSuccessAt + finalReads.length * 30_000);
+      assert.ok(clock.ms < TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS);
+    });
+  });
+}
 
 for (const releaseScope of [HOSTED_RELEASE_SCOPE_FOREGROUND, HOSTED_RELEASE_SCOPE_PRODUCTION_CORE]) {
   for (const advanceAt of [0, 1, 2]) {
@@ -1228,59 +1271,188 @@ test("controller cancels only its accepted run when status polling becomes uncer
   }));
 });
 
-test("controller times out and cancels only its accepted run", async () => {
-  const controlUrls = [];
-  let nowMs = 0;
-  let forceCancelFinishedAt = null;
-  let runReads = 0;
-  await withCompatibilityEnv(async () => withFetch(async (url) => {
-      nowMs += 30_000;
-      if (url.endsWith(`/git/ref/heads/${TEMPORAL_COMPATIBILITY_PRIVATE_BRANCH}`)) {
-        return jsonResponse(privateMainRef());
+for (const settles of [true, false]) {
+  test(`controller exhausts the shared budget and ${settles ? "settles" : "fails closed on"} its exact run`, async () => {
+    const deadline = TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS - TEMPORAL_COMPATIBILITY_SETTLEMENT_RESERVE_MS;
+    let forceCancelFinishedAt;
+    await withTimedController({
+      respond: ({ kind, timeoutMs }, clock) => {
+        if (kind === "cancel" || kind === "force-cancel") clock.ms += 30_000;
+        if (kind === "force-cancel") forceCancelFinishedAt = clock.ms;
+        if (kind === "run") {
+          // Use the full request allowance without delivering a response at or
+          // after its abort boundary; sleeps consume the rest of each wait.
+          clock.ms += timeoutMs - 1;
+          const complete = settles && forceCancelFinishedAt !== undefined
+            && clock.ms >= forceCancelFinishedAt + 2 * 60_000 - 15_000;
+          return jsonResponse(privateRun({
+            status: complete ? "completed" : "in_progress",
+            conclusion: complete ? "cancelled" : null,
+          }));
+        }
+      },
+    }, async ({ clock, run }) => {
+      await assert.rejects(run, (error) => {
+        assert.equal(error instanceof AggregateError, !settles);
+        if (settles) assert.match(error.message, /run timed out/u);
+        else assert.match(error.message, /could not be proven terminal/u);
+        return true;
+      });
+      const cancellation = clock.calls.filter(({ kind }) => kind === "cancel" || kind === "force-cancel");
+      assert.deepEqual(cancellation.map(({ kind, at }) => [kind, at]), [
+        ["cancel", deadline], ["force-cancel", deadline + 30_000 + 2 * 60_000],
+      ]);
+      assert.ok(cancellation.every(({ url }) => url.includes(`/actions/runs/${RUN_ID}/`)));
+      assert.ok(clock.ms <= deadline + 2 * 30_000 + 2 * 2 * 60_000);
+      assert.ok(clock.ms < TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS);
+      assert.equal(clock.calls.filter(({ kind }) => kind === "jobs").length, 0);
+    });
+  });
+}
+
+for (const failure of ["failed run", "failed proof job", "malformed attestation", "incomplete jobs", "changed public head"]) {
+  test(`controller still rejects ${failure} after the old timeout ceiling`, async () => {
+    await withTimedController({
+      respond: async ({ kind, occurrence }, clock, response) => {
+        if (kind === "run") {
+          if (clock.ms < 45 * 60_000) {
+            return jsonResponse(privateRun({ status: "in_progress", conclusion: null }));
+          }
+          if (failure === "failed run") return jsonResponse(privateRun({ conclusion: "failure" }));
+        }
+        if (kind === "jobs") {
+          const page = await response.json();
+          if (failure === "failed proof job") page.jobs[0].conclusion = "failure";
+          if (failure === "malformed attestation") page.jobs[3].name = "Temporal compatibility attestation [malformed]";
+          if (failure === "incomplete jobs") page.total_count += 1;
+          return jsonResponse(page);
+        }
+        if (kind === "public" && occurrence === 2 && failure === "changed public head") {
+          return jsonResponse(pullRequest({
+            head: { repo: { full_name: "cobuildwithus/murph" }, sha: MOVED_PRIVATE_SHA },
+          }));
+        }
+      },
+    }, async ({ clock, run }) => {
+      await assert.rejects(run, (error) => !(error instanceof AggregateError));
+      assert.equal(clock.ms, 45 * 60_000);
+      // The exact run is already terminal; do not cancel it or dispatch another.
+      assert.deepEqual(clock.calls.filter(({ method }) => method === "POST").map(({ kind }) => kind), ["dispatch"]);
+    });
+  });
+}
+
+for (const ordinaryCancelStatus of [202, 503]) {
+  test(`controller clips late cancellation and settlement after cancel HTTP ${ordinaryCancelStatus}`, async () => {
+    let settling = false;
+    await withTimedController({
+      respond: ({ kind, timeoutMs }, clock) => {
+        if (kind === "cancel") {
+          assert.equal(timeoutMs, 10_000);
+          settling = true;
+          return new Response(null, { status: ordinaryCancelStatus });
+        }
+        if (kind === "force-cancel") assert.equal(timeoutMs, 10_000);
+        if (kind === "run") {
+          if (!settling) {
+            clock.ms = TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS - 10_000;
+            return new Response(null, { status: 503 });
+          }
+          assert.equal(timeoutMs, 10_000);
+          clock.ms += 9_999;
+          return jsonResponse(privateRun({ conclusion: "cancelled" }));
+        }
+      },
+    }, async ({ clock, run }) => {
+      await assert.rejects(run, (error) => {
+        assert.ok(!(error instanceof AggregateError));
+        assert.match(error.message, /run lookup failed with HTTP 503/u);
+        return true;
+      });
+      assert.equal(clock.ms, TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS - 1);
+      assert.deepEqual(clock.calls.filter(({ method }) => method === "POST").map(({ kind }) => kind),
+        ordinaryCancelStatus === 202 ? ["dispatch", "cancel"] : ["dispatch", "cancel", "force-cancel"]);
+    });
+  });
+}
+
+for (const elapsed of [
+  TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS - TEMPORAL_COMPATIBILITY_SETTLEMENT_RESERVE_MS - 30_000,
+  TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS,
+]) {
+  test(`controller does not dispatch when preflight consumes ${elapsed}ms`, async () => {
+    await withTimedController({
+      respond: ({ kind }, clock) => {
+        if (kind === "public") clock.ms = elapsed;
+      },
+    }, async ({ clock, run }) => {
+      await assert.rejects(run);
+      assert.deepEqual(clock.calls.map(({ kind }) => kind), ["private", "workflow", "public"]);
+    });
+  });
+}
+
+test("controller clips finalization HTTP to the remaining credential budget", async () => {
+  await withTimedController({
+    respond: ({ kind, occurrence, timeoutMs }, clock) => {
+      if (kind === "jobs") clock.ms = TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS - 5_000;
+      if (kind === "public" && occurrence === 2) {
+        assert.equal(timeoutMs, 5_000);
+        clock.ms += timeoutMs;
       }
-      if (url.includes("/actions/workflows/") && !url.endsWith("/dispatches")) {
-        return jsonResponse({
-          id: WORKFLOW_ID,
-          name: TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW_NAME,
-          path: TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW_PATH,
-          state: "active",
-        });
-      }
-      if (url.endsWith("/pulls/42")) return jsonResponse(pullRequest());
-      if (url.endsWith("/dispatches")) return jsonResponse({ workflow_run_id: RUN_ID });
-      if (url.endsWith(`/actions/runs/${RUN_ID}/cancel`)) {
-        controlUrls.push(url);
-        return new Response(null, { status: 202 });
-      }
-      if (url.endsWith(`/actions/runs/${RUN_ID}/force-cancel`)) {
-        controlUrls.push(url);
-        forceCancelFinishedAt = nowMs;
-        return new Response(null, { status: 202 });
-      }
-      if (url.endsWith(`/actions/runs/${RUN_ID}`)) {
-        runReads += 1;
-        const forceCancellationSettled = forceCancelFinishedAt !== null
-          && nowMs - forceCancelFinishedAt >= 2 * 60_000;
-        return jsonResponse(privateRun(forceCancellationSettled
-          ? { conclusion: "cancelled", status: "completed" }
-          : { conclusion: null, status: "in_progress" }));
-      }
-      throw new Error(`unexpected URL ${url}`);
-    }, async () => {
-      await assert.rejects(() => runTemporalCompatibility(compatibilityArgs({
-        now: () => nowMs,
-        sleepFn: async (duration) => {
-          nowMs += duration;
-        },
-      })), /run timed out/u);
-    }));
-  assert.deepEqual(controlUrls, [
-    `https://api.github.com/repos/${TEMPORAL_COMPATIBILITY_PRIVATE_REPOSITORY}/actions/runs/${RUN_ID}/cancel`,
-    `https://api.github.com/repos/${TEMPORAL_COMPATIBILITY_PRIVATE_REPOSITORY}/actions/runs/${RUN_ID}/force-cancel`,
-  ]);
-  assert.ok(runReads > 2);
-  assert.ok(nowMs < TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS);
+    },
+  }, async ({ clock, run }) => {
+    await assert.rejects(run, /timing budget/u);
+    assert.equal(clock.ms, TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS);
+    assert.equal(clock.calls.at(-1).kind, "public");
+  });
 });
+
+test("controller shares the usable deadline with initial exact-run visibility recovery", async () => {
+  const deadline = TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS - TEMPORAL_COMPATIBILITY_SETTLEMENT_RESERVE_MS;
+  let cancelled = false;
+  await withTimedController({
+    respond: ({ kind }, clock) => {
+      if (kind === "public") clock.ms = deadline - 30_001;
+      if (kind === "dispatch") clock.ms += 30_000;
+      if (kind === "cancel") cancelled = true;
+      if (kind === "run" && !cancelled) return new Response(null, { status: 404 });
+    },
+  }, async ({ clock, run }) => {
+    await assert.rejects(run, (error) => !(error instanceof AggregateError));
+    assert.deepEqual(clock.calls.filter(({ kind }) => kind === "run" || kind === "cancel")
+      .map(({ kind, at, timeoutMs }) => [kind, at, timeoutMs]), [
+      ["run", deadline - 1, 1], ["cancel", deadline, 30_000], ["run", deadline, 30_000],
+    ]);
+  });
+});
+
+for (const lateKind of ["cancel", "force-cancel", "settlement"]) {
+  test(`controller cannot extend the credential boundary during ${lateKind}`, async () => {
+    let cancelling = false;
+    let forceCancelled = false;
+    await withTimedController({
+      respond: ({ kind, timeoutMs }, clock) => {
+        if (kind === "cancel") cancelling = true;
+        if (kind === "force-cancel") forceCancelled = true;
+        if (kind === lateKind) clock.ms = TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS;
+        if (kind === "run") {
+          if (!cancelling) return new Response(null, { status: 503 });
+          if (lateKind === "settlement") {
+            clock.ms = TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS;
+            return jsonResponse(privateRun({ conclusion: "cancelled" }));
+          }
+          if (!forceCancelled) clock.ms += timeoutMs - 1;
+          return jsonResponse(privateRun({ status: "in_progress", conclusion: null }));
+        }
+      },
+    }, async ({ clock, run }) => {
+      await assert.rejects(run, AggregateError);
+      assert.equal(clock.calls.at(-1).kind, lateKind === "settlement" ? "run" : lateKind);
+      assert.ok(clock.calls.every(({ at }) => at < TEMPORAL_COMPATIBILITY_TOKEN_BUDGET_MS));
+    });
+  });
+}
 
 test("missing dispatch identity never issues a broad or guessed cancellation", async () => {
   const controls = [];
@@ -1327,6 +1499,8 @@ test("accepted-run cancellation force-cancels only after ordinary cancellation s
     if (url.endsWith(`/actions/runs/${RUN_ID}`)) {
       const forceCancellationSettled = forceCancelFinishedAt !== null
         && nowMs - forceCancelFinishedAt >= 2 * 60_000;
+      // Deliver the terminal response just inside the two-minute wait.
+      if (forceCancellationSettled) nowMs -= 1;
       return jsonResponse(privateRun(forceCancellationSettled
         ? { conclusion: "cancelled", status: "completed" }
         : { conclusion: null, status: "in_progress" }));
@@ -1345,7 +1519,7 @@ test("accepted-run cancellation force-cancels only after ordinary cancellation s
     });
     assert.deepEqual(controls, ["cancel", "force-cancel"]);
     assert.equal(forceCancelFinishedAt, 3 * 60_000);
-    assert.equal(nowMs, 5 * 60_000);
+    assert.equal(nowMs, 5 * 60_000 - 1);
   });
 });
 
@@ -1517,6 +1691,78 @@ test("Repo Hygiene owns the focused controller contract test", async () => {
   );
   assert.match(workflow, /node --test scripts\/hosted-orchestration-compatibility\.test\.mjs/u);
 });
+
+// Fake only HTTP and time; all admission, polling, proof and settlement run in
+// the real controller. Record the actual AbortSignal timeout of every request.
+async function withTimedController({
+  releaseScope = HOSTED_RELEASE_SCOPE_NONE,
+  respond = () => undefined,
+}, fn) {
+  const clock = { ms: 0, calls: [] };
+  const timeouts = new WeakMap();
+  const originalTimeout = AbortSignal.timeout;
+  AbortSignal.timeout = (ms) => {
+    const signal = originalTimeout(ms);
+    timeouts.set(signal, ms);
+    return signal;
+  };
+  try {
+    await withFetch(async (url, init) => {
+      let kind;
+      let response;
+      if (url.includes(`/repos/${TEMPORAL_COMPATIBILITY_PRIVATE_REPOSITORY}/git/ref/`)) {
+        kind = "private";
+        response = jsonResponse(privateMainRef());
+      } else if (url.endsWith("/pulls/42") || url.endsWith("/git/ref/heads/main")) {
+        kind = "public";
+        response = jsonResponse(url.endsWith("/pulls/42") ? pullRequest() : publicMainRef());
+      } else if (url.includes("/compare/")) {
+        kind = "ancestry";
+        response = jsonResponse({ status: "ahead", base_commit: { sha: PUBLIC_SHA },
+          merge_base_commit: { sha: PUBLIC_SHA } });
+      } else if (url.endsWith("/dispatches")) {
+        kind = "dispatch";
+        response = jsonResponse({ workflow_run_id: RUN_ID });
+      } else if (url.includes("/actions/workflows/")) {
+        kind = "workflow";
+        response = jsonResponse({ id: WORKFLOW_ID, name: TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW_NAME,
+          path: TEMPORAL_COMPATIBILITY_PRIVATE_WORKFLOW_PATH, state: "active" });
+      } else if (url.endsWith(`/actions/runs/${RUN_ID}`)) {
+        kind = "run";
+        response = jsonResponse(privateRun());
+      } else if (url.includes(`/actions/runs/${RUN_ID}/jobs?`)) {
+        kind = "jobs";
+        const jobs = proofJobs({ releaseScope });
+        response = jsonResponse({ jobs, total_count: jobs.length });
+      } else if (url.endsWith(`/actions/runs/${RUN_ID}/cancel`)
+        || url.endsWith(`/actions/runs/${RUN_ID}/force-cancel`)) {
+        kind = url.endsWith("/force-cancel") ? "force-cancel" : "cancel";
+        response = new Response(null, { status: 202 });
+      } else {
+        throw new Error(`unexpected URL ${url}`);
+      }
+      const call = { kind, url, at: clock.ms, method: init.method ?? "GET",
+        timeoutMs: timeouts.get(init.signal),
+        occurrence: 1 + clock.calls.filter((entry) => entry.kind === kind).length };
+      assert.ok(call.timeoutMs > 0 && call.timeoutMs <= 30_000);
+      clock.calls.push(call);
+      return await respond(call, clock, response) ?? response;
+    }, () => fn({
+      clock,
+      run: (overrides = {}) => runTemporalCompatibility(compatibilityArgs({
+        dispatchMode: releaseScope === HOSTED_RELEASE_SCOPE_NONE ? "temporal_compatibility" : HOSTED_RELEASE_ADMISSION_MODE,
+        expectedTemporalTargetDigest: TEMPORAL_TARGET_DIGEST,
+        releaseScope,
+        prNumber: releaseScope === HOSTED_RELEASE_SCOPE_NONE ? 42 : null,
+        now: () => clock.ms,
+        sleepFn: async (ms) => { clock.ms += ms; },
+        ...overrides,
+      })),
+    }));
+  } finally {
+    AbortSignal.timeout = originalTimeout;
+  }
+}
 
 async function withCompatibilityEnv(fn) {
   return fn();


### PR DESCRIPTION
## Why and outcome

A runtime can begin requiring route audience or emitting a new diagnostic event while the serving Web still has the older callback contract. Local validation and container smoke can each pass even though that deployed pair cannot deliver scheduled work or ingest its diagnostics. This change requires fresh, signed evidence from the serving Web's actual audience encoder and log parser before hosted activation.

The release controller also replaces its independent forty-minute ceiling with the existing credential deadline minus settlement reserve. Queueing, execution, final attestation, and cancellation remain bounded by that same deadline; exact candidate, private-head, and scenario proof are unchanged. The active execution plan records the causal retrospective and the remaining live recovery and scenario-coverage work.

## Product UX

- Effort: Not applicable — internal deployment and release-proof controls; existing audience authorization and member journeys are preserved.
- Result: Not applicable.
- Walkthrough: A compatible Web permits activation. Missing audience, an older log reader, unavailable Web, or drift during activation stops further mutation. No guessed audience, member messages, provider calls, or automatic replay are introduced.

## Evidence

- Direct: 72 focused Cloudflare tests pass, including the actual deploy CLI composed with the admission client, rejected legacy wire shapes, supported current/superset readers, worker-only mode, all activation boundaries, retries, deadlines, and transport limits.
- Direct: 14 Web tests pass, including real signed request authentication/replay rejection, both authority-handler audience shapes, and the actual log handler accepting the processing-summary payload and rejecting it under synthetic older enum membership.
- Direct: All 75 release-controller tests pass under Node 24, including twenty minutes queued plus twenty-five minutes executing, exhausted proof budgets, late finalization, and bounded cancellation settlement.
- Direct: Both application typechecks, the hosted-execution package build, workspace boundary verification, doc gardening, and diff whitespace checks pass.
- Coverage: Tests keep application-private imports within their owners and connect actual producer/parser/handler behavior through public contracts and synthetic wire shapes. This proves the directed callback obligations; it does not claim every protocol or global Web replica convergence.
- Final ReviewGPT round 1 passed on b655af16f7e07ce7c8d7d2eec1dd45740c5b40c1 with captured gpt-6-pro model evidence and no qualifying findings. Response SHA-256: d3e5ecfebeb06f366ea7a7400f3cabe5e80bea6b78dfc0f6cca1852c1fe266eb. External controller tests passed under Node 22; local proof above passed under required Node 24.
- Required checks pass on b655af16f7e07ce7c8d7d2eec1dd45740c5b40c1. The new guard is not yet deployed. Natural production delivery and log-ingestion verification remain part of recovery.

## Non-obvious affected surfaces

The existing Worker authority parser and Web authority response encoder move into reusable owners without changing their ordinary callback semantics. The system callback verifier accepts a caller-selected nonce owner while preserving its existing Temporal default. Worker-only deployment retains the same conservative Web floor. Release finalization and cancellation share the original credential boundary.

## Architecture and reuse

- Existing systems reused: Web callback ECDSA authentication, nonce store, actual runtime-log parser, actual authority encoder/parser, deployment activation seams, live Worker identity checks, and the existing GitHub proof controller.
- New logic: Bounded fresh consumer evidence before release mutations, with candidate producer vocabulary as a subset of accepted reader vocabulary; one absolute proof/settlement deadline.
- New abstractions: One additive signed admission route and its public wire contract plus a deployment probe. The extracted authority parser and encoder remain the ordinary callback owners.
- Complexity intentionally avoided: No capability database, persisted compatibility receipt, SHA ordering rule, deployment service, skip flag, unbounded retry, or guessed product state.

## Complexity impact

- Guard: pass — `pnpm complexity:diff`; all 11 authored source files pass, with no increased complexity debt.
- Hotspots: Existing unchanged `parseHostedExecutionWake` (39), `parseHostedExecutionEvent` (30), and `inspectHostedRuntimeAutomationLaneTimingSubdivision` (25). Their bodies are not modified; unrelated decomposition would expand scope.
- Agent judgment: Transport bounds, actual-owner evidence, and activation placement each enforce distinct invariants. The response parser extraction reduces the existing effects-port maximum from 20 to 12. Further restructuring is not justified by this patch.

## Hot reply path impact

- Path status: The existing authority encoder/parser are extracted without changing behavior; no awaited operations are added to foreground processing.
- Database calls: None added to the reply path. Each deployment-only sample consumes one nonce through the existing store; there is no member collection scan or external work in a new transaction.
- Network/provider calls: None added to the reply path. Deployment admission uses three serial signed Web requests, spaced one second apart, each bounded to ten seconds and 16 KiB; failure ends that attempt.
- Other awaited latency: None on the reply path.
- Before/after proof: Legacy authority semantics, direct/group encoding, and actual callback tests pass. Deployment tests prove admission precedes activation and identity is rechecked after Web I/O.

## Murph initial provider input impact

Not applicable for both individual and group Murph: no prompts, tools, schemas exposed to models, or first-request assembly paths change. No provider-input measurement was run.

## Deployment concerns

- Deployment: applicable
- Supported skew: Older callers continue using the existing callback shape. A newer Web reader may advertise extra events; the candidate does not require equal source revisions. A Web without the new endpoint is deliberately rejected by the new deployment CLI.
- Safe order: Deploy and propagate the additive Web endpoint with compatible readers first, then adopt this CLI in the protected runtime workflow. Keep the serving alias stable throughout activation. Cross-repository scenario requirements likewise need the private selecting manifest first.
- Rollback floor: Retain this endpoint and compatible audience/log readers while this CLI or a requiring producer is in use. Preserve the separately documented custom-inference activation floor; this directed callback check does not attest that opposite-direction contract.
- Expected exposure: One bounded probe sequence at each activation boundary. Three samples do not prove global atomic propagation or prevent an independent later rollback.
- Reversibility: The route is additive. Reverting the guard requires retaining the existing consumer-first operating procedure; no data migration is introduced. Production rollback still requires its separate authorization.
- Convergence proof: Existing artifact smoke, native container convergence, and Worker identity receipts remain mandatory. Protocol admission supplements those checks and is never treated as container convergence.
- Post-deploy checks: Verify the canonical Web/Worker versions, require successful live admission and release convergence, then inspect fresh bounded failure aggregates plus positive scheduled delivery and runtime-log ingestion.

## Change-shape breakdown

Classification rule: test files and test helpers are tests/fixtures; Markdown is docs; remaining scripts are tooling; other authored TypeScript is source. No binary or generated files.

| Category | Added | Deleted |
| --- | ---: | ---: |
| Source | 329 | 44 |
| Tests / fixtures | 768 | 101 |
| Docs | 261 | 0 |
| Config / tooling | 48 | 16 |
| Generated / other | 0 | 0 |
| **Total** | **1406** | **161** |

## Changelog

- Changelog: not applicable
- Reason: Internal deployment admission and release-proof infrastructure; no new member-facing behavior or interface.

ReviewGPT first-reviewed head: b655af16f7e07ce7c8d7d2eec1dd45740c5b40c1
ReviewGPT context sensitivity: sensitive
Classification reason: Cross-application runtime callback authentication, production activation boundaries, and release deadline/cancellation behavior.
