### PR TITLE
test: repair scheduled Telegram tool fixture

### DIFF
--- a/apps/cloudflare/test/hosted-local-telegram-scheduled-reminder-e2e.test.ts
+++ b/apps/cloudflare/test/hosted-local-telegram-scheduled-reminder-e2e.test.ts
@@ -317,7 +317,14 @@ function buildHostedAssistantAutomationSaveResponses(input: {
       action: "save",
       continuityPolicy: "fresh",
       instructions: scheduledReminderInstructions,
-      schedule: { at: input.dueAtIso, kind: "at" },
+      schedule: {
+        kind: "at",
+        localAt: {
+          date: input.dueAtIso.slice(0, 10),
+          time: input.dueAtIso.slice(11, 16),
+          timeZone: "UTC",
+        },
+      },
       summary: "One-shot sleep reminder.",
       tags: ["assistant", "scheduled"],
       title: "Sleep reminder",
@@ -573,7 +580,7 @@ function summarizeObservedTelegramRequests(): Array<{
 function resolveScheduledReminderTimes(now = new Date()): {
   dueAtIso: string;
 } {
-  const dueAtMs = now.getTime() + scheduledReminderLeadMs;
+  const dueAtMs = Math.ceil((now.getTime() + scheduledReminderLeadMs) / 60_000) * 60_000;
   return {
     dueAtIso: new Date(dueAtMs).toISOString(),
   };


### PR DESCRIPTION
## Why and outcome

The newly selected Telegram reminder journey failed before scheduling because its scripted automation tool call still used retired `schedule.at`. Use the current `schedule.localAt` date, time, and timezone fields. Round the synthetic due instant up to a whole minute so the saved schedule and wait deadline agree.

Land this fixture repair before rerunning the private Telegram integration lane, then require that lane through public #3350. Full private integration deliberately tests public main, so an unmerged candidate override cannot supply this repair.

## Product UX

- Effort: Not applicable — scripted test fixture only.
- Result: Ready.
- Walkthrough: Preserve the direct and group scheduled-send assertions, absence of manual wake nudges, route checks, and exactly-once direct-send check.

## Evidence

- The first selected hosted CI run failed while waiting for the direct reminder to arm. Source inspection identifies the obsolete raw-ISO tool payload; the current production tool schema requires localAt.
- All 45 automation model input-schema tests pass on the identical fixture candidate in the originating task checkout. The fixture body is byte-identical here.
- Direct replay extracted the actual fixture functions and passed their generated payload through the production automation parser: the old raw-ISO shape is rejected and the repaired shape is accepted, including minute and year-rollover boundaries. This is fixture admission proof, not full hosted delivery.
- Parent reviewed the complete two-hunk diff and its minute alignment, including the unchanged minimum runway and send assertions. Diff whitespace check passes.
- Full hosted proof remains pending until this fixture is on public main. All required exact-head CI passed in [Murph Host Support](https://github.com/cobuildwithus/murph/actions/runs/34666738404) and the required Stripe boundary.
- Final ReviewGPT is not routed: this is an isolated test-fixture correction with no production or release-authority change.

## Non-obvious affected surfaces

The due-time helper also supplies the group cron fixture. Whole-minute rounding keeps its cron minute aligned with its existing due-time wait. Both actual delivery assertions remain unchanged.

## Architecture and reuse

- Existing systems reused: Current automation tool contract and Telegram scenario.
- New logic: Minute-aligned synthetic timing and current tool arguments.
- New abstractions: None; the existing fixture and due-time helper already own both values.
- Complexity intentionally avoided: No new helper, harness, workflow, or runtime fallback.

## Complexity impact

- Guard: pass — `pnpm complexity:diff` passed on the identical fixture change; the guard reports no changed production function.
- Hotspots: No new or changed production-function hotspots; both edits remain inside existing test fixtures.
- Agent judgment: Two fixture edits preserve the existing end-to-end proof.

## Hot reply path impact

Not applicable — test-only payload and clock construction; no runtime operations change.

## Murph initial provider input impact

Not applicable to production individual or group runtimes. Only the scripted provider response in this test changes; production prompts and tools are unchanged.

## Deployment concerns

- Deployment: not applicable
- Reason: Existing test-fixture repair only. Public main must contain it before the private full-integration workflow can execute the corrected journey.

## Change-shape breakdown

Tests/fixtures +9/-2; all other categories +0/-0. Total +9/-2. No binary or generated files.

## Changelog

- Changelog: not applicable
- Reason: Internal test fixture; existing member behavior is unchanged.

ReviewGPT context sensitivity: routine
Classification reason: Isolated scripted fixture repair; no runtime, trust, or deployment contract changes.
