### PR TITLE
test: isolate Environment handoff provider counts

### DIFF
--- a/.agents/friction-log/20260911211229-environment-handoff-provider/friction.md
+++ b/.agents/friction-log/20260911211229-environment-handoff-provider/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Environment handoff provider-count proof shares earlier members'' background traffic'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The Environment handoff scenario should count only the workload it has admitted while retaining its strict one-provider-request assertion.
+
+## Current Behavior
+
+The scenario runs after a system-mailbox fixture on a shared provider stub. Import and handoff completion do not require all earlier members' asynchronous provider work to finish. Requests from that earlier workload can arrive between the Environment scenario's baseline and final assertion.
+
+## Possible Solution
+
+Run the exact-count Environment scenario before any other member seeds background work. Preserve its existing assertions and the later system-mailbox proof.
+
+## Minimal Reproducible Example
+
+On one shared request array, capture a baseline after member A admits background work. Admit one foreground request for member B, then let member A append a delayed provider request. The global delta is two even though member B made exactly one request.
+
+## Context
+
+This creates an order-dependent false failure in hosted foreground-priority release verification.

--- a/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-foreground-reply-priority-e2e.test.ts
@@ -220,6 +220,111 @@ describe.sequential("hosted local foreground reply priority e2e", () => {
     linqStub = null;
   }, 120_000);
 
+  // This suite shares its provider stub. Keep the exact provider-count proof
+  // before other members seed background work that can call the same stub later.
+  it("drains queued Environment work after the active foreground turn", async () => {
+    await seedProbe(environmentHandoffProbe);
+    const baselineStatus = await requireScenario().harness.readUserStatus(
+      environmentHandoffProbe.userId,
+    );
+    const baselineReplicaRef = baselineStatus.workspace?.browserVaultReplicaRef;
+    expect(baselineReplicaRef).toBeDefined();
+    const providerRequestBaseline =
+      requireScenario().assistantProviderRequests.length;
+    const foregroundText =
+      "Finish this foreground turn before applying my queued Environment answer.";
+    const foregroundReply =
+      "The foreground turn finished before Environment work took ownership.";
+    const replyPath = replyPathFor(environmentHandoffProbe);
+    const replyMatcher = matchLinqMessageText(foregroundReply);
+    const replyBaseline = requireLinqStub().countAcceptedSends(
+      replyPath,
+      replyMatcher,
+    );
+    const heldProviderResponse = createHeldAssistantProviderTextResponse(
+      foregroundReply,
+    );
+    requireScenario().queueAssistantResponses(
+      [heldProviderResponse.response],
+      { matchInputContains: foregroundText },
+    );
+
+    const foregroundResponse = await postSignedLinqWebhook(
+      buildHostedLinqInboundEvent(
+        environmentHandoffProbe.userId,
+        environmentHandoffProbe.chatId,
+        {
+          eventId: `evt_priority_environment_handoff_${runId}`,
+          messageId: `msg_priority_environment_handoff_${runId}`,
+          text: foregroundText,
+        },
+      ),
+    );
+    expect(foregroundResponse.status).toBe(202);
+    await expect(foregroundResponse.json()).resolves.toMatchObject({
+      ok: true,
+      reason: "wake-appended-active-member",
+    });
+    await heldProviderResponse.started;
+    await waitForRuntimeInFlight(
+      environmentHandoffProbe.userId,
+      "foreground work before Environment handoff",
+      "default",
+    );
+
+    const environmentCompletion = await appendEnvironmentInterviewCompletion(
+      environmentHandoffProbe,
+      "handoff",
+    );
+    const runtimeWakeBefore = await readRuntimeWakeObservation({
+      scenario: requireScenario(),
+      userId: environmentHandoffProbe.userId,
+    });
+    let providerReleased = false;
+    try {
+      await signalTemporalRuntime(environmentHandoffProbe.userId, {
+        kind: "mailbox_appended",
+        lane: "system",
+        laneSeq: environmentCompletion.append.wake.seq,
+        mailboxItemId: environmentCompletion.append.wake.id,
+      });
+      await waitForRuntimeWakeExecution({
+        previous: runtimeWakeBefore,
+        scenario: requireScenario(),
+        userId: environmentHandoffProbe.userId,
+      });
+      await expect(
+        readActiveRuntimeFenceForTest(environmentHandoffProbe.userId),
+      ).resolves.toMatchObject({
+        processingMode: "default",
+      });
+      heldProviderResponse.release();
+      providerReleased = true;
+    } finally {
+      if (!providerReleased) {
+        heldProviderResponse.release();
+      }
+    }
+
+    await waitForAcceptedReplyInScenario({
+      baselineCount: replyBaseline,
+      identity: environmentHandoffProbe,
+      label: "foreground-to-Environment handoff",
+      linqStub: requireLinqStub(),
+      matcher: replyMatcher,
+      replyPath,
+      scenario: requireScenario(),
+    });
+    await waitForEnvironmentCompletion({
+      baselineReplicaRef,
+      completion: environmentCompletion,
+      identity: environmentHandoffProbe,
+    });
+    expect(requireScenario().assistantProviderRequests).toHaveLength(
+      providerRequestBaseline + 1,
+    );
+  }, 300_000);
+
   it("retains the authorized foreground owner and preserves durable system continuation", async () => {
     // Production maintains the memberless standby before member traffic arrives.
     // Establish that real precondition before starting the deliberately heavy
@@ -429,109 +534,6 @@ describe.sequential("hosted local foreground reply priority e2e", () => {
     }
 
     writeLatencyProof("system_mailbox", latencyMs);
-  }, 300_000);
-
-  it("drains queued Environment work after the active foreground turn", async () => {
-    await seedProbe(environmentHandoffProbe);
-    const baselineStatus = await requireScenario().harness.readUserStatus(
-      environmentHandoffProbe.userId,
-    );
-    const baselineReplicaRef = baselineStatus.workspace?.browserVaultReplicaRef;
-    expect(baselineReplicaRef).toBeDefined();
-    const providerRequestBaseline =
-      requireScenario().assistantProviderRequests.length;
-    const foregroundText =
-      "Finish this foreground turn before applying my queued Environment answer.";
-    const foregroundReply =
-      "The foreground turn finished before Environment work took ownership.";
-    const replyPath = replyPathFor(environmentHandoffProbe);
-    const replyMatcher = matchLinqMessageText(foregroundReply);
-    const replyBaseline = requireLinqStub().countAcceptedSends(
-      replyPath,
-      replyMatcher,
-    );
-    const heldProviderResponse = createHeldAssistantProviderTextResponse(
-      foregroundReply,
-    );
-    requireScenario().queueAssistantResponses(
-      [heldProviderResponse.response],
-      { matchInputContains: foregroundText },
-    );
-
-    const foregroundResponse = await postSignedLinqWebhook(
-      buildHostedLinqInboundEvent(
-        environmentHandoffProbe.userId,
-        environmentHandoffProbe.chatId,
-        {
-          eventId: `evt_priority_environment_handoff_${runId}`,
-          messageId: `msg_priority_environment_handoff_${runId}`,
-          text: foregroundText,
-        },
-      ),
-    );
-    expect(foregroundResponse.status).toBe(202);
-    await expect(foregroundResponse.json()).resolves.toMatchObject({
-      ok: true,
-      reason: "wake-appended-active-member",
-    });
-    await heldProviderResponse.started;
-    await waitForRuntimeInFlight(
-      environmentHandoffProbe.userId,
-      "foreground work before Environment handoff",
-      "default",
-    );
-
-    const environmentCompletion = await appendEnvironmentInterviewCompletion(
-      environmentHandoffProbe,
-      "handoff",
-    );
-    const runtimeWakeBefore = await readRuntimeWakeObservation({
-      scenario: requireScenario(),
-      userId: environmentHandoffProbe.userId,
-    });
-    let providerReleased = false;
-    try {
-      await signalTemporalRuntime(environmentHandoffProbe.userId, {
-        kind: "mailbox_appended",
-        lane: "system",
-        laneSeq: environmentCompletion.append.wake.seq,
-        mailboxItemId: environmentCompletion.append.wake.id,
-      });
-      await waitForRuntimeWakeExecution({
-        previous: runtimeWakeBefore,
-        scenario: requireScenario(),
-        userId: environmentHandoffProbe.userId,
-      });
-      await expect(
-        readActiveRuntimeFenceForTest(environmentHandoffProbe.userId),
-      ).resolves.toMatchObject({
-        processingMode: "default",
-      });
-      heldProviderResponse.release();
-      providerReleased = true;
-    } finally {
-      if (!providerReleased) {
-        heldProviderResponse.release();
-      }
-    }
-
-    await waitForAcceptedReplyInScenario({
-      baselineCount: replyBaseline,
-      identity: environmentHandoffProbe,
-      label: "foreground-to-Environment handoff",
-      linqStub: requireLinqStub(),
-      matcher: replyMatcher,
-      replyPath,
-      scenario: requireScenario(),
-    });
-    await waitForEnvironmentCompletion({
-      baselineReplicaRef,
-      completion: environmentCompletion,
-      identity: environmentHandoffProbe,
-    });
-    expect(requireScenario().assistantProviderRequests).toHaveLength(
-      providerRequestBaseline + 1,
-    );
   }, 300_000);
 
   it("replies promptly while retention-only work owns the runner", async () => {


### PR DESCRIPTION
## Why and outcome

The Environment handoff proof used a suite-wide provider counter after another member had queued background work. Late requests from that earlier fixture could fail the exact-count assertion during an otherwise successful handoff.

Run the Environment scenario first in the existing sequential suite, before other members seed asynchronous work. Every test callback, assertion, timeout, and runtime behavior remains unchanged.

## Product UX

- Effort: Not applicable — test isolation only.
- Result: Ready.
- Walkthrough: The Environment proof retains its exact one-request assertion, accepted foreground reply, persisted completion, and active-owner checks. The system-mailbox and latency proofs still run afterward.

## Evidence

- Direct: A controlled replay executes the actual Environment callback extracted from the test source. Late unrelated requests reproduce the global-counter failure; an isolated single request passes; an extra request still fails. This proves the observer boundary, not a full hosted runtime replay.
- Readback: AST extraction confirms every existing test callback is byte-identical, and the Environment callback is now first in the sequential suite.
- `pnpm --dir apps/cloudflare typecheck`: passed.
- `pnpm complexity:diff`: passed.
- `git diff --check`: passed; parent reviewed the full diff and public-safe Frog entry.
- Required exact-head CI: all 36 checks passed on `dc6d3c95e7cda7c943aa5084ca07db20f49b47c3`. Merged as `9ef8e92dea36f80f6c6c6b463d0c90544a4297ab`; managed production admission passed.
- All five hosted production scenarios and final attestation passed on `77d953863f487588be93b0ee27756ac7ffacb62c`: [private proof](https://github.com/cobuildwithus/murph-cloud/actions/runs/34666585237) and [public admission](https://github.com/cobuildwithus/murph/actions/runs/34665620956). With explicit incident-specific approval, promoted Vercel deployment `dpl_CD2dR8wEuGQFEqAmMAdi2bjeccqg` after its GitHub-backed check remained stale despite successful admission. On 2026-09-12, verified `www.withmurph.ai` resolves to that deployment, its immutable source is `77d953863f487588be93b0ee27756ac7ffacb62c`, and it is promoted with domains assigned. Git ancestry confirms the workout fix is included. Post-deploy smoke: homepage HTTP 200 and unauthenticated member-action POST HTTP 401. These checks prove deployment and the auth boundary; an ordinary authenticated member retry remains unobserved. Repository-wide deployment policy was not changed.
- Final ReviewGPT: not routed for this isolated test-order correction; no runtime, protocol, or production configuration changes.

## Non-obvious affected surfaces

The provider stub is shared for the suite. Running the exact-count scenario before any other member is seeded keeps that counter uncontaminated without narrowing or weakening its assertion.

## Architecture and reuse

- Existing systems reused: The sequential Vitest suite and current provider stub.
- New logic: One existing test is registered earlier, with a comment explaining the isolation constraint.
- New abstractions: None; the existing sequential suite already supplies the required isolation.
- Complexity intentionally avoided: No new harness, request-filtering heuristic, provider identity field, polling, or relaxed count.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` reports no authored production source changes.
- Hotspots: No changed callback body or new function.
- Agent judgment: Reordering preserves the complete existing proof with the smallest change.

## Hot reply path impact

Not applicable: test registration only, with no runtime calls or latency changes.

## Murph initial provider input impact

Not applicable for individual or group runtimes: prompts, tools, schemas, and provider-visible inputs are unchanged.

## Deployment concerns

- Deployment: not applicable
- Reason: Test ordering only. The normal hosted production admission must verify the full scenario before any application candidate goes live.

## Change-shape breakdown

Tests +105/-103 (one unchanged callback moved plus two comment lines); docs +24/-0 (Frog); source/config/generated +0/-0. Total +129/-103. No binary files.

## Changelog

- Changelog: not applicable
- Reason: Internal hosted verification isolation only.

ReviewGPT context sensitivity: routine
Classification reason: Existing sequential test reordering with unchanged callbacks and assertions.
